### PR TITLE
Use relative tag

### DIFF
--- a/src/libtiled/mapreader.h
+++ b/src/libtiled/mapreader.h
@@ -99,9 +99,12 @@ protected:
     /**
      * Called for each \a reference to an external file. Should return the path
      * to be used when loading this file. \a mapPath contains the path to the
-     * map or tileset that is currently being loaded.
+     * map or tileset that is currently being loaded. \a relative can be used to
+     * force an absolute ("false") or relative ("true") reference. Default
+     * behaviour is autodetection ("auto").
      */
     virtual QString resolveReference(const QString &reference,
+                                     const QStringRef &relative,
                                      const QString &mapPath);
 
     /**

--- a/src/tiled/tmxmapreader.cpp
+++ b/src/tiled/tmxmapreader.cpp
@@ -41,9 +41,12 @@ protected:
     /**
      * Overridden to make sure the resolved reference is canonical.
      */
-    QString resolveReference(const QString &reference, const QString &mapPath)
+    QString resolveReference(const QString &reference,
+                             const QStringRef &relative,
+                             const QString &mapPath)
     {
-        QString resolved = MapReader::resolveReference(reference, mapPath);
+        QString resolved =
+                MapReader::resolveReference(reference, relative, mapPath);
         QString canonical = QFileInfo(resolved).canonicalFilePath();
 
         // Make sure that we're not returning an empty string when the file is


### PR DESCRIPTION
I store my TMX files and the tile images at different locations, namely assets/gfx/tileset.png and assets/maps/name/map.tmx. When I set <image source="gfx/tileset.png"> in map.tmx, the current behavior of libtiled is to search for assets/maps/name/gfx/tileset.png. I'd like to have this more flexible, so I introduced a "relative" attribute with the following values:
- "true": treat the source attribute as a relative path
- "false": treat the source attribute as an absolute path
- "auto": auto detect (which is the current behavior)

The "relative" attribute is optional and "auto" is the default value. For all unknown values (i.e. actually all besides "true" and "false) it falls back to "auto".

I have tested my patch for tiled and tmxviewer and it does what I expected it to do. I would be glad if this patch could make it into the library.

By the way, thank you a lot for this helpful tool and the awesome documentation and well written code. This made it incredibly simple to write the patch.
