### PR TITLE
Automapping: fix crash

### DIFF
--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -857,12 +857,21 @@ void AutoMapper::copyTileRegion(TileLayer *srcLayer, int srcX, int srcY,
                                 int width, int height,
                                 TileLayer *dstLayer, int dstX, int dstY)
 {
-    for (int x = 0; x < width; ++x) {
-        for (int y = 0; y < height; ++y) {
-            const Cell &cell = srcLayer->cellAt(srcX + x, srcY + y);
+    const int startX = qMax(dstX, 0);
+    const int startY = qMax(dstY, 0);
+
+    const int endX = qMin(dstX + width, dstLayer->width());
+    const int endY = qMin(dstY + height, dstLayer->height());
+
+    const int offsetX = srcX - dstX;
+    const int offsetY = srcY - dstY;
+
+    for (int x = startX; x < endX; ++x) {
+        for (int y = startY; y < endY; ++y) {
+            const Cell &cell = srcLayer->cellAt(x + offsetX, y + offsetY);
             if (!cell.isEmpty()) {
                 // this is without graphics update, it's done afterwards for all
-                dstLayer->setCell(dstX + x, dstY + y, cell);
+                dstLayer->setCell(x, y, cell);
             }
         }
     }


### PR DESCRIPTION
It must be made sure, that TileLayer::setCell
only gets valid input coordinates. 

The pullrequest is indeed for master, as it is a regression of the Automapping rewrite.
The crash could not be reproduced with 0.8, though the patch would apply there without errors.
