### PR TITLE
Preferences ignored when saving map

### DIFF
--- a/src/tiled/tmxmapwriter.cpp
+++ b/src/tiled/tmxmapwriter.cpp
@@ -33,9 +33,7 @@ bool TmxMapWriter::write(const Map *map, const QString &fileName)
 {
     Preferences *prefs = Preferences::instance();
 
-    Map::LayerDataFormat format = map->layerDataFormat();
-    if (format == Map::Default)
-        format = prefs->layerDataFormat();
+    Map::LayerDataFormat format = prefs->layerDataFormat();
 
     MapWriter writer;
     writer.setLayerDataFormat(format);


### PR DESCRIPTION
Example: When I open map that has it's layers in base64 encoding with whatever compression, then I open Preferences and I change store type to XML or CVS or whatever different, then I save map.

When I open .tmx file in text editor I see that preferences was totally ignored and previous format was used.

I think this is a bug and when I change layer format It should be reflected on saves afterwards.
