### PR TITLE
Eliminate some building issues on Windows

### DIFF
--- a/src/libtiled/objectgroup.cpp
+++ b/src/libtiled/objectgroup.cpp
@@ -31,12 +31,12 @@
 #include "objectgroup.h"
 
 #include "layer.h"
+#include "map.h"
 #include "mapobject.h"
 #include "tile.h"
 #include "tileset.h"
 
 #include <cmath>
-#include <map.h>
 
 using namespace Tiled;
 

--- a/tiled.pri
+++ b/tiled.pri
@@ -9,14 +9,15 @@ macx {
     contains(QT_CONFIG, ppc):CONFIG += x86 ppc
 }
 
-win32 {
-    # This allows Tiled to use up to 3 GB on 32-bit systems and 4 GB on
-    # 64-bit systems, rather than being limited to just 2 GB.
+# This allows Tiled to use up to 3 GB on 32-bit systems and 4 GB on
+# 64-bit systems, rather than being limited to just 2 GB.
+win32-g++* {
+    QMAKE_LFLAGS += -Wl,--large-address-aware
+} else:win32 {
     QMAKE_LFLAGS += /LARGEADDRESSAWARE
 }
 
 CONFIG += depend_includepath
-
 
 !isEmpty(USE_FHS_PLUGIN_PATH) {
     DEFINES += TILED_PLUGIN_DIR=\\\"$${LIBDIR}/tiled/plugins/\\\"


### PR DESCRIPTION
- Use --large-address-aware instead of /LARGEADDRESSAWARE with MinGW
- Adjust an #include in libtiled/objectgroup.cpp
- ~~Build tmxviewer as a console application~~
