### PR TITLE
Added export to GameMaker Studio 2

### DIFF
--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -168,6 +168,7 @@
 
                 <File Source="$(var.InstallRoot)\plugins\tiled\tbin.dll" />
                 <File Source="$(var.InstallRoot)\plugins\tiled\tengine.dll" />
+                <File Source="$(var.InstallRoot)\plugins\tiled\yy.dll" />
               </Component>
             </Directory>
             <Directory Id="platformPlugins" Name="platforms">

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -369,7 +369,7 @@ void CellRenderer::render(const Cell &cell, const QPointF &screenPos, const QSiz
     } else if (cell.flippedAntiDiagonally()) {
         fragment.rotation = 90;
 
-        flippedHorizontally = cell.flippedVertically();
+        flippedHorizontally = flippedVertically;
         flippedVertically = !cell.flippedHorizontally();
 
         // Compensate for the swap of image dimensions

--- a/src/plugins/gmx/gmxplugin.cpp
+++ b/src/plugins/gmx/gmxplugin.cpp
@@ -1,6 +1,7 @@
 /*
  * GMX Tiled Plugin
  * Copyright 2016, Jones Blunt <mrjonesblunt@gmail.com>
+ * Copyright 2016-2020, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
  *
  * This file is part of Tiled.
  *

--- a/src/plugins/plugins.pro
+++ b/src/plugins/plugins.pro
@@ -10,7 +10,8 @@ SUBDIRS = csv \
           lua \
           replicaisland \
           tbin \
-          tengine
+          tengine \
+          yy
 
 include(python/find_python.pri)
 

--- a/src/plugins/plugins.qbs
+++ b/src/plugins/plugins.qbs
@@ -15,6 +15,7 @@ Project {
         "replicaisland",
         "rpmap",
         "tbin",
-        "tengine"
+        "tengine",
+        "yy"
     ]
 }

--- a/src/plugins/yy/jsonwriter.cpp
+++ b/src/plugins/yy/jsonwriter.cpp
@@ -1,0 +1,259 @@
+/*
+ * jsonwriter.cpp
+ * Copyright 2011-2021, Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "jsonwriter.h"
+
+#include <QIODevice>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QJsonValue>
+
+namespace Yy {
+
+JsonWriter::JsonWriter(QIODevice *device)
+    : m_device(device)
+{
+}
+
+void JsonWriter::writeEndDocument()
+{
+    Q_ASSERT(m_scopes.isEmpty());
+    write('\n');
+}
+
+void JsonWriter::writeStartScope(Scope scope)
+{
+    prepareNewValue();
+    write(scope == Object ? '{' : '[');
+    m_scopes.push(scope);
+    m_newLine = false;
+    m_valueWritten = false;
+}
+
+void JsonWriter::writeStartScope(Scope scope, const char *name)
+{
+    writeKey(name);
+    write(scope == Object ? '{' : '[');
+    m_scopes.push(scope);
+    m_newLine = false;
+    m_valueWritten = false;
+}
+
+void JsonWriter::writeStartScope(Scope scope, const QString &name)
+{
+    writeKey(name);
+    write(scope == Object ? '{' : '[');
+    m_scopes.push(scope);
+    m_newLine = false;
+    m_valueWritten = false;
+}
+
+void JsonWriter::writeEndScope(Scope scope)
+{
+    Q_ASSERT(m_scopes.last() == scope);
+    m_scopes.pop();
+    if (m_valueWritten) {
+        write(m_valueSeparator);    // This is not JSON-conform, but it's what GameMaker does
+        writeNewline();
+    }
+    write(scope == Object ? '}' : ']');
+    m_newLine = false;
+    m_valueWritten = true;
+}
+
+void JsonWriter::writeValue(const QByteArray &value)
+{
+    Q_ASSERT(m_scopes.last() == Array);
+    prepareNewValue();
+    write('"');
+    write(value);
+    write('"');
+    m_newLine = false;
+    m_valueWritten = true;
+}
+
+void JsonWriter::writeValue(const QJsonValue &value)
+{
+    switch (value.type()) {
+    case QJsonValue::Null:
+        writeUnquotedValue("null");
+        break;
+    case QJsonValue::Bool:
+        writeUnquotedValue(value.toBool() ? "true" : "false");
+        break;
+    case QJsonValue::Double: {
+        const double d = value.toDouble();
+        if (qIsFinite(d))
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+            writeUnquotedValue(QByteArray::number(d, 'g', QLocale::FloatingPointShortest));
+#else
+            writeUnquotedValue(QByteArray::number(d));
+#endif
+        else
+            writeUnquotedValue("null"); // +INF || -INF || NaN (see RFC4627#section2.4)
+        break;
+    }
+    case QJsonValue::String:
+        writeValue(value.toString());
+        break;
+    case QJsonValue::Array: {
+        writeStartArray();
+        const QJsonArray array = value.toArray();
+        for (auto v : array)
+            writeValue(v);
+        writeEndArray();
+        break;
+    }
+    case QJsonValue::Object: {
+        writeStartObject();
+        const QJsonObject object = value.toObject();
+        for (auto it = object.begin(); it != object.end(); ++it)
+            writeMember(it.key().toUtf8(), it.value());
+        writeEndObject();
+        break;
+    }
+    case QJsonValue::Undefined:
+        Q_UNREACHABLE();
+        break;
+    }
+}
+
+void JsonWriter::writeUnquotedValue(const QByteArray &value)
+{
+    prepareNewValue();
+    write(value);
+    m_newLine = false;
+    m_valueWritten = true;
+}
+
+void JsonWriter::writeMember(const QByteArray &key, const char *value)
+{
+    writeKey(key.data());
+    write('"');
+    write(value);
+    write('"');
+    m_newLine = false;
+    m_valueWritten = true;
+}
+
+void JsonWriter::writeMember(const QByteArray &key, const QByteArray &value)
+{
+    writeKey(key.data());
+    write('"');
+    write(value);
+    write('"');
+    m_newLine = false;
+    m_valueWritten = true;
+}
+
+void JsonWriter::writeMember(const QByteArray &key, const QJsonValue &value)
+{
+    writeKey(key.data());
+    writeValue(value);
+}
+
+void JsonWriter::writeUnquotedMember(const QByteArray &key,
+                                     const QByteArray &value)
+{
+    writeKey(key.data());
+    write(value);
+    m_newLine = false;
+    m_valueWritten = true;
+}
+
+/**
+ * Quotes the given string, escaping special characters as necessary.
+ */
+QString JsonWriter::quote(const QString &str)
+{
+    QString quoted;
+    quoted.reserve(str.length() + 2);   // most likely scenario
+    quoted.append(QLatin1Char('"'));
+
+    for (const QChar c : str) {
+        switch (c.unicode()) {
+        case '\\':  quoted.append(QStringLiteral("\\\\"));  break;
+        case '"':   quoted.append(QStringLiteral("\\\""));  break;
+        case '\n':  quoted.append(QStringLiteral("\\n"));   break;
+        default:    quoted.append(c);
+        }
+    }
+
+    quoted.append(QLatin1Char('"'));
+    return quoted;
+}
+
+void JsonWriter::prepareNewLine()
+{
+    if (m_valueWritten) {
+        write(m_valueSeparator);
+        m_valueWritten = false;
+    }
+    writeNewline();
+}
+
+void JsonWriter::prepareNewValue()
+{
+    if (!m_valueWritten) {
+        writeNewline();
+    } else {
+        write(m_valueSeparator);
+        if (!m_minimize)
+            write(' ');
+    }
+}
+
+void JsonWriter::writeIndent()
+{
+    for (int level = m_scopes.size(); level; --level)
+        write("  ");
+}
+
+void JsonWriter::writeNewline()
+{
+    if (!m_newLine) {
+        if (!m_minimize) {
+            if (m_suppressNewlines) {
+                write(' ');
+            } else {
+                write('\n');
+                writeIndent();
+            }
+        }
+        m_newLine = true;
+    }
+}
+
+void JsonWriter::writeKey(const char *key)
+{
+    Q_ASSERT(m_scopes.last() == Object);
+    prepareNewLine();
+    write('"');
+    write(key);
+    write(m_minimize ? "\":" : "\": ");
+}
+
+void JsonWriter::write(const char *bytes, qint64 length)
+{
+    if (m_device->write(bytes, length) != length)
+        m_error = true;
+}
+
+} // namespace Yy

--- a/src/plugins/yy/jsonwriter.cpp
+++ b/src/plugins/yy/jsonwriter.cpp
@@ -116,8 +116,10 @@ void JsonWriter::writeValue(const QJsonValue &value)
     case QJsonValue::Array: {
         writeStartArray();
         const QJsonArray array = value.toArray();
-        for (auto v : array)
+        for (auto v : array) {
+            prepareNewLine();
             writeValue(v);
+        }
         writeEndArray();
         break;
     }
@@ -211,13 +213,10 @@ void JsonWriter::prepareNewLine()
 
 void JsonWriter::prepareNewValue()
 {
-    if (!m_valueWritten) {
+    if (!m_valueWritten)
         writeNewline();
-    } else {
+    else
         write(m_valueSeparator);
-        if (!m_minimize)
-            write(' ');
-    }
 }
 
 void JsonWriter::writeIndent()
@@ -229,13 +228,9 @@ void JsonWriter::writeIndent()
 void JsonWriter::writeNewline()
 {
     if (!m_newLine) {
-        if (!m_minimize) {
-            if (m_suppressNewlines) {
-                write(' ');
-            } else {
-                write('\n');
-                writeIndent();
-            }
+        if (!m_minimize && !m_suppressNewlines) {
+            write('\n');
+            writeIndent();
         }
         m_newLine = true;
     }

--- a/src/plugins/yy/jsonwriter.cpp
+++ b/src/plugins/yy/jsonwriter.cpp
@@ -24,6 +24,7 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QLocale>
 
 namespace Yy {
 

--- a/src/plugins/yy/jsonwriter.h
+++ b/src/plugins/yy/jsonwriter.h
@@ -49,33 +49,32 @@ public:
 
     void writeStartObject()                     { writeStartScope(Object); }
     void writeStartObject(const char *name)     { writeStartScope(Object, name); }
-    void writeStartObject(const QString &name)  { writeStartScope(Object, name); }
     void writeEndObject()                       { writeEndScope(Object); }
 
     void writeStartArray()                      { writeStartScope(Array); }
     void writeStartArray(const char *name)      { writeStartScope(Array, name); }
-    void writeStartArray(const QString &name)   { writeStartScope(Array, name); }
     void writeEndArray()                        { writeEndScope(Array); }
 
     void writeValue(int value);
     void writeValue(unsigned value);
+    void writeValue(double value);
     void writeValue(const QByteArray &value);
     void writeValue(const QString &value);
     void writeValue(const QJsonValue &value);
 
     void writeUnquotedValue(const QByteArray &value);
 
-    void writeMember(const QByteArray &key, int value);
-    void writeMember(const QByteArray &key, unsigned value);
-    void writeMember(const QByteArray &key, float value);
-    void writeMember(const QByteArray &key, double value);
-    void writeMember(const QByteArray &key, bool value);
-    void writeMember(const QByteArray &key, const char *value);
-    void writeMember(const QByteArray &key, const QByteArray &value);
-    void writeMember(const QByteArray &key, const QString &value);
-    void writeMember(const QByteArray &key, const QJsonValue &value);
+    void writeMember(const char *key, int value);
+    void writeMember(const char *key, unsigned value);
+    void writeMember(const char *key, float value);
+    void writeMember(const char *key, double value);
+    void writeMember(const char *key, bool value);
+    void writeMember(const char *key, const char *value);
+    void writeMember(const char *key, const QByteArray &value);
+    void writeMember(const char *key, const QString &value);
+    void writeMember(const char *key, const QJsonValue &value);
 
-    void writeUnquotedMember(const QByteArray &key,
+    void writeUnquotedMember(const char *key,
                              const QByteArray &value);
 
     void setSuppressNewlines(bool suppressNewlines);
@@ -93,14 +92,12 @@ public:
 private:
     void writeStartScope(Scope scope);
     void writeStartScope(Scope scope, const char *name);
-    void writeStartScope(Scope scope, const QString &name);
     void writeEndScope(Scope scope);
 
     void prepareNewValue();
     void writeIndent();
 
     void writeNewline();
-    void writeKey(const QString &key) { writeKey(quote(key).toUtf8().constData()); }
     void writeKey(const char *key);
     void write(const char *bytes, qint64 length);
     void write(const char *bytes);
@@ -127,22 +124,22 @@ inline void JsonWriter::writeValue(unsigned value)
 inline void JsonWriter::writeValue(const QString &value)
 { writeUnquotedValue(quote(value).toUtf8()); }
 
-inline void JsonWriter::writeMember(const QByteArray &key, int value)
+inline void JsonWriter::writeMember(const char *key, int value)
 { writeUnquotedMember(key, QByteArray::number(value)); }
 
-inline void JsonWriter::writeMember(const QByteArray &key, unsigned value)
+inline void JsonWriter::writeMember(const char *key, unsigned value)
 { writeUnquotedMember(key, QByteArray::number(value)); }
 
-inline void JsonWriter::writeMember(const QByteArray &key, float value)
+inline void JsonWriter::writeMember(const char *key, float value)
 { writeMember(key, static_cast<double>(value)); }
 
-inline void JsonWriter::writeMember(const QByteArray &key, double value)
-{ writeUnquotedMember(key, QByteArray::number(value)); }
+inline void JsonWriter::writeMember(const char *key, double value)
+{ writeKey(key); writeValue(value); }
 
-inline void JsonWriter::writeMember(const QByteArray &key, bool value)
+inline void JsonWriter::writeMember(const char *key, bool value)
 { writeUnquotedMember(key, value ? "true" : "false"); }
 
-inline void JsonWriter::writeMember(const QByteArray &key, const QString &value)
+inline void JsonWriter::writeMember(const char *key, const QString &value)
 { writeUnquotedMember(key, quote(value).toUtf8()); }
 
 inline void JsonWriter::write(const char *bytes)

--- a/src/plugins/yy/jsonwriter.h
+++ b/src/plugins/yy/jsonwriter.h
@@ -155,8 +155,7 @@ inline void JsonWriter::write(char c)
 { write(&c, 1); }
 
 /**
- * Sets whether newlines should be suppressed. While newlines are suppressed,
- * the writer will write out spaces instead of newlines.
+ * Sets whether newlines should be suppressed.
  */
 inline void JsonWriter::setSuppressNewlines(bool suppressNewlines)
 { m_suppressNewlines = suppressNewlines; }

--- a/src/plugins/yy/jsonwriter.h
+++ b/src/plugins/yy/jsonwriter.h
@@ -1,0 +1,177 @@
+/*
+ * jsonwriter.h
+ * Copyright 2011-2021, Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QByteArray>
+#include <QStack>
+#include <QString>
+#include <QVariant>
+
+class QIODevice;
+
+namespace Yy {
+
+/**
+ * Writes a JSON file, providing a high level of control over its contents.
+ *
+ * Using this writer, as opposed to the QJsonDocument, gives control over the
+ * order of the properties and when to use newlines.
+ */
+class JsonWriter
+{
+    enum Scope {
+        Array,
+        Object
+    };
+
+public:
+    JsonWriter(QIODevice *device);
+
+    void writeEndDocument();
+
+    void writeStartObject()                     { writeStartScope(Object); }
+    void writeStartObject(const char *name)     { writeStartScope(Object, name); }
+    void writeStartObject(const QString &name)  { writeStartScope(Object, name); }
+    void writeEndObject()                       { writeEndScope(Object); }
+
+    void writeStartArray()                      { writeStartScope(Array); }
+    void writeStartArray(const char *name)      { writeStartScope(Array, name); }
+    void writeStartArray(const QString &name)   { writeStartScope(Array, name); }
+    void writeEndArray()                        { writeEndScope(Array); }
+
+    void writeValue(int value);
+    void writeValue(unsigned value);
+    void writeValue(const QByteArray &value);
+    void writeValue(const QString &value);
+    void writeValue(const QJsonValue &value);
+
+    void writeUnquotedValue(const QByteArray &value);
+
+    void writeMember(const QByteArray &key, int value);
+    void writeMember(const QByteArray &key, unsigned value);
+    void writeMember(const QByteArray &key, float value);
+    void writeMember(const QByteArray &key, double value);
+    void writeMember(const QByteArray &key, bool value);
+    void writeMember(const QByteArray &key, const char *value);
+    void writeMember(const QByteArray &key, const QByteArray &value);
+    void writeMember(const QByteArray &key, const QString &value);
+    void writeMember(const QByteArray &key, const QJsonValue &value);
+
+    void writeUnquotedMember(const QByteArray &key,
+                             const QByteArray &value);
+
+    void setSuppressNewlines(bool suppressNewlines);
+    bool suppressNewlines() const;
+
+    void setMinimize(bool minimize);
+    bool minimize() const;
+
+    void prepareNewLine();
+
+    bool hasError() const { return m_error; }
+
+    static QString quote(const QString &str);
+
+private:
+    void writeStartScope(Scope scope);
+    void writeStartScope(Scope scope, const char *name);
+    void writeStartScope(Scope scope, const QString &name);
+    void writeEndScope(Scope scope);
+
+    void prepareNewValue();
+    void writeIndent();
+
+    void writeNewline();
+    void writeKey(const QString &key) { writeKey(quote(key).toUtf8().constData()); }
+    void writeKey(const char *key);
+    void write(const char *bytes, qint64 length);
+    void write(const char *bytes);
+    void write(const QByteArray &bytes);
+    void write(char c);
+
+    QIODevice *m_device;
+
+    QStack<Scope> m_scopes;
+    char m_valueSeparator { ',' };
+    bool m_suppressNewlines { false };
+    bool m_minimize { false };
+    bool m_newLine { true };
+    bool m_valueWritten { false };
+    bool m_error { false };
+};
+
+inline void JsonWriter::writeValue(int value)
+{ writeUnquotedValue(QByteArray::number(value)); }
+
+inline void JsonWriter::writeValue(unsigned value)
+{ writeUnquotedValue(QByteArray::number(value)); }
+
+inline void JsonWriter::writeValue(const QString &value)
+{ writeUnquotedValue(quote(value).toUtf8()); }
+
+inline void JsonWriter::writeMember(const QByteArray &key, int value)
+{ writeUnquotedMember(key, QByteArray::number(value)); }
+
+inline void JsonWriter::writeMember(const QByteArray &key, unsigned value)
+{ writeUnquotedMember(key, QByteArray::number(value)); }
+
+inline void JsonWriter::writeMember(const QByteArray &key, float value)
+{ writeMember(key, static_cast<double>(value)); }
+
+inline void JsonWriter::writeMember(const QByteArray &key, double value)
+{ writeUnquotedMember(key, QByteArray::number(value)); }
+
+inline void JsonWriter::writeMember(const QByteArray &key, bool value)
+{ writeUnquotedMember(key, value ? "true" : "false"); }
+
+inline void JsonWriter::writeMember(const QByteArray &key, const QString &value)
+{ writeUnquotedMember(key, quote(value).toUtf8()); }
+
+inline void JsonWriter::write(const char *bytes)
+{ write(bytes, qstrlen(bytes)); }
+
+inline void JsonWriter::write(const QByteArray &bytes)
+{ write(bytes.constData(), bytes.length()); }
+
+inline void JsonWriter::write(char c)
+{ write(&c, 1); }
+
+/**
+ * Sets whether newlines should be suppressed. While newlines are suppressed,
+ * the writer will write out spaces instead of newlines.
+ */
+inline void JsonWriter::setSuppressNewlines(bool suppressNewlines)
+{ m_suppressNewlines = suppressNewlines; }
+
+inline bool JsonWriter::suppressNewlines() const
+{ return m_suppressNewlines; }
+
+/**
+ * Sets whether output should be minimized. This implies suppressing newlines
+ * and in addition will avoid printing unnecessary spaces.
+ */
+inline void JsonWriter::setMinimize(bool minimize)
+{ m_minimize = minimize; }
+
+inline bool JsonWriter::minimize() const
+{ return m_minimize; }
+
+} // namespace Yy

--- a/src/plugins/yy/plugin.json
+++ b/src/plugins/yy/plugin.json
@@ -1,0 +1,1 @@
+{ "defaultEnable": true }

--- a/src/plugins/yy/yy.pro
+++ b/src/plugins/yy/yy.pro
@@ -1,0 +1,7 @@
+include(../plugin.pri)
+
+DEFINES += YY_LIBRARY
+
+SOURCES += yyplugin.cpp
+HEADERS += yyplugin.h \
+    yy_global.h

--- a/src/plugins/yy/yy.qbs
+++ b/src/plugins/yy/yy.qbs
@@ -1,0 +1,14 @@
+import qbs 1.0
+
+TiledPlugin {
+    cpp.defines: base.concat(["YY_LIBRARY"])
+
+    files: [
+        "jsonwriter.cpp",
+        "jsonwriter.h",
+        "plugin.json",
+        "yy_global.h",
+        "yyplugin.cpp",
+        "yyplugin.h",
+    ]
+}

--- a/src/plugins/yy/yy_global.h
+++ b/src/plugins/yy/yy_global.h
@@ -1,7 +1,6 @@
 /*
- * GMX Tiled Plugin
- * Copyright 2016, Jones Blunt <mrjonesblunt@gmail.com>
- * Copyright 2016-2020, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ * YY Tiled Plugin
+ * Copyright 2021, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
  *
  * This file is part of Tiled.
  *
@@ -21,29 +20,10 @@
 
 #pragma once
 
-#include "mapformat.h"
+#include <QtCore/qglobal.h>
 
-#include "gmx_global.h"
-
-namespace Gmx {
-
-class GMXSHARED_EXPORT GmxPlugin : public Tiled::WritableMapFormat
-{
-    Q_OBJECT
-    Q_PLUGIN_METADATA(IID "org.mapeditor.MapFormat" FILE "plugin.json")
-
-public:
-    GmxPlugin();
-
-    bool write(const Tiled::Map *map, const QString &fileName, Options options) override;
-    QString errorString() const override;
-    QString shortName() const override;
-
-protected:
-    QString nameFilter() const override;
-
-private:
-    QString mError;
-};
-
-} // namespace Gmx
+#if defined(YY_LIBRARY)
+#  define YYSHARED_EXPORT Q_DECL_EXPORT
+#else
+#  define YYSHARED_EXPORT Q_DECL_IMPORT
+#endif

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -687,7 +687,7 @@ bool YyPlugin::write(const Map *map, const QString &fileName, Options options)
     json.writeEndObject();
 
     json.writeStartObject("parent");
-    const QString path = optionalProperty(map, "path", QLatin1String("folders/Rooms.yy"));
+    const QString path = optionalProperty(map, "path", QStringLiteral("folders/Rooms.yy"));
     json.writeMember("name", QFileInfo(path).completeBaseName());
     json.writeMember("path", path);
     json.writeEndObject();

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -932,8 +932,10 @@ static void processLayers(std::vector<std::unique_ptr<GMRLayer>> &gmrLayers,
 
                     instance.tags = readTags(mapObject);
 
-                    context.instanceCreationOrder.push_back({ instance.name,
-                                                              takeProperty(props, "creationOrder", 0) });
+                    context.instanceCreationOrder.push_back(InstanceCreation {
+                                                                instance.name,
+                                                                takeProperty(props, "creationOrder", 0)
+                                                            });
 
                     // Remaining unknown custom properties are assumed to
                     // override properties defined on the GameMaker object.

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -1,0 +1,254 @@
+/*
+ * YY Tiled Plugin
+ * Copyright 2021, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "yyplugin.h"
+
+#include "jsonwriter.h"
+#include "logginginterface.h"
+#include "map.h"
+#include "mapobject.h"
+#include "objectgroup.h"
+#include "savefile.h"
+#include "tile.h"
+#include "tilelayer.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+
+#include "qtcompat_p.h"
+
+using namespace Tiled;
+using namespace Yy;
+
+template <typename T>
+static T optionalProperty(const Object *object, const QString &name, const T &def)
+{
+    const QVariant var = object->resolvedProperty(name);
+    return var.isValid() ? var.value<T>() : def;
+}
+
+template <typename T>
+static void writeProperty(JsonWriter &writer,
+                          const Object *object,
+                          const QString &propertyName,
+                          const char *memberName,
+                          const T &def)
+{
+    const T value = optionalProperty(object, propertyName, def);
+    writer.writeMember(memberName, value);
+}
+
+template <typename T>
+static void writeProperty(JsonWriter &writer,
+                          const Object *object,
+                          const char *name,
+                          const T &def)
+{
+    writeProperty(writer, object, QString::fromLatin1(name), name, def);
+}
+
+static bool checkIfViewsDefined(const Map *map)
+{
+    LayerIterator iterator(map);
+    while (const Layer *layer = iterator.next()) {
+
+        if (layer->layerType() != Layer::ObjectGroupType)
+            continue;
+
+        const ObjectGroup *objectLayer = static_cast<const ObjectGroup*>(layer);
+
+        for (const MapObject *object : objectLayer->objects()) {
+            const QString type = object->effectiveType();
+            if (type == "view")
+                return true;
+        }
+    }
+
+    return false;
+}
+
+YyPlugin::YyPlugin()
+{
+}
+
+bool YyPlugin::write(const Map *map, const QString &fileName, Options options)
+{
+    SaveFile file(fileName);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        mError = QCoreApplication::translate("File Errors", "Could not open file for writing.");
+        return false;
+    }
+
+    JsonWriter json(file.device());
+
+    json.setMinimize(options.testFlag(WriteMinimized));
+
+    json.writeStartObject();
+
+    writeProperty(json, map, "isDnd", false);
+    writeProperty(json, map, "volume", 1.0);
+    json.writeMember("parentRoom", QJsonValue(QJsonValue::Null));    // TODO: Provide a way to set this?
+
+    // Check if views are defined
+    const bool enableViews = checkIfViewsDefined(map);
+
+    // Write out views
+    // Last view in Object layer is the first view in the room
+    if (enableViews) {
+        json.writeStartArray("views");
+        int viewCount = 0;
+        for (const Layer *layer : map->objectGroups()) {
+            const ObjectGroup *objectLayer = static_cast<const ObjectGroup*>(layer);
+
+            for (const MapObject *object : objectLayer->objects()) {
+                const QString type = object->effectiveType();
+                if (type != "view")
+                    continue;
+
+                // GM only has 8 views so drop anything more than that
+                if (viewCount > 7) {
+                    Tiled::ERROR(QLatin1String("YY plugin: Can't export more than 8 views."),
+                                 Tiled::JumpToObject { object });
+                    break;
+                }
+
+                viewCount++;
+                json.writeStartObject();
+                json.setMinimize(true);
+
+                writeProperty(json, object, "inherit", false);
+                json.writeMember("visible", object->isVisible());
+                // Note: GM only supports ints for positioning
+                // so views could be off if user doesn't align to whole number
+                json.writeMember("xview", QString::number(qRound(object->x())));
+                json.writeMember("yview", QString::number(qRound(object->y())));
+                json.writeMember("wview", QString::number(qRound(object->width())));
+                json.writeMember("hview", QString::number(qRound(object->height())));
+                // Round these incase user adds properties as floats and not ints
+                json.writeMember("xport", QString::number(qRound(optionalProperty(object, "xport", 0.0))));
+                json.writeMember("yport", QString::number(qRound(optionalProperty(object, "yport", 0.0))));
+                json.writeMember("wport", QString::number(qRound(optionalProperty(object, "wport", 1024.0))));
+                json.writeMember("hport", QString::number(qRound(optionalProperty(object, "hport", 768.0))));
+                json.writeMember("hborder", QString::number(qRound(optionalProperty(object, "hborder", 32.0))));
+                json.writeMember("vborder", QString::number(qRound(optionalProperty(object, "vborder", 32.0))));
+                json.writeMember("hspeed", QString::number(qRound(optionalProperty(object, "hspeed", -1.0))));
+                json.writeMember("vspeed", QString::number(qRound(optionalProperty(object, "vspeed", -1.0))));
+                json.writeMember("objectId", QJsonValue::Null);    // TODO: Provide a way to set this?
+
+                json.setMinimize(false);
+                json.writeEndObject();
+            }
+        }
+
+        json.writeEndArray();
+    }
+
+    json.writeStartArray("layers");
+
+    LayerIterator iterator(map);
+    while (const Layer *layer = iterator.next()) {
+        // TODO
+        Q_UNUSED(layer);
+    }
+
+    json.writeEndArray();
+
+    writeProperty(json, map, "inheritLayers", false);
+    writeProperty(json, map, "creationCodeFile", QString());
+    writeProperty(json, map, "inheritCode", false);
+
+    json.writeStartArray("instanceCreationOrder");
+    // TODO
+    //      {"name":"inst_967BF0","path":"rooms/Room1/Room1.yy",},
+    //      {"name":"inst_1D2061C1","path":"rooms/Room1/Room1.yy",},
+    //      {"name":"inst_6C3C7802","path":"rooms/Room1/Room1.yy",},
+    json.writeEndArray();
+
+    writeProperty(json, map, "inheritCreationOrder", false);
+    json.writeMember("sequenceId", QJsonValue::Null);
+
+    const int mapPixelWidth = map->tileWidth() * map->width();
+    const int mapPixelHeight = map->tileHeight() * map->height();
+
+    json.writeStartObject("roomSettings");
+    writeProperty(json, map, "inheritRoomSettings", false);
+    json.writeMember("Width", mapPixelWidth);
+    json.writeMember("Height", mapPixelHeight);
+    writeProperty(json, map, "persistent", false);
+    json.writeEndObject();
+
+    json.writeStartObject("viewSettings");
+    writeProperty(json, map, "inheritViewSettings", false);
+    writeProperty(json, map, "enableViews", enableViews);
+    writeProperty(json, map, "clearViewBackground", false);
+    writeProperty(json, map, "clearDisplayBuffer", true);
+    json.writeEndObject();
+
+    json.writeStartObject("physicsSettings");
+    writeProperty(json, map, "inheritPhysicsSettings", false);
+    writeProperty(json, map, "PhysicsWorld", false);
+    writeProperty(json, map, "PhysicsWorldGravityX", 0.0);
+    writeProperty(json, map, "PhysicsWorldGravityY", 10.0);
+    writeProperty(json, map, "PhysicsWorldPixToMetres", 0.1);
+    json.writeEndObject();
+
+    json.writeStartObject("parent");
+    const QString path = optionalProperty(map, "path", QLatin1String("folders/Rooms.yy"));
+    json.writeMember("name", QFileInfo(path).completeBaseName());
+    json.writeMember("path", path);
+    json.writeEndObject();
+
+    writeProperty(json, map, "resourceVersion", QString("1.0"));
+    writeProperty(json, map, "name", QFileInfo(fileName).completeBaseName());
+    const QString tags = optionalProperty(map, "tags", QString());
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    const QStringList tagList = tags.split(QLatin1Char(','), QString::SkipEmptyParts);
+#else
+    const QStringList tagList = tags.split(QLatin1Char(','), Qt::SkipEmptyParts);
+#endif
+    json.writeMember("tags", QJsonArray::fromStringList(tagList));
+    json.writeMember("resourceType", "GMRoom");
+
+    json.writeEndObject();
+    json.writeEndDocument();
+
+    if (!file.commit()) {
+        mError = file.errorString();
+        return false;
+    }
+
+    return true;
+}
+
+QString YyPlugin::errorString() const
+{
+    return mError;
+}
+
+QString YyPlugin::nameFilter() const
+{
+    return tr("GameMaker Studio 2 Files (*.yy)");
+}
+
+QString YyPlugin::shortName() const
+{
+    return QStringLiteral("yy");
+}

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -1241,7 +1241,7 @@ static void autoAssignDepth(const std::vector<std::unique_ptr<GMRLayer>> &layers
                 depthIncrement = 100;
             } else {
                 if ((*next)->depth < depth)
-                    Tiled::WARNING(QStringLiteral("YY plugin: User defined layer depths are not adequately spaced, result in game are undefined."));
+                    Tiled::WARNING(QStringLiteral("YY plugin: User defined layer depths are not adequately spaced, results in game are undefined."));
 
                 const int diff = (*next)->depth - (*current)->depth;
                 const int dist = std::distance(current, next);

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -1230,7 +1230,7 @@ static void autoAssignDepth(const std::vector<std::unique_ptr<GMRLayer>> &layers
     int depthIncrement = 100;
 
     if (next != end)
-        depth = (*next)->depth - std::distance(current, next) * -100;
+        depth = (*next)->depth - std::distance(current, next) * depthIncrement;
 
     for (; current != end; ++current) {
         if (current == next) {

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -1240,6 +1240,14 @@ bool YyPlugin::write(const Map *map, const QString &fileName, Options options)
     std::vector<std::unique_ptr<GMRLayer>> layers;
     processLayers(layers, map->layers(), context);
 
+    // If a valid background color is set, create a background layer with this color.
+    if (map->backgroundColor().isValid()) {
+        auto gmrBackgroundLayer = std::make_unique<GMRBackgroundLayer>();
+        gmrBackgroundLayer->name = QStringLiteral("Background_Color");
+        gmrBackgroundLayer->colour = map->backgroundColor();
+        layers.push_back(std::move(gmrBackgroundLayer));
+    }
+
     const bool enableViews = !context.views.empty();
 
     // Write out views

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -20,6 +20,8 @@
 
 #include "yyplugin.h"
 
+#include "grouplayer.h"
+#include "imagelayer.h"
 #include "jsonwriter.h"
 #include "logginginterface.h"
 #include "map.h"
@@ -33,10 +35,111 @@
 #include <QDir>
 #include <QFileInfo>
 
+#include <vector>
+
 #include "qtcompat_p.h"
 
 using namespace Tiled;
 using namespace Yy;
+
+namespace Yy {
+
+struct GMRLayer
+{
+    bool visible = true;
+    int depth = 0;
+    bool userdefinedDepth = false;
+    bool inheritLayerDepth = false;
+    bool inheritLayerSettings = false;
+    int gridX = 32;
+    int gridY = 32;
+    bool hierarchyFrozen = false;
+    QString resourceVersion = QStringLiteral("1.0");
+    QString name;
+    QStringList tags;
+};
+
+struct GMRGraphic
+{
+    QString spriteId;
+    bool isSprite = false;
+
+    union {
+        // part of a bigger sprite (isSprite == false)
+        struct {
+            int w;
+            int h;
+            int u0;
+            int v0;
+            int u1;
+            int v1;
+        };
+
+        // for whole sprites (isSprite == true)
+        struct {
+            double headPosition;
+            double rotation;
+            double scaleX;
+            double scaleY;
+            double animationSpeed;
+        };
+    };
+
+    QColor colour = Qt::white;
+    QString inheritedItemId;
+    QString inheritedItemPath;
+    bool frozen = false;
+    bool ignore = false;
+    bool inheritItemSettings = false;
+    double x = 0.0;
+    double y = 0.0;
+    QString resourceVersion = QStringLiteral("1.0");
+    QString name;
+    QStringList tags;
+};
+
+struct GMRInstance
+{
+    bool isDnd = false;
+    QString objectId;
+    bool inheritCode = false;
+    bool hasCreationCode = false;
+    QColor colour = Qt::white;
+    double rotation = 0.0;
+    double scaleX = 1.0;
+    double scaleY = 1.0;
+    int imageIndex = 0;
+    double imageSpeed = 1.0;
+    QString inheritedItemId;
+    QString inheritedItemPath;
+    bool frozen = false;
+    bool ignore = false;
+    bool inheritItemSettings = false;
+    double x = 0.0;
+    double y = 0.0;
+    QString resourceVersion = QStringLiteral("1.0");
+    QString name;
+    QStringList tags;
+};
+
+struct GMPath
+{
+    int kind = 0;
+    bool closed = false;
+    int precision = 4;
+    QVector<QPointF> points;
+    QString name;
+    QStringList tags;
+};
+
+struct Context
+{
+    int depth = 0;
+    QSet<QString> usedNames;
+    std::vector<GMPath> paths;
+};
+
+} // namespace Yy
 
 template <typename T>
 static T optionalProperty(const Object *object, const QString &name, const T &def)
@@ -46,23 +149,401 @@ static T optionalProperty(const Object *object, const QString &name, const T &de
 }
 
 template <typename T>
-static void writeProperty(JsonWriter &writer,
+static void writeProperty(JsonWriter &json,
                           const Object *object,
                           const QString &propertyName,
                           const char *memberName,
                           const T &def)
 {
     const T value = optionalProperty(object, propertyName, def);
-    writer.writeMember(memberName, value);
+    json.writeMember(memberName, value);
 }
 
 template <typename T>
-static void writeProperty(JsonWriter &writer,
+static void writeProperty(JsonWriter &json,
                           const Object *object,
                           const char *name,
                           const T &def)
 {
-    writeProperty(writer, object, QString::fromLatin1(name), name, def);
+    writeProperty(json, object, QString::fromLatin1(name), name, def);
+}
+
+static QStringList readTags(const Object *object)
+{
+    const QString tags = optionalProperty(object, "tags", QString());
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    const QStringList tagList = tags.split(QLatin1Char(','), QString::SkipEmptyParts);
+#else
+    const QStringList tagList = tags.split(QLatin1Char(','), Qt::SkipEmptyParts);
+#endif
+    return tagList;
+}
+
+static void writeTags(JsonWriter &json, const QStringList &tags)
+{
+    json.writeMember("tags", QJsonArray::fromStringList(tags));
+}
+
+static void writeTags(JsonWriter &json, const Object *object)
+{
+    writeTags(json, readTags(object));
+}
+
+static QString sanitizeName(QString name)
+{
+    static const QRegularExpression regexp(QLatin1String("[^a-zA-Z0-9]"));
+    return name.replace(regexp, QStringLiteral("_"));
+}
+
+static void writeLayers(JsonWriter &json, const QList<Layer *> &layers, Context &context)
+{
+    json.writeStartArray("layers");
+
+    for (const Layer *layer : layers) {
+        json.prepareNewLine();
+        json.writeStartObject();
+
+        auto layerOffset = layer->totalOffset().toPoint();
+
+        GMRLayer gmrLayer;
+
+        gmrLayer.visible = optionalProperty(layer, "visible", true);
+        gmrLayer.depth = optionalProperty(layer, "depth", context.depth);
+        gmrLayer.userdefinedDepth = layer->resolvedProperty(QStringLiteral("depth")).isValid();
+        gmrLayer.inheritLayerDepth = optionalProperty(layer, "inheritLayerDepth", false);
+        gmrLayer.inheritLayerSettings = optionalProperty(layer, "inheritLayerSettings", false);
+        gmrLayer.gridX = optionalProperty(layer, "gridX", layer->map()->tileWidth());
+        gmrLayer.gridY = optionalProperty(layer, "gridY", layer->map()->tileHeight());
+        gmrLayer.hierarchyFrozen = layer->isLocked();
+        gmrLayer.name = layer->name();
+        gmrLayer.tags = readTags(layer);
+
+        context.depth = gmrLayer.depth + 100;   // TODO: Better support for overridden depth logic
+
+        std::vector<GMRGraphic> graphics;
+        std::vector<GMRInstance> instances;
+        std::vector<GMPath> paths;
+
+        switch (layer->layerType()) {
+        case Layer::TileLayerType: {
+            auto tileLayer = static_cast<const TileLayer*>(layer);
+            auto tilesets = tileLayer->usedTilesets().values();
+
+            if (!tilesets.isEmpty()) {
+                const auto tileset = tilesets.takeFirst().data();
+
+                json.writeStartObject("tilesetId");
+                json.writeMember("name", tileset->name());
+                writeProperty(json, tileset, "path", QStringLiteral("tilesets/%1/%1.yy").arg(tileset->name()));
+                json.writeEndObject();
+
+                json.writeMember("x", layerOffset.x());
+                json.writeMember("y", layerOffset.y());
+
+                json.writeStartObject("tiles");
+                json.writeMember("SerialiseWidth", tileLayer->width());
+                json.writeMember("SerialiseHeight", tileLayer->height());
+                json.writeStartArray("TileSerialiseData");
+
+                constexpr unsigned Unintialized         = 0x80000000;
+                constexpr unsigned FlippedHorizontally  = 0x10000000;
+                constexpr unsigned FlippedVertically    = 0x20000000;
+                constexpr unsigned Rotated90            = 0x40000000;
+
+                for (int y = 0; y < tileLayer->height(); ++y) {
+                    json.prepareNewLine();
+
+                    for (int x = 0; x < tileLayer->width(); ++x) {
+                        const Cell &cell = tileLayer->cellAt(x, y);
+                        if (cell.tileset() != tileset) {
+                            json.writeValue(Unintialized);
+                            continue;
+                        }
+
+                        unsigned tileId = cell.tileId();
+
+                        if (cell.flippedAntiDiagonally()) {
+                            tileId |= Rotated90;
+                            if (cell.flippedVertically())
+                                tileId |= FlippedHorizontally;
+                            if (!cell.flippedHorizontally())
+                                tileId |= FlippedVertically;
+                        } else {
+                            if (cell.flippedHorizontally())
+                                tileId |= FlippedHorizontally;
+                            if (cell.flippedVertically())
+                                tileId |= FlippedVertically;
+                        }
+
+                        json.writeValue(tileId);
+                    }
+                }
+
+                json.writeEndArray();   // TileSerialiseData
+                json.writeEndObject();  // tiles
+            }
+            break;
+        }
+        case Layer::ObjectGroupType: {
+            auto objectGroup = static_cast<const ObjectGroup*>(layer);
+            const bool frozen = !layer->isUnlocked();
+            auto color = layer->effectiveTintColor();
+            color.setAlphaF(color.alphaF() * layer->effectiveOpacity());
+
+            for (const MapObject *mapObject : *objectGroup) {
+                if (!mapObject->type().isEmpty())
+                {
+                    // TODO: Export as instance
+                }
+                else if (mapObject->isTileObject())
+                {
+                    const Cell &cell = mapObject->cell();
+                    const Tile *tile = cell.tile();
+                    if (!tile)
+                        continue;
+
+                    graphics.emplace_back();
+                    GMRGraphic &g = graphics.back();
+
+                    g.isSprite = !tile->imageSource().isEmpty();
+
+                    QPointF origin(optionalProperty(mapObject, "originX", 0.0),
+                                   optionalProperty(mapObject, "originY", 0.0));
+
+                    // Tile objects don't necessarily have top-left origin in Tiled,
+                    // so the position needs to be translated for top-left origin in
+                    // GameMaker, taking into account the rotation.
+                    origin -= alignmentOffset(mapObject->bounds(), mapObject->alignment());
+
+                    if (g.isSprite) {
+                        g.spriteId = QFileInfo(tile->imageSource().path()).completeBaseName();
+                        g.headPosition = optionalProperty(mapObject, "headPosition", 0.0);
+                        g.rotation = -mapObject->rotation();
+
+                        const QSize tileSize = tile->size();
+                        g.scaleX = mapObject->width() / tileSize.width();
+                        g.scaleY = mapObject->height() / tileSize.height();
+
+                        if (cell.flippedHorizontally()) {
+                            g.scaleX *= -1;
+                            origin += QPointF(mapObject->width() - 2 * origin.x(), 0);
+                        }
+                        if (cell.flippedVertically()) {
+                            g.scaleY *= -1;
+                            origin += QPointF(0, mapObject->height() - 2 * origin.y());
+                        }
+
+                        // Allow overriding the scale using custom properties
+                        g.scaleX = optionalProperty(mapObject, "scaleX", g.scaleX);
+                        g.scaleY = optionalProperty(mapObject, "scaleY", g.scaleY);
+
+                        g.animationSpeed = optionalProperty(mapObject, "animationSpeed", 1.0);
+                    } else {
+                        const Tileset *tileset = tile->tileset();
+                        g.spriteId = QFileInfo(tileset->imageSource().path()).completeBaseName();
+                        g.w = qRound(mapObject->width());
+                        g.h = qRound(mapObject->height());
+
+                        const int xInTilesetGrid = tile->id() % tileset->columnCount();
+                        const int yInTilesetGrid = static_cast<int>(tile->id() / tileset->columnCount());
+
+                        g.u0 = tileset->margin() + (tileset->tileSpacing() + tileset->tileWidth()) * xInTilesetGrid;
+                        g.v0 = tileset->margin() + (tileset->tileSpacing() + tileset->tileHeight()) * yInTilesetGrid;
+                        g.u1 = g.u0 + tileset->tileWidth();
+                        g.v1 = g.v0 + tileset->tileHeight();
+                    }
+
+                    // Adjust the position based on the origin
+                    QTransform transform;
+                    transform.rotate(mapObject->rotation());
+                    const QPointF pos = mapObject->position() + transform.map(origin);
+
+                    g.colour = color.rgba();
+                    // TODO: g.inheritedItemId
+                    g.frozen = frozen;
+                    g.ignore = optionalProperty(mapObject, "ignore", g.ignore);
+                    g.inheritItemSettings = optionalProperty(mapObject, "inheritItemSettings", g.inheritItemSettings);
+                    g.x = pos.x();
+                    g.y = pos.y();
+
+                    // Include object ID in the name when necessary because duplicates are not allowed
+                    if (mapObject->name().isEmpty()) {
+                        if (g.isSprite)
+                            g.name = QStringLiteral("graphic_%1").arg(mapObject->id());
+                        else
+                            g.name = QStringLiteral("tile_%1").arg(mapObject->id());
+                    } else {
+                        g.name = sanitizeName(mapObject->name());
+
+                        while (context.usedNames.contains(g.name))
+                            g.name += QString("_%1").arg(mapObject->id());
+
+                        context.usedNames.insert(g.name);
+                    }
+
+                    g.tags = readTags(mapObject);
+                }
+                else if (mapObject->shape() == MapObject::Polygon || mapObject->shape() == MapObject::Polyline)
+                {
+                    paths.emplace_back();
+                    GMPath &p = paths.back();
+
+                    p.kind = optionalProperty(mapObject, "smooth", false);
+                    p.closed = mapObject->shape() == MapObject::Polygon;
+                    p.precision = optionalProperty(mapObject, "precision", 4);
+
+                    QTransform transform;
+                    transform.rotate(mapObject->rotation());
+                    const QPointF offset = mapObject->position() + layerOffset;
+                    transform.translate(offset.x(), offset.y());
+
+                    p.points = transform.map(mapObject->polygon());
+
+                    p.name = sanitizeName(mapObject->name());
+                    if (p.name.isEmpty())
+                        p.name = QStringLiteral("Path%1").arg(mapObject->id());
+
+                    p.tags = readTags(mapObject);
+
+                    context.paths.push_back(p);
+                }
+            }
+
+            if (!graphics.empty()) {
+                json.writeStartArray("assets");
+                for (const auto &g : graphics) {
+                    json.prepareNewLine();
+                    json.writeStartObject();
+                    const bool wasMinimize = json.minimize();
+                    json.setMinimize(true);
+
+                    json.writeStartObject("spriteId");
+                    json.writeMember("name", g.spriteId);
+                    json.writeMember("path", QStringLiteral("sprites/%1/%1.yy").arg(g.spriteId));
+                    json.writeEndObject();  // spriteId
+
+                    if (g.isSprite) {
+                        json.writeMember("headPosition", g.headPosition);
+                        json.writeMember("rotation", g.rotation);
+                        json.writeMember("scaleX", g.scaleX);
+                        json.writeMember("scaleY", g.scaleY);
+                        json.writeMember("animationSpeed", g.animationSpeed);
+                    } else {
+                        json.writeMember("w", g.w);
+                        json.writeMember("h", g.h);
+                        json.writeMember("u0", g.u0);
+                        json.writeMember("v0", g.v0);
+                        json.writeMember("u1", g.u1);
+                        json.writeMember("v1", g.v1);
+                    }
+                    json.writeMember("colour", g.colour.rgba());
+                    if (g.inheritedItemId.isEmpty()) {
+                        json.writeMember("inheritedItemId", QJsonValue(QJsonValue::Null));
+                    } else {
+                        json.writeStartObject("inheritedItemId");
+                        json.writeMember("name", g.inheritedItemId);
+                        json.writeMember("path", g.inheritedItemPath);
+                        json.writeEndObject();
+                    }
+                    json.writeMember("frozen", g.frozen);
+                    json.writeMember("ignore", g.ignore);
+                    json.writeMember("inheritItemSettings", g.inheritItemSettings);
+                    json.writeMember("x", g.x);
+                    json.writeMember("y", g.y);
+                    json.writeMember("resourceVersion", g.resourceVersion);
+                    json.writeMember("name", g.name);
+                    writeTags(json, g.tags);
+                    json.writeMember("resourceType", g.isSprite ? "GMRSpriteGraphic" : "GMRGraphic");
+
+                    json.writeEndObject();
+                    json.setMinimize(wasMinimize);
+                }
+                json.writeEndArray();
+            }
+
+            // TODO: instances
+
+            // TODO: pathId
+
+            break;
+        }
+        case Layer::ImageLayerType: {
+            auto imageLayer = static_cast<const ImageLayer*>(layer);
+
+            json.writeStartObject("spriteId");
+            const QString spriteName = QFileInfo(imageLayer->imageSource().toLocalFile()).completeBaseName();
+            json.writeMember("name", spriteName);
+            json.writeMember("path", QStringLiteral("sprites/%1/%1.yy").arg(spriteName));
+            json.writeEndObject();
+
+            auto color = layer->effectiveTintColor();
+            color.setAlphaF(color.alphaF() * layer->effectiveOpacity());
+            json.writeMember("colour", color.rgba());
+
+            json.writeMember("x", layerOffset.x());
+            json.writeMember("y", layerOffset.y());
+
+            writeProperty(json, layer, "htiled", false);
+            writeProperty(json, layer, "vtiled", false);
+            writeProperty(json, layer, "hspeed", 0.0);
+            writeProperty(json, layer, "vspeed", 0.0);
+            writeProperty(json, layer, "stretch", false);
+            writeProperty(json, layer, "animationFPS", 15);
+            writeProperty(json, layer, "animationSpeedType", 0);
+            json.writeMember("userdefinedAnimFPS", layer->resolvedProperty(QStringLiteral("animationFPS")).isValid());
+            break;
+        }
+        case Layer::GroupLayerType:
+            break;
+        }
+
+        json.writeMember("visible", gmrLayer.visible);
+        json.writeMember("depth", gmrLayer.depth);
+        json.writeMember("userdefinedDepth", gmrLayer.userdefinedDepth);
+        json.writeMember("inheritLayerDepth", gmrLayer.inheritLayerDepth);
+        json.writeMember("inheritLayerSettings", gmrLayer.inheritLayerSettings);
+        json.writeMember("gridX", gmrLayer.gridX);
+        json.writeMember("gridY", gmrLayer.gridY);
+
+        if (layer->isGroupLayer()) {
+            auto groupLayer = static_cast<const GroupLayer*>(layer);
+            writeLayers(json, groupLayer->layers(), context);
+        } else {
+            // TODO: Sub-layers for tile layers using multiple tilesets
+            // TODO: Sub-layers for object layers containing instances, assets and/or paths
+            writeLayers(json, {}, context);
+
+
+            std::vector<GMRGraphic> graphics;
+            std::vector<GMRInstance> instances;
+            std::vector<GMPath> paths;
+        }
+
+        json.writeMember("hierarchyFrozen", gmrLayer.hierarchyFrozen);
+        json.writeMember("resourceVersion", gmrLayer.resourceVersion);
+        json.writeMember("name", gmrLayer.name);
+        writeTags(json, gmrLayer.tags);
+
+        switch (layer->layerType()) {
+        case Layer::TileLayerType:
+            json.writeMember("resourceType", "GMRTileLayer");
+            break;
+        case Layer::ObjectGroupType:
+            json.writeMember("resourceType", "GMRAssetLayer");   // and/or GMRInstanceLayer
+            // TODO: Convert polygons to GMPath on GMRPathLayer
+            break;
+        case Layer::ImageLayerType:
+            json.writeMember("resourceType", "GMRBackgroundLayer");
+            break;
+        case Layer::GroupLayerType:
+            json.writeMember("resourceType", "GMRLayer");
+            break;
+        }
+
+        json.writeEndObject();
+    }
+
+    json.writeEndArray();   // layers
 }
 
 static bool checkIfViewsDefined(const Map *map)
@@ -131,45 +612,40 @@ bool YyPlugin::write(const Map *map, const QString &fileName, Options options)
                 }
 
                 viewCount++;
+                json.prepareNewLine();
                 json.writeStartObject();
+                const bool wasMinimize = json.minimize();
                 json.setMinimize(true);
 
                 writeProperty(json, object, "inherit", false);
                 json.writeMember("visible", object->isVisible());
                 // Note: GM only supports ints for positioning
                 // so views could be off if user doesn't align to whole number
-                json.writeMember("xview", QString::number(qRound(object->x())));
-                json.writeMember("yview", QString::number(qRound(object->y())));
-                json.writeMember("wview", QString::number(qRound(object->width())));
-                json.writeMember("hview", QString::number(qRound(object->height())));
+                json.writeMember("xview", qRound(object->x()));
+                json.writeMember("yview", qRound(object->y()));
+                json.writeMember("wview", qRound(object->width()));
+                json.writeMember("hview", qRound(object->height()));
                 // Round these incase user adds properties as floats and not ints
-                json.writeMember("xport", QString::number(qRound(optionalProperty(object, "xport", 0.0))));
-                json.writeMember("yport", QString::number(qRound(optionalProperty(object, "yport", 0.0))));
-                json.writeMember("wport", QString::number(qRound(optionalProperty(object, "wport", 1024.0))));
-                json.writeMember("hport", QString::number(qRound(optionalProperty(object, "hport", 768.0))));
-                json.writeMember("hborder", QString::number(qRound(optionalProperty(object, "hborder", 32.0))));
-                json.writeMember("vborder", QString::number(qRound(optionalProperty(object, "vborder", 32.0))));
-                json.writeMember("hspeed", QString::number(qRound(optionalProperty(object, "hspeed", -1.0))));
-                json.writeMember("vspeed", QString::number(qRound(optionalProperty(object, "vspeed", -1.0))));
-                json.writeMember("objectId", QJsonValue::Null);    // TODO: Provide a way to set this?
+                json.writeMember("xport", qRound(optionalProperty(object, "xport", 0.0)));
+                json.writeMember("yport", qRound(optionalProperty(object, "yport", 0.0)));
+                json.writeMember("wport", qRound(optionalProperty(object, "wport", 1024.0)));
+                json.writeMember("hport", qRound(optionalProperty(object, "hport", 768.0)));
+                json.writeMember("hborder", qRound(optionalProperty(object, "hborder", 32.0)));
+                json.writeMember("vborder", qRound(optionalProperty(object, "vborder", 32.0)));
+                json.writeMember("hspeed", qRound(optionalProperty(object, "hspeed", -1.0)));
+                json.writeMember("vspeed", qRound(optionalProperty(object, "vspeed", -1.0)));
+                json.writeMember("objectId", QJsonValue(QJsonValue::Null));    // TODO: Provide a way to set this?
 
-                json.setMinimize(false);
                 json.writeEndObject();
+                json.setMinimize(wasMinimize);
             }
         }
 
         json.writeEndArray();
     }
 
-    json.writeStartArray("layers");
-
-    LayerIterator iterator(map);
-    while (const Layer *layer = iterator.next()) {
-        // TODO
-        Q_UNUSED(layer);
-    }
-
-    json.writeEndArray();
+    Context context;
+    writeLayers(json, map->layers(), context);
 
     writeProperty(json, map, "inheritLayers", false);
     writeProperty(json, map, "creationCodeFile", QString());
@@ -218,13 +694,7 @@ bool YyPlugin::write(const Map *map, const QString &fileName, Options options)
 
     writeProperty(json, map, "resourceVersion", QString("1.0"));
     writeProperty(json, map, "name", QFileInfo(fileName).completeBaseName());
-    const QString tags = optionalProperty(map, "tags", QString());
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    const QStringList tagList = tags.split(QLatin1Char(','), QString::SkipEmptyParts);
-#else
-    const QStringList tagList = tags.split(QLatin1Char(','), Qt::SkipEmptyParts);
-#endif
-    json.writeMember("tags", QJsonArray::fromStringList(tagList));
+    writeTags(json, map);
     json.writeMember("resourceType", "GMRoom");
 
     json.writeEndObject();
@@ -245,7 +715,7 @@ QString YyPlugin::errorString() const
 
 QString YyPlugin::nameFilter() const
 {
-    return tr("GameMaker Studio 2 Files (*.yy)");
+    return tr("GameMaker Studio 2 files (*.yy)");
 }
 
 QString YyPlugin::shortName() const

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -660,7 +660,7 @@ bool YyPlugin::write(const Map *map, const QString &fileName, Options options)
     json.writeEndArray();
 
     writeProperty(json, map, "inheritCreationOrder", false);
-    json.writeMember("sequenceId", QJsonValue::Null);
+    json.writeMember("sequenceId", QJsonValue(QJsonValue::Null));
 
     const int mapPixelWidth = map->tileWidth() * map->width();
     const int mapPixelHeight = map->tileHeight() * map->height();

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -34,6 +34,7 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
+#include <QRegularExpression>
 
 #include <vector>
 

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -272,7 +272,6 @@ struct InstanceCreation
 
 struct Context
 {
-    int depth = 0;
     QSet<QString> usedNames;
     std::vector<GMRView> views;
     std::vector<GMPath> paths;
@@ -938,6 +937,8 @@ static void processLayers(std::vector<std::unique_ptr<GMRLayer>> &gmrLayers,
                     const QPointF pos = mapObject->position() + transform.map(origin);
 
                     // TODO: Support creation code - takeProperty(props, "code", QString());
+                    // Would need to be written out as a separate file
+                    instance.hasCreationCode = takeProperty(props, "hasCreationCode", instance.hasCreationCode);
                     instance.colour = color;
                     instance.rotation = -mapObject->rotation();
                     instance.imageIndex = takeProperty(props, "imageIndex", instance.imageIndex);
@@ -1093,7 +1094,6 @@ static void processLayers(std::vector<std::unique_ptr<GMRLayer>> &gmrLayers,
 
             std::vector<std::unique_ptr<GMRLayer>> gmrLayers;
 
-            // TODO: Sub-layers for object layers containing instances, assets and/or paths
             if (!assets.empty()) {
                 auto gmrAssetLayer = std::make_unique<GMRAssetLayer>();
                 gmrAssetLayer->name = sanitizeName(QStringLiteral("%1_Assets").arg(layer->name()));
@@ -1168,7 +1168,7 @@ static void processLayers(std::vector<std::unique_ptr<GMRLayer>> &gmrLayers,
             continue;
 
         gmrLayer->visible = optionalProperty(layer, "visible", layer->isVisible());
-        gmrLayer->depth = optionalProperty(layer, "depth", context.depth);
+        gmrLayer->depth = optionalProperty(layer, "depth", 0);
         gmrLayer->userdefinedDepth = layer->resolvedProperty(QStringLiteral("depth")).isValid();
         gmrLayer->inheritLayerDepth = optionalProperty(layer, "inheritLayerDepth", false);
         gmrLayer->inheritLayerSettings = optionalProperty(layer, "inheritLayerSettings", false);
@@ -1177,8 +1177,6 @@ static void processLayers(std::vector<std::unique_ptr<GMRLayer>> &gmrLayers,
         gmrLayer->hierarchyFrozen = layer->isLocked();
         gmrLayer->name = sanitizeName(layer->name());
         gmrLayer->tags = readTags(layer);
-
-        context.depth = gmrLayer->depth + 100;   // TODO: Better support for overridden depth logic
 
         if (layer->isGroupLayer()) {
             auto groupLayer = static_cast<const GroupLayer*>(layer);

--- a/src/plugins/yy/yyplugin.h
+++ b/src/plugins/yy/yyplugin.h
@@ -1,7 +1,6 @@
 /*
- * GMX Tiled Plugin
- * Copyright 2016, Jones Blunt <mrjonesblunt@gmail.com>
- * Copyright 2016-2020, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ * YY Tiled Plugin
+ * Copyright 2021, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
  *
  * This file is part of Tiled.
  *
@@ -23,17 +22,17 @@
 
 #include "mapformat.h"
 
-#include "gmx_global.h"
+#include "yy_global.h"
 
-namespace Gmx {
+namespace Yy {
 
-class GMXSHARED_EXPORT GmxPlugin : public Tiled::WritableMapFormat
+class YYSHARED_EXPORT YyPlugin : public Tiled::WritableMapFormat
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.mapeditor.MapFormat" FILE "plugin.json")
 
 public:
-    GmxPlugin();
+    YyPlugin();
 
     bool write(const Tiled::Map *map, const QString &fileName, Options options) override;
     QString errorString() const override;
@@ -46,4 +45,4 @@ private:
     QString mError;
 };
 
-} // namespace Gmx
+} // namespace Yy


### PR DESCRIPTION
Closes #1642

Quite a bit of work done, but some tasks remain and no testing was done at all yet.


- [x] Export tile layers as `GMRTileLayer` (single tileset per layer) 
- [x] Export tile objects as `GMRSpriteGraphic` or `GMRGraphic` on `GMRAssetLayer`
- [x] Export of image layers as `GMRBackgroundLayer`
- [x] Export group layers as `GMRLayer`
- [x] Export of instances (objects with type) to `GMRInstanceLayer`
- [x] Support tile layers using multiple tilesets (create a group layer with multiple child tile layers)
- [ ] Export paths (polyline and polygon) as `GMPath` asset and a `GMRPathLayer`
- [x] Export tile layers to asset layers when they use image collection tilesets, or tiles where the size doesn't match the map grid size.
- [x] Export instance creation order
- [x] Handle overriding depth better
