### PR TITLE
libtiled-java: Do not output width and height for ObjectGroup when writing TMX files.

### DIFF
--- a/util/java/libtiled-java/src/tiled/io/TMXMapWriter.java
+++ b/util/java/libtiled-java/src/tiled/io/TMXMapWriter.java
@@ -307,8 +307,12 @@ public class TMXMapWriter
         }
 
         w.writeAttribute("name", l.getName());
-        w.writeAttribute("width", bounds.width);
-        w.writeAttribute("height", bounds.height);
+        if (bounds.width != 0) {
+            w.writeAttribute("width", bounds.width);
+        }
+        if (bounds.height != 0) {
+            w.writeAttribute("height", bounds.height);
+        }
         if (bounds.x != 0) {
             w.writeAttribute("x", bounds.x);
         }


### PR DESCRIPTION
Since width and height of ObjectGroup is deprecated, we should not output them when writing TMX files using TMXFileWriter.

This patch changes the TMXFileWriter so that width/height of a MapLayer is only written if they contain an actual value (which ObjectGroup objects do not).
