### PR TITLE
Fixes a bug in MapView: the view reset its position...

### DIFF
--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -168,11 +168,11 @@ void MapView::wheelEvent(QWheelEvent *event)
         return;
     }
 
+    QGraphicsView::wheelEvent(event);
+
     // We are scrolling. The mouse do not move, but the view bellow it yes.
     // So its global position did not change, but its position in the scene yes.
     mLastMouseScenePos = mapToScene(viewport()->mapFromGlobal(mLastMousePos));
-
-    QGraphicsView::wheelEvent(event);
 }
 
 /**


### PR DESCRIPTION
... when we scroll the view using the mouse wheel, quickly followed by a control-wheel to zoom.

Steps to reproduce the problem:
- in the map view
- move the mouse somewhere on the map
- hold tight the mouse
- without moving: scroll the view (hor. or vert.) using the mouse wheel
- without moving: zoom using control-wheel

The view will reset its position where it was before the scroll begins.
