### PR TITLE
Stamp will not miss tiles anymore, when drawing fast.

### DIFF
--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -176,10 +176,13 @@ static QVector<QPoint> calculateLine(int x0, int y0, int x1, int y1)
 
 void StampBrush::tilePositionChanged(const QPoint &)
 {
+    const int x = mStampX;
+    const int y = mStampY;
     updatePosition();
     switch (mBrushBehavior) {
     case Paint:
-        doPaint(true, mStampX, mStampY);
+        foreach (const QPoint &p, calculateLine(x, y, mStampX, mStampY))
+            doPaint(true, p.x(), p.y());
         break;
     case LineStartSet:
         configureBrush(calculateLine(mStampReferenceX, mStampReferenceY,


### PR DESCRIPTION
(Resolving https://sourceforge.net/apps/mantisbt/tiled/view.php?id=52)
(Is bananattack at tiled mantis the same bananattack as we have here at github?)
@bananattack said: 
This is minor, but sort of annoying. If you move the mouse too fast while plotting tiles with the stamp tool by clicking and dragging, it will sometimes miss tiles in between locations dragged over.

I think that internally, the plotting should create a line between the previous mouse position and the current mouse position, each time a dragging motion update is made. This way the plotting will not miss anything. 
