### PR TITLE
libtiled-java: Read width and height when unmarshaling ObjectGroup from TMX files.

### DIFF
--- a/util/java/libtiled-java/src/tiled/core/MapLayer.java
+++ b/util/java/libtiled-java/src/tiled/core/MapLayer.java
@@ -114,7 +114,7 @@ public abstract class MapLayer implements Cloneable
      *
      * @param bounds
      */
-    protected void setBounds(Rectangle bounds) {
+    public void setBounds(Rectangle bounds) {
         this.bounds = new Rectangle(bounds);
     }
 

--- a/util/java/libtiled-java/src/tiled/core/TileLayer.java
+++ b/util/java/libtiled-java/src/tiled/core/TileLayer.java
@@ -207,7 +207,7 @@ public class TileLayer extends MapLayer
      * @param bounds new new bounds of this tile layer (in tiles)
      * @see MapLayer#setBounds
      */
-    protected void setBounds(Rectangle bounds) {
+    public void setBounds(Rectangle bounds) {
         super.setBounds(bounds);
         map = new Tile[bounds.height][bounds.width];
 

--- a/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
@@ -30,6 +30,7 @@ package tiled.io;
 
 import java.awt.Color;
 import java.awt.Image;
+import java.awt.Rectangle;
 import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -505,7 +506,9 @@ public class TMXMapReader
 
         final int offsetX = getAttribute(t, "x", 0);
         final int offsetY = getAttribute(t, "y", 0);
-        og.setOffset(offsetX, offsetY);
+        final int layerWidth = getAttribute(t, "width", 0);
+        final int layerHeight = getAttribute(t, "height", 0);
+        og.setBounds(new Rectangle(offsetX, offsetY, layerWidth, layerHeight));
 
         // Add all objects from the objects group
         NodeList children = t.getChildNodes();


### PR DESCRIPTION
When reading TMX files, the width and height properties of <objectgroup> nodes are currently not read or stored on the resulting ObjectGroup objects.

This patch updates the TMXMapReader so that these fields are read.
