### PR TITLE
Fix loading extension path from project config

### DIFF
--- a/src/tiled/project.cpp
+++ b/src/tiled/project.cpp
@@ -116,7 +116,7 @@ bool Project::load(const QString &fileName)
 
     const QJsonObject project = document.object();
 
-    mExtensionsPath = absolute(dir, project.value(QLatin1String("extensionsFolder")).toString(QLatin1String("extensions")));
+    mExtensionsPath = absolute(dir, project.value(QLatin1String("extensionsPath")).toString(QLatin1String("extensions")));
     mObjectTypesFile = absolute(dir, project.value(QLatin1String("objectTypesFile")).toString());
     mAutomappingRulesFile = absolute(dir, project.value(QLatin1String("automappingRulesFile")).toString());
 


### PR DESCRIPTION
Extension path was getting saved under the `extensionsPath` key
but getting read from the `extensionsFolder` key.

Read the value back from the written `extensionsPath` key.