### PR TITLE
Added tile rotation 90 CW

### DIFF
--- a/src/libtiled/gidmapper.cpp
+++ b/src/libtiled/gidmapper.cpp
@@ -29,6 +29,7 @@ using namespace Tiled;
 // Bits on the far end of the 32-bit global tile ID are used for tile flags
 const int FlippedHorizontallyFlag = 0x80000000;
 const int FlippedVerticallyFlag   = 0x40000000;
+const int RotatedCWFlag = 0x20000000;
 
 GidMapper::GidMapper()
 {
@@ -50,9 +51,10 @@ Cell GidMapper::gidToCell(uint gid, bool &ok) const
     // Read out the flags
     result.flippedHorizontally = (gid & FlippedHorizontallyFlag);
     result.flippedVertically = (gid & FlippedVerticallyFlag);
-
+    result.rotatedCW = (gid & RotatedCWFlag);
+	
     // Clear the flags
-    gid &= ~(FlippedHorizontallyFlag | FlippedVerticallyFlag);
+    gid &= ~(FlippedHorizontallyFlag | FlippedVerticallyFlag | RotatedCWFlag);
 
     if (gid == 0) {
         ok = true;
@@ -106,6 +108,8 @@ uint GidMapper::cellToGid(const Cell &cell) const
         gid |= FlippedHorizontallyFlag;
     if (cell.flippedVertically)
         gid |= FlippedVerticallyFlag;
+    if (cell.rotatedCW)
+        gid |= RotatedCWFlag;
 
     return gid;
 }

--- a/src/libtiled/tilelayer.cpp
+++ b/src/libtiled/tilelayer.cpp
@@ -163,6 +163,43 @@ void TileLayer::flip(FlipDirection direction)
     mGrid = newGrid;
 }
 
+void TileLayer::rotate(RotateDirection direction)
+{
+    static char rotateCWMask[8] = { 1, 6, 5, 2, 3, 4, 7, 0 };
+    static char rotateCCWMask[8] = { 7, 0, 3, 4, 5, 2, 1, 6 };
+
+    int newWidth = mHeight;
+    int newHeight = mWidth;
+    QVector<Cell> newGrid(newWidth * newHeight);
+
+    for (int y = 0; y < mHeight; ++y) {
+        for (int x = 0; x < mWidth; ++x) {
+            const Cell &source = cellAt(x, y);
+            Cell dest = source;
+
+            unsigned char mask = (dest.flippedHorizontally << 2) | (dest.flippedVertically << 1) | (dest.rotatedCW << 0);
+
+            if (direction == RotateCW)
+                mask = rotateCWMask[mask];
+            else
+                mask = rotateCCWMask[mask];
+
+            dest.flippedHorizontally = (mask & 4) != 0;
+            dest.flippedVertically = (mask & 2) != 0;
+            dest.rotatedCW = (mask & 1) != 0;
+
+            if (direction == RotateCW)
+                newGrid[x * newWidth + (mHeight-y-1)] = dest;
+            else
+                newGrid[(mWidth-x-1) * newWidth + y] = dest;
+        }
+    }
+
+    mWidth = newWidth;
+    mHeight = newHeight;
+    mGrid = newGrid;
+}
+
 QSet<Tileset*> TileLayer::usedTilesets() const
 {
     QSet<Tileset*> tilesets;

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -51,13 +51,15 @@ public:
     Cell() :
         tile(0),
         flippedHorizontally(false),
-        flippedVertically(false)
+        flippedVertically(false),
+		rotatedCW(false)
     {}
 
     explicit Cell(Tile *tile) :
         tile(tile),
         flippedHorizontally(false),
-        flippedVertically(false)
+        flippedVertically(false),
+		rotatedCW(false)
     {}
 
     bool isEmpty() const { return tile == 0; }
@@ -66,19 +68,22 @@ public:
     {
         return tile == other.tile
                 && flippedHorizontally == other.flippedHorizontally
-                && flippedVertically == other.flippedVertically;
+                && flippedVertically == other.flippedVertically
+				&& rotatedCW == other.rotatedCW;
     }
 
     bool operator != (const Cell &other) const
     {
         return tile != other.tile
                 || flippedHorizontally != other.flippedHorizontally
-                || flippedVertically != other.flippedVertically;
+                || flippedVertically != other.flippedVertically
+				|| rotatedCW != other.rotatedCW;
     }
 
     Tile *tile;
     bool flippedHorizontally;
     bool flippedVertically;
+	bool rotatedCW;
 };
 
 /**
@@ -95,6 +100,10 @@ public:
         FlipHorizontally,
         FlipVertically
     };
+	enum RotateDirection {
+		RotateCW,
+		RotateCCW
+	};
 
     /**
      * Constructor.
@@ -169,6 +178,13 @@ public:
      */
     void flip(FlipDirection direction);
 
+	/**
+	 * Rotate this tile layer by 90 degrees clockwise or counter-clockwise.
+	 * The tile positions are rotated within the layer, and the tiles
+	 * themselves are rotated. The dimensions of the tile layer are swapped.
+	 */
+    void rotate(RotateDirection direction);
+	
     /**
      * Computes and returns the set of tilesets used by this tile layer.
      */

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -362,7 +362,9 @@ MainWindow::MainWindow(QWidget *parent, Qt::WFlags flags)
 
     new QShortcut(tr("X"), this, SLOT(flipStampHorizontally()));
     new QShortcut(tr("Y"), this, SLOT(flipStampVertically()));
-
+    new QShortcut(tr("Z"), this, SLOT(rotateStampCW()));
+    new QShortcut(tr("Shift+Z"), this, SLOT(rotateStampCCW()));
+	
     updateActions();
     readSettings();
     setupQuickStamps();
@@ -1196,6 +1198,24 @@ void MainWindow::flipStampVertically()
     if (TileLayer *stamp = mStampBrush->stamp()) {
         stamp = static_cast<TileLayer*>(stamp->clone());
         stamp->flip(TileLayer::FlipVertically);
+        setStampBrush(stamp);
+    }
+}
+
+void MainWindow::rotateStampCW()
+{
+    if (TileLayer *stamp = mStampBrush->stamp()) {
+        stamp = static_cast<TileLayer*>(stamp->clone());
+        stamp->rotate(TileLayer::RotateCW);
+        setStampBrush(stamp);
+    }
+}
+
+void MainWindow::rotateStampCCW()
+{
+    if (TileLayer *stamp = mStampBrush->stamp()) {
+        stamp = static_cast<TileLayer*>(stamp->clone());
+        stamp->rotate(TileLayer::RotateCCW);
         setStampBrush(stamp);
     }
 }

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -139,6 +139,8 @@ public slots:
 
     void flipStampHorizontally();
     void flipStampVertically();
+	void rotateStampCW();
+    void rotateStampCCW();
 
     void setStampBrush(const TileLayer *tiles);
     void updateStatusInfoLabel(const QString &statusInfo);


### PR DESCRIPTION
I modified wadetb's rotation code and changed it's "philosophy". Now 3rd bit represents 90 degrees CW rotation. Press 'Z' to rotate clockwise and 'Shift+Z' to rotate counter-clockwise. Changes to your initial brunch are minor so it should be easy for you to check it.
