### PR TITLE
Tileset delete draw fix.

### DIFF
--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -460,6 +460,8 @@ void TilesetDock::tilesetRemoved(Tileset *tileset)
     }
     if (mCurrentTile && mCurrentTile->tileset() == tileset)
         setCurrentTile(0);
+
+    updateActions();
 }
 
 void TilesetDock::tilesetMoved(int from, int to)


### PR DESCRIPTION
Bug repro steps:
1.  Create new map.
2.  Add new tileset.
3.  Add new tileset.
4.  Go to tileset dock and click delete tileset button.

The first tileset should be deleted and the selected tileset should switch
to the second tileset.  However, the tileset view is blank.
