### PR TITLE
Fix for tileset add crash.

### DIFF
--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -434,7 +434,15 @@ void TilesetDock::tilesetChanged(Tileset *tileset)
 {
     // Update the affected tileset model, if it exists
     const int index = mTilesets.indexOf(tileset);
-    Q_ASSERT(index != -1);
+
+    /*
+     * The reference counts and the actual tileset lists are not guaranteed
+     * to be completely synchronized.  If the TilesetManager tells us a file
+     * has changed but the tileset using that file no longer exists in the
+     * dock, just ignore it.
+     */
+    if (index < 0)
+        return;
 
     if (TilesetModel *model = tilesetViewAt(index)->tilesetModel())
         model->tilesetChanged();


### PR DESCRIPTION
Bug repro steps:
1.  Create new map.
2.  Add a tileset using an image.
3.  Delete the newly added tileset.
4.  Add another tileset using the same image.

Crash occurs on step 4 due to hitting an assert.

I'm not too familiar with your codebase, but this was the best I could do to fix the crash I encountered without spending a huge amount of time to investigate the code more thoroughly.
