### PR TITLE
Added appdata file

### DIFF
--- a/docs/tiled.appdata.xml
+++ b/docs/tiled.appdata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+ <id type="desktop">tiled.desktop</id>
+ <metadata_license>CC-BY-3.0 and GPL-2.0</metadata_license>
+ <project_license>GPL-2.0+ and BSD-2-Clause</project_license>
+ <name>Tiled</name>
+ <summary>General purpose map editor</summary>
+ <description>
+  <p>
+   Tiled is a general purpose 2D level editor with powerful tile map editing
+   features. It’s built to be easy to use and is suitable for many type of
+   games.
+  </p>
+  <p>
+   The Tiled map format is supported by a large amount of game engines and
+   libraries. In addition, Tiled supports plugins to read and write map formats
+   other than its own map format.
+  </p>
+ </description>
+ <screenshots>
+  <!-- GPL 2 by TMW -->
+  <screenshot type="default" width="800" height="600">http://www.mapeditor.org/img/appdata/screenshot_objects.png</screenshot>
+  <!-- CC BY SA 3.0 By Clint Bellanger -->
+  <screenshot width="800" height="600">http://www.mapeditor.org/img/appdata/screenshot_terrain.png</screenshot>
+ </screenshots>
+ <url type="homepage">http://www.mapeditor.org/</url>
+ <updatecontact>ablu@fedoraproject.org</updatecontact>
+</application>


### PR DESCRIPTION
The appdata currently fails validation since the fedora validator
does not yet support multiple licenses for the metadata.

Fixes #596.
