### PR TITLE
Make highlighted grid cells outside map red

### DIFF
--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -113,13 +113,13 @@ void BrushItem::paint(QPainter *painter,
     QRegion outsideMapRegion = mRegion.subtracted(mapRegion);
 
     const MapRenderer *renderer = mMapDocument->renderer();
-    const qreal opacity = painter->opacity();
     if (mTileLayer) {
+        const qreal opacity = painter->opacity();
         painter->setOpacity(0.75);
         renderer->drawTileLayer(painter, mTileLayer, option->exposedRect);
+        painter->setOpacity(opacity);
     }
 
-    painter->setOpacity(opacity);
     renderer->drawTileSelection(painter, insideMapRegion,
                                 insideMapHighlight,
                                 option->exposedRect);


### PR DESCRIPTION
Any cells highlighted that are outside of the map will turn red indicating that they are not valid cells to place tiles.
