### PR TITLE
Fix ImageIO throwing IIOException

### DIFF
--- a/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
@@ -309,9 +309,9 @@ public class TMXMapReader
 
         String tilesetBaseDir = xmlPath;
 
-		if (tilesetBaseDir.startsWith("file:/")) {
-			tilesetBaseDir = tilesetBaseDir.substring(6);
-		}
+        if (tilesetBaseDir.startsWith("file:/")) {
+            tilesetBaseDir = tilesetBaseDir.substring(6);
+        }
 
         if (basedir != null) {
             tilesetBaseDir = basedir; //makeUrl(basedir);


### PR DESCRIPTION
This pull request strips "file:/" from absolute path to load image with ImageIO. Prior to the change the absolute path would start with "file:/", which would make ImageIO throw an IIOException saying it could not find the file. 

This made the library function on my Windows 7 64 machine using Java 1.8.0_05, running from Eclipse Luna.
All test cases succeed.
