### PR TITLE
Flare plugin bugfix introduced during style changes

### DIFF
--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -110,11 +110,11 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
         }
         if (ObjectGroup *group = layer->asObjectGroup()) {
             foreach (const MapObject *o, group->objects()) {
-                if (o->type().isEmpty()) {
+                if ((!o->type().isEmpty())) {
                     out << "[" << group->name() << "]\n";
 
                     // display object name as comment
-                    if (o->name().isEmpty()) {
+                    if (!(o->name().isEmpty())) {
                         out << "# " << o->name() << "\n";
                     }
 


### PR DESCRIPTION
After upgrading to 8.1 I noticed this was broken. No objects are output to Flare's format.

You can see the error introduced here:

https://github.com/clintbellanger/tiled/commit/41da15ed9373b89146633a486586f3c1e10c3a74

Looks like an accidental replacement of != "" with isEmpty(), when it should be !...isEmpty().
