### PR TITLE
Fixed a typo in the Object Dock

### DIFF
--- a/src/tiled/objectsdock.cpp
+++ b/src/tiled/objectsdock.cpp
@@ -64,7 +64,7 @@ ObjectsDock::ObjectsDock(QWidget *parent)
 
     mActionObjectProperties = new QAction(this);
     mActionObjectProperties->setIcon(QIcon(QLatin1String(":/images/16x16/document-properties.png")));
-    mActionObjectProperties->setToolTip(tr("Object Propertes"));
+    mActionObjectProperties->setToolTip(tr("Object Properties"));
 
     Utils::setThemeIcon(mActionRemoveObjects, "edit-delete");
     Utils::setThemeIcon(mActionObjectProperties, "document-properties");


### PR DESCRIPTION
In the object dock, one of the buttons said "Object Propertes" in the tooltip. I fixed it to say "Object Properties".
