### PR TITLE
Ignore build artifacts on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 build
-bin/automappingconverter
-bin/tiled
-bin/tmxrasterizer
-bin/tmxviewer
+bin
 lib/tiled/plugins/*
 lib/*.so*
 Makefile*
@@ -26,6 +23,9 @@ automappingconverter.exe
 *.lib
 *.exp
 *.intermediate.manifest
+
+# Build artifacts on Mac
+translations/phony_target.app
 
 tests/test_mapreader
 


### PR DESCRIPTION
The built applications have a .app extension on mac so they don't get ignored like the windows/linux binaries do.

I ignored the whole bin directory since I didn't see a reason not to, but if there was a good reason each binary was individually ignored, we could do the same for the .app versions.
