### PR TITLE
Automapping: Remove the no-tile exception. (Incompatible!)

### DIFF
--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -656,44 +656,40 @@ static QVector<Cell> cellsInRegion(const QVector<TileLayer*> &list,
  * If all positions of the region are considered "good" return true.
  *
  * Now there are several cases to distinguish:
- * - setLayer is 0:
- *      obviously there should be no automapping.
- *      So here no rule should be applied. return false
- * - setLayer is not 0:
- *      - both listYes and listNo are empty:
- *          This should not happen, because with that configuration, absolutely
- *          no condition is given.
- *          return false, assuming this is an errornous rule being applied
+ *  - both listYes and listNo are empty:
+ *      This should not happen, because with that configuration, absolutely
+ *      no condition is given.
+ *      return false, assuming this is an errornous rule being applied
  *
- *      - both listYes and listNo are not empty:
- *          When comparing a tile at a certain position of tile layer setLayer
- *          to all available tiles in listYes, there must be at least
- *          one layer, in which there is a match of tiles of setLayer and
- *           listYes to consider this position good.
- *          In listNo there must not be a match to consider this position
- *          good.
- *          If there are no tiles within all available tiles within all layers
- *          of one list, all tiles in setLayer are considered good,
- *          while inspecting this list.
- *          All available tiles are all tiles within the whole rule region in
- *          all tile layers of the list.
+ *  - both listYes and listNo are not empty:
+ *      When comparing a tile at a certain position of tile layer setLayer
+ *      to all available tiles in listYes, there must be at least
+ *      one layer, in which there is a match of tiles of setLayer and
+ *      listYes to consider this position good.
+ *      In listNo there must not be a match to consider this position
+ *      good.
+ *      If there are no tiles within all available tiles within all layers
+ *      of one list, all tiles in setLayer are considered good,
+ *      while inspecting this list.
+ *      All available tiles are all tiles within the whole rule region in
+ *      all tile layers of the list.
  *
- *      - either of both lists are not empty
- *          When comparing a certain position of tile layer setLayer
- *          to all Tiles at the corresponding position this can happen:
- *          A tile of setLayer matches a tile of a layer in the list. Then this
- *          is considered as good, if the layer is from the listYes.
- *          Otherwise it is considered bad.
+ *  - either of both lists are not empty
+ *      When comparing a certain position of tile layer setLayer
+ *      to all Tiles at the corresponding position this can happen:
+ *      A tile of setLayer matches a tile of a layer in the list. Then this
+ *      is considered as good, if the layer is from the listYes.
+ *      Otherwise it is considered bad.
  *
- *          Exception, when having only the listYes:
- *          if at the examined position there are no tiles within all Layers
- *          of the listYes, all tiles except all used tiles within
- *          the layers of that list are considered good.
+ *      Exception, when having only the listYes:
+ *      if at the examined position there are no tiles within all Layers
+ *      of the listYes, all tiles except all used tiles within
+ *      the layers of that list are considered good.
  *
- *          This exception was added to have a better functionality
- *          (need of less layers.)
- *          It was not added to the case, when having only listNo layers to
- *          avoid total symmetrie between those lists.
+ *      This exception was added to have a better functionality
+ *      (need of less layers.)
+ *      It was not added to the case, when having only listNo layers to
+ *      avoid total symmetrie between those lists.
  *
  * If all positions are considered good, return true.
  * return false otherwise.
@@ -729,11 +725,6 @@ static bool compareLayerTo(const TileLayer *setLayer,
 
                 const Cell &c1 = setLayer->cellAt(x + offset.x(),
                                                   y + offset.y());
-
-                // when there is no tile in setLayer,
-                // there should be no rule at all
-                if (c1.isEmpty())
-                    return false;
 
                 // ruleDefined will be set when there is a tile in at least
                 // one layer. if there is a tile in at least one layer, only


### PR DESCRIPTION
This change closes #306.
The no-tile exception made sense at times when the set layer was
the only input layer. (That is version 0.8.1 and before.)
Now this exception causes trouble as Automapping does not
produce expected results.

This commit finally makes the Automapping incompatible to the
Automapping rules of version 0.8.1 and before.
Having spare input layers produces a different behaviour
now than before.
However not all hope is lost, the Automapping on quite filled
input layers behaves the same as before, which I expect to be the
standard usecase.
