### PR TITLE
Fixed automapping object region check.

### DIFF
--- a/src/tiled/automappingutils.cpp
+++ b/src/tiled/automappingutils.cpp
@@ -68,7 +68,12 @@ const QList<MapObject*> objectsInRegion(ObjectGroup *layer,
         // tile objects. polygons and polylines are not covered correctly by this
         // erase method (we are in fact deleting too many objects)
         // TODO2: toAlignedRect may even break rects.
-        if (where.intersects(obj->bounds().toAlignedRect()))
+        const QRect rect = obj->bounds().toAlignedRect();
+
+        // QRegion::intersects() returns false for empty regions even if they are
+        // contained within the region, so we also check for containment of the
+        // top left to include the case of zero size objects.
+        if (where.intersects(rect) || where.contains(rect.topLeft()))
             ret += obj;
     }
     return ret;


### PR DESCRIPTION
Some proposed fixes for automapping issues with objects mentioned in #691.

Based on a very simple test the fixes seem to work in the orthogonal and normal isometric orientations. However, staggered isometric does not work as you would expect because of the layout of tiles in staggered and how tileToPixelCoords(QRectF) does the conversion.
