### PR TITLE
Object angle. Hopefully it's the correct thing

### DIFF
--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -376,6 +376,17 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
     painter->restore();
 }
 
+void IsometricRenderer::drawMapObjectAngleArrow(QPainter *painter,
+                               const MapObject *object,
+                               const QColor &color,
+                               qreal arrowLength) const
+{
+    Q_UNUSED(painter);
+    Q_UNUSED(object);
+    Q_UNUSED(color);
+    Q_UNUSED(arrowLength);
+}
+
 QPointF IsometricRenderer::pixelToTileCoords(qreal x, qreal y) const
 {
     const int tileWidth = map()->tileWidth();

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -66,6 +66,11 @@ public:
                        const MapObject *object,
                        const QColor &color) const;
 
+    virtual void drawMapObjectAngleArrow(QPainter *painter,
+                                   const MapObject *object,
+                                   const QColor &color,
+                                   qreal arrowLength) const;
+
     using MapRenderer::pixelToTileCoords;
     QPointF pixelToTileCoords(qreal x, qreal y) const;
 

--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -35,7 +35,8 @@ MapObject::MapObject():
     mSize(0, 0),
     mShape(Rectangle),
     mTile(0),
-    mObjectGroup(0)
+    mObjectGroup(0),
+    mAngle(0.0f)
 {
 }
 
@@ -48,7 +49,8 @@ MapObject::MapObject(const QString &name, const QString &type,
     mSize(size),
     mShape(Rectangle),
     mTile(0),
-    mObjectGroup(0)
+    mObjectGroup(0),
+    mAngle(0.0f)
 {
 }
 
@@ -59,5 +61,6 @@ MapObject *MapObject::clone() const
     o->setPolygon(mPolygon);
     o->setShape(mShape);
     o->setTile(mTile);
+    o->setAngle(mAngle);
     return o;
 }

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -228,6 +228,16 @@ public:
      */
     MapObject *clone() const;
 
+    /**
+     * Sets the angle of the object
+     */
+    void setAngle(qreal angle) { mAngle = angle; }
+
+    /**
+     * Returns the angle of the object.
+     */
+    qreal angle() const { return mAngle; }
+
 private:
     QString mName;
     QString mType;
@@ -237,6 +247,7 @@ private:
     Shape mShape;
     Tile *mTile;
     ObjectGroup *mObjectGroup;
+    qreal mAngle;
 };
 
 } // namespace Tiled

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -602,6 +602,14 @@ MapObject *MapReaderPrivate::readObject()
     MapObject *object = new MapObject(name, type, pos, QSizeF(size.x(),
                                                               size.y()));
 
+
+    // read the angle
+    bool angleOk;
+    const qreal angle = atts.value(QLatin1String("angle")).toString().toDouble(&angleOk);
+    if (angleOk) {
+        object->setAngle(angle);
+    }
+
     if (gid) {
         const Cell cell = cellForGid(gid);
         object->setTile(cell.tile);

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -48,7 +48,7 @@ class TileLayer;
 class TILEDSHARED_EXPORT MapRenderer
 {
 public:
-    MapRenderer(const Map *map) : mMap(map) {}
+    MapRenderer(const Map *map) : mShowAngleArrows(false), mMap(map) {}
     virtual ~MapRenderer() {}
 
     /**
@@ -112,6 +112,15 @@ public:
                                const QColor &color) const = 0;
 
     /**
+     * Draws the arrow showing the angle of the \a object in the given \a color
+     * using the \a painter.
+     */
+    virtual void drawMapObjectAngleArrow(QPainter *painter,
+                                   const MapObject *object,
+                                   const QColor &color,
+                                   qreal arrowLength) const = 0;
+
+    /**
      * Returns the tile coordinates matching the given pixel position.
      */
     virtual QPointF pixelToTileCoords(qreal x, qreal y) const = 0;
@@ -137,11 +146,23 @@ public:
 
     static QPolygonF lineToPolygon(const QPointF &start, const QPointF &end);
 
+    /**
+     * Returns whether the object angle arrow is drawn.
+     */
+    bool showAngleArrows() const { return mShowAngleArrows; }
+
+    /**
+     * Sets if the object angle arrow should be drawn.
+     */
+    void setShowAngleArrows(bool showAngleArrows) { mShowAngleArrows = showAngleArrows; }
+
 protected:
     /**
      * Returns the map this renderer is associated with.
      */
     const Map *map() const { return mMap; }
+
+    bool mShowAngleArrows;
 
 private:
     const Map *mMap;

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -448,6 +448,11 @@ void MapWriterPrivate::writeObject(QXmlStreamWriter &w,
     if (size.y() != 0)
         w.writeAttribute(QLatin1String("height"), QString::number(size.y()));
 
+    const qreal angle = mapObject->angle();
+    if (angle != 0.0)
+        w.writeAttribute(QLatin1String("angle"), QString::number(angle));
+
+
     writeProperties(w, mapObject->properties());
 
     const QPolygonF &polygon = mapObject->polygon();

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -70,15 +70,44 @@ QRectF OrthogonalRenderer::boundingRect(const MapObject *object) const
                               bottomLeft.y() - img.height(),
                               img.width(),
                               img.height()).adjusted(-1, -1, 1, 1);
+        qreal wdiff = 1, hdiff = 1;
+        if (boundingRect.width() < 66) {
+            wdiff = (66 - boundingRect.width()) / 2;
+        }
+        if (boundingRect.height() < 66) {
+            hdiff = (66 - boundingRect.height()) / 2;
+        }
+        boundingRect = boundingRect.adjusted(-wdiff, -hdiff, wdiff, hdiff);
     } else {
         // The -2 and +3 are to account for the pen width and shadow
         switch (object->shape()) {
         case MapObject::Rectangle:
             if (rect.isNull()) {
-                boundingRect = rect.adjusted(-10 - 2, -10 - 2, 10 + 3, 10 + 3);
+                // 32 is the size of the angle arrow - this should be configurable
+                boundingRect = rect.adjusted(-32 - 2, -32 - 2, 32 + 3, 32 + 3);
             } else {
+                // 64 is 2x32, the size of the angle arrow
                 const int nameHeight = object->name().isEmpty() ? 0 : 15;
-                boundingRect = rect.adjusted(-2, -nameHeight - 2, 3, 3);
+                boundingRect = rect;
+                if (boundingRect.width() < 64) {
+                    const qreal missing = (64 - boundingRect.width()) / 2;
+                    boundingRect.setLeft(boundingRect.left() - missing);
+                    boundingRect.setRight(boundingRect.right() + missing);
+                }
+                if (boundingRect.height() < 64) {
+                    const qreal missing = (64 - boundingRect.height()) / 2;
+                    boundingRect.setBottom(boundingRect.bottom() + missing);
+                    if (missing < nameHeight) {
+                        boundingRect.setTop(boundingRect.top() - nameHeight);
+                    } else {
+                        boundingRect.setTop(boundingRect.top() - missing);
+                    }
+                } else {
+                    boundingRect.setTop(boundingRect.top() - nameHeight);
+                }
+
+                //boundingRect = rect.adjusted(-2, -nameHeight - 2, 3, 3);
+                boundingRect.adjust(-2, - 2, 3, 3);
             }
             break;
 
@@ -357,7 +386,74 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
     }
 
     painter->restore();
+
+    if (mShowAngleArrows)
+        drawMapObjectAngleArrow(painter, object, color, 32);
 }
+
+void OrthogonalRenderer::drawMapObjectAngleArrow(QPainter *painter,
+                               const MapObject *object,
+                               const QColor &color,
+                               qreal arrowLength) const {
+
+    if (object->shape() == MapObject::Polyline || object->shape() == MapObject::Polygon)
+        return;
+
+    painter->save();
+
+    const QRectF bounds = object->bounds();
+    QRectF rect(tileToPixelCoords(bounds.topLeft()),
+                tileToPixelCoords(bounds.bottomRight()));
+
+    painter->translate(rect.topLeft());
+    rect.moveTopLeft(QPointF(0, 0));
+
+    const QPen linePen(color, 2);
+    const QPen shadowPen(Qt::black, 2);
+
+    // calculate arrow
+    QPointF center;
+    if (object->tile()) {
+        const QPixmap &img = object->tile()->image();
+        center = QPointF(rect.x() + img.width() / 2, rect.y() - img.height() / 2);
+    } else {
+        center = rect.center();
+    }
+    const qreal arrowArmStart = arrowLength - 4;
+    const qreal arrowArmAngle = 12 * M_PI / 180;
+    const qreal angleRad = object->angle() * M_PI / 180;
+    const qreal angleCos = cos(angleRad);
+    const qreal angleSin = sin(angleRad);
+    const QPointF arrowEnd = QPointF(
+                    center.x() + arrowLength * angleCos,
+                    center.y() + arrowLength * angleSin
+                );
+    const QPointF arrowLeft = QPointF(
+                    center.x() + arrowArmStart * cos(angleRad + arrowArmAngle),
+                    center.y() + arrowArmStart * sin(angleRad + arrowArmAngle)
+                );
+    const QPointF arrowRight = QPointF(
+                    center.x() + arrowArmStart * cos(angleRad - arrowArmAngle),
+                    center.y() + arrowArmStart * sin(angleRad - arrowArmAngle)
+                );
+    // draw arrow
+    const QLineF lineCenter = QLineF(center, arrowEnd);
+    const QLineF lineLeft = QLineF(arrowLeft, arrowEnd);
+    const QLineF lineRight = QLineF(arrowRight, arrowEnd);
+
+    painter->setPen(shadowPen);
+    painter->drawLine(lineCenter.translated(1, 1));
+    painter->drawLine(lineLeft.translated(1, 1));
+    painter->drawLine(lineRight.translated(1, 1));
+
+    painter->setPen(linePen);
+    painter->drawLine(lineCenter);
+    painter->drawLine(lineLeft);
+    painter->drawLine(lineRight);
+
+    painter->restore();
+}
+
 
 QPointF OrthogonalRenderer::pixelToTileCoords(qreal x, qreal y) const
 {

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -63,6 +63,12 @@ public:
                        const MapObject *object,
                        const QColor &color) const;
 
+    virtual void drawMapObjectAngleArrow(QPainter *painter,
+                                   const MapObject *object,
+                                   const QColor &color,
+                                   qreal arrowLength) const;
+
+
     QPointF pixelToTileCoords(qreal x, qreal y) const;
 
     using MapRenderer::tileToPixelCoords;

--- a/src/plugins/json/maptovariantconverter.cpp
+++ b/src/plugins/json/maptovariantconverter.cpp
@@ -198,6 +198,7 @@ QVariant MapToVariantConverter::toVariant(const ObjectGroup *objectGroup)
         objectVariant["y"] = pos.y();
         objectVariant["width"] = size.x();
         objectVariant["height"] = size.y();
+        objectVariant["angle"] = object->angle();
 
         /* Polygons are stored in this format:
          *

--- a/src/plugins/json/varianttomapconverter.cpp
+++ b/src/plugins/json/varianttomapconverter.cpp
@@ -268,6 +268,7 @@ ObjectGroup *VariantToMapConverter::toObjectGroup(const QVariantMap &variantMap)
         const int y = objectVariantMap["y"].toInt();
         const int width = objectVariantMap["width"].toInt();
         const int height = objectVariantMap["height"].toInt();
+        const qreal angle = objectVariantMap["angle"].toReal();
 
         const QPointF pos = toTile(x, y);
         const QPointF size = toTile(width, height);
@@ -275,6 +276,7 @@ ObjectGroup *VariantToMapConverter::toObjectGroup(const QVariantMap &variantMap)
         MapObject *object = new MapObject(name, type,
                                           pos,
                                           QSizeF(size.x(), size.y()));
+        object->setAngle(angle);
 
         if (gid) {
             bool ok;

--- a/src/plugins/lua/luaplugin.cpp
+++ b/src/plugins/lua/luaplugin.cpp
@@ -268,6 +268,7 @@ void LuaPlugin::writeMapObject(LuaTableWriter &writer,
     writer.writeKeyAndValue("y", pos.y());
     writer.writeKeyAndValue("width", size.x());
     writer.writeKeyAndValue("height", size.y());
+    writer.writeKeyAndValue("angle", mapObject->angle());
 
     if (Tile *tile = mapObject->tile())
         writer.writeKeyAndValue("gid", mGidMapper.cellToGid(Cell(tile)));

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -177,6 +177,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WFlags flags)
     mUi->actionShowGrid->setChecked(preferences->showGrid());
     mUi->actionSnapToGrid->setChecked(preferences->snapToGrid());
     mUi->actionHighlightCurrentLayer->setChecked(preferences->highlightCurrentLayer());
+    mUi->actionShowAngleArrows->setChecked(preferences->showAngleArrows());
 
     // Make sure Ctrl+= also works for zooming in
     QList<QKeySequence> keys = QKeySequence::keyBindings(QKeySequence::ZoomIn);
@@ -256,6 +257,8 @@ MainWindow::MainWindow(QWidget *parent, Qt::WFlags flags)
             preferences, SLOT(setSnapToGrid(bool)));
     connect(mUi->actionHighlightCurrentLayer, SIGNAL(toggled(bool)),
             preferences, SLOT(setHighlightCurrentLayer(bool)));
+    connect(mUi->actionShowAngleArrows, SIGNAL(toggled(bool)),
+            preferences, SLOT(setShowAngleArrows(bool)));
     connect(mUi->actionZoomIn, SIGNAL(triggered()), SLOT(zoomIn()));
     connect(mUi->actionZoomOut, SIGNAL(triggered()), SLOT(zoomOut()));
     connect(mUi->actionZoomNormal, SIGNAL(triggered()), SLOT(zoomNormal()));
@@ -1355,6 +1358,9 @@ void MainWindow::addMapDocument(MapDocument *mapDocument)
     mapScene->setGridVisible(prefs->showGrid());
     connect(prefs, SIGNAL(showGridChanged(bool)),
             mapScene, SLOT(setGridVisible(bool)));
+    mapScene->setShowAngleArrows(prefs->showAngleArrows());
+    connect(prefs, SIGNAL(showAngleArrowsChanged(bool)),
+            mapScene, SLOT(setShowAngleArrows(bool)));
 }
 
 void MainWindow::aboutTiled()

--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -32,7 +32,7 @@
      <x>0</x>
      <y>0</y>
      <width>553</width>
-     <height>23</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -100,6 +100,7 @@
     <addaction name="actionShowGrid"/>
     <addaction name="actionSnapToGrid"/>
     <addaction name="actionHighlightCurrentLayer"/>
+    <addaction name="actionShowAngleArrows"/>
     <addaction name="separator"/>
     <addaction name="actionZoomIn"/>
     <addaction name="actionZoomOut"/>
@@ -402,6 +403,14 @@
    </property>
    <property name="shortcut">
     <string>H</string>
+   </property>
+  </action>
+  <action name="actionShowAngleArrows">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show &amp;Angle Arrows</string>
    </property>
   </action>
  </widget>

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -426,6 +426,20 @@ void MapScene::setGridVisible(bool visible)
     update();
 }
 
+void MapScene::setShowAngleArrows(bool showAngleArrow)
+{
+    if (mMapDocument->renderer()->showAngleArrows() == showAngleArrow)
+        return;
+
+    mMapDocument->renderer()->setShowAngleArrows(showAngleArrow);
+    update();
+}
+
+bool MapScene::showAngleArrows() const
+{
+    return mMapDocument->renderer()->showAngleArrows();
+}
+
 void MapScene::setHighlightCurrentLayer(bool highlightCurrentLayer)
 {
     if (mHighlightCurrentLayer == highlightCurrentLayer)

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -76,6 +76,11 @@ public:
     bool isGridVisible() const { return mGridVisible; }
 
     /**
+     * Returns whether the object angle arrow is drawn.
+     */
+    bool showAngleArrows() const;
+
+    /**
      * Returns the set of selected map object items.
      */
     const QSet<MapObjectItem*> &selectedObjectItems() const
@@ -113,6 +118,11 @@ public slots:
      * Sets whether the tile grid is visible.
      */
     void setGridVisible(bool visible);
+
+    /**
+     * Sets whether the angle arrow of objects is visible.
+     */
+    void setShowAngleArrows(bool showAngleArrows);
 
     /**
      * Sets whether the current layer should be highlighted.

--- a/src/tiled/objectpropertiesdialog.cpp
+++ b/src/tiled/objectpropertiesdialog.cpp
@@ -27,6 +27,7 @@
 #include "movemapobject.h"
 #include "objecttypesmodel.h"
 #include "resizemapobject.h"
+#include "rotatemapobject.h"
 
 #include <QGridLayout>
 #include <QLabel>
@@ -61,6 +62,7 @@ ObjectPropertiesDialog::ObjectPropertiesDialog(MapDocument *mapDocument,
     mUi->y->setValue(mMapObject->y());
     mUi->width->setValue(mMapObject->width());
     mUi->height->setValue(mMapObject->height());
+    mUi->angle->setValue(mMapObject->angle());
 
     qobject_cast<QBoxLayout*>(layout())->insertWidget(0, widget);
 
@@ -84,6 +86,7 @@ void ObjectPropertiesDialog::accept()
     const qreal newPosY = mUi->y->value();
     const qreal newWidth = mUi->width->value();
     const qreal newHeight = mUi->height->value();
+    const qreal newAngle = mUi->angle->value();
 
     bool changed = false;
     changed |= mMapObject->name() != newName;
@@ -92,6 +95,7 @@ void ObjectPropertiesDialog::accept()
     changed |= mMapObject->y() != newPosY;
     changed |= mMapObject->width() != newWidth;
     changed |= mMapObject->height() != newHeight;
+    changed |= mMapObject->angle() != newAngle;
 
     if (changed) {
         QUndoStack *undo = mMapDocument->undoStack();
@@ -108,6 +112,10 @@ void ObjectPropertiesDialog::accept()
         mMapObject->setWidth(newWidth);
         mMapObject->setHeight(newHeight);
         undo->push(new ResizeMapObject(mMapDocument, mMapObject, oldSize));
+
+        const qreal oldAngle = mMapObject->angle();
+        mMapObject->setAngle(newAngle);
+        undo->push(new RotateMapObject(mMapDocument, mMapObject, oldAngle));
 
         PropertiesDialog::accept(); // Let PropertiesDialog add its command
         undo->endMacro();

--- a/src/tiled/objectpropertiesdialog.ui
+++ b/src/tiled/objectpropertiesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>308</width>
-    <height>156</height>
+    <width>334</width>
+    <height>192</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -29,8 +29,15 @@
    <property name="margin">
     <number>0</number>
    </property>
-   <item row="0" column="0" colspan="4">
+   <item row="0" column="0" colspan="5">
     <layout class="QGridLayout" name="gridLayout_3">
+     <item row="1" column="1">
+      <widget class="QComboBox" name="type">
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="nameLabel">
        <property name="text">
@@ -54,14 +61,50 @@
      <item row="0" column="1">
       <widget class="QLineEdit" name="name"/>
      </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="type">
-       <property name="editable">
-        <bool>true</bool>
+     <item row="2" column="1">
+      <widget class="QDoubleSpinBox" name="angle">
+       <property name="minimum">
+        <double>-360.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="angleLabel">
+       <property name="text">
+        <string>Angle:</string>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="1" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="4">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="positionGroupBox">
@@ -95,14 +138,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="yLabel">
         <property name="text">
          <string>Y:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QDoubleSpinBox" name="y">
         <property name="decimals">
          <number>3</number>
@@ -117,19 +160,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item row="1" column="1">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="1" column="2">
     <widget class="QGroupBox" name="sizeGroupBox">
@@ -179,19 +209,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item row="1" column="3">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -68,6 +68,7 @@ Preferences::Preferences()
                                               false).toBool();
     mShowTilesetGrid = mSettings->value(QLatin1String("ShowTilesetGrid"),
                                         true).toBool();
+    mShowAngleArrows = mSettings->value(QLatin1String("ShowAngleArrow"), false).toBool();
     mLanguage = mSettings->value(QLatin1String("Language"),
                                  QString()).toString();
     mUseOpenGL = mSettings->value(QLatin1String("OpenGL"), false).toBool();
@@ -139,6 +140,16 @@ void Preferences::setShowTilesetGrid(bool showTilesetGrid)
     mSettings->setValue(QLatin1String("Interface/ShowTilesetGrid"),
                         mShowTilesetGrid);
     emit showTilesetGridChanged(mShowTilesetGrid);
+}
+
+void Preferences::setShowAngleArrows(bool showAngleArrow)
+{
+    if (mShowAngleArrows == showAngleArrow)
+        return;
+
+    mShowAngleArrows = showAngleArrow;
+    mSettings->setValue(QLatin1String("Interface/ShowAngleArrow"), mShowAngleArrows);
+    emit showAngleArrowsChanged(mShowAngleArrows);
 }
 
 MapWriter::LayerDataFormat Preferences::layerDataFormat() const

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -47,6 +47,7 @@ public:
     bool snapToGrid() const { return mSnapToGrid; }
     bool highlightCurrentLayer() const { return mHighlightCurrentLayer; }
     bool showTilesetGrid() const { return mShowTilesetGrid; }
+    bool showAngleArrows() const { return mShowAngleArrows; }
 
     MapWriter::LayerDataFormat layerDataFormat() const;
     void setLayerDataFormat(MapWriter::LayerDataFormat layerDataFormat);
@@ -87,12 +88,14 @@ public slots:
     void setSnapToGrid(bool snapToGrid);
     void setHighlightCurrentLayer(bool highlight);
     void setShowTilesetGrid(bool showTilesetGrid);
+    void setShowAngleArrows(bool showAngleArrows);
 
 signals:
     void showGridChanged(bool showGrid);
     void snapToGridChanged(bool snapToGrid);
     void highlightCurrentLayerChanged(bool highlight);
     void showTilesetGridChanged(bool showTilesetGrid);
+    void showAngleArrowsChanged(bool showAngleArrows);
 
     void useOpenGLChanged(bool useOpenGL);
 
@@ -108,6 +111,7 @@ private:
     bool mSnapToGrid;
     bool mHighlightCurrentLayer;
     bool mShowTilesetGrid;
+    bool mShowAngleArrows;
 
     MapWriter::LayerDataFormat mLayerDataFormat;
     bool mDtdEnabled;

--- a/src/tiled/rotatemapobject.cpp
+++ b/src/tiled/rotatemapobject.cpp
@@ -1,0 +1,56 @@
+/*
+ * rotatemapobject.cpp
+ * Copyright 2012, Przemysław Grzywacz <nexather@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "rotatemapobject.h"
+
+#include "mapdocument.h"
+#include "mapobject.h"
+
+#include <QCoreApplication>
+
+namespace Tiled {
+namespace Internal {
+
+
+RotateMapObject::RotateMapObject(MapDocument *mapDocument,
+                MapObject *mapObject,
+                qreal oldAngle)
+    : mMapDocument(mapDocument),
+      mMapObject(mapObject),
+      mOldAngle(oldAngle),
+      mNewAngle(mapObject->angle())
+{
+    setText(QCoreApplication::translate("Undo Commands", "Rotate Object"));
+}
+
+void RotateMapObject::undo()
+{
+    mMapObject->setAngle(mOldAngle);
+    mMapDocument->emitObjectChanged(mMapObject);
+}
+
+void RotateMapObject::redo() {
+    mMapObject->setAngle(mNewAngle);
+    mMapDocument->emitObjectChanged(mMapObject);
+}
+
+
+} // namespace Internal
+} // namespace Tiled

--- a/src/tiled/rotatemapobject.h
+++ b/src/tiled/rotatemapobject.h
@@ -1,0 +1,53 @@
+/*
+ * rotatemapobject.h
+ * Copyright 2012, Przemysław Grzywacz <nexather@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ROTATEMAPOBJECT_H
+#define ROTATEMAPOBJECT_H
+
+#include <QUndoCommand>
+
+
+namespace Tiled {
+
+class MapObject;
+
+namespace Internal {
+
+class MapDocument;
+
+class RotateMapObject : public QUndoCommand
+{
+public:
+    RotateMapObject(MapDocument *mapDocument,
+                    MapObject *mapObject,
+                    qreal oldAngle);
+    void undo();
+    void redo();
+
+private:
+    MapDocument *mMapDocument;
+    MapObject *mMapObject;
+    qreal mOldAngle;
+    qreal mNewAngle;
+};
+
+} // namespace Internal
+} // namespace Tiled
+#endif // ROTATEMAPOBJECT_H

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -124,7 +124,8 @@ SOURCES += aboutdialog.cpp \
     selectionrectangle.cpp \
     objecttypes.cpp \
     objecttypesmodel.cpp \
-    commandlineparser.cpp
+    commandlineparser.cpp \
+    rotatemapobject.cpp
 
 HEADERS += aboutdialog.h \
     automapper.h \
@@ -216,7 +217,8 @@ HEADERS += aboutdialog.h \
     objecttypes.h \
     objecttypesmodel.h \
     commandlineparser.h \
-    macsupport.h
+    macsupport.h \
+    rotatemapobject.h
 
 macx {
     OBJECTIVE_SOURCES += macsupport.mm


### PR DESCRIPTION
Added support for angle in TMX, Lua and JSON plugins
Added support for angle drawing in orthogonal map renderer
Added angle to Object Properties window
Fixed MapObject bounding box (only rect shape and tile object) in orthogonal map renderer to contain the angle arrow.
Added a view option to enable or disable angle arrow
Poly\* don't have angle arrows
