### PR TITLE
Added the Maps dock.

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -49,6 +49,7 @@
 #include "mapobject.h"
 #include "mappropertiesdialog.h"
 #include "maprenderer.h"
+#include "mapsdock.h"
 #include "mapscene.h"
 #include "newmapdialog.h"
 #include "newtilesetdialog.h"
@@ -109,6 +110,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WFlags flags)
     , mMapDocument(0)
     , mActionHandler(new MapDocumentActionHandler(this))
     , mLayerDock(new LayerDock(this))
+    , mMapsDock(new MapsDock(this))
     , mObjectsDock(new ObjectsDock())
     , mTilesetDock(new TilesetDock(this))
     , mTerrainDock(new TerrainDock(this))
@@ -166,11 +168,13 @@ MainWindow::MainWindow(QWidget *parent, Qt::WFlags flags)
 
     addDockWidget(Qt::RightDockWidgetArea, mLayerDock);
     addDockWidget(Qt::RightDockWidgetArea, undoDock);
+    addDockWidget(Qt::RightDockWidgetArea, mMapsDock);
     addDockWidget(Qt::RightDockWidgetArea, mObjectsDock);
     addDockWidget(Qt::RightDockWidgetArea, mTerrainDock);
     addDockWidget(Qt::RightDockWidgetArea, mTilesetDock);
     tabifyDockWidget(undoDock, mObjectsDock);
     tabifyDockWidget(mObjectsDock, mLayerDock);
+    tabifyDockWidget(mLayerDock, mMapsDock);
     tabifyDockWidget(mTerrainDock, mTilesetDock);
 
     statusBar()->addPermanentWidget(mZoomComboBox);

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -50,6 +50,7 @@ class ClipboardManager;
 class DocumentManager;
 class LayerDock;
 class MapDocumentActionHandler;
+class MapsDock;
 class MapScene;
 class StampBrush;
 class BucketFillTool;
@@ -207,6 +208,7 @@ private:
     MapDocument *mMapDocument;
     MapDocumentActionHandler *mActionHandler;
     LayerDock *mLayerDock;
+    MapsDock *mMapsDock;
     ObjectsDock *mObjectsDock;
     TilesetDock *mTilesetDock;
     TerrainDock *mTerrainDock;

--- a/src/tiled/mapsdock.cpp
+++ b/src/tiled/mapsdock.cpp
@@ -1,0 +1,211 @@
+/*
+ * mapsdock.cpp
+ * Copyright 2012, Tim Baker <treectrl@hotmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mapsdock.h"
+
+#include "mainwindow.h"
+#include "preferences.h"
+#include "utils.h"
+
+#include <QBoxLayout>
+#include <QCompleter>
+#include <QDirModel>
+#include <QEvent>
+#include <QFileDialog>
+#include <QFileSystemModel>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QToolButton>
+
+using namespace Tiled;
+using namespace Tiled::Internal;
+
+MapsDock::MapsDock(MainWindow *mainWindow, QWidget *parent)
+    : QDockWidget(parent)
+    , mMapsView(new MapsView(mainWindow))
+{
+    setObjectName(QLatin1String("MapsDock"));
+
+    QWidget *widget = new QWidget(this);
+    QVBoxLayout *layout = new QVBoxLayout(widget);
+    layout->setMargin(5);
+
+    QHBoxLayout *dirLayout = new QHBoxLayout;
+    QLabel *label = new QLabel(tr("Folder:"));
+
+    // QDirModel is obsolete, but I could not get QFileSystemModel to work here
+    QLineEdit *edit = mDirectoryEdit = new QLineEdit();
+    QDirModel *model = new QDirModel(this);
+    model->setFilter(QDir::AllDirs | QDir::Dirs | QDir::Drives | QDir::NoDotAndDotDot);
+    QCompleter *completer = new QCompleter(model, this);
+    edit->setCompleter(completer);
+
+    QToolButton *button = new QToolButton();
+    button->setIcon(QIcon(QLatin1String(":/images/16x16/document-properties.png")));
+    button->setToolTip(tr("Choose Folder"));
+    dirLayout->addWidget(label);
+    dirLayout->addWidget(edit);
+    dirLayout->addWidget(button);
+
+    layout->addWidget(mMapsView);
+    layout->addLayout(dirLayout);
+
+    setWidget(widget);
+    retranslateUi();
+
+    connect(button, SIGNAL(clicked()), this, SLOT(browse()));
+
+    Preferences *prefs = Preferences::instance();
+    connect(prefs, SIGNAL(mapsDirectoryChanged()), this, SLOT(onMapsDirectoryChanged()));
+    edit->setText(prefs->mapsDirectory());
+    connect(edit, SIGNAL(returnPressed()), this, SLOT(editedMapsDirectory()));
+
+    // Workaround since a tabbed dockwidget that is not currently visible still
+    // returns true for isVisible()
+    connect(this, SIGNAL(visibilityChanged(bool)),
+            mMapsView, SLOT(setVisible(bool)));
+}
+
+void MapsDock::browse()
+{
+    QString f = QFileDialog::getExistingDirectory(this, tr("Choose the Maps Folder"),
+        mDirectoryEdit->text());
+    if (!f.isEmpty()) {
+        Preferences *prefs = Preferences::instance();
+        prefs->setMapsDirectory(f);
+    }
+}
+
+void MapsDock::editedMapsDirectory()
+{
+    Preferences *prefs = Preferences::instance();
+    prefs->setMapsDirectory(mDirectoryEdit->text());
+}
+
+void MapsDock::onMapsDirectoryChanged()
+{
+    Preferences *prefs = Preferences::instance();
+    mDirectoryEdit->setText(prefs->mapsDirectory());
+}
+
+void MapsDock::changeEvent(QEvent *e)
+{
+    QDockWidget::changeEvent(e);
+    switch (e->type()) {
+    case QEvent::LanguageChange:
+        retranslateUi();
+        break;
+    default:
+        break;
+    }
+}
+
+void MapsDock::retranslateUi()
+{
+    setWindowTitle(tr("Maps"));
+}
+
+///// ///// ///// ///// /////
+
+MapsView::MapsView(MainWindow *mainWindow, QWidget *parent)
+    : QTreeView(parent)
+    , mMainWindow(mainWindow)
+{
+    setRootIsDecorated(false);
+    setHeaderHidden(true);
+    setItemsExpandable(false);
+    setUniformRowHeights(true);
+    setDragEnabled(true);
+    setDefaultDropAction(Qt::MoveAction);
+
+    Preferences *prefs = Preferences::instance();
+    connect(prefs, SIGNAL(mapsDirectoryChanged()), this, SLOT(onMapsDirectoryChanged()));
+
+    QDir mapsDir(prefs->mapsDirectory());
+    if (!mapsDir.exists())
+        mapsDir.setPath(QDir::currentPath());
+
+    QFileSystemModel *model = mFSModel = new QFileSystemModel;
+    model->setRootPath(mapsDir.absolutePath());
+
+    model->setFilter(QDir::AllDirs | QDir::NoDot | QDir::Files);
+    model->setNameFilters(QStringList(QLatin1String("*.tmx")));
+    model->setNameFilterDisables(false); // hide filtered files
+
+    setModel(model);
+
+    QHeaderView* hHeader = header();
+    hHeader->hideSection(1); // Size column
+    hHeader->hideSection(2);
+    hHeader->hideSection(3);
+
+    setRootIndex(model->index(mapsDir.absolutePath()));
+    
+    header()->setStretchLastSection(false);
+    header()->setResizeMode(0, QHeaderView::Stretch);
+
+    connect(this, SIGNAL(activated(QModelIndex)), SLOT(onActivated(QModelIndex)));
+}
+
+QSize MapsView::sizeHint() const
+{
+    return QSize(130, 100);
+}
+
+void MapsView::mousePressEvent(QMouseEvent *event)
+{
+    QModelIndex index = indexAt(event->pos());
+    if (index.isValid()) {
+        // Prevent drag-and-drop starting when clicking on an unselected item.
+        setDragEnabled(selectionModel()->isSelected(index));
+
+        // Hack: disable dragging folders.
+        // FIXME: the correct way to do this would be to override the flags()
+        // method of QFileSystemModel.
+        if (model()->isDir(index))
+            setDragEnabled(false);
+    }
+
+    QTreeView::mousePressEvent(event);
+}
+
+void MapsView::onMapsDirectoryChanged()
+{
+    Preferences *prefs = Preferences::instance();
+    QDir mapsDir(prefs->mapsDirectory());
+    if (!mapsDir.exists())
+        mapsDir.setPath(QDir::currentPath());
+    model()->setRootPath(mapsDir.canonicalPath());
+    setRootIndex(model()->index(mapsDir.absolutePath()));
+}
+
+void MapsView::onActivated(const QModelIndex &index)
+{
+    QString path = model()->filePath(index);
+    QFileInfo fileInfo(path);
+    if (fileInfo.isDir()) {
+        Preferences *prefs = Preferences::instance();
+        prefs->setMapsDirectory(fileInfo.canonicalFilePath());
+        return;
+    }
+    mMainWindow->openFile(path);
+}

--- a/src/tiled/mapsdock.h
+++ b/src/tiled/mapsdock.h
@@ -1,0 +1,90 @@
+/*
+ * mapsdock.h
+ * Copyright 2012, Tim Baker <treectrl@hotmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MAPSDOCK_H
+#define MAPSDOCK_H
+
+#include <QDockWidget>
+#include <QTreeView>
+
+class QFileSystemModel;
+class QLabel;
+class QLineEdit;
+class QModelIndex;
+class QTreeView;
+
+namespace Tiled {
+namespace Internal {
+
+class MainWindow;
+class MapsView;
+
+class MapsDock : public QDockWidget
+{
+    Q_OBJECT
+
+public:
+    MapsDock(MainWindow *mainWindow, QWidget *parent = 0);
+
+private slots:
+    void browse();
+    void editedMapsDirectory();
+    void onMapsDirectoryChanged();
+
+protected:
+    void changeEvent(QEvent *e);
+
+private:
+    void retranslateUi();
+
+    QLineEdit *mDirectoryEdit;
+    MapsView *mMapsView;
+};
+
+/**
+ * This view makes sure the size hint makes sense and implements the context
+ * menu.
+ */
+class MapsView : public QTreeView
+{
+    Q_OBJECT
+
+public:
+    MapsView(MainWindow *mainWindow, QWidget *parent = 0);
+
+    QSize sizeHint() const;
+
+    void mousePressEvent(QMouseEvent *event);
+
+    QFileSystemModel *model() const { return mFSModel; }
+
+private slots:
+    void onMapsDirectoryChanged();
+    void onActivated(const QModelIndex &index);
+
+private:
+    MainWindow *mMainWindow;
+    QFileSystemModel *mFSModel;
+};
+
+} // namespace Internal
+} // namespace Tiled
+
+#endif // MAPSDOCK_H

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -92,6 +92,10 @@ Preferences::Preferences()
                                        false).toBool();
     mSettings->endGroup();
 
+    mSettings->beginGroup(QLatin1String("MapsDirectory"));
+    mMapsDirectory = mSettings->value(QLatin1String("Current"), QString()).toString();
+    mSettings->endGroup();
+
     TilesetManager *tilesetManager = TilesetManager::instance();
     tilesetManager->setReloadTilesetsOnChange(mReloadTilesetsOnChange);
 }
@@ -305,4 +309,19 @@ void Preferences::setAutomappingDrawing(bool enabled)
 {
     mAutoMapDrawing = enabled;
     mSettings->setValue(QLatin1String("Automapping/WhileDrawing"), enabled);
+}
+
+QString Preferences::mapsDirectory() const
+{
+    return mMapsDirectory;
+}
+
+void Preferences::setMapsDirectory(const QString &path)
+{
+    if (mMapsDirectory == path)
+        return;
+    mMapsDirectory = path;
+    mSettings->setValue(QLatin1String("MapsDirectory/Current"), path);
+
+    emit mapsDirectoryChanged();
 }

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -81,6 +81,9 @@ public:
     bool automappingDrawing() const { return mAutoMapDrawing; }
     void setAutomappingDrawing(bool enabled);
 
+    QString mapsDirectory() const;
+    void setMapsDirectory(const QString &path);
+
     /**
      * Provides access to the QSettings instance to allow storing/retrieving
      * arbitrary values. The naming style for groups and keys is CamelCase.
@@ -105,6 +108,8 @@ signals:
 
     void objectTypesChanged();
 
+    void mapsDirectoryChanged();
+
 private:
     Preferences();
     ~Preferences();
@@ -125,6 +130,8 @@ private:
     ObjectTypes mObjectTypes;
 
     bool mAutoMapDrawing;
+
+    QString mMapsDirectory;
 
     static Preferences *mInstance;
 };

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -85,6 +85,7 @@ SOURCES += aboutdialog.cpp \
     mapobjectmodel.cpp \
     mappropertiesdialog.cpp \
     mapscene.cpp \
+    mapsdock.cpp \
     mapview.cpp \
     movelayer.cpp \
     movemapobject.cpp \
@@ -186,6 +187,7 @@ HEADERS += aboutdialog.h \
     mappropertiesdialog.h \
     mapreaderinterface.h \
     mapscene.h \
+    mapsdock.h \
     mapview.h \
     mapwriterinterface.h \
     movelayer.h \


### PR DESCRIPTION
This is the Maps dock from TileZed.
The directory QLineEdit now has autocomplete.
Maps can be opened by dragging a file to the window, double-clicking a file in the list, or by tapping Enter.
The directory path is saved in the preferences under MapsDirectory/Current.
