### PR TITLE
Add option to include background image when saving as image

### DIFF
--- a/src/tiled/newmapdialog.cpp
+++ b/src/tiled/newmapdialog.cpp
@@ -116,7 +116,6 @@ MapDocument *NewMapDialog::createMap()
                        tileWidth, tileHeight);
 
     map->setLayerDataFormat(layerFormat);
-    map->setBackgroundColor(Qt::gray);
 
     const size_t gigabyte = 1073741824;
     const size_t memory = size_t(mapWidth) * size_t(mapHeight) * sizeof(Cell);

--- a/src/tiled/saveasimagedialog.cpp
+++ b/src/tiled/saveasimagedialog.cpp
@@ -153,8 +153,12 @@ void SaveAsImageDialog::accept()
 
     QImage image(mapSize, QImage::Format_ARGB32_Premultiplied);
 
-    if (includeBackgroundColor)
-        image.fill(mMapDocument->map()->backgroundColor());
+    if (includeBackgroundColor) {
+        if (mMapDocument->map()->backgroundColor().isValid())
+            image.fill(mMapDocument->map()->backgroundColor());
+        else
+            image.fill(Qt::gray);
+    }
     else
         image.fill(Qt::transparent);
 


### PR DESCRIPTION
This adds the option to save the background image when saving the map as an image as requested in the first part of #430.
