### PR TITLE
When exporting, use map name as default

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -89,6 +89,7 @@
 #include <QUndoStack>
 #include <QUndoView>
 #include <QImageReader>
+#include <QRegExp>
 #include <QSignalMapper>
 #include <QShortcut>
 #include <QToolButton>
@@ -752,11 +753,27 @@ void MainWindow::exportAs()
     QString selectedFilter =
             mSettings.value(QLatin1String("lastUsedExportFilter")).toString();
 
+    QFileInfo baseNameInfo = QFileInfo(mMapDocument->fileName());
+    QString baseName = baseNameInfo.baseName();
+
+    QRegExp extensionFinder(QLatin1String("\\(\\*\\.([^\\)\\s]*)"));
+    extensionFinder.indexIn(selectedFilter);
+    const QString extension = extensionFinder.cap(1);
+
+    Preferences *pref = Preferences::instance();
+    QString lastExportedFilePath = pref->lastPath(Preferences::ExportedFile);
+
+    QString suggestedFilename = lastExportedFilePath
+                                + QLatin1String("/") + baseName
+                                + QLatin1Char('.') + extension;
+
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export As..."),
-                                                    fileDialogStartLocation(),
+                                                    suggestedFilename,
                                                     filter, &selectedFilter);
     if (fileName.isEmpty())
         return;
+
+    pref->setLastPath(Preferences::ExportedFile, QFileInfo(fileName).path());
 
     MapWriterInterface *chosenWriter = 0;
 

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -244,6 +244,9 @@ static QString lastPathKey(Preferences::FileType fileType)
     case Preferences::ImageFile:
         key.append(QLatin1String("Images"));
         break;
+    case Preferences::ExportedFile:
+        key.append(QLatin1String("ExportedFile"));
+        break;
     default:
         Q_ASSERT(false); // Getting here means invalid file type
     }

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -68,7 +68,8 @@ public:
 
     enum FileType {
         ObjectTypesFile,
-        ImageFile
+        ImageFile,
+        ExportedFile
     };
 
     QString lastPath(FileType fileType) const;


### PR DESCRIPTION
When exporting a map to a custom format,
the basename of the maps filename is kept and only
the extension is replaced as a proposal of the
file dialog.

The solution as provided here 
https://sourceforge.net/apps/mantisbt/tiled/view.php?id=86
does not add the correct file extension.
