### PR TITLE
Added a USE_FHS_PLUGIN_PATH switch

### DIFF
--- a/src/tiled/pluginmanager.cpp
+++ b/src/tiled/pluginmanager.cpp
@@ -62,11 +62,16 @@ void PluginManager::loadPlugins()
         mPlugins.append(Plugin(QLatin1String("<static>"), instance));
 
     // Determine the plugin path based on the application location
+#ifndef TILED_PLUGIN_DIR
     QString pluginPath = QCoreApplication::applicationDirPath();
+#endif
+
 #ifdef Q_OS_WIN32
     pluginPath += QLatin1String("/plugins/tiled");
 #elif defined(Q_OS_MAC)
     pluginPath += QLatin1String("/../PlugIns");
+#elif defined(TILED_PLUGIN_DIR)
+    QString pluginPath = QLatin1String(TILED_PLUGIN_DIR);
 #else
     pluginPath += QLatin1String("/../lib/tiled/plugins");
 #endif

--- a/tiled.pri
+++ b/tiled.pri
@@ -10,3 +10,8 @@ macx {
 }
 
 CONFIG += depend_includepath
+
+
+!isEmpty(USE_FHS_PLUGIN_PATH) {
+    DEFINES += TILED_PLUGIN_DIR=\\\"$${LIBDIR}/tiled/plugins/\\\"
+}


### PR DESCRIPTION
Setting this variable during the qmake run will make tiled
correctly picking up the install dir of plugins if the
lib path differs from "../lib" (generally the case for 64 bit releases).

Fixes: #269
