### PR TITLE
add precompiled header.

### DIFF
--- a/src/libtiled/libtiled.pro
+++ b/src/libtiled/libtiled.pro
@@ -16,6 +16,7 @@ win32 {
     lessThan(QT_MAJOR_VERSION, 5) {
         INCLUDEPATH += ../zlib
     }
+    QMAKE_PROJECT_NAME = libtiled
 } else {
     # On other platforms it is necessary to link to zlib explicitly
     LIBS += -lz

--- a/src/tiled/pch.h
+++ b/src/tiled/pch.h
@@ -1,0 +1,62 @@
+#include <algorithm>
+#include <string>
+#include <iostream>
+
+// Qt
+#include <QtCore/QString>
+#include <QtCore/QObject>
+#include <QtCore/QVariant>
+#include <QtCore/QRegularExpression>
+#include <QtCore/QEvent>
+#include <QtCore/QVector>
+#include <QtCore/QMap>
+#include <QtCore/QtPlugin>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QTimer>
+#include <QtCore/QDebug>
+
+#include <QtGui/QImage>
+#include <QtGui/QPixmap>
+#include <QtGui/QPalette>
+#include <QtGui/QTextDocument>
+
+#include <QtWidgets/QWidget>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QUndoCommand>
+
+#include <QtWidgets/QBoxLayout>
+#include <QtWidgets/QFrame>
+
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QPinchGesture>
+#include <QtWidgets/QTreeView>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QCheckBox>
+
+#include <QtWidgets/QGraphicsView>
+#include <QtWidgets/QGraphicsScene>
+#include <QtWidgets/QGraphicsItem>
+#include <QtWidgets/QGraphicsSceneMouseEvent>
+
+#include <QtWidgets/QPlainTextEdit>
+#include <QtWidgets/QFileDialog>
+
+#include <qtvariantproperty.h>
+
+// libtiled
+#include <tile.h>
+#include <tileset.h>
+#include <layer.h>
+#include <terrain.h>
+#include <mapdocument.h>
+#include <mapobject.h>
+#include <objectgroup.h>
+
+// tiled
+#include "abstractobjecttool.h"
+#include "preferences.h"
+
+#include "documentmanager.h"
+#include "mapscene.h"
+#include "tilesetmanager.h"
+#include "tmxmapwriter.h"

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -342,6 +342,7 @@ macx {
 }
 win32 {
     RC_FILE = tiled.rc
+    PRECOMPILED_HEADER = pch.h
 }
 win32:INCLUDEPATH += .
 contains(CONFIG, static) {


### PR DESCRIPTION
Hi! i love tiled project.
but it compiled is too slow in windows. i add add precompiled header.
i don't know the pch file can work on other platform.
i add in `win32` section in tiled/tiled.pro
need to test on other platform.

also i add `QMAKE_PROJECT_NAME = libtiled`
because create vs project dll and exe same name.
