### PR TITLE
Allow scripts to extend the object context menu

### DIFF
--- a/src/tiled/abstractobjecttool.cpp
+++ b/src/tiled/abstractobjecttool.cpp
@@ -25,6 +25,7 @@
 #include "changemapobject.h"
 #include "changetileobjectgroup.h"
 #include "documentmanager.h"
+#include "mainwindow.h"
 #include "mapdocument.h"
 #include "map.h"
 #include "mapobject.h"
@@ -612,6 +613,8 @@ void AbstractObjectTool::showContextMenu(MapObject *clickedObject,
 
     Utils::setThemeIcon(removeAction, "edit-delete");
     Utils::setThemeIcon(propertiesAction, "document-properties");
+
+    MainWindow::instance()->addCustomObjectActions(&menu);
 
     QAction *action = menu.exec(screenPos);
     if (!action)

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -523,6 +523,9 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     ActionManager::registerMenu(mNewLayerMenu, "NewLayer");
     ActionManager::registerMenu(mGroupLayerMenu, "GroupLayer");
 
+    mCustomObjectMenu = new QMenu(this);
+    ActionManager::registerMenu(mCustomObjectMenu, "ObjectActions");
+
     connect(mUi->actionNewMap, &QAction::triggered, this, &MainWindow::newMap);
     connect(mUi->actionNewTileset, &QAction::triggered, this, [this] { newTileset(); });
     connect(mUi->actionOpen, &QAction::triggered, this, &MainWindow::openFileDialog);
@@ -1903,6 +1906,16 @@ bool MainWindow::addRecentProjectsActions(QMenu *menu) const
     }
 
     return !files.isEmpty();
+}
+
+bool MainWindow::addCustomObjectActions(QMenu *menu) const
+{
+    bool didAdd = false;
+    for (QAction *action : mCustomObjectMenu->actions()) {
+        menu->addAction(action);
+        didAdd = true;
+    }
+    return didAdd;
 }
 
 void MainWindow::updateRecentProjectsMenu()

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -95,6 +95,7 @@ public:
     bool openFile(const QString &fileName, FileFormat *fileFormat = nullptr);
 
     bool addRecentProjectsActions(QMenu *menu) const;
+    bool addCustomObjectActions(QMenu *menu) const;
 
     static MainWindow *instance();
 
@@ -234,6 +235,7 @@ private:
     QMenu *mNewLayerMenu;
     QMenu *mGroupLayerMenu;
     QMenu *mViewsAndToolbarsMenu;
+    QMenu *mCustomObjectMenu;
     QAction *mViewsAndToolbarsAction;
     QAction *mShowObjectTypesEditor;
 


### PR DESCRIPTION
Presently, there is no way for extension scripts to modify the
context menus shown, e.g., when right-clicking an object.

Resolve this by:
- Add a `QMenu *mCustomObjectMenu` to MainWindow.  Define it as empty, but call registerMenu on it.
- Add a `void addCustomObjectActions(QMenu *menu) const` to MainWindow. This is kinda like the existing addRecentProjectsActions API on it.
- Update `AbstractObjectTool::showContextMenu` to call `MainWindow::Instance().addCustomObjectActions(menu)` before calling exec.