### PR TITLE
Add `%scriptargs` for Command replacement

### DIFF
--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -27,6 +27,7 @@
 #include "mapdocument.h"
 #include "mapobject.h"
 #include "projectmanager.h"
+#include "scriptmanager.h"
 #include "worlddocument.h"
 #include "worldmanager.h"
 
@@ -76,7 +77,9 @@ static QString replaceVariables(const QString &string, bool quoteValues = true)
         QFileInfo fileInfo(fileName);
         const QString mapPath = fileInfo.absolutePath();
         const QString projectPath = QFileInfo(ProjectManager::instance()->project().fileName()).absolutePath();
+        const QString scriptArgs = ScriptManager::instance().getCommandArguments();
 
+        finalString.replace(QLatin1String("%scriptargs"), replaceString.arg(scriptArgs));
         finalString.replace(QLatin1String("%mapfile"), replaceString.arg(fileName));
         finalString.replace(QLatin1String("%mappath"), replaceString.arg(mapPath));
         finalString.replace(QLatin1String("%projectpath"), replaceString.arg(projectPath));

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -367,4 +367,14 @@ void ScriptManager::refreshExtensionsPaths()
     }
 }
 
+void ScriptManager::setCommandArguments(const QString &commandArguments)
+{
+    mCommandArguments = commandArguments;
+}
+
+QString ScriptManager::getCommandArguments()
+{
+    return mCommandArguments;
+}
+
 } // namespace Tiled

--- a/src/tiled/scriptmanager.h
+++ b/src/tiled/scriptmanager.h
@@ -68,6 +68,8 @@ public:
     void throwNullArgError(int argNumber);
 
     void refreshExtensionsPaths();
+    void setCommandArguments(const QString &commandArguments);
+    QString getCommandArguments();
 
 private:
     explicit ScriptManager(QObject *parent = nullptr);
@@ -86,6 +88,7 @@ private:
     FileSystemWatcher mWatcher;
     QString mExtensionsPath;
     QStringList mExtensionsPaths;
+    QString mCommandArguments;
     int mTempCount = 0;
 
     static ScriptManager *mInstance;

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -484,12 +484,13 @@ void ScriptModule::trigger(const QByteArray &actionName) const
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Unknown action"));
 }
 
-void ScriptModule::executeCommand(const QString &name, bool inTerminal) const
+void ScriptModule::executeCommand(const QString &name, bool inTerminal, const QString &scriptArgs) const
 {
     const auto commands = CommandManager::instance()->allCommands();
 
     for (const Command &command : commands) {
         if (command.name == name) {
+            ScriptManager::instance().setCommandArguments(scriptArgs);
             command.execute(inTerminal);
             return;
         }

--- a/src/tiled/scriptmodule.h
+++ b/src/tiled/scriptmodule.h
@@ -130,7 +130,7 @@ signals:
 
 public slots:
     void trigger(const QByteArray &actionName) const;
-    void executeCommand(const QString &name, bool inTerminal = false) const;
+    void executeCommand(const QString &name, bool inTerminal = false, const QString &scriptArgs = QString()) const;
 
     void alert(const QString &text, const QString &title = QString()) const;
     bool confirm(const QString &text, const QString &title = QString()) const;


### PR DESCRIPTION
When invoking a command from an extension script, there isn't a
great way to specify custom arguments to the command.

Solve this by:
- Adding an extra parameter to the `tiled.executeCommand()` function
- Replacing the contents of %scriptargs in the command definition with that parameter