### PR TITLE
Add shortcut to reload tilesets.

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -177,7 +177,11 @@ MainWindow::MainWindow(QWidget *parent, Qt::WFlags flags)
     mUi->actionShowGrid->setChecked(preferences->showGrid());
     mUi->actionSnapToGrid->setChecked(preferences->snapToGrid());
     mUi->actionHighlightCurrentLayer->setChecked(preferences->highlightCurrentLayer());
-
+    
+    QShortcut *reloadTilesetsShortcut = new QShortcut(QKeySequence(tr("Ctrl+T")), this);
+    connect(reloadTilesetsShortcut, SIGNAL(activated()),
+            this, SLOT(reloadTilesets()));
+    
     // Make sure Ctrl+= also works for zooming in
     QList<QKeySequence> keys = QKeySequence::keyBindings(QKeySequence::ZoomIn);
     keys += QKeySequence(tr("Ctrl+="));
@@ -277,7 +281,9 @@ MainWindow::MainWindow(QWidget *parent, Qt::WFlags flags)
 
     connect(mTilesetDock, SIGNAL(tilesetsDropped(QStringList)),
             SLOT(newTilesets(QStringList)));
-
+            
+            
+    
     // Add recent file actions to the recent files menu
     for (int i = 0; i < MaxRecentFiles; ++i)
     {
@@ -991,6 +997,18 @@ void MainWindow::newTilesets(const QStringList &paths)
     foreach (const QString &path, paths)
         if (!newTileset(path))
             return;
+}
+
+void MainWindow::reloadTilesets()
+{
+    Map* map = mMapDocument->map();
+    if( !map )
+        return;
+     
+    TilesetManager *tilesetManager = TilesetManager::instance();
+    foreach( Tileset *tileset, map->tilesets() ) {
+        tilesetManager->forceTilesetReload(tileset);
+    }
 }
 
 void MainWindow::addExternalTileset()

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -123,6 +123,7 @@ public slots:
 
     bool newTileset(const QString &path = QString());
     void newTilesets(const QStringList &paths);
+    void reloadTilesets();
     void addExternalTileset();
     void resizeMap();
     void offsetMap();

--- a/src/tiled/tilesetmanager.cpp
+++ b/src/tiled/tilesetmanager.cpp
@@ -133,6 +133,40 @@ QList<Tileset*> TilesetManager::tilesets() const
     return mTilesets.keys();
 }
 
+void TilesetManager::forceTilesetReload( Tileset *tileset )
+{
+    if( tilesets().indexOf(tileset) == -1 )
+        return;
+    
+    QString fileName = tileset->imageSource();
+    if (tileset->loadFromImage(QImage(fileName), fileName))
+        emit tilesetChanged(tileset);
+}
+
+void TilesetManager::forceTilesetReloadByName( const QString &name )
+{
+    // There could be tilesets with the same name
+    foreach (Tileset *tileset, tilesets()) {
+        QString tilesetName = tileset->name();
+        if ( tilesetName != name )
+            continue;
+        
+        forceTilesetReload(tileset);
+    }
+}
+
+void TilesetManager::forcceTilesetReloadBySource( const QString &path )
+{
+    // There could be tilesets with the same image source
+    foreach (Tileset *tileset, tilesets()) {
+        QString tilesetImageSource = tileset->imageSource();
+        if ( tilesetImageSource != path )
+            continue;
+        
+        forceTilesetReload(tileset);
+    }
+}
+
 void TilesetManager::setReloadTilesetsOnChange(bool enabled)
 {
     mReloadTilesetsOnChange = enabled;

--- a/src/tiled/tilesetmanager.h
+++ b/src/tiled/tilesetmanager.h
@@ -111,7 +111,22 @@ public:
      * Returns all currently available tilesets.
      */
     QList<Tileset*> tilesets() const;
-
+    
+    /**
+     * Forces a tileset to reload.
+     */
+    void forceTilesetReload( Tileset *tileset );
+    
+    /**
+     * Forces a tileset reload by name.
+     */
+    void forceTilesetReloadByName( const QString &name );
+    
+    /**
+     * Forces a tileset reload by path.
+     */
+    void forcceTilesetReloadBySource( const QString &source );
+    
     /**
      * Sets whether tilesets are automatically reloaded when their tileset
      * image changes.


### PR DESCRIPTION
Although hot-reloading is available for tilesets manual control is sometimes required (wanted) so now Ctrl+T reloads the current map's tilesets.
