### PR TITLE
[WIP] Relocate tiles

### DIFF
--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -443,7 +443,8 @@ void MapWriterPrivate::writeTileset(QXmlStreamWriter &w, const Tileset &tileset,
     }
 
     // Write the properties for those tiles that have them
-    for (const Tile *tile : tileset.tiles()) {
+    for (int id : tileset.sortedTileIds()) {
+        const Tile *tile = tileset.findTile(id);
         if (imageSource.isEmpty() || includeTile(tile)) {
             w.writeStartElement(QStringLiteral("tile"));
             w.writeAttribute(QStringLiteral("id"), QString::number(tile->id()));

--- a/src/libtiled/tileset.cpp
+++ b/src/libtiled/tileset.cpp
@@ -124,6 +124,14 @@ void Tileset::setMargin(int margin)
 }
 
 /**
+ * Returns the location of the tile with the given ID.
+ */
+int Tileset::findTileLocation(int id)
+{
+    return mSortedTileIds.indexOf(id);
+}
+
+/**
  * Returns the tile with the given ID, creating it when it does not exist yet.
  */
 Tile *Tileset::findOrCreateTile(int id)

--- a/src/libtiled/tileset.cpp
+++ b/src/libtiled/tileset.cpp
@@ -767,9 +767,9 @@ void Tileset::deleteTile(int id)
 /**
  * Move the tile with the given \a id to the \a position
  */
-void Tileset::moveTile(int id, int position)
+void Tileset::relocateTile(int id, int location)
 {
-    mSortedTileIds.move(mSortedTileIds.indexOf(id), position);
+    mSortedTileIds.move(mSortedTileIds.indexOf(id), location);
 }
 
 /**

--- a/src/libtiled/tileset.h
+++ b/src/libtiled/tileset.h
@@ -142,6 +142,7 @@ public:
     const QList<int> &sortedTileIds() const;
     inline Tile *findTile(int id) const;
     Tile *tileAt(int id) const { return findTile(id); } // provided for Python
+    int findTileLocation(int id);
     Tile *findOrCreateTile(int id);
     int tileCount() const;
 

--- a/src/libtiled/tileset.h
+++ b/src/libtiled/tileset.h
@@ -205,7 +205,7 @@ public:
     void addTiles(const QList<Tile*> &tiles);
     void removeTiles(const QList<Tile *> &tiles);
     void deleteTile(int id);
-    void moveTile(int id, int position);
+    void relocateTile(int id, int location);
 
     void setNextTileId(int nextId);
     int nextTileId() const;

--- a/src/libtiled/tileset.h
+++ b/src/libtiled/tileset.h
@@ -139,6 +139,7 @@ public:
     void setGridSize(QSize gridSize);
 
     const QMap<int, Tile*> &tiles() const;
+    const QList<int> &sortedTileIds() const;
     inline Tile *findTile(int id) const;
     Tile *tileAt(int id) const { return findTile(id); } // provided for Python
     Tile *findOrCreateTile(int id);
@@ -203,6 +204,7 @@ public:
     void addTiles(const QList<Tile*> &tiles);
     void removeTiles(const QList<Tile *> &tiles);
     void deleteTile(int id);
+    void moveTile(int id, int position);
 
     void setNextTileId(int nextId);
     int nextTileId() const;
@@ -278,6 +280,7 @@ private:
     int mNextTileId;
     int mMaximumTerrainDistance;
     QMap<int, Tile*> mTiles;
+    QList<int> mSortedTileIds;
     QList<Terrain*> mTerrainTypes;
     QList<WangSet*> mWangSets;
     bool mTerrainDistancesDirty;
@@ -444,6 +447,14 @@ inline void Tileset::setGridSize(QSize gridSize)
 inline const QMap<int, Tile *> &Tileset::tiles() const
 {
     return mTiles;
+}
+
+/**
+ * Returns a const reference to the tiles in this tileset.
+ */
+inline const QList<int> &Tileset::sortedTileIds() const
+{
+    return mSortedTileIds;
 }
 
 /**

--- a/src/tiled/relocatetile.cpp
+++ b/src/tiled/relocatetile.cpp
@@ -1,0 +1,47 @@
+/*
+ * relocatetile.cpp
+ * Copyright 2015, Alexander "theHacker" Münch <git@thehacker.biz>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "relocatetile.h"
+
+#include "changeevents.h"
+#include "tilesetdocument.h"
+
+#include <QCoreApplication>
+
+namespace Tiled {
+
+RelocateTile::RelocateTile(TilesetDocument *tilesetDocument,
+                     Tile *tile,
+                     int location)
+    : QUndoCommand(QCoreApplication::translate("Undo Commands",
+                                               "Relocate Tile"))
+    , mTilesetDocument(tilesetDocument)
+    , mTile(tile)
+    , mLocation(location)
+{
+    mPrevLocation = mTilesetDocument->tileset()->findTileLocation(tile->id());
+}
+
+void RelocateTile::relocate(const Tile *tile, int location)
+{
+    mTilesetDocument->tileset()->moveTile(tile->id(), location);
+}
+
+} // namespace Tiled

--- a/src/tiled/relocatetile.cpp
+++ b/src/tiled/relocatetile.cpp
@@ -41,7 +41,7 @@ RelocateTile::RelocateTile(TilesetDocument *tilesetDocument,
 
 void RelocateTile::relocate(const Tile *tile, int location)
 {
-    mTilesetDocument->tileset()->moveTile(tile->id(), location);
+    mTilesetDocument->relocateTile(tile, location);
 }
 
 } // namespace Tiled

--- a/src/tiled/relocatetile.h
+++ b/src/tiled/relocatetile.h
@@ -47,8 +47,8 @@ public:
               Tile *tile,
               int location);
 
-    void undo() { relocate(mTile, mLocation); }
-    void redo() { relocate(mTile, mPrevLocation); }
+    void undo() { relocate(mTile, mPrevLocation); }
+    void redo() { relocate(mTile, mLocation); }
 
 private:
     void relocate(const Tile *tile, int location);

--- a/src/tiled/relocatetile.h
+++ b/src/tiled/relocatetile.h
@@ -1,0 +1,62 @@
+/*
+ * relocatetile.h
+ * Copyright 2015, Alexander "theHacker" Münch <git@thehacker.biz>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "undocommands.h"
+
+#include <QUndoCommand>
+
+namespace Tiled {
+
+class Tile;
+
+class TilesetDocument;
+
+/**
+ * A command that changes the location of a tile on the tileset.
+ */
+class RelocateTile : public QUndoCommand
+{
+public:
+    /**
+     * Constructor.
+     *
+     * @param tilesetDocument the tileset document that's being edited
+     * @param tile            the source tile
+     * @param location        the target location
+     */
+    RelocateTile(TilesetDocument *tilesetDocument,
+              Tile *tile,
+              int location);
+
+    void undo() { relocate(mTile, mLocation); }
+    void redo() { relocate(mTile, mPrevLocation); }
+
+private:
+    void relocate(const Tile *tile, int location);
+
+    TilesetDocument *mTilesetDocument;
+    Tile *mTile;
+    int mLocation;
+    int mPrevLocation;
+};
+
+} // namespace Tiled

--- a/src/tiled/tileanimationeditor.cpp
+++ b/src/tiled/tileanimationeditor.cpp
@@ -365,6 +365,7 @@ void TileAnimationEditor::setTile(Tile *tile)
         mFrameListModel->setFrames(tile->tileset(), tile->frames());
 
         TilesetModel *tilesetModel = new TilesetModel(tile->tileset(),
+                                                      mTilesetDocument,
                                                       mUi->tilesetView);
         mUi->tilesetView->setModel(tilesetModel);
     } else {

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -205,6 +205,7 @@ SOURCES += aboutdialog.cpp \
     propertybrowser.cpp \
     raiselowerhelper.cpp \
     regionvaluetype.cpp \
+    relocatetile.cpp \
     reparentlayers.cpp \
     replacetemplate.cpp \
     replacetileset.cpp \
@@ -441,6 +442,7 @@ HEADERS += aboutdialog.h \
     randompicker.h \
     rangeset.h \
     regionvaluetype.h \
+    relocatetile.h \
     reparentlayers.h \
     replacetemplate.h \
     replacetileset.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -394,6 +394,8 @@ QtGuiApplication {
         "rangeset.h",
         "regionvaluetype.cpp",
         "regionvaluetype.h",
+        "relocatetile.cpp",
+        "relocatetile.h",
         "reparentlayers.cpp",
         "reparentlayers.h",
         "replacetemplate.cpp",

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -1038,7 +1038,7 @@ TilesetView *TilesetDock::tilesetViewAt(int index) const
 
 void TilesetDock::setupTilesetModel(TilesetView *view, Tileset *tileset)
 {
-    view->setModel(new TilesetModel(tileset, view));
+    view->setModel(new TilesetModel(tileset, view->tilesetDocument(), view));
 
     QItemSelectionModel *s = view->selectionModel();
     connect(s, &QItemSelectionModel::selectionChanged,

--- a/src/tiled/tilesetdocument.cpp
+++ b/src/tiled/tilesetdocument.cpp
@@ -347,6 +347,13 @@ void TilesetDocument::removeTiles(const QList<Tile *> &tiles)
     emit tilesetChanged(mTileset.data());
 }
 
+void TilesetDocument::relocateTile(const Tile *tile, int location)
+{
+    mTileset->relocateTile(tile->id(), location);
+    /* TODO: is that the right signal? */
+    emit tilesetChanged(mTileset.data());
+}
+
 void TilesetDocument::setSelectedTiles(const QList<Tile*> &selectedTiles)
 {
     mSelectedTiles = selectedTiles;

--- a/src/tiled/tilesetdocument.h
+++ b/src/tiled/tilesetdocument.h
@@ -99,6 +99,7 @@ public:
 
     void addTiles(const QList<Tile*> &tiles);
     void removeTiles(const QList<Tile*> &tiles);
+    void relocateTile(const Tile *tile, int location);
 
     const QList<Tile*> &selectedTiles() const;
     void setSelectedTiles(const QList<Tile*> &selectedTiles);

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -153,7 +153,7 @@ TilesetEditor::TilesetEditor(QObject *parent)
     ActionManager::registerAction(editWang, "EditWang");
     ActionManager::registerAction(mAddTiles, "AddTiles");
     ActionManager::registerAction(mRemoveTiles, "RemoveTiles");
-    ActionManager::registerAction(mRemoveTiles, "RelocateTiles");
+    ActionManager::registerAction(mRelocateTiles, "RelocateTiles");
     ActionManager::registerAction(mShowAnimationEditor, "ShowAnimationEditor");
     ActionManager::registerAction(mDynamicWrappingToggle, "DynamicWrappingToggle");
 

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -278,7 +278,7 @@ void TilesetEditor::addDocument(Document *document)
     view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 
     Tileset *tileset = tilesetDocument->tileset().data();
-    TilesetModel *tilesetModel = new TilesetModel(tileset, view);
+    TilesetModel *tilesetModel = new TilesetModel(tileset, tilesetDocument, view);
     view->setModel(tilesetModel);
 
     connect(tilesetDocument, &TilesetDocument::tileWangSetChanged,

--- a/src/tiled/tileseteditor.h
+++ b/src/tiled/tileseteditor.h
@@ -89,6 +89,7 @@ public:
 
     QAction *addTilesAction() const;
     QAction *removeTilesAction() const;
+    QAction *relocateTilesAction() const;
     QAction *editCollisionAction() const;
     QAction *editWangSetsAction() const;
     QAction *showAnimationEditor() const;
@@ -117,6 +118,7 @@ private:
     void addTiles(const QList<QUrl> &urls);
     void removeTiles();
 
+    void setRelocateTiles(bool relocateTiles);
     void setEditCollision(bool editCollision);
     void hasSelectedCollisionObjectsChanged();
 
@@ -147,6 +149,7 @@ private:
 
     QAction *mAddTiles;
     QAction *mRemoveTiles;
+    QAction *mRelocateTiles;
     QAction *mShowAnimationEditor;
     QAction *mDynamicWrappingToggle;
 
@@ -174,6 +177,11 @@ inline QAction *TilesetEditor::addTilesAction() const
 inline QAction *TilesetEditor::removeTilesAction() const
 {
     return mRemoveTiles;
+}
+
+inline QAction *TilesetEditor::relocateTilesAction() const
+{
+    return mRelocateTiles;
 }
 
 inline QAction *TilesetEditor::showAnimationEditor() const

--- a/src/tiled/tilesetmodel.cpp
+++ b/src/tiled/tilesetmodel.cpp
@@ -95,9 +95,16 @@ Qt::ItemFlags TilesetModel::flags(const QModelIndex &index) const
     Qt::ItemFlags defaultFlags = QAbstractListModel::flags(index);
 
     if (index.isValid())
-        defaultFlags |= Qt::ItemIsDragEnabled;
+        defaultFlags |= Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+    else
+        defaultFlags |= Qt::ItemIsDropEnabled;
 
     return defaultFlags;
+}
+
+Qt::DropActions TilesetModel::supportedDropActions() const
+{
+    return Qt::MoveAction;
 }
 
 QStringList TilesetModel::mimeTypes() const
@@ -125,6 +132,16 @@ QMimeData *TilesetModel::mimeData(const QModelIndexList &indexes) const
 
     mimeData->setData(QLatin1String(TILES_MIMETYPE), encodedData);
     return mimeData;
+}
+
+bool TilesetModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) {
+    if (!data || action != Qt::MoveAction)
+        return false;
+    if (!data->hasFormat(QLatin1String(TILES_MIMETYPE)))
+        return false;
+
+    /* TODO */
+    return true;
 }
 
 Tile *TilesetModel::tileAt(const QModelIndex &index) const
@@ -191,21 +208,6 @@ void TilesetModel::setColumnCountOverride(int columnCount)
 
     beginResetModel();
     mColumnCountOverride = columnCount;
-    endResetModel();
-}
-
-void TilesetModel::relocateTile(const Tile *tile, QModelIndex newPosition)
-{
-    if (tile->tileset() != mTileset)
-        return;
-
-    const QModelIndex oldPosition = tileIndex(tile);
-    const int columnCount = TilesetModel::columnCount();
-    const int newIndex = newPosition.row() * columnCount + newPosition.column();
-    const int oldIndex = oldPosition.row() * columnCount + oldPosition.column();
-
-    beginResetModel();
-    mTileIds.move(oldIndex, newIndex);
     endResetModel();
 }
 

--- a/src/tiled/tilesetmodel.cpp
+++ b/src/tiled/tilesetmodel.cpp
@@ -194,6 +194,21 @@ void TilesetModel::setColumnCountOverride(int columnCount)
     endResetModel();
 }
 
+void TilesetModel::relocateTile(const Tile *tile, QModelIndex newPosition)
+{
+    if (tile->tileset() != mTileset)
+        return;
+
+    const QModelIndex oldPosition = tileIndex(tile);
+    const int columnCount = TilesetModel::columnCount();
+    const int newIndex = newPosition.row() * columnCount + newPosition.column();
+    const int oldIndex = oldPosition.row() * columnCount + oldPosition.column();
+
+    beginResetModel();
+    mTileIds.move(oldIndex, newIndex);
+    endResetModel();
+}
+
 void TilesetModel::tilesChanged(const QList<Tile *> &tiles)
 {
     if (tiles.first()->tileset() != mTileset)

--- a/src/tiled/tilesetmodel.cpp
+++ b/src/tiled/tilesetmodel.cpp
@@ -171,7 +171,6 @@ bool TilesetModel::dropMimeData(const QMimeData *data, Qt::DropAction action,
                          : mTileIds.size() - 1;
 
     beginResetModel();
-    mTilesetDocument->tileset()->moveTile(sourceId, destinationIndex);
     mTilesetDocument->undoStack()->push(new RelocateTile(mTilesetDocument,
                                                          sourceTile,
                                                          destinationIndex));

--- a/src/tiled/tilesetmodel.cpp
+++ b/src/tiled/tilesetmodel.cpp
@@ -152,7 +152,7 @@ bool TilesetModel::dropMimeData(const QMimeData *data, Qt::DropAction action,
     QDataStream stream(&encodedData, QDataStream::ReadOnly);
 #endif
 
-    int sourceId, destinationId;
+    int sourceId;
 
     while (!stream.atEnd()) {
         stream >> sourceId;
@@ -168,6 +168,7 @@ bool TilesetModel::dropMimeData(const QMimeData *data, Qt::DropAction action,
 
     beginResetModel();
     mTileIds.move(mTileIds.indexOf(sourceId), destinationIndex);
+    mTileset->moveTile(sourceId, destinationIndex);
     endResetModel();
 
     return true;
@@ -282,8 +283,7 @@ void TilesetModel::tileChanged(Tile *tile)
 void TilesetModel::refreshTileIds()
 {
     mTileIds.clear();
-    for (Tile *tile : mTileset->tiles())
-        mTileIds.append(tile->id());
+    mTileIds = mTileset->sortedTileIds();
 }
 
 #include "moc_tilesetmodel.cpp"

--- a/src/tiled/tilesetmodel.h
+++ b/src/tiled/tilesetmodel.h
@@ -77,10 +77,12 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;
 
+    Qt::DropActions supportedDropActions() const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
 
     QStringList mimeTypes() const override;
     QMimeData *mimeData(const QModelIndexList &indexes) const override;
+    bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
 
     /**
      * Returns the tile at the given index.
@@ -111,7 +113,6 @@ public:
      */
     void tilesetChanged();
 
-    void relocateTile(const Tile *tile, QModelIndex newPos);
     void setColumnCountOverride(int columnCount);
 
 public slots:

--- a/src/tiled/tilesetmodel.h
+++ b/src/tiled/tilesetmodel.h
@@ -111,6 +111,7 @@ public:
      */
     void tilesetChanged();
 
+    void relocateTile(const Tile *tile, QModelIndex newPos);
     void setColumnCountOverride(int columnCount);
 
 public slots:

--- a/src/tiled/tilesetmodel.h
+++ b/src/tiled/tilesetmodel.h
@@ -77,12 +77,14 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;
 
-    Qt::DropActions supportedDropActions() const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
+    Qt::DropActions supportedDropActions() const override;
 
     QStringList mimeTypes() const override;
     QMimeData *mimeData(const QModelIndexList &indexes) const override;
-    bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
+    bool dropMimeData(const QMimeData *data, Qt::DropAction action,
+                      int row, int column,
+                      const QModelIndex &parent) override;
 
     /**
      * Returns the tile at the given index.

--- a/src/tiled/tilesetmodel.h
+++ b/src/tiled/tilesetmodel.h
@@ -28,6 +28,7 @@
 namespace Tiled {
 
 class Tileset;
+class TilesetDocument;
 
 /**
  * A model wrapping a tileset of a map. Used to display the tiles.
@@ -49,7 +50,7 @@ public:
      *
      * @param tileset the initial tileset to display
      */
-    TilesetModel(Tileset *tileset, QObject *parent = nullptr);
+    TilesetModel(Tileset *tileset, TilesetDocument *tilesetDocument, QObject *parent = nullptr);
 
     /**
      * Returns the number of rows.
@@ -142,6 +143,7 @@ private:
     void refreshTileIds();
 
     Tileset *mTileset;
+    TilesetDocument *mTilesetDocument;
     QList<int> mTileIds;
     int mColumnCountOverride = 0;
 };

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -487,12 +487,15 @@ void TilesetView::setRelocateTiles(bool enabled)
 
     QModelIndex currentIndex = selectionModel()->currentIndex();
     selectionModel()->setCurrentIndex(currentIndex, QItemSelectionModel::Clear);
-    setSelectionMode(enabled
-                     ? QAbstractItemView::SingleSelection
-                     : QAbstractItemView::ExtendedSelection);
 
-    setDragEnabled(enabled);
-    setAcceptDrops(enabled);
+    if (enabled) {
+        setSelectionMode(QAbstractItemView::SingleSelection);
+        setDragDropMode(QTableView::InternalMove);
+    } else {
+        setSelectionMode(QAbstractItemView::ExtendedSelection);
+        setDragDropMode(QTableView::NoDragDrop);
+    }
+
     setMouseTracking(true);
     viewport()->update();
 }

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -672,9 +672,6 @@ void TilesetView::mouseMoveEvent(QMouseEvent *event)
         return;
     }
 
-    if (mRelocateTiles)
-        /* TODO */;
-
     QTableView::mouseMoveEvent(event);
 }
 
@@ -691,9 +688,6 @@ void TilesetView::mouseReleaseEvent(QMouseEvent *event)
 
         return;
     }
-
-    if (mRelocateTiles)
-        /* TODO */;
 
     QTableView::mouseReleaseEvent(event);
 }

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -477,6 +477,16 @@ void TilesetView::keyPressEvent(QKeyEvent *event)
     return QTableView::keyPressEvent(event);
 }
 
+void TilesetView::setRelocateTiles(bool enabled)
+{
+    if (mRelocateTiles == enabled)
+        return;
+
+    mRelocateTiles = enabled;
+    setMouseTracking(true);
+    viewport()->update();
+}
+
 void TilesetView::setEditWangSet(bool enabled)
 {
     if (mEditWangSet == enabled)
@@ -539,6 +549,9 @@ void TilesetView::mousePressEvent(QMouseEvent *event)
 
         return;
     }
+
+    if (mRelocateTiles)
+        /* TODO */;
 
     QTableView::mousePressEvent(event);
 }
@@ -640,6 +653,9 @@ void TilesetView::mouseMoveEvent(QMouseEvent *event)
         return;
     }
 
+    if (mRelocateTiles)
+        /* TODO */;
+
     QTableView::mouseMoveEvent(event);
 }
 
@@ -656,6 +672,9 @@ void TilesetView::mouseReleaseEvent(QMouseEvent *event)
 
         return;
     }
+
+    if (mRelocateTiles)
+        /* TODO */;
 
     QTableView::mouseReleaseEvent(event);
     return;

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -288,6 +288,7 @@ TilesetView::TilesetView(QWidget *parent)
     setItemDelegate(new TileDelegate(this, this));
     setShowGrid(false);
     setTabKeyNavigation(false);
+    setDropIndicatorShown(true);
 
     QHeaderView *hHeader = horizontalHeader();
     QHeaderView *vHeader = verticalHeader();
@@ -483,6 +484,15 @@ void TilesetView::setRelocateTiles(bool enabled)
         return;
 
     mRelocateTiles = enabled;
+
+    QModelIndex currentIndex = selectionModel()->currentIndex();
+    selectionModel()->setCurrentIndex(currentIndex, QItemSelectionModel::Clear);
+    setSelectionMode(enabled
+                     ? QAbstractItemView::SingleSelection
+                     : QAbstractItemView::ExtendedSelection);
+
+    setDragEnabled(enabled);
+    setAcceptDrops(enabled);
     setMouseTracking(true);
     viewport()->update();
 }
@@ -550,8 +560,14 @@ void TilesetView::mousePressEvent(QMouseEvent *event)
         return;
     }
 
-    if (mRelocateTiles)
-        /* TODO */;
+    if (mRelocateTiles) {
+        const QPoint pos = event->pos();
+        const QModelIndex hoveredIndex = indexAt(pos);
+
+        Tile *tile = tilesetModel()->tileAt(hoveredIndex);
+        if (!tile)
+            return;
+    }
 
     QTableView::mousePressEvent(event);
 }
@@ -677,7 +693,6 @@ void TilesetView::mouseReleaseEvent(QMouseEvent *event)
         /* TODO */;
 
     QTableView::mouseReleaseEvent(event);
-    return;
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/tiled/tilesetview.h
+++ b/src/tiled/tilesetview.h
@@ -80,6 +80,9 @@ public:
     void setMarkAnimatedTiles(bool enabled);
     bool markAnimatedTiles() const;
 
+    void setRelocateTiles(bool enabled);
+    bool isRelocateTiles() const { return mRelocateTiles; }
+
     void setEditWangSet(bool enabled);
     bool isEditWangSet() const { return mEditWangSet; }
 
@@ -152,6 +155,7 @@ private:
     TilesetDocument *mTilesetDocument = nullptr;
     bool mDrawGrid;
     bool mMarkAnimatedTiles = true;
+    bool mRelocateTiles = false;
     bool mEditWangSet = false;
     WrapBehavior mWrapBehavior = WrapDefault;
     WangBehavior mWangBehavior = AssignWholeId;


### PR DESCRIPTION
**WIP:** The patch works: I think I've fixed all the bugs I could have introduced and it's ready for code review. However, there are still some details I want to fix before merging.

This PR allows tiles in a tileset to be moved around at will. Previously, the tileset order was fixed and couldn't be changed. That was acceptable for prebuilt tilesets but horrendous for collections of images (after you've added some tile, it was appended to the list couldn't be placed elsewhere, which made working with them a nightmare).