### PR TITLE
Export/Import map background color to/from JSON

### DIFF
--- a/src/plugins/json/maptovariantconverter.cpp
+++ b/src/plugins/json/maptovariantconverter.cpp
@@ -48,6 +48,10 @@ QVariant MapToVariantConverter::toVariant(const Map *map, const QDir &mapDir)
     mapVariant["tileheight"] = map->tileHeight();
     mapVariant["properties"] = toVariant(map->properties());
 
+    const QColor bgColor = map->backgroundColor();
+    if (bgColor.isValid())
+        mapVariant["backgroundcolor"] = bgColor.name();
+
     QVariantList tilesetVariants;
 
     unsigned firstGid = 1;

--- a/src/plugins/json/varianttomapconverter.cpp
+++ b/src/plugins/json/varianttomapconverter.cpp
@@ -58,6 +58,13 @@ Map *VariantToMapConverter::toMap(const QVariant &variant,
 
     mMap->setProperties(toProperties(variantMap["properties"]));
 
+    const QString bgColor = variantMap["backgroundcolor"].toString();
+    if (!bgColor.isEmpty())
+#if QT_VERSION >= 0x040700
+        if (QColor::isValidColor(bgColor))
+#endif
+            mMap->setBackgroundColor(QColor(bgColor));
+
     foreach (const QVariant &tilesetVariant, variantMap["tilesets"].toList()) {
         Tileset *tileset = toTileset(tilesetVariant);
         if (!tileset) {


### PR DESCRIPTION
This adds backgroundcolor support to the JSON plugin. The data is encoded the same way as an image's transparentcolor (#RRGGBB).
