### PR TITLE
Maps can be reordered

### DIFF
--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -56,6 +56,7 @@ DocumentManager::DocumentManager(QObject *parent)
 {
     mTabWidget->setDocumentMode(true);
     mTabWidget->setTabsClosable(true);
+    mTabWidget->setMovable(true);
 
     connect(mTabWidget, SIGNAL(currentChanged(int)),
             SLOT(currentIndexChanged()));


### PR DESCRIPTION
Setting the movable property in the tab widget,
which was introduced in Qt 4.5.
