### PR TITLE
JSON plugin: Added .txt as valid file extension

### DIFF
--- a/src/plugins/json/jsonplugin.cpp
+++ b/src/plugins/json/jsonplugin.cpp
@@ -124,7 +124,7 @@ bool JsonPlugin::write(const Tiled::Map *map, const QString &fileName)
 QStringList JsonPlugin::nameFilters() const
 {
     QStringList filters;
-    filters.append(tr("Json files (*.json)"));
+    filters.append(tr("Json files (*.json *.txt)"));
     filters.append(tr("JavaScript files (*.js)"));
     return filters;
 }
@@ -132,7 +132,8 @@ QStringList JsonPlugin::nameFilters() const
 bool JsonPlugin::supportsFile(const QString &fileName) const
 {
     return fileName.endsWith(QLatin1String(".json"), Qt::CaseInsensitive) ||
-           fileName.endsWith(QLatin1String(".js"), Qt::CaseInsensitive);
+           fileName.endsWith(QLatin1String(".js"), Qt::CaseInsensitive) ||
+           fileName.endsWith(QLatin1String(".txt"), Qt::CaseInsensitive);
 }
 
 QString JsonPlugin::errorString() const


### PR DESCRIPTION
This might be something only I need (#262) and might be too specific of a use case (Optimally you would just make it so you could save files as any extension in OSX but I don't know if its possible or not) but putting it out there for you to decide. This small fix allows you to save .json as .txt on OSX since it is added as a valid file extension for Json files.
