### PR TITLE
Aboutdialog: add commit hash and build date

### DIFF
--- a/src/tiled/main.cpp
+++ b/src/tiled/main.cpp
@@ -1,6 +1,7 @@
 /*
  * main.cpp
  * Copyright 2008-2010, Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
+ * Copyright 2011, Stefan Beller <stefanbeller@googlemail.com>
  *
  * This file is part of Tiled.
  *
@@ -31,6 +32,9 @@ Q_IMPORT_PLUGIN(qgif)
 Q_IMPORT_PLUGIN(qjpeg)
 Q_IMPORT_PLUGIN(qtiff)
 #endif
+
+#define STRINGIFY(x) #x
+#define AS_STRING(x) STRINGIFY(x)
 
 using namespace Tiled::Internal;
 
@@ -111,7 +115,12 @@ int main(int argc, char *argv[])
 
     a.setOrganizationDomain(QLatin1String("mapeditor.org"));
     a.setApplicationName(QLatin1String("Tiled"));
+#ifdef BUILD_INFO_VERSION
+    a.setApplicationVersion(QLatin1String(AS_STRING(BUILD_INFO_VERSION));
+#else
     a.setApplicationVersion(QLatin1String("0.7.1"));
+#endif
+
 #ifdef Q_WS_MAC
     a.setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif


### PR DESCRIPTION
The commit hash and build date can be included optionally by putting
these information into a custom header file called buildinfo.h
An extra header file is needed, so the aboutdialog will be recompiled
whenever the build information changes.
Below is a script, which updates the buildinformations, turns on build
information and recompiles tiled.

---

commit=$(git rev-parse HEAD)
timenow=$(date -R)
echo "#define BUILD_INFO_GIT $commit" > ./src/tiled/buildinfo.h
echo "#define BUILD_INFO_TIME \"$timenow\"" >> ./src/tiled/buildinfo.h
qmake QMAKE_CXXFLAGS+=-DBUILD_INFO -r
make

---

Signed-off-by: Stefan Beller stefanbeller@googlemail.com
