### PR TITLE
Update tmxrasterizer OSX install

### DIFF
--- a/dist/make-dist-mac.rb
+++ b/dist/make-dist-mac.rb
@@ -33,6 +33,7 @@ Dir.mktmpdir do |tempDir|
     end
     FileUtils.cp_r File.join(baseDir, 'examples'), tempDir
     FileUtils.cp_r binAppDir, tempDir
+    FileUtils.mv   File.join(binDir,'tmxrasterizer'), File.join(tempDir, 'Tiled.app/Contents/MacOS')
     FileUtils.ln_s '/Applications', File.join(tempDir, 'Applications') #Symlink to Applications for easy install
     FileUtils.cp File.join(baseDir, 'src/tiled/images/tmx-icon-mac.icns'), File.join(tempDir, 'Tiled.app/Contents/Resources')
 
@@ -42,7 +43,7 @@ Dir.mktmpdir do |tempDir|
     raise "macdeployqt error #{$?}" unless $? == 0
 
     # Modify plugins to use Qt frameworks contained within the app bundle (is there some way to get macdeployqt to do this?)
-    Dir["#{File.join tempDir, 'Tiled.app'}/**/*.dylib"].each do |library|
+    Dir["#{File.join tempDir, 'Tiled.app'}/**/*.dylib","#{File.join tempDir, 'Tiled.app'}/Contents/MacOS/tmxrasterizer"].each do |library|
         ["QtCore", "QtGui"].each do |qtlib|
             #find any qt dependencies within this library
             qtdependency = `otool -L "#{library}" | grep #{qtlib}`.split(' ')[0]

--- a/src/tmxrasterizer/tmxrasterizer.pro
+++ b/src/tmxrasterizer/tmxrasterizer.pro
@@ -18,6 +18,7 @@ win32 {
 }
 
 macx {
+    CONFIG -= app_bundle
     QMAKE_LIBDIR += $$OUT_PWD/../../bin/Tiled.app/Contents/Frameworks
 } else:win32 {
     LIBS += -L$$OUT_PWD/../../lib


### PR DESCRIPTION
On OSX, "tmxrasterizer" is currently built as an app bundle by default and is also not included in the file dmg distribution file.

I use it as a command line tool in my xcode build process and I'm also planning on creating a tmx optimiser utility which I will base off tmxrasterizer so just wanted to get things setup to use in an easier way on OSX.

I've modified the tmxrasterizer.pro file to build it as a command line file only and then modified the ruby script to copy it into the Tiled.app/Content/MacOS directory.  From there the framework paths are fixed and can be run using the libs bundled in the tiled.app.

I've built and tested this on a mac mini using OSX 10.9.4.
