### PR TITLE
Flare export plugin: Remove checks for certain layers being there

### DIFF
--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -249,13 +249,6 @@ QString FlarePlugin::errorString() const
 
 bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
 {
-    if (!checkOneLayerWithName(map, QLatin1String("background")))
-        return false;
-    if (!checkOneLayerWithName(map, QLatin1String("object")))
-        return false;
-    if (!checkOneLayerWithName(map, QLatin1String("collision")))
-        return false;
-
     QFile file(fileName);
     if (!file.open(QFile::WriteOnly | QFile::Text)) {
         mError = tr("Could not open file for writing.");
@@ -347,25 +340,6 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
         }
     }
     file.close();
-    return true;
-}
-
-bool FlarePlugin::checkOneLayerWithName(const Tiled::Map *map,
-                                        const QString &name)
-{
-    int count = 0;
-    foreach (const Layer *layer, map->layers())
-        if (layer->name() == name)
-            count++;
-
-    if (count == 0) {
-        mError = tr("No \"%1\" layer found!").arg(name);
-        return false;
-    } else if (count > 1) {
-        mError = tr("Multiple \"%1\" layers found!").arg(name);
-        return false;
-    }
-
     return true;
 }
 

--- a/src/plugins/flare/flareplugin.h
+++ b/src/plugins/flare/flareplugin.h
@@ -58,8 +58,6 @@ public:
     QString errorString() const;
 
 private:
-    bool checkOneLayerWithName(const Tiled::Map *map, const QString &name);
-
     QString mError;
 };
 


### PR DESCRIPTION
The flare engine evolved and supports 2 more layers optionally.
The three layers which were checked being there, should still be there,
but are not necessary. Also I cannot recall any errors due to missing
or miss spelled layers during flare development, so I think we do not
need this check for flare.

The check for these three layers unintentionally hindered other projects
using this format, which is another reason to drop the check.
