### PR TITLE
add include for climits for INT_MAX for lucid

### DIFF
--- a/src/tiled/terrainbrush.cpp
+++ b/src/tiled/terrainbrush.cpp
@@ -34,6 +34,7 @@
 
 #include <math.h>
 #include <QVector>
+#include <climits>
 
 using namespace Tiled;
 using namespace Tiled::Internal;


### PR DESCRIPTION
added an include <climits> so tiled can be build on lucid again
