### PR TITLE
Solves issue #67

### DIFF
--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -64,11 +64,17 @@ QRect IsometricRenderer::boundingRect(const QRect &rect) const
 
 QRectF IsometricRenderer::boundingRect(const MapObject *object) const
 {
+    return boundingRect(&*object, true);
+}
+
+QRectF IsometricRenderer::boundingRect(const MapObject *object, bool useOffset) const
+{
     if (object->tile()) {
         const QPointF bottomCenter = tileToPixelCoords(object->position());
         const QPixmap &img = object->tile()->image();
+        qreal yoff = (useOffset) ? -img.height() : 0;
         return QRectF(bottomCenter.x() - img.width() / 2,
-                      bottomCenter.y() - img.height(),
+                      bottomCenter.y() - yoff,
                       img.width(),
                       img.height()).adjusted(-1, -1, 1, 1);
     } else if (!object->polygon().isEmpty()) {
@@ -261,13 +267,22 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
                                       const MapObject *object,
                                       const QColor &color) const
 {
+    return drawMapObject(&*painter, &*object, color, true);
+}
+
+void IsometricRenderer::drawMapObject(QPainter *painter,
+                                      const MapObject *object,
+                                      const QColor &color,
+                                      bool useOffset) const
+{
     painter->save();
 
     QPen pen(Qt::black);
 
     if (object->tile()) {
         const QPixmap &img = object->tile()->image();
-        QPointF paintOrigin(-img.width() / 2, -img.height());
+        qreal yoff = (useOffset) ? -img.height() : 0;
+        QPointF paintOrigin(-img.width() / 2, yoff);
         paintOrigin += tileToPixelCoords(object->position()).toPoint();
         painter->drawPixmap(paintOrigin, img);
 

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -50,6 +50,8 @@ public:
     QRect boundingRect(const QRect &rect) const;
 
     QRectF boundingRect(const MapObject *object) const;
+    QRectF boundingRect(const MapObject *object, bool useOffset) const;
+
     QPainterPath shape(const MapObject *object) const;
 
     void drawGrid(QPainter *painter, const QRectF &rect) const;
@@ -65,6 +67,11 @@ public:
     void drawMapObject(QPainter *painter,
                        const MapObject *object,
                        const QColor &color) const;
+
+    void drawMapObject(QPainter *painter,
+                       const MapObject *object,
+                       const QColor &color,
+                       bool useOffset) const;
 
     using MapRenderer::pixelToTileCoords;
     QPointF pixelToTileCoords(qreal x, qreal y) const;

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -67,9 +67,16 @@ public:
 
     /**
      * Returns the bounding rectangle in pixels of the given \a object, as it
-     * would be drawn by drawMapObject().
+     * would be drawn by drawMapObject().  Y indices are offset by 1 tile.
      */
     virtual QRectF boundingRect(const MapObject *object) const = 0;
+
+    /**
+     * Returns the bounding rectangle in pixels of the given \a object, as it
+     * would be drawn by drawMapObject().  Y indicies are offset by 1
+     * if useOffset is true.
+     */
+    virtual QRectF boundingRect(const MapObject *object, bool useOffset) const = 0;
 
     /**
      * Returns the shape in pixels of the given \a object. This is used for
@@ -106,10 +113,20 @@ public:
 
     /**
      * Draws the \a object in the given \a color using the \a painter.
+     * Y indices are offset by 1.
      */
     virtual void drawMapObject(QPainter *painter,
                                const MapObject *object,
                                const QColor &color) const = 0;
+
+    /**
+     * Draws the \a object in the given \a color using the \a painter.
+     * Y indices are offset by 1 if useOffset is true.
+     */
+    virtual void drawMapObject(QPainter *painter,
+                               const MapObject *object,
+                               const QColor &color,
+                               bool useOffset) const = 0;
 
     /**
      * Returns the tile coordinates matching the given pixel position.

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -56,6 +56,11 @@ QRect OrthogonalRenderer::boundingRect(const QRect &rect) const
 
 QRectF OrthogonalRenderer::boundingRect(const MapObject *object) const
 {
+    return boundingRect(&*object, true);
+}
+
+QRectF OrthogonalRenderer::boundingRect(const MapObject *object, bool useOffset) const
+{
     const QRectF bounds = object->bounds();
     const QRectF rect(tileToPixelCoords(bounds.topLeft()),
                       tileToPixelCoords(bounds.bottomRight()));
@@ -65,8 +70,10 @@ QRectF OrthogonalRenderer::boundingRect(const MapObject *object) const
     if (object->tile()) {
         const QPointF topLeft = rect.topLeft();
         const QPixmap &img = object->tile()->image();
+        qreal tly = topLeft.y();
+        if (useOffset) tly -= img.height();
         boundingRect = QRectF(topLeft.x(),
-                              topLeft.y(),
+                              tly,
                               img.width(),
                               img.height()).adjusted(-1, -1, 1, 1);
     } else {
@@ -241,6 +248,14 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
                                        const MapObject *object,
                                        const QColor &color) const
 {
+    drawMapObject(&*painter, &*object, color, true);
+}
+
+void OrthogonalRenderer::drawMapObject(QPainter *painter,
+                                       const MapObject *object,
+                                       const QColor &color,
+                                       bool useOffset) const
+{
     painter->save();
 
     const QRectF bounds = object->bounds();
@@ -252,7 +267,8 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
 
     if (object->tile()) {
         const QPixmap &img = object->tile()->image();
-        const QPoint paintOrigin(0, 0);
+        qreal tly = (useOffset) ? -img.height() : 0;
+        const QPoint paintOrigin(0, tly);
         painter->drawPixmap(paintOrigin, img);
 
         QPen pen(Qt::SolidLine);

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -47,6 +47,8 @@ public:
     QRect boundingRect(const QRect &rect) const;
 
     QRectF boundingRect(const MapObject *object) const;
+    QRectF boundingRect(const MapObject *object, bool useOffset) const;
+
     QPainterPath shape(const MapObject *object) const;
 
     void drawGrid(QPainter *painter, const QRectF &rect) const;
@@ -62,6 +64,11 @@ public:
     void drawMapObject(QPainter *painter,
                        const MapObject *object,
                        const QColor &color) const;
+
+    void drawMapObject(QPainter *painter,
+                       const MapObject *object,
+                       const QColor &color,
+                       bool useOffset) const;
 
     QPointF pixelToTileCoords(qreal x, qreal y) const;
 

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -263,7 +263,8 @@ void MapObjectItem::paint(QPainter *painter,
                           QWidget *)
 {
     painter->translate(-pos());
-    mMapDocument->renderer()->drawMapObject(painter, mObject, mColor);
+    bool useOffset = Preferences::instance()->useIssue67();
+    mMapDocument->renderer()->drawMapObject(painter, mObject, mColor, useOffset);
 
     if (mIsEditable) {
         painter->translate(pos());

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -69,6 +69,10 @@ Preferences::Preferences()
     mUseOpenGL = mSettings->value(QLatin1String("OpenGL"), false).toBool();
     mSettings->endGroup();
 
+    mSettings->beginGroup(QLatin1String("Compatibility"));
+    mUseIssue67 = mSettings->value(QLatin1String("Issue67"), false).toBool();
+    mSettings->endGroup();
+
     // Retrieve defined object types
     mSettings->beginGroup(QLatin1String("ObjectTypes"));
     const QStringList names =
@@ -181,6 +185,15 @@ void Preferences::setUseOpenGL(bool useOpenGL)
     mSettings->setValue(QLatin1String("Interface/OpenGL"), mUseOpenGL);
 
     emit useOpenGLChanged(mUseOpenGL);
+}
+
+void Preferences::setUseIssue67(bool useOffset)
+{
+    if (mUseIssue67 == useOffset)
+        return;
+
+    mUseIssue67 = useOffset;
+    mSettings->setValue(QLatin1String("Compatibility/Issue67"), useOffset);
 }
 
 void Preferences::setObjectTypes(const ObjectTypes &objectTypes)

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -61,6 +61,9 @@ public:
     bool useOpenGL() const { return mUseOpenGL; }
     void setUseOpenGL(bool useOpenGL);
 
+    bool useIssue67() const { return mUseIssue67; }
+    void setUseIssue67(bool useOffset);
+
     const ObjectTypes &objectTypes() const { return mObjectTypes; }
     void setObjectTypes(const ObjectTypes &objectTypes);
 
@@ -103,6 +106,7 @@ private:
     QString mLanguage;
     bool mReloadTilesetsOnChange;
     bool mUseOpenGL;
+    bool mUseIssue67;
     ObjectTypes mObjectTypes;
 
     static Preferences *mInstance;

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -134,6 +134,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
     connect(mUi->languageCombo, SIGNAL(currentIndexChanged(int)),
             SLOT(languageSelected(int)));
     connect(mUi->openGL, SIGNAL(toggled(bool)), SLOT(useOpenGLToggled(bool)));
+    connect(mUi->issue67, SIGNAL(toggled(bool)), SLOT(useIssue67Toggled(bool)));
 
     connect(mUi->objectTypesTable->selectionModel(),
             SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
@@ -187,6 +188,11 @@ void PreferencesDialog::languageSelected(int index)
 void PreferencesDialog::useOpenGLToggled(bool useOpenGL)
 {
     Preferences::instance()->setUseOpenGL(useOpenGL);
+}
+
+void PreferencesDialog::useIssue67Toggled(bool useOffset)
+{
+    Preferences::instance()->setUseIssue67(useOffset);
 }
 
 void PreferencesDialog::addObjectType()
@@ -289,6 +295,7 @@ void PreferencesDialog::fromPreferences()
     mUi->enableDtd->setChecked(prefs->dtdEnabled());
     if (mUi->openGL->isEnabled())
         mUi->openGL->setChecked(prefs->useOpenGL());
+    mUi->issue67->setChecked(prefs->useIssue67());
 
     int formatIndex = 0;
     switch (prefs->layerDataFormat()) {

--- a/src/tiled/preferencesdialog.h
+++ b/src/tiled/preferencesdialog.h
@@ -54,6 +54,7 @@ protected:
 private slots:
     void languageSelected(int index);
     void useOpenGLToggled(bool useOpenGL);
+    void useIssue67Toggled(bool useOffset);
 
     void addObjectType();
     void selectedObjectTypesChanged();

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>421</width>
-    <height>313</height>
+    <width>423</width>
+    <height>335</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -122,14 +122,30 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="title">
+          <string>Compatibiliity</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QCheckBox" name="issue67">
+            <property name="text">
+             <string>Increase Tile Object y index by 1</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>381</width>
-           <height>1</height>
+           <width>20</width>
+           <height>40</height>
           </size>
          </property>
         </spacer>

--- a/src/tiled/saveasimagedialog.cpp
+++ b/src/tiled/saveasimagedialog.cpp
@@ -124,6 +124,7 @@ void SaveAsImageDialog::accept()
     const bool visibleLayersOnly = mUi->visibleLayersOnly->isChecked();
     const bool useCurrentScale = mUi->currentZoomLevel->isChecked();
     const bool drawTileGrid = mUi->drawTileGrid->isChecked();
+    const bool useOffset = Preferences::instance()->useIssue67();
 
     MapRenderer *renderer = mMapDocument->renderer();
     QSize mapSize = renderer->mapSize();
@@ -156,7 +157,7 @@ void SaveAsImageDialog::accept()
         } else if (objGroup) {
             foreach (const MapObject *object, objGroup->objects()) {
                 const QColor color = MapObjectItem::objectColor(object);
-                renderer->drawMapObject(&painter, object, color);
+                renderer->drawMapObject(&painter, object, color, useOffset);
             }
         }
     }


### PR DESCRIPTION
Solves issue #67 for the orthogonal renderer.  QGraphicItem was being biased for an inverted y axis leading to an off-by-one difference between the tile position and rendered tile position.
