### PR TITLE
libtiled-java: Do not store firstGid in each TileSet.

### DIFF
--- a/util/java/libtiled-java/src/tiled/core/Map.java
+++ b/util/java/libtiled-java/src/tiled/core/Map.java
@@ -310,24 +310,6 @@ public class Map implements Iterable<MapLayer>
     }
 
     /**
-     * Get the tile set that matches the given global tile id, only to be used
-     * when loading a map.
-     *
-     * @param gid a global tile id
-     * @return the tileset containing the tile with the given global tile id,
-     *         or <code>null</code> when no such tileset exists
-     */
-    public TileSet findTileSetForTileGID(int gid) {
-        TileSet has = null;
-        for (TileSet tileset : tileSets) {
-            if (tileset.getFirstGid() <= gid) {
-                has = tileset;
-            }
-        }
-        return has;
-    }
-
-    /**
      * Returns width of map in tiles.
      *
      * @return int

--- a/util/java/libtiled-java/src/tiled/core/Tile.java
+++ b/util/java/libtiled-java/src/tiled/core/Tile.java
@@ -107,18 +107,6 @@ public class Tile
     }
 
     /**
-     * Returns the global tile id by adding the tile id to the map-assigned.
-     *
-     * @return id
-     */
-    public int getGid() {
-        if (tileset != null) {
-            return id + tileset.getFirstGid();
-        }
-        return id;
-    }
-
-    /**
      * Returns the {@link tiled.core.TileSet} that this tile is part of.
      *
      * @return TileSet

--- a/util/java/libtiled-java/src/tiled/core/TileSet.java
+++ b/util/java/libtiled-java/src/tiled/core/TileSet.java
@@ -54,7 +54,6 @@ public class TileSet implements Iterable<Tile>
 {
     private String base;
     final private Vector<Tile> tiles = new Vector<Tile>();
-    private int firstGid;
     private long tilebmpFileLastModified;
     private TileCutter tileCutter;
     private Rectangle tileDimensions;
@@ -245,15 +244,6 @@ public class TileSet implements Iterable<Tile>
         else {
             tilebmpFile = null;
         }
-    }
-
-    /**
-     * Sets the first global id used by this tileset.
-     *
-     * @param firstGid first global id
-     */
-    public void setFirstGid(int firstGid) {
-        this.firstGid = firstGid;
     }
 
     /**
@@ -461,15 +451,6 @@ public class TileSet implements Iterable<Tile>
         }
 
         return null;
-    }
-
-    /**
-     * Returns the first global id connected to this tileset.
-     *
-     * @return first global id
-     */
-    public int getFirstGid() {
-        return firstGid;
     }
 
     /**


### PR DESCRIPTION
We should not store firstGid in each TileSet, since it depends on the file being read or written.

Instead, they should be calculated on-the-fly when writing a TMX file.
Loading TMX files should parse the gids while the file is being loaded, but not persist them inside the TileSet.

This patch removes firstGid from TileSet, and manages internal structures inside TMXFileWriter/TMXFileReader that are only kept while writing/reading files.

Credits for the very clever idea of using TreeMap&lt;Integer, TileSet&gt; goes to Thorbjørn Lindeijer :)
