### PR TITLE
Fix library directory order

### DIFF
--- a/src/automappingconverter/automappingconverter.pro
+++ b/src/automappingconverter/automappingconverter.pro
@@ -12,7 +12,7 @@ macx {
 } else:win32 {
     LIBS += -L$$OUT_PWD/../../lib
 } else {
-    QMAKE_LIBDIR += $$OUT_PWD/../../lib
+    QMAKE_LIBDIR = $$OUT_PWD/../../lib $$QMAKE_LIBDIR
 }
 
 # Make sure the executable can find libtiled

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -25,7 +25,7 @@ macx {
 } else:win32 {
     LIBS += -L$$OUT_PWD/../../lib
 } else {
-    QMAKE_LIBDIR += $$OUT_PWD/../../lib
+    QMAKE_LIBDIR = $$OUT_PWD/../../lib $$QMAKE_LIBDIR
 }
 
 # Make sure the Tiled executable can find libtiled

--- a/src/tmxrasterizer/tmxrasterizer.pro
+++ b/src/tmxrasterizer/tmxrasterizer.pro
@@ -22,7 +22,7 @@ macx {
 } else:win32 {
     LIBS += -L$$OUT_PWD/../../lib
 } else {
-    QMAKE_LIBDIR += $$OUT_PWD/../../lib
+    QMAKE_LIBDIR = $$OUT_PWD/../../lib $$QMAKE_LIBDIR
 }
 
 # Make sure the executable can find libtiled

--- a/src/tmxviewer/tmxviewer.pro
+++ b/src/tmxviewer/tmxviewer.pro
@@ -22,7 +22,7 @@ macx {
 } else:win32 {
     LIBS += -L$$OUT_PWD/../../lib
 } else {
-    QMAKE_LIBDIR += $$OUT_PWD/../../lib
+    QMAKE_LIBDIR = $$OUT_PWD/../../lib $$QMAKE_LIBDIR
 }
 
 # Make sure the executable can find libtiled


### PR DESCRIPTION
This moves path to -ltiled before system library locations, fixing the
case where libtiled from (older) installed version of tiled is
picked up instead of newly built one.
