### PR TITLE
Fix Python plugin linking issue with Python 3.8

### DIFF
--- a/src/plugins/python/find_python.pri
+++ b/src/plugins/python/find_python.pri
@@ -1,6 +1,10 @@
 !contains(DISABLE_PYTHON_PLUGIN, yes) {
     unix {
-        packagesExist(python3) {
+        packagesExist(python3-embed) {
+            HAVE_PYTHON = yes
+            CONFIG += link_pkgconfig
+            PKGCONFIG += python3-embed
+        } else:packagesExist(python3) {
             HAVE_PYTHON = yes
             CONFIG += link_pkgconfig
             PKGCONFIG += python3


### PR DESCRIPTION
The default pkg-config module no longer contains -lpython3.8.

Reference: https://docs.python.org/3/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build