### PR TITLE
Add PainterScale to MapRenderer.

### DIFF
--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -311,7 +311,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         }
     } else {
         const qreal lineWidth = objectLineWidth();
-        const qreal scale = painter->transform().m11();
+        const qreal scale = painterScale();
         const qreal shadowOffset = (lineWidth == 0 ? 1 : lineWidth) / scale;
 
         QColor brushColor = color;

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -61,6 +61,7 @@ public:
         : mMap(map)
         , mFlags(0)
         , mObjectLineWidth(2)
+        , mPainterScale(1)
     {}
 
     virtual ~MapRenderer() {}
@@ -170,6 +171,9 @@ public:
     bool testFlag(RenderFlag flag) const
     { return mFlags.testFlag(flag); }
 
+    qreal painterScale() const { return mPainterScale; }
+    void setPainterScale(qreal painterScale) { mPainterScale = painterScale; }
+
     RenderFlags flags() const { return mFlags; }
     void setFlags(RenderFlags flags) { mFlags = flags; }
 
@@ -186,6 +190,7 @@ private:
 
     RenderFlags mFlags;
     qreal mObjectLineWidth;
+    qreal mPainterScale;
 };
 
 /**

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -299,7 +299,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
         }
     } else {
         const qreal lineWidth = objectLineWidth();
-        const qreal scale = painter->transform().m11();
+        const qreal scale = painterScale();
         const qreal shadowDist = (lineWidth == 0 ? 1 : lineWidth) / scale;
         const QPointF shadowOffset = QPointF(shadowDist * 0.5,
                                              shadowDist * 0.5);

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -27,11 +27,13 @@
 #include "mapobjectmodel.h"
 #include "maprenderer.h"
 #include "mapscene.h"
+#include "mapview.h"
 #include "objectgroup.h"
 #include "objectgroupitem.h"
 #include "preferences.h"
 #include "resizemapobject.h"
 #include "tile.h"
+#include "zoomable.h"
 
 #include <QApplication>
 #include <QGraphicsSceneMouseEvent>
@@ -279,9 +281,11 @@ QPainterPath MapObjectItem::shape() const
 
 void MapObjectItem::paint(QPainter *painter,
                           const QStyleOptionGraphicsItem *,
-                          QWidget *)
+                          QWidget *widget)
 {
+    qreal scale = static_cast<MapView*>(widget->parent())->zoomable()->scale();
     painter->translate(-pos());
+    mMapDocument->renderer()->setPainterScale(scale);
     mMapDocument->renderer()->drawMapObject(painter, mObject, mColor);
 
     if (mIsEditable) {

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -213,6 +213,7 @@ void MiniMap::renderMapToImage()
     painter.setRenderHints(QPainter::SmoothPixmapTransform |
                            QPainter::HighQualityAntialiasing);
     painter.setTransform(QTransform::fromScale(scale, scale));
+    renderer->setPainterScale(scale);
 
     foreach (const Layer *layer, mMapDocument->map()->layers()) {
         if (visibleLayersOnly && !layer->isVisible())

--- a/src/tiled/saveasimagedialog.cpp
+++ b/src/tiled/saveasimagedialog.cpp
@@ -155,7 +155,9 @@ void SaveAsImageDialog::accept()
                                QPainter::HighQualityAntialiasing);
         painter.setTransform(QTransform::fromScale(mCurrentScale,
                                                    mCurrentScale));
-    }
+        renderer->setPainterScale(mCurrentScale);
+    } else
+        renderer->setPainterScale(1);
 
     foreach (const Layer *layer, mMapDocument->map()->layers()) {
         if (visibleLayersOnly && !layer->isVisible())


### PR DESCRIPTION
As requested, adds a painterScale value to MapRenderer, to fix the bounding shadows when objects are rotated.
