### PR TITLE
Enable support for high-dpi images with Qt::AA_UseHighDpiPixmaps

### DIFF
--- a/src/tiled/tiledapplication.cpp
+++ b/src/tiled/tiledapplication.cpp
@@ -28,6 +28,10 @@ using namespace Tiled::Internal;
 TiledApplication::TiledApplication(int &argc, char **argv) :
     QApplication(argc, argv)
 {
+#if QT_VERSION >= 0x050100
+    // Enable support for highres images (added in Qt 5.1, but off by default)
+    setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
 }
 
 bool TiledApplication::event(QEvent *event)


### PR DESCRIPTION
This completes more of #295, but we still need larger assets

Without higher res icons, this only increases the sharpness of the Tiled logo in the title bar, but I can look into other icons next.
