### PR TITLE
set maximum size for the about dialog

### DIFF
--- a/src/tiled/aboutdialog.cpp
+++ b/src/tiled/aboutdialog.cpp
@@ -30,8 +30,7 @@ AboutDialog::AboutDialog(QWidget *parent): QDialog(parent)
     setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-    setMaximumWidth(432);
-    setMaximumHeight(460);
+    setMaximumSize(432, 460);
 
     const QString html = QCoreApplication::translate(
             "AboutDialog",


### PR DESCRIPTION
see #796, have done this now with an local clone its better! removed `this->` and `setMaximumWidth` and `setMaximumHeight` works! I hope its ok @bjorn :)
