### PR TITLE
Flareplugin: initialize number base to 10 when reading maps.

### DIFF
--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -61,7 +61,7 @@ Tiled::Map *FlarePlugin::read(const QString &fileName)
     QString sectionName;
     bool newsection = false;
     QString path = QFileInfo(file).absolutePath();
-    int base;
+    int base = 10;
     GidMapper gidMapper;
     int gid = 1;
     TileLayer *tilelayer = 0;


### PR DESCRIPTION
The default of flare maps is 10.

This commit removes the compiler warning:
........\tiled\src\plugins\flare\flareplugin.cpp:170:60:
warning: 'base' may be used uninitialized in this function
[-Wmaybe-uninitialized]
