### PR TITLE
Added option to change object selection behavior

### DIFF
--- a/src/tiled/abstractobjecttool.cpp
+++ b/src/tiled/abstractobjecttool.cpp
@@ -80,7 +80,7 @@ static bool isChangedTemplateInstance(MapObject *mapObject)
 }
 
 Preference<AbstractObjectTool::SelectionBehavior> AbstractObjectTool::ourSelectionBehavior {
-    "AbstractObjectTool/SelectionBehavior", AbstractObjectTool::PreferSelectedLayers
+    "AbstractObjectTool/SelectionBehavior", AbstractObjectTool::AllLayers
 };
 
 AbstractObjectTool::AbstractObjectTool(Id id,
@@ -192,9 +192,19 @@ void AbstractObjectTool::populateToolBar(QToolBar *toolBar)
     toolBar->addAction(mRotateRight);
 }
 
-void AbstractObjectTool::filterMapObjects(QList<MapObject *> &mapObjects) const
+AbstractObjectTool::SelectionBehavior AbstractObjectTool::selectionBehavior()
 {
     const SelectionBehavior behavior = ourSelectionBehavior;
+
+    if (behavior == AllLayers && Preferences::instance()->highlightCurrentLayer())
+        return PreferSelectedLayers;
+
+    return behavior;
+}
+
+void AbstractObjectTool::filterMapObjects(QList<MapObject *> &mapObjects) const
+{
+    const SelectionBehavior behavior = selectionBehavior();
 
     if (behavior != AllLayers) {
         const auto &selectedLayers = mapDocument()->selectedLayers();
@@ -248,9 +258,7 @@ QList<MapObject*> AbstractObjectTool::mapObjectsAt(const QPointF &pos) const
 MapObject *AbstractObjectTool::topMostMapObjectAt(const QPointF &pos) const
 {
     const QList<QGraphicsItem *> &items = mapScene()->items(pos);
-
-    const auto &selectedLayers = mapDocument()->selectedLayers();
-    const SelectionBehavior behavior = ourSelectionBehavior;
+    const SelectionBehavior behavior = selectionBehavior();
 
     MapObject *topMost = nullptr;
 

--- a/src/tiled/abstractobjecttool.h
+++ b/src/tiled/abstractobjecttool.h
@@ -43,9 +43,9 @@ class AbstractObjectTool : public AbstractTool
 
 public:
     enum SelectionBehavior {
-        IgnoreLayer,
+        AllLayers,
         PreferSelectedLayers,
-        PreferHighlightedLayers
+        SelectedLayers
     };
     Q_ENUM(SelectionBehavior)
 
@@ -68,6 +68,8 @@ public:
     void languageChanged() override;
 
     void populateToolBar(QToolBar*) override;
+
+    void filterMapObjects(QList<MapObject*> &mapObjects) const;
 
 protected:
     /**

--- a/src/tiled/abstractobjecttool.h
+++ b/src/tiled/abstractobjecttool.h
@@ -69,6 +69,7 @@ public:
 
     void populateToolBar(QToolBar*) override;
 
+    static SelectionBehavior selectionBehavior();
     void filterMapObjects(QList<MapObject*> &mapObjects) const;
 
 protected:

--- a/src/tiled/abstractobjecttool.h
+++ b/src/tiled/abstractobjecttool.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "abstracttool.h"
+#include "preferences.h"
 
 class QAction;
 
@@ -41,6 +42,15 @@ class AbstractObjectTool : public AbstractTool
     Q_INTERFACES(Tiled::AbstractTool)
 
 public:
+    enum SelectionBehavior {
+        IgnoreLayer,
+        PreferSelectedLayers,
+        PreferHighlightedLayers
+    };
+    Q_ENUM(SelectionBehavior)
+
+    static Preference<SelectionBehavior> ourSelectionBehavior;
+
     /**
      * Constructs an abstract object tool with the given \a name and \a icon.
      */

--- a/src/tiled/editpolygontool.cpp
+++ b/src/tiled/editpolygontool.cpp
@@ -208,23 +208,7 @@ void EditPolygonTool::mousePressed(QGraphicsSceneMouseEvent *event)
         mMousePressed = true;
         mStart = event->scenePos();
         mScreenStart = event->screenPos();
-
-        const QList<QGraphicsItem *> items = mapScene()->items(mStart,
-                                                               Qt::IntersectsItemShape,
-                                                               Qt::DescendingOrder,
-                                                               viewTransform(event));
-
-        mClickedObject = nullptr;
-        for (QGraphicsItem *item : items) {
-            if (!item->isEnabled())
-                continue;
-            if (auto mapObjectItem = qgraphicsitem_cast<MapObjectItem*>(item)) {
-                if (mapObjectItem->mapObject()->objectGroup()->isUnlocked()) {
-                    mClickedObject = mapObjectItem->mapObject();
-                    break;
-                }
-            }
-        }
+        mClickedObject = topMostMapObjectAt(mStart);
         break;
     }
     case Qt::RightButton: {
@@ -487,7 +471,10 @@ void EditPolygonTool::updateSelection(QGraphicsSceneMouseEvent *event)
                 selectedObjects.append(mapObjectItem->mapObject());
         }
 
-        mapDocument()->setSelectedObjects(selectedObjects);
+        filterMapObjects(selectedObjects);
+
+        if (!selectedObjects.isEmpty())
+            mapDocument()->setSelectedObjects(selectedObjects);
     } else {
         // Update the selected handles
         QSet<PointHandle*> selectedHandles;

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -335,6 +335,12 @@ ObjectSelectionTool::ObjectSelectionTool(QObject *parent)
         mRotateHandles[i] = new RotateHandle(static_cast<AnchorPosition>(i));
     for (int i = 0; i < AnchorCount; ++i)
         mResizeHandles[i] = new ResizeHandle(static_cast<AnchorPosition>(i));
+
+    connect(Preferences::instance(), &Preferences::highlightCurrentLayerChanged,
+            this, [this] {
+        if (mapScene() && mapDocument()->hoveredMapObject())
+            updateHover(mLastMousePos);
+    });
 }
 
 ObjectSelectionTool::~ObjectSelectionTool()

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -1111,6 +1111,8 @@ void ObjectSelectionTool::updateSelection(const QPointF &pos,
             selectedObjects.append(mapObjectItem->mapObject());
     }
 
+    filterMapObjects(selectedObjects);
+
     if (modifiers & (Qt::ControlModifier | Qt::ShiftModifier)) {
         for (MapObject *object : mapDocument()->selectedObjects())
             if (!selectedObjects.contains(object))

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -78,12 +78,6 @@ public:
     ObjectLabelVisiblity objectLabelVisibility() const;
     void setObjectLabelVisibility(ObjectLabelVisiblity visiblity);
 
-    enum ObjectSelectionBehavior {
-        IgnoreLayer,
-        PreferSelectedLayers,
-        PreferHighlightedLayers
-    };
-
     bool labelForHoveredObject() const;
     void setLabelForHoveredObject(bool enabled);
 

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -78,6 +78,12 @@ public:
     ObjectLabelVisiblity objectLabelVisibility() const;
     void setObjectLabelVisibility(ObjectLabelVisiblity visiblity);
 
+    enum ObjectSelectionBehavior {
+        IgnoreLayer,
+        PreferSelectedLayers,
+        PreferHighlightedLayers
+    };
+
     bool labelForHoveredObject() const;
     void setLabelForHoveredObject(bool enabled);
 

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -69,7 +69,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
 
     mUi->objectSelectionBehaviorCombo->addItems({ tr("Select From Any Layer"),
                                                   tr("Prefer Selected Layers"),
-                                                  tr("Prefer Highlighted Layers") });
+                                                  tr("Selected Layers Only") });
 
     PluginListModel *pluginListModel = new PluginListModel(this);
     QSortFilterProxyModel *pluginProxyModel = new QSortFilterProxyModel(this);
@@ -230,7 +230,7 @@ void PreferencesDialog::retranslateUi()
 
     mUi->objectSelectionBehaviorCombo->setItemText(0, tr("Select From Any Layer"));
     mUi->objectSelectionBehaviorCombo->setItemText(1, tr("Prefer Selected Layers"));
-    mUi->objectSelectionBehaviorCombo->setItemText(2, tr("Prefer Highlighted Layers"));
+    mUi->objectSelectionBehaviorCombo->setItemText(3, tr("Selected Layers Only"));
 }
 
 void PreferencesDialog::styleComboChanged()

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -21,6 +21,7 @@
 #include "preferencesdialog.h"
 #include "ui_preferencesdialog.h"
 
+#include "abstractobjecttool.h"
 #include "languagemanager.h"
 #include "pluginlistmodel.h"
 #include "preferences.h"
@@ -60,12 +61,15 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
     mUi->languageCombo->model()->sort(0);
     mUi->languageCombo->insertItem(0, tr("System default"));
 
-    mUi->styleCombo->addItems(QStringList()
-                              << QApplication::translate("PreferencesDialog", "Native")
-                              << QApplication::translate("PreferencesDialog", "Tiled Fusion"));
+    mUi->styleCombo->addItems({ QApplication::translate("PreferencesDialog", "Native"),
+                                QApplication::translate("PreferencesDialog", "Tiled Fusion") });
 
     mUi->styleCombo->setItemData(0, Preferences::SystemDefaultStyle);
     mUi->styleCombo->setItemData(1, Preferences::TiledStyle);
+
+    mUi->objectSelectionBehaviorCombo->addItems({ tr("Select From Any Layer"),
+                                                  tr("Prefer Selected Layers"),
+                                                  tr("Prefer Highlighted Layers") });
 
     PluginListModel *pluginListModel = new PluginListModel(this);
     QSortFilterProxyModel *pluginProxyModel = new QSortFilterProxyModel(this);
@@ -117,6 +121,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
 
     connect(mUi->styleCombo, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, &PreferencesDialog::styleComboChanged);
+    connect(mUi->objectSelectionBehaviorCombo, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this, [] (int index) { AbstractObjectTool::ourSelectionBehavior = static_cast<AbstractObjectTool::SelectionBehavior>(index); });
     connect(mUi->baseColor, &ColorButton::colorChanged,
             preferences, &Preferences::setBaseColor);
     connect(mUi->selectionColor, &ColorButton::colorChanged,
@@ -205,6 +211,7 @@ void PreferencesDialog::fromPreferences()
         styleComboIndex = 1;
 
     mUi->styleCombo->setCurrentIndex(styleComboIndex);
+    mUi->objectSelectionBehaviorCombo->setCurrentIndex(AbstractObjectTool::ourSelectionBehavior);
     mUi->baseColor->setColor(prefs->baseColor());
     mUi->selectionColor->setColor(prefs->selectionColor());
     bool systemStyle = prefs->applicationStyle() == Preferences::SystemDefaultStyle;
@@ -220,6 +227,10 @@ void PreferencesDialog::retranslateUi()
 
     mUi->styleCombo->setItemText(0, QApplication::translate("PreferencesDialog", "Native"));
     mUi->styleCombo->setItemText(1, QApplication::translate("PreferencesDialog", "Tiled Fusion"));
+
+    mUi->objectSelectionBehaviorCombo->setItemText(0, tr("Select From Any Layer"));
+    mUi->objectSelectionBehaviorCombo->setItemText(1, tr("Prefer Selected Layers"));
+    mUi->objectSelectionBehaviorCombo->setItemText(2, tr("Prefer Highlighted Layers"));
 }
 
 void PreferencesDialog::styleComboChanged()

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -133,6 +133,19 @@
           <string>Interface</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="4">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
@@ -140,6 +153,43 @@
             </property>
             <property name="buddy">
              <cstring>languageCombo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Grid color:</string>
+            </property>
+            <property name="buddy">
+             <cstring>gridColor</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Object line width:</string>
+            </property>
+            <property name="buddy">
+             <cstring>objectLineWidth</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0" colspan="4">
+           <widget class="QCheckBox" name="wheelZoomsByDefault">
+            <property name="text">
+             <string>Mouse wheel &amp;zooms by default</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QSpinBox" name="gridFine">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>128</number>
             </property>
            </widget>
           </item>
@@ -162,16 +212,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Grid color:</string>
-            </property>
-            <property name="buddy">
-             <cstring>gridColor</cstring>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
@@ -182,7 +222,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="4">
+          <item row="6" column="0" colspan="4">
            <widget class="QCheckBox" name="openGL">
             <property name="text">
              <string>Hardware &amp;accelerated drawing (OpenGL)</string>
@@ -192,45 +232,18 @@
           <item row="2" column="3">
            <widget class="Tiled::ColorButton" name="gridColor"/>
           </item>
-          <item row="3" column="3">
-           <widget class="QSpinBox" name="gridFine">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>128</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label">
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Object line width:</string>
+             <string>Object selection behavior:</string>
             </property>
             <property name="buddy">
-             <cstring>objectLineWidth</cstring>
+             <cstring>objectSelectionBehaviorCombo</cstring>
             </property>
            </widget>
           </item>
-          <item row="6" column="0" colspan="4">
-           <widget class="QCheckBox" name="wheelZoomsByDefault">
-            <property name="text">
-             <string>Mouse wheel &amp;zooms by default</string>
-            </property>
-           </widget>
+          <item row="5" column="3">
+           <widget class="QComboBox" name="objectSelectionBehaviorCombo"/>
           </item>
          </layout>
         </widget>
@@ -462,6 +475,7 @@
   <tabstop>gridColor</tabstop>
   <tabstop>gridFine</tabstop>
   <tabstop>objectLineWidth</tabstop>
+  <tabstop>objectSelectionBehaviorCombo</tabstop>
   <tabstop>openGL</tabstop>
   <tabstop>wheelZoomsByDefault</tabstop>
   <tabstop>displayNewsCheckBox</tabstop>


### PR DESCRIPTION
Previously when clicking objects it would always take the top-most object from any visible and unlocked layer.

This new option allows changing that such that when available, an object from one of the currently selected layers is preferred. It can also be set to only do this, when the highlighting of current layer option is enabled (the new default).

This would close #354.