### PR TITLE
Have qmake pick up the compiler variables of Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,16 @@ addons:
     build_command: make
     branch_pattern: coverity_scan
 
-compiler:
-  - gcc
-  - clang
+matrix:
+    include:
+        - compiler: gcc
+        - compiler: clang
+          env: QMAKESPEC=unsupported/linux-clang
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libqt4-dev libqt4-opengl-dev zlib1g-dev cppcheck
+  - qmake -version
   - Xvfb :1 &
   - xv -display :1 &
 script:


### PR DESCRIPTION
Currently Tiled is being compiled with g++ also when it is meant to be compiled with clang++. This is an attempt at fixing that.

Would probably be better to use the right mkspec instead.
