### PR TITLE
Update pytiled-parser and arcade description in docs

### DIFF
--- a/docs/reference/support-for-tmx-maps.rst
+++ b/docs/reference/support-for-tmx-maps.rst
@@ -150,9 +150,9 @@ Python
 ~~~~~~
 
 -  `pytiled-parser <https://github.com/Beefy-Swain/pytiled_parser>`__: Python parser
-   for TMX maps
+   for JSON maps(No support for TMX format as of v1.0.0)
 -  `Arcade <http://arcade.academy>`__: 2D game library that uses pytiled-parser for 
-   easy loading of TMX maps into a game. `Arcade TMX Examples <http://arcade.academy/examples/index.html#tmx-files-tiled-map-editor>`_
+   easy loading of JSON maps into a game.(No support for TMX format as of v2.6.0) `Arcade Tiled Examples <http://arcade.academy/examples/index.html#tmx-files-tiled-map-editor>`_
 -  `pytmxlib <http://pytmxlib.readthedocs.org/en/latest/>`__: library
    for programmatic manipulation of TMX maps
 -  `python-tmx <http://python-tmx.nongnu.org>`__: a simple library for


### PR DESCRIPTION
I am a developer on both pytiled-parser and Arcade Python libraries.

Both have just finished undergoing re-writes to only suppport the JSON file format as opposed to TMX, so clarifying that here. At time of writing Arcade does not yet have those changes in a release, but will be included in the next version, which I've made note of in the updated description.