### PR TITLE
Small tweaks to the desktop file

### DIFF
--- a/docs/tiled.desktop
+++ b/docs/tiled.desktop
@@ -1,6 +1,8 @@
 [Desktop Entry]
 Name=Tiled
+GenericName=Map editor
 Comment=Tile map editor
+TryExec=tiled
 Exec=tiled
 Terminal=false
 Type=Application


### PR DESCRIPTION
The TryExec line makes sure that tiled is only listed if the executable
exists. Meaning that the desktopfile should not be displayed as an menu
entry if the executable is missing in $PATH (for example if you install
with a custom prefix).

Setting the GenericName might have some use for some window managers /
application menus (I was unable to find this displayed anywhere in the
gnome-panel manu, but it cannot hurt).
