### PR TITLE
Fixes modifier key detection

### DIFF
--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -451,20 +451,21 @@ void MapScene::dragMoveEvent(QGraphicsSceneDragDropEvent *event)
 
 bool MapScene::eventFilter(QObject *, QEvent *event)
 {
-    switch (event->type()) {
-    case QEvent::KeyPress:
-    case QEvent::KeyRelease: {
-            QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
-            Qt::KeyboardModifiers newModifiers = keyEvent->modifiers();
+    if (mActiveTool) {
+        switch (event->type()) {
+        case QEvent::KeyPress:
+        case QEvent::KeyRelease: {
+            Qt::KeyboardModifiers newModifiers = qGuiApp->queryKeyboardModifiers();
 
-            if (mActiveTool && newModifiers != mCurrentModifiers) {
+            if (newModifiers != mCurrentModifiers) {
                 mActiveTool->modifiersChanged(newModifiers);
                 mCurrentModifiers = newModifiers;
             }
         }
-        break;
-    default:
-        break;
+            break;
+        default:
+            break;
+        }
     }
 
     return false;


### PR DESCRIPTION
Intel i5-5300U
Linux 4.14.13-1-ARCH
Qt5.10

While on Windows it seems to work as intended, on Linux QKeyEvent::modifiers() does not detect keys correctly. For example press CTRL_L and CTRL_R detects Qt::ControlModifier but releasing only one CTRL key returns Qt:NoModifier although one CTRL key is still pressed.
When I read a bit in the Qt docs it actually explicitly says that [QKeyEvent::modifier()](https://doc.qt.io/qt-5/qkeyevent.html#modifiers) is unreliable in those cases.

Another problem is in certain cases remapping keys in X11.
Qt cannot correctly recognize Shift keys if their keysym on release differs from the keysym on press (although keycode is identical).
It can be reproduced by setting `setxkbmap -option shift:both_capslock`.
I [reported it as a bug](https://bugs.freedesktop.org/show_bug.cgi?id=104765) to xorg but it seems to be the expected behavior.
Moreover, according to daniel there are many more cases where this can occur.

What I found to work reliable is querying the modifier state directly (not looking at the event queue) with QGuiApplication::queryKeyboardModifiers().
Although I already pulled out the mActiveTool check (what cuts it down to about 1/3 of modifier queries) it peaks at ~8% CPU usage when spamming keys, compared to 0-2% with QKeyEvent::modifiers().

Over the years there have been multiple bug reports on the Qt tracker concerning modifier keys not being recognized. It seems [this PR](https://codereview.qt-project.org/#/c/194697/) could be fixing this once it gets merged.
In the meanwhile, this could be a possible workaround.
