### PR TITLE
Explicitly define java compiler version

### DIFF
--- a/util/java/libtiled-java/build.xml
+++ b/util/java/libtiled-java/build.xml
@@ -30,7 +30,7 @@
   </target>
 
   <target name="test" depends="init" description="Run all unit-tests">
-    <javac destdir="${build.test}" debug="true">
+    <javac destdir="${build.test}" debug="true" source="1.5" target="1.5">
       <src path="${src}" />
       <src path="${test}" />
       <classpath refid="classpath.test"/>
@@ -50,7 +50,7 @@
   </target>
 
   <target name="jar" depends="init" description="Build libtiled.jar">
-    <javac destdir="${build}">
+    <javac destdir="${build}" source="1.5" target="1.5">
       <src path="${src}" />
       <classpath refid="classpath"/>
     </javac>


### PR DESCRIPTION
The build.xml for libtiled-java should explicitly define the javac version instead of defaulting to the version of the currently installed jdk. This pull request explicitly defines 1.5 because it is the lowest version supported by the source code and is equal to the definition in tmxviewer-java.
