### PR TITLE
libtiled-java: Add support in TMXMapReader for caching and reusing loaded tilesets.

### DIFF
--- a/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
@@ -66,6 +66,12 @@ public class TMXMapReader
     private String error;
     private final EntityResolver entityResolver = new MapEntityResolver();
     private TreeMap<Integer, TileSet> tilesetPerFirstGid;
+    public final TMXMapReaderSettings settings = new TMXMapReaderSettings();
+    private final HashMap<String, TileSet> cachedTilesets = new HashMap<String, TileSet>();
+
+    public static final class TMXMapReaderSettings {
+        public boolean reuseCachedTilesets = false;
+    }
 
     public TMXMapReader() {
     }
@@ -318,9 +324,22 @@ public class TMXMapReader
             final int tileSpacing = getAttribute(t, "spacing", 0);
             final int tileMargin = getAttribute(t, "margin", 0);
 
-            TileSet set = new TileSet();
+            final String name = getAttributeValue(t, "name");
 
-            set.setName(getAttributeValue(t, "name"));
+            TileSet set;
+            if (settings.reuseCachedTilesets) {
+                set = cachedTilesets.get(name);
+                if (set != null) {
+                    setFirstGidForTileset(set, firstGid);
+                    return set;
+                }
+                set = new TileSet();
+                cachedTilesets.put(name, set);
+            } else {
+                set = new TileSet();
+            }
+
+            set.setName(name);
             set.setBaseDir(basedir);
             setFirstGidForTileset(set, firstGid);
 


### PR DESCRIPTION
In the game that I develop, we have a lot of TMX files (>300) that all have the same definition of their tilesets, they all use the same tileset images, and all tilesets have the same gids in all TMX files.

When loading all of the TMX files one by one, most of the execution time is spent loading the bitmaps for the maps. In out use-case, since all of the bitmaps are the same, it ought to be possible to reuse the ones that have been loaded for the first few maps.

This patch adds support in TMXMapReader to reuse cached tilesets, that have the same name and gid. This drastically speeds up loading times when parsing several TMX files using the same TMXMapReader object instance.
