### PR TITLE
Add Scripting Function `tiled.execute(command, arguments)`

### DIFF
--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -498,6 +498,21 @@ void ScriptModule::executeCommand(const QString &name, bool inTerminal) const
     ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Unknown command"));
 }
 
+void ScriptModule::execute(const QString &executable, const QString &arguments, bool showOutput, bool inTerminal) const
+{
+    const auto command = new Command();
+    command->name = QString::fromLatin1("Script Command");
+    command->executable = executable;
+    command->arguments = arguments;
+    command->isEnabled = true;
+    command->saveBeforeExecute = false;
+    // command->shortcut = shortcut.value<QKeySequence>();
+     command->showOutput = showOutput;
+    // command->workingDirectory = workingDirectory.toString();
+    command->execute(inTerminal);
+    return;
+}
+
 void ScriptModule::alert(const QString &text, const QString &title) const
 {
     QMessageBox::warning(MainWindow::instance(), title, text);

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -500,17 +500,14 @@ void ScriptModule::executeCommand(const QString &name, bool inTerminal) const
 
 void ScriptModule::execute(const QString &executable, const QString &arguments, bool showOutput, bool inTerminal) const
 {
-    const auto command = new Command();
-    command->name = QString::fromLatin1("Script Command");
-    command->executable = executable;
-    command->arguments = arguments;
-    command->isEnabled = true;
-    command->saveBeforeExecute = false;
-    // command->shortcut = shortcut.value<QKeySequence>();
-     command->showOutput = showOutput;
-    // command->workingDirectory = workingDirectory.toString();
-    command->execute(inTerminal);
-    return;
+    Command command;
+    command.name = tr("Script Command");
+    command.executable = executable;
+    command.arguments = arguments;
+    command.saveBeforeExecute = false;
+    command.showOutput = showOutput;
+
+    command.execute(inTerminal);
 }
 
 void ScriptModule::alert(const QString &text, const QString &title) const

--- a/src/tiled/scriptmodule.h
+++ b/src/tiled/scriptmodule.h
@@ -131,6 +131,7 @@ signals:
 public slots:
     void trigger(const QByteArray &actionName) const;
     void executeCommand(const QString &name, bool inTerminal = false) const;
+    void execute(const QString &executable, const QString &arguments, bool showOutput = false, bool inTerminal = false) const;
 
     void alert(const QString &text, const QString &title = QString()) const;
     bool confirm(const QString &text, const QString &title = QString()) const;


### PR DESCRIPTION
Currently, there is no way to pass custom arguments from your
script to commands via `tiled.executeCommand()`.  This change
implements a raw, `tiled.execute()` which takes the executable
and parameters as an argument, and runs that.

Obsoletes #2957