### PR TITLE
[Testers needed] Components

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -394,6 +394,9 @@ jobs:
           asset_name: Tiled-${{ needs.version.outputs.version }}-macos.zip
           asset_content_type: application/zip
 
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         env:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -86,7 +86,7 @@ jobs:
         qbs install --install-root Tiled config:release qbs.installPrefix:/usr projects.Tiled.enableZstd:true projects.Tiled.sentry:true qbs.debugInformation:true modules.cpp.separateDebugInformation:true
 
     - name: Upload symbols to Sentry
-      if: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      if: github.repository == 'mapeditor/tiled' && github.event_name == 'push'
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -59,10 +59,6 @@ jobs:
         ./dist/install-qt.sh --version ${QT_VERSION} qtbase qtdeclarative qtscript qtsvg qtimageformats qttools icu | tee -a $GITHUB_PATH
         ./dist/install-qt.sh --version ${QTCREATOR_VERSION} qtcreator | tee -a $GITHUB_PATH
 
-    - name: Install sentry-cli
-      run: |
-        curl -sL https://sentry.io/get-cli/ | bash
-
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v1.8
       with:
@@ -90,11 +86,13 @@ jobs:
         qbs install --install-root Tiled config:release qbs.installPrefix:/usr projects.Tiled.enableZstd:true projects.Tiled.sentry:true qbs.debugInformation:true modules.cpp.separateDebugInformation:true
 
     - name: Upload symbols to Sentry
+      if: ${{ secrets.SENTRY_AUTH_TOKEN }}
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
       run: |
+        curl -sL https://sentry.io/get-cli/ | bash
         sentry-cli upload-dif .
 
     - name: Build AppImage

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-### Tiled 1.6.0 (... 2021)
+### Tiled 1.6.0 (23 April 2021)
 
 * Added object selection preview
 * Added toggle to select enclosed rather than touched objects (#3023)
@@ -29,6 +29,7 @@
 * JSON plugin: Write out "version" property as string (#3033)
 * YY plugin: Fixed plugin loading issue for qmake builds
 * libtiled-java: Optimized for multithreaded usage (by Samuel Manflame, #3004)
+* Updated Bulgarian, French, Portuguese (Portugal), Swedish and Turkish translations
 
 ### Tiled 1.5.0 (23 March 2021)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 * Windows: Re-enabled code signing by SignPath (was missing for Tiled 1.5)
 * snap: Added 'removable-media' plug, for accessing USB drives
 * snap: "Open Containing Folder" action now also selects the file
+* JSON plugin: Write out "version" property as string (#3033)
 * YY plugin: Fixed plugin loading issue for qmake builds
 * libtiled-java: Optimized for multithreaded usage (by Samuel Manflame, #3004)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * Fixed switching to Terrain Brush when clicked terrain is already selected (#3015)
 * Fixed state of "dynamic wrapping" toggle button on startup
 * Fixed parallax layer positioning when reordering layers (#3009)
+* Windows: Fixed Swedish translation missing from installer
 * Windows: Re-enabled code signing by SignPath (was missing for Tiled 1.5)
 * snap: Added 'removable-media' plug, for accessing USB drives
 * snap: "Open Containing Folder" action now also selects the file

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 * YY plugin: Fixed plugin loading issue for qmake builds
 * libtiled-java: Optimized for multithreaded usage (by Samuel Manflame, #3004)
 * Updated Bulgarian, French, Portuguese (Portugal), Swedish and Turkish translations
+* Added Thai translation (by Thanachart Monpassorn, currently at 54%)
 
 ### Tiled 1.5.0 (23 March 2021)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,13 @@ environment:
       PUSH_RELEASE: true
       ENABLE_ZSTD: true
       TILED_ITCH_CHANNEL: windows-64bit
+    - QTDIR: C:\Qt\5.15\mingw81_32
+      PYTHONHOME: C:\Python37
+      MINGW: C:\Qt\Tools\mingw810_32
+      DEFAULT_PROFILE: i686-w64-mingw32-gcc-8_1_0
+      PUSH_RELEASE: true
+      ENABLE_ZSTD: true
+      TILED_ITCH_CHANNEL: windows-32bit
 
 matrix:
   exclude:
@@ -40,6 +47,8 @@ matrix:
       QTDIR: C:\Qt\5.12\msvc2017_64
     - image: Visual Studio 2015
       QTDIR: C:\Qt\5.15\mingw81_64
+    - image: Visual Studio 2015
+      QTDIR: C:\Qt\5.15\mingw81_32
     - image: Visual Studio 2019
       QTDIR: C:\Qt\5.6.3\mingw49_32
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
       PYTHONHOME: C:\Python37
       MINGW: C:\Qt\Tools\mingw492_32
       DEFAULT_PROFILE: i686-w64-mingw32-gcc-4_9_2
-      PUSH_RELEASE: false
+      PUSH_RELEASE: true
       PUSH_SNAPSHOT: true
       ENABLE_ZSTD: true
       TILED_ITCH_CHANNEL: winxp-32bit

--- a/dist/distribute.qbs
+++ b/dist/distribute.qbs
@@ -238,6 +238,7 @@ Product {
                              "pt",
                              "pt_PT",
                              "ru",
+                             "th",
                              "tr",
                              "zh_CN",
                              "zh_TW"];

--- a/dist/distribute.qbs
+++ b/dist/distribute.qbs
@@ -238,6 +238,7 @@ Product {
                              "pt",
                              "pt_PT",
                              "ru",
+                             "sv",
                              "th",
                              "tr",
                              "zh_CN",

--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -220,20 +220,24 @@
               <File Source="$(var.InstallRoot)\translations\tiled_pt.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_pt_PT.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_ru.qm" />
+              <File Source="$(var.InstallRoot)\translations\tiled_sv.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_th.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_tr.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_zh_CN.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_zh_TW.qm" />
 
               <!-- Qt translations -->
+              <File Source="$(var.QtDir)\translations\qt_bg.qm"/>
               <File Source="$(var.QtDir)\translations\qt_cs.qm"/>
               <File Source="$(var.QtDir)\translations\qt_de.qm"/>
               <File Source="$(var.QtDir)\translations\qt_es.qm"/>
               <File Source="$(var.QtDir)\translations\qt_fr.qm"/>
               <File Source="$(var.QtDir)\translations\qt_he.qm"/>
               <File Source="$(var.QtDir)\translations\qt_ja.qm"/>
+              <File Source="$(var.QtDir)\translations\qt_pl.qm"/>
               <File Source="$(var.QtDir)\translations\qt_pt.qm"/>
               <File Source="$(var.QtDir)\translations\qt_ru.qm"/>
+              <File Source="$(var.QtDir)\translations\qt_sv.qm"/>
               <File Source="$(var.QtDir)\translations\qt_zh_CN.qm"/>
               <File Source="$(var.QtDir)\translations\qt_zh_TW.qm"/>
             </Component>

--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -227,7 +227,6 @@
               <File Source="$(var.InstallRoot)\translations\tiled_zh_TW.qm" />
 
               <!-- Qt translations -->
-              <File Source="$(var.QtDir)\translations\qt_bg.qm"/>
               <File Source="$(var.QtDir)\translations\qt_cs.qm"/>
               <File Source="$(var.QtDir)\translations\qt_de.qm"/>
               <File Source="$(var.QtDir)\translations\qt_es.qm"/>

--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -220,6 +220,7 @@
               <File Source="$(var.InstallRoot)\translations\tiled_pt.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_pt_PT.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_ru.qm" />
+              <File Source="$(var.InstallRoot)\translations\tiled_th.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_tr.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_zh_CN.qm" />
               <File Source="$(var.InstallRoot)\translations\tiled_zh_TW.qm" />

--- a/docs/locale/sv/LC_MESSAGES/index.po
+++ b/docs/locale/sv/LC_MESSAGES/index.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tiled Documentation Writers
+# This file is distributed under the same license as the Tiled package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Tiled 1.4\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-10 10:03+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../index.rst:8
+#: ../../index.rst:8
+msgid "User Manual"
+msgstr ""
+
+#: ../../index.rst:30
+#: ../../index.rst:30
+msgid "Reference"
+msgstr ""
+
+#: ../../index.rst:2
+msgid "Tiled Documentation"
+msgstr ""
+
+#: ../../index.rst:5
+msgid "If you're not finding what you're looking for in these pages, please don't hesitate to ask questions on the `Tiled Forum <http://discourse.mapeditor.org>`_."
+msgstr ""

--- a/docs/locale/sv/LC_MESSAGES/index.po
+++ b/docs/locale/sv/LC_MESSAGES/index.po
@@ -8,28 +8,33 @@ msgstr ""
 "Project-Id-Version: Tiled 1.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-06-10 10:03+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"PO-Revision-Date: 2021-04-22 15:31+0000\n"
+"Last-Translator: Mattias Münster <mattiasmun@gmail.com>\n"
+"Language-Team: Swedish <https://hosted.weblate.org/projects/tiled/"
+"documentation-index/sv/>\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.7-dev\n"
 
 #: ../../index.rst:8
 #: ../../index.rst:8
 msgid "User Manual"
-msgstr ""
+msgstr "Användarhandbok"
 
 #: ../../index.rst:30
 #: ../../index.rst:30
 msgid "Reference"
-msgstr ""
+msgstr "Referens"
 
 #: ../../index.rst:2
 msgid "Tiled Documentation"
-msgstr ""
+msgstr "Tiled dokumentation"
 
 #: ../../index.rst:5
 msgid "If you're not finding what you're looking for in these pages, please don't hesitate to ask questions on the `Tiled Forum <http://discourse.mapeditor.org>`_."
 msgstr ""
+"Om du inte hittar det du letar efter på dessa sidor, tveka inte att ställa "
+"frågor på `Tiled Forum <http://discourse.mapeditor.org>`_."

--- a/docs/reference/json-map-format.rst
+++ b/docs/reference/json-map-format.rst
@@ -37,7 +37,7 @@ Map
     tilesets,         array,            "Array of :ref:`Tilesets <json-tileset>`"
     tilewidth,        int,              "Map grid width"
     type,             string,           "``map`` (since 1.0)"
-    version,          number,           "The JSON format version"
+    version,          string,           "The JSON format version (previously a number, saved as string since 1.6)"
     width,            int,              "Number of tile columns"
 
 Map Example
@@ -446,7 +446,7 @@ Tileset
     transformations,  :ref:`json-tileset-transformations`, "Allowed transformations (optional)"
     transparentcolor, string,           "Hex-formatted color (#RRGGBB) (optional)"
     type,             string,           "``tileset`` (for tileset files, since 1.0)"
-    version,          number,           "The JSON format version"
+    version,          string,           "The JSON format version (previously a number, saved as string since 1.6)"
     wangsets,         array,            "Array of :ref:`Wang sets <json-wangset>` (since 1.1.5)"
 
 Each tileset has a ``firstgid`` (first global ID) property which
@@ -744,10 +744,16 @@ A point on a polygon or a polyline, relative to the position of the object.
 Changelog
 ---------
 
+Tiled 1.6
+~~~~~~~~~
+
+* The ``version`` property is now written as a string ("1.6") instead of a
+  number (1.5).
+
 Tiled 1.5
 ~~~~~~~~~
 
-* Unified ``cornercolors`` and ``edgecolors`` attributes of :ref:`json-wangset`
+* Unified ``cornercolors`` and ``edgecolors`` properties of :ref:`json-wangset`
   as the new ``colors`` property.
 
 * :ref:`json-wangcolor` can now store ``properties``.
@@ -796,7 +802,7 @@ Tiled 1.2
 * Custom properties are now stored in an array instead of an object
   where the property names were the keys. Each property is now an object
   that stores the name, type and value of the property. The separate
-  ``propertytypes`` and ``tilepropertytypes`` attributes have been
+  ``propertytypes`` and ``tilepropertytypes`` properties have been
   removed.
 
 Tiled 1.1

--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -138,8 +138,10 @@ QRect HexagonalRenderer::boundingRect(const QRect &rect) const
 }
 
 void HexagonalRenderer::drawGrid(QPainter *painter, const QRectF &exposed,
-                                 QColor gridColor) const
+                                 QColor gridColor, int gridMajor) const
 {
+    Q_UNUSED(gridMajor)  // Unclear how this should apply to hexagonal maps
+
     QRect rect = exposed.toAlignedRect();
     if (rect.isNull())
         return;
@@ -184,7 +186,9 @@ void HexagonalRenderer::drawGrid(QPainter *painter, const QRectF &exposed,
     QVector<QLine> lines;
     lines.reserve(8);
 
-    QPen gridPen = makeGridPen(painter->device(), gridColor);
+    QPen _gridPen, gridPen; // always use major grid pen for hex maps
+    setupGridPens(painter->device(), gridColor, _gridPen, gridPen);
+
     painter->setPen(gridPen);
 
     if (p.staggerX) {

--- a/src/libtiled/hexagonalrenderer.h
+++ b/src/libtiled/hexagonalrenderer.h
@@ -78,7 +78,7 @@ public:
     QRect boundingRect(const QRect &rect) const override;
 
     void drawGrid(QPainter *painter, const QRectF &exposed,
-                  QColor gridColor) const override;
+                  QColor gridColor, int gridMajor = 0) const override;
 
     using MapRenderer::drawTileLayer;
     void drawTileLayer(const RenderTileCallback &renderTile,

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -226,7 +226,7 @@ QPainterPath IsometricRenderer::interactionShape(const MapObject *object) const
 }
 
 void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect,
-                                 QColor gridColor) const
+                                 QColor gridColor, int gridMajor) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -247,17 +247,21 @@ void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect,
         endY = qMin(map()->height(), endY);
     }
 
-    QPen gridPen = makeGridPen(painter->device(), gridColor);
-    painter->setPen(gridPen);
+    QPen gridPen, majorGridPen;
+    setupGridPens(painter->device(), gridColor, gridPen, majorGridPen);
 
     for (int y = startY; y <= endY; ++y) {
         const QPointF start = tileToScreenCoords(startX, y);
         const QPointF end = tileToScreenCoords(endX, y);
+
+        painter->setPen(gridMajor != 0 && y % gridMajor == 0 ? majorGridPen : gridPen);
         painter->drawLine(start, end);
     }
     for (int x = startX; x <= endX; ++x) {
         const QPointF start = tileToScreenCoords(x, startY);
         const QPointF end = tileToScreenCoords(x, endY);
+
+        painter->setPen(gridMajor != 0 && x % gridMajor == 0 ? majorGridPen : gridPen);
         painter->drawLine(start, end);
     }
 }

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -52,7 +52,7 @@ public:
     QPainterPath shape(const MapObject *object) const override;
     QPainterPath interactionShape(const MapObject *object) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &rect, QColor grid) const override;
+    void drawGrid(QPainter *painter, const QRectF &rect, QColor grid, int gridMajor) const override;
 
     using MapRenderer::drawTileLayer;
     void drawTileLayer(const RenderTileCallback &renderTile,

--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -361,6 +361,7 @@ MapObject *MapObject::clone() const
     MapObject *o = new MapObject(mName, mType, mPos, mSize);
     o->setId(mId);
     o->setProperties(properties());
+    o->setComponents(components());
     o->setTextData(mTextData);
     o->setPolygon(mPolygon);
     o->setShape(mShape);
@@ -384,6 +385,7 @@ void MapObject::copyPropertiesFrom(const MapObject *object)
     setRotation(object->rotation());
     setVisible(object->isVisible());
     setProperties(object->properties());
+    setComponents(object->components());
     setChangedProperties(object->changedProperties());
     setObjectTemplate(object->objectTemplate());
 }

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -1243,8 +1243,7 @@ std::unique_ptr<MapObject> MapReaderPrivate::readObject()
             object->setShape(MapObject::Point);
             object->setPropertyChanged(MapObject::ShapeProperty);
         } else if (xml.name() == QLatin1String("components")) {
-            Components c = readComponents();
-            object->setComponents(c);
+            object->setComponents(readComponents());
         } else {
             readUnknownElement();
         }
@@ -1461,37 +1460,33 @@ void MapReaderPrivate::readProperty(Properties *properties)
 
 Components MapReaderPrivate::readComponents()
 {
-  Q_ASSERT(xml.isStartElement() && xml.name() == QLatin1String("components"));
+    Q_ASSERT(xml.isStartElement() && xml.name() == QLatin1String("components"));
 
-  Components commponents;
+    Components commponents;
 
-  while (xml.readNextStartElement()) {
-    if (xml.name() == QLatin1String("component"))
-      readComponent(&commponents);
-    else
-      readUnknownElement();
-  }
+    while (xml.readNextStartElement()) {
+        if (xml.name() == QLatin1String("component"))
+            readComponent(&commponents);
+        else
+            readUnknownElement();
+    }
 
-  return commponents;
+    return commponents;
 }
 
 void MapReaderPrivate::readComponent(Components *components)
 {
-  Q_ASSERT(xml.isStartElement() && xml.name() == QLatin1String("component"));
+    Q_ASSERT(xml.isStartElement() && xml.name() == QLatin1String("component"));
 
-  const QXmlStreamAttributes atts = xml.attributes();
-  QString componentName = atts.value(QLatin1String("name")).toString();
+    const QXmlStreamAttributes atts = xml.attributes();
+    QString componentName = atts.value(QLatin1String("name")).toString();
 
-  while (xml.readNext() != QXmlStreamReader::Invalid) {
-    if (xml.isEndElement()) {
-      break;
-    } else if (xml.name() == QLatin1String("properties")) {
-      Properties props = readProperties();
-      components->insert(componentName, props);
-    } else if (xml.isStartElement()) {
-      readUnknownElement();
+    while (xml.readNextStartElement()) {
+        if (xml.name() == QLatin1String("properties"))
+            components->insert(componentName, readProperties());
+        else
+            readUnknownElement();
     }
-  }
 }
 
 

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -242,7 +242,8 @@ QPolygonF MapRenderer::lineToPolygon(const QPointF &start, const QPointF &end)
     return polygon;
 }
 
-QPen MapRenderer::makeGridPen(const QPaintDevice *device, QColor color)
+void MapRenderer::setupGridPens(const QPaintDevice *device, QColor color,
+                                QPen &gridPen, QPen &majorGridPen)
 {
     const qreal devicePixelRatio = device->devicePixelRatioF();
 
@@ -252,14 +253,18 @@ QPen MapRenderer::makeGridPen(const QPaintDevice *device, QColor color)
     const qreal dpiScale = device->logicalDpiX() / 96.0;
 #endif
 
-    const qreal dashLength = std::ceil(2.0 * dpiScale * devicePixelRatio);
+    const qreal dashLength = std::ceil(2.0 * dpiScale);
 
-    color.setAlpha(128);
+    color.setAlpha(96);
 
-    QPen pen(color);
-    pen.setCosmetic(true);
-    pen.setDashPattern({dashLength, dashLength});
-    return pen;
+    gridPen = QPen(color, 1.0 * devicePixelRatio);
+    gridPen.setCosmetic(true);
+    gridPen.setDashPattern({dashLength, dashLength});
+
+    color.setAlpha(192);
+
+    majorGridPen = gridPen;
+    majorGridPen.setColor(color);
 }
 
 

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -133,7 +133,7 @@ public:
      * \a painter.
      */
     virtual void drawGrid(QPainter *painter, const QRectF &rect,
-                          QColor gridColor = Qt::black) const = 0;
+                          QColor gridColor = Qt::black, int gridMajor = 0) const = 0;
 
     typedef std::function<void(QPoint, const QPointF &)> RenderTileCallback;
 
@@ -270,7 +270,8 @@ public:
     static QPolygonF lineToPolygon(const QPointF &start, const QPointF &end);
 
 protected:
-    static QPen makeGridPen(const QPaintDevice *device, QColor color);
+    static void setupGridPens(const QPaintDevice *device, QColor color,
+                              QPen &gridPen, QPen &majorGridPen);
 
     void setCellType(CellType cellType) { mCellType = cellType; }
 

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -512,6 +512,7 @@ QVariant MapToVariantConverter::toVariant(const MapObject &object) const
     const QString &type = object.type();
 
     addProperties(objectVariant, object.properties());
+    // TODO: add components support
 
     if (const ObjectTemplate *objectTemplate = object.objectTemplate()) {
         QString relativeFileName = mDir.relativeFilePath(objectTemplate->fileName());
@@ -779,3 +780,4 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
         variantMap[QStringLiteral("properties")] = propertiesVariantList;
     }
 }
+

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -45,7 +45,10 @@ QVariant MapToVariantConverter::toVariant(const Map &map, const QDir &mapDir)
     QVariantMap mapVariant;
 
     mapVariant[QStringLiteral("type")] = QLatin1String("map");
-    mapVariant[QStringLiteral("version")] = (mVersion == 2) ? 1.5 : 1.1;
+    if (mVersion == 2)
+        mapVariant[QStringLiteral("version")] = QStringLiteral("1.6");
+    else
+        mapVariant[QStringLiteral("version")] = 1.1;
     mapVariant[QStringLiteral("tiledversion")] = QCoreApplication::applicationVersion();
     mapVariant[QStringLiteral("orientation")] = orientationToString(map.orientation());
     mapVariant[QStringLiteral("renderorder")] = renderOrderToString(map.renderOrder());
@@ -161,7 +164,10 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
         tilesetVariant[QStringLiteral("type")] = QLatin1String("tileset");
 
         // Include version in external tilesets
-        tilesetVariant[QStringLiteral("version")] = (mVersion == 2) ? 1.5 : 1.1;
+        if (mVersion == 2)
+            tilesetVariant[QStringLiteral("version")] = QStringLiteral("1.6");
+        else
+            tilesetVariant[QStringLiteral("version")] = 1.1;
         tilesetVariant[QStringLiteral("tiledversion")] = QCoreApplication::applicationVersion();
     }
 

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -94,6 +94,7 @@ private:
     void writeGroupLayer(QXmlStreamWriter &w, const GroupLayer &groupLayer);
     void writeProperties(QXmlStreamWriter &w,
                          const Properties &properties);
+    void writeComponents(QXmlStreamWriter &w, const Components &components);
 
     QDir mDir;      // The directory in which the file is being saved
     GidMapper mGidMapper;
@@ -703,6 +704,7 @@ void MapWriterPrivate::writeObjectGroup(QXmlStreamWriter &w,
 
     writeLayerAttributes(w, objectGroup);
     writeProperties(w, objectGroup.properties());
+    writeComponents(w, objectGroup.components());
 
     for (const MapObject *mapObject : objectGroup.objects())
         writeObject(w, *mapObject);
@@ -768,6 +770,7 @@ void MapWriterPrivate::writeObject(QXmlStreamWriter &w,
         w.writeAttribute(QStringLiteral("visible"), QLatin1String(mapObject.isVisible() ? "1" : "0"));
 
     writeProperties(w, mapObject.properties());
+    writeComponents(w, mapObject.components());
 
     switch (mapObject.shape()) {
     case MapObject::Rectangle:
@@ -934,6 +937,32 @@ void MapWriterPrivate::writeProperties(QXmlStreamWriter &w,
             w.writeCharacters(value);
         else
             w.writeAttribute(QStringLiteral("value"), value);
+
+        w.writeEndElement();
+    }
+
+    w.writeEndElement();
+}
+
+void MapWriterPrivate::writeComponents(QXmlStreamWriter &w,
+                                       const Components &components)
+{
+    if (components.isEmpty())
+        return;
+
+    w.writeStartElement(QStringLiteral("components"));
+
+    QMapIterator<QString, Properties> it(components);
+    while (it.hasNext()) {
+        it.next();
+
+        const QString &componentName = it.key();
+        const Properties &properties = it.value();
+
+        w.writeStartElement(QStringLiteral("component"));
+        w.writeAttribute(QStringLiteral("name"), componentName);
+
+        writeProperties(w, properties);
 
         w.writeEndElement();
     }

--- a/src/libtiled/object.cpp
+++ b/src/libtiled/object.cpp
@@ -140,6 +140,23 @@ QVariantMap Object::resolvedProperties() const
     return allProperties;
 }
 
+void Object::addComponent(const QString &name)
+{
+    const ObjectType *type = nullptr;
+    for (const ObjectType &t : Object::objectTypes()) {
+        if (t.name.compare(name) == 0) {
+            type = &t;
+            break;
+        }
+    }
+
+    if (type) {
+        mComponents[name] = Properties {};
+        Properties &props = mComponents[name];
+        props = type->defaultProperties;
+    }
+}
+
 void Object::setObjectTypes(const ObjectTypes &objectTypes)
 {
     mObjectTypes = objectTypes;

--- a/src/libtiled/object.cpp
+++ b/src/libtiled/object.cpp
@@ -140,18 +140,9 @@ QVariantMap Object::resolvedProperties() const
     return allProperties;
 }
 
-void Object::addComponent(const QString &name)
+void Object::addComponent(const QString &name, const Properties &properties)
 {
-    const ObjectType *type = nullptr;
-    for (const ObjectType &t : Object::objectTypes()) {
-        if (t.name.compare(name) == 0) {
-            type = &t;
-            break;
-        }
-    }
-
-    if (type)
-        mComponents[name] = type->defaultProperties;
+    mComponents[name] = properties;
 }
 
 void Object::setObjectTypes(const ObjectTypes &objectTypes)

--- a/src/libtiled/object.cpp
+++ b/src/libtiled/object.cpp
@@ -150,11 +150,8 @@ void Object::addComponent(const QString &name)
         }
     }
 
-    if (type) {
-        mComponents[name] = Properties {};
-        Properties &props = mComponents[name];
-        props = type->defaultProperties;
-    }
+    if (type)
+        mComponents[name] = type->defaultProperties;
 }
 
 void Object::setObjectTypes(const ObjectTypes &objectTypes)

--- a/src/libtiled/object.h
+++ b/src/libtiled/object.h
@@ -132,6 +132,23 @@ public:
 
     bool isPartOfTileset() const;
 
+    void addComponent(const QString &name);
+
+    void removeComponent(const QString &name)
+    { mComponents.remove(name); }
+
+    bool hasComponent(const QString &name)
+    { return mComponents.contains(name); }
+
+    const Components &components() const
+    { return mComponents; }
+
+    void setComponents(const Components &components)
+    { mComponents = components; }
+
+    Properties &componentProperties(const QString &componentName)
+    { return mComponents[componentName]; }
+
     static void setObjectTypes(const ObjectTypes &objectTypes);
     static const ObjectTypes &objectTypes()
     { return mObjectTypes; }
@@ -139,6 +156,7 @@ public:
 private:
     const TypeId mTypeId;
     Properties mProperties;
+    Components mComponents;
 
     static ObjectTypes mObjectTypes;
 };

--- a/src/libtiled/object.h
+++ b/src/libtiled/object.h
@@ -132,7 +132,7 @@ public:
 
     bool isPartOfTileset() const;
 
-    void addComponent(const QString &name);
+    void addComponent(const QString &name, const Properties &properties);
 
     void removeComponent(const QString &name)
     { mComponents.remove(name); }

--- a/src/libtiled/object.h
+++ b/src/libtiled/object.h
@@ -137,7 +137,7 @@ public:
     void removeComponent(const QString &name)
     { mComponents.remove(name); }
 
-    bool hasComponent(const QString &name)
+    bool hasComponent(const QString &name) const
     { return mComponents.contains(name); }
 
     const Components &components() const

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -224,7 +224,7 @@ QPainterPath OrthogonalRenderer::interactionShape(const MapObject *object) const
 }
 
 void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect,
-                                  QColor gridColor) const
+                                  QColor gridColor, int gridMajor) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -232,32 +232,39 @@ void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect,
     if (tileWidth <= 0 || tileHeight <= 0)
         return;
 
-    int startX = qFloor(rect.x() / tileWidth) * tileWidth;
-    int startY = qFloor(rect.y() / tileHeight) * tileHeight;
-    int endX = qCeil(rect.right());
-    int endY = qCeil(rect.bottom());
+    int startX = qFloor(rect.x() / tileWidth);
+    int startY = qFloor(rect.y() / tileHeight);
+    int endX = qCeil(rect.right() / tileWidth);
+    int endY = qCeil(rect.bottom() / tileHeight);
 
     if (!map()->infinite()) {
         startX = qMax(0, startX);
         startY = qMax(0, startY);
-        endX = qMin(endX, map()->width() * tileWidth + 1);
-        endY = qMin(endY, map()->height() * tileHeight + 1);
+        endX = qMin(endX, map()->width());
+        endY = qMin(endY, map()->height());
     }
 
-    QPen gridPen = makeGridPen(painter->device(), gridColor);
+    QPen gridPen, majorGridPen;
+    setupGridPens(painter->device(), gridColor, gridPen, majorGridPen);
 
     if (startY < endY) {
-        gridPen.setDashOffset(startY);
-        painter->setPen(gridPen);
-        for (int x = startX; x < endX; x += tileWidth)
-            painter->drawLine(x, startY, x, endY - 1);
+        gridPen.setDashOffset(startY * tileHeight);
+        majorGridPen.setDashOffset(startY * tileHeight);
+
+        for (int x = startX; x < endX; ++x) {
+            painter->setPen(gridMajor != 0 && x % gridMajor == 0 ? majorGridPen : gridPen);
+            painter->drawLine(x * tileWidth, startY * tileHeight, x * tileWidth, endY * tileHeight);
+        }
     }
 
     if (startX < endX) {
-        gridPen.setDashOffset(startX);
-        painter->setPen(gridPen);
-        for (int y = startY; y < endY; y += tileHeight)
-            painter->drawLine(startX, y, endX - 1, y);
+        gridPen.setDashOffset(startX * tileWidth);
+        majorGridPen.setDashOffset(startX * tileWidth);
+
+        for (int y = startY; y < endY; ++y) {
+            painter->setPen(gridMajor != 0 && y % gridMajor == 0 ? majorGridPen : gridPen);
+            painter->drawLine(startX * tileWidth, y * tileHeight, endX * tileWidth, y * tileHeight);
+        }
     }
 }
 

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -50,7 +50,7 @@ public:
     QPainterPath interactionShape(const MapObject *object) const override;
 
     void drawGrid(QPainter *painter, const QRectF &rect,
-                  QColor gridColor) const override;
+                  QColor gridColor, int gridMajor = 0) const override;
 
     using MapRenderer::drawTileLayer;
     void drawTileLayer(const RenderTileCallback &renderTile,

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -105,6 +105,8 @@ private:
  */
 using Properties = QVariantMap;
 
+using Components = QMap<QString, Properties>;
+
 /**
  * Collection of properties with information about the consistency of their
  * presence and value over several property collections.

--- a/src/tiled/changecomponents.cpp
+++ b/src/tiled/changecomponents.cpp
@@ -7,7 +7,7 @@
 
 using namespace Tiled;
 
-static Properties GetObjectTypeProperties(const QString &name)
+static Properties objectTypeProperties(const QString &name)
 {
     const ObjectType *type = nullptr;
     for (const ObjectType &t : Object::objectTypes()) {
@@ -17,11 +17,7 @@ static Properties GetObjectTypeProperties(const QString &name)
         }
     }
 
-    Properties properties;
-    if (type) {
-        properties = type->defaultProperties;
-    }
-    return properties;
+    return type ? type->defaultProperties : Properties {};
 }
 
 AddComponent::AddComponent(Document *document,
@@ -32,6 +28,7 @@ AddComponent::AddComponent(Document *document,
     , mDocument(document)
     , mObject(object)
     , mName(name)
+    , mProperties(objectTypeProperties(mName))
 {
     setText(QCoreApplication::translate("Undo Commands", "Add Component"));
 }
@@ -43,8 +40,9 @@ void AddComponent::undo()
 
 void AddComponent::redo()
 {
-    mDocument->addComponent(mObject, mName, GetObjectTypeProperties(mName));
+    mDocument->addComponent(mObject, mName, mProperties);
 }
+
 
 RemoveComponent::RemoveComponent(Document *document,
                                  Object *object,
@@ -69,6 +67,7 @@ void RemoveComponent::redo()
     mDocument->removeComponent(mComponentName, mObject);
 }
 
+
 SetComponentProperty::SetComponentProperty(Document *document,
                                            Object *object,
                                            const QString &componentName,
@@ -82,7 +81,7 @@ SetComponentProperty::SetComponentProperty(Document *document,
     , mPropertyName(propertyName)
     , mNewValue(value)
 {
-    setText(QCoreApplication::translate("Undo Commands", "Set property"));
+    setText(QCoreApplication::translate("Undo Commands", "Set Property"));
 
     Properties &props = mObject->componentProperties(componentName);
     mOldValue = props[propertyName];

--- a/src/tiled/changecomponents.cpp
+++ b/src/tiled/changecomponents.cpp
@@ -7,6 +7,23 @@
 
 using namespace Tiled;
 
+static Properties GetObjectTypeProperties(const QString &name)
+{
+    const ObjectType *type = nullptr;
+    for (const ObjectType &t : Object::objectTypes()) {
+        if (t.name.compare(name) == 0) {
+            type = &t;
+            break;
+        }
+    }
+
+    Properties properties;
+    if (type) {
+        properties = type->defaultProperties;
+    }
+    return properties;
+}
+
 AddComponent::AddComponent(Document *document,
                            Object *object,
                            const QString &name,
@@ -26,7 +43,7 @@ void AddComponent::undo()
 
 void AddComponent::redo()
 {
-    mDocument->addComponent(mObject, mName);
+    mDocument->addComponent(mObject, mName, GetObjectTypeProperties(mName));
 }
 
 RemoveComponent::RemoveComponent(Document *document,

--- a/src/tiled/changecomponents.cpp
+++ b/src/tiled/changecomponents.cpp
@@ -1,0 +1,82 @@
+#include "changecomponents.h"
+
+#include "object.h"
+#include "document.h"
+
+#include <QCoreApplication>
+
+using namespace Tiled;
+
+AddComponent::AddComponent(Document *document,
+                           Object *object,
+                           const QString &name,
+                           QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , mDocument(document)
+    , mObject(object)
+    , mName(name)
+{
+    setText(QCoreApplication::translate("Undo Commands", "Add Component"));
+}
+
+void AddComponent::undo()
+{
+    mDocument->removeComponent(mName, mObject);
+}
+
+void AddComponent::redo()
+{
+    mDocument->addComponent(mObject, mName);
+}
+
+RemoveComponent::RemoveComponent(Document *document,
+                                 Object *object,
+                                 const QString &componentName,
+                                 QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , mDocument(document)
+    , mObject(object)
+    , mComponentName(componentName)
+{
+    setText(QCoreApplication::translate("Undo Commands", "Remove Component"));
+}
+
+void RemoveComponent::undo()
+{
+    mDocument->addComponent(mObject, mComponentName, mProperties);
+}
+
+void RemoveComponent::redo()
+{
+    mProperties = mObject->componentProperties(mComponentName);
+    mDocument->removeComponent(mComponentName, mObject);
+}
+
+SetComponentProperty::SetComponentProperty(Document *document,
+                                           Object *object,
+                                           const QString &componentName,
+                                           const QString &propertyName,
+                                           QVariant value,
+                                           QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , mDocument(document)
+    , mObject(object)
+    , mComponentName(componentName)
+    , mPropertyName(propertyName)
+    , mNewValue(value)
+{
+    setText(QCoreApplication::translate("Undo Commands", "Set property"));
+
+    Properties &props = mObject->componentProperties(componentName);
+    mOldValue = props[propertyName];
+}
+
+void SetComponentProperty::undo()
+{
+    mDocument->setComponentProperty(mObject, mComponentName, mPropertyName, mOldValue);
+}
+
+void SetComponentProperty::redo()
+{
+    mDocument->setComponentProperty(mObject, mComponentName, mPropertyName, mNewValue);
+}

--- a/src/tiled/changecomponents.h
+++ b/src/tiled/changecomponents.h
@@ -26,6 +26,7 @@ private:
     Document *mDocument;
     Object *mObject;
     const QString mName;
+    Properties mProperties;
 
 };
 

--- a/src/tiled/changecomponents.h
+++ b/src/tiled/changecomponents.h
@@ -39,6 +39,7 @@ public:
 
     void undo() override;
     void redo() override;
+
 private:
     Document *mDocument;
     Object *mObject;
@@ -67,5 +68,4 @@ private:
     const QVariant mNewValue;
 };
 
-}
-
+} // namespace Tiled

--- a/src/tiled/changecomponents.h
+++ b/src/tiled/changecomponents.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "properties.h"
+
+#include <QString>
+#include <QUndoCommand>
+#include <QVariant>
+
+namespace Tiled {
+
+class Object;
+class Document;
+
+class AddComponent : public QUndoCommand
+{
+public:
+    AddComponent(Document *document,
+                 Object *object,
+                 const QString &name,
+                 QUndoCommand *parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    Document *mDocument;
+    Object *mObject;
+    const QString mName;
+
+};
+
+class RemoveComponent : public QUndoCommand
+{
+public:
+    RemoveComponent(Document *document,
+                    Object *object,
+                    const QString &name,
+                    QUndoCommand *parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+private:
+    Document *mDocument;
+    Object *mObject;
+    const QString mComponentName;
+    Properties mProperties;
+};
+
+class SetComponentProperty : public QUndoCommand
+{
+public:
+    SetComponentProperty(Document *document,
+                         Object *object,
+                         const QString &componentName,
+                         const QString &propertyName,
+                         QVariant value,
+                         QUndoCommand *parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+private:
+    Document *mDocument;
+    Object *mObject;
+    const QString mComponentName;
+    const QString mPropertyName;
+    QVariant mOldValue;
+    const QVariant mNewValue;
+};
+
+}
+

--- a/src/tiled/document.cpp
+++ b/src/tiled/document.cpp
@@ -144,6 +144,40 @@ void Document::removeProperty(Object *object, const QString &name)
     emit propertyRemoved(object, name);
 }
 
+void Document::addComponent(Object *object, const QString &name, const Properties &assignProperties)
+{
+    if (!object->hasComponent(name)) {
+        object->addComponent(name);
+
+        Properties &properties = object->componentProperties(name);
+        Tiled::mergeProperties(properties, assignProperties);
+
+        emit componentAdded(object, name);
+    }
+}
+
+void Document::removeComponent(const QString &name, Object *object)
+{
+    if (object->hasComponent(name)) {
+        object->removeComponent(name);
+
+        emit componentRemoved(object, name);
+    }
+}
+
+void Document::setComponentProperty(Object *object,
+                                    const QString &componentName,
+                                    const QString &propertyName,
+                                    const QVariant &value)
+{
+    if (object->hasComponent(componentName)) {
+        Properties &props = object->componentProperties(componentName);
+        props[propertyName] = value;
+
+        emit componentPropertyChanged(object, componentName, propertyName, value);
+    }
+}
+
 void Document::setIgnoreBrokenLinks(bool ignoreBrokenLinks)
 {
     if (mIgnoreBrokenLinks == ignoreBrokenLinks)

--- a/src/tiled/document.cpp
+++ b/src/tiled/document.cpp
@@ -148,7 +148,6 @@ void Document::addComponent(Object *object, const QString &name, const Propertie
 {
     if (!object->hasComponent(name)) {
         object->addComponent(name, properties);
-
         emit componentAdded(object, name);
     }
 }
@@ -157,7 +156,6 @@ void Document::removeComponent(const QString &name, Object *object)
 {
     if (object->hasComponent(name)) {
         object->removeComponent(name);
-
         emit componentRemoved(object, name);
     }
 }
@@ -170,7 +168,6 @@ void Document::setComponentProperty(Object *object,
     if (object->hasComponent(componentName)) {
         Properties &props = object->componentProperties(componentName);
         props[propertyName] = value;
-
         emit componentPropertyChanged(object, componentName, propertyName, value);
     }
 }

--- a/src/tiled/document.cpp
+++ b/src/tiled/document.cpp
@@ -144,13 +144,10 @@ void Document::removeProperty(Object *object, const QString &name)
     emit propertyRemoved(object, name);
 }
 
-void Document::addComponent(Object *object, const QString &name, const Properties &assignProperties)
+void Document::addComponent(Object *object, const QString &name, const Properties &properties)
 {
     if (!object->hasComponent(name)) {
-        object->addComponent(name);
-
-        Properties &properties = object->componentProperties(name);
-        Tiled::mergeProperties(properties, assignProperties);
+        object->addComponent(name, properties);
 
         emit componentAdded(object, name);
     }

--- a/src/tiled/document.h
+++ b/src/tiled/document.h
@@ -105,6 +105,10 @@ public:
     void setProperties(Object *object, const Properties &properties);
     void removeProperty(Object *object, const QString &name);
 
+    void addComponent(Object *object, const QString &name, const Properties &assignProperties = {});
+    void removeComponent(const QString &name, Object *object);
+    void setComponentProperty(Object *object, const QString &componentName, const QString &propertyName, const QVariant &value);
+
     bool ignoreBrokenLinks() const;
     void setIgnoreBrokenLinks(bool ignoreBrokenLinks);
 
@@ -140,6 +144,10 @@ signals:
     void propertyRemoved(Object *object, const QString &name);
     void propertyChanged(Object *object, const QString &name);
     void propertiesChanged(Object *object);
+
+    void componentAdded(Object *object, const QString &name);
+    void componentRemoved(Object *object, const QString &name);
+    void componentPropertyChanged(Object *object, const QString &componentName, const QString &propertyName, const QVariant &value);
 
     void ignoreBrokenLinksChanged(bool ignoreBrokenLinks);
 

--- a/src/tiled/document.h
+++ b/src/tiled/document.h
@@ -105,7 +105,7 @@ public:
     void setProperties(Object *object, const Properties &properties);
     void removeProperty(Object *object, const QString &name);
 
-    void addComponent(Object *object, const QString &name, const Properties &assignProperties = {});
+    void addComponent(Object *object, const QString &name, const Properties &properties);
     void removeComponent(const QString &name, Object *object);
     void setComponentProperty(Object *object, const QString &componentName, const QString &propertyName, const QVariant &value);
 

--- a/src/tiled/editablemapobject.h
+++ b/src/tiled/editablemapobject.h
@@ -79,6 +79,8 @@ class EditableMapObject : public EditableObject
     Q_PROPERTY(Tiled::EditableMap *map READ map)
 //    Q_PROPERTY(ChangedProperties mChangedProperties)
 
+    // TODO: add components
+
 public:
     // Synchronized with MapObject::Shape
     enum Shape {

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -71,6 +71,7 @@ public:
         Preferences *prefs = Preferences::instance();
         connect(prefs, &Preferences::showGridChanged, this, [this] (bool visible) { setVisible(visible); });
         connect(prefs, &Preferences::gridColorChanged, this, [this] { update(); });
+        connect(prefs, &Preferences::gridMajorChanged, this, [this] { update(); });
 
         // New layer may have a different offset
         connect(mapDocument, &MapDocument::currentLayerChanged,
@@ -107,7 +108,7 @@ public:
         Preferences *prefs = Preferences::instance();
         mMapDocument->renderer()->drawGrid(painter,
                                            option->exposedRect.translated(-mOffset),
-                                           prefs->gridColor());
+                                           prefs->gridColor(), prefs->gridMajor());
     }
 
     void updateOffset()

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -111,10 +111,8 @@ void MapObjectItem::setIsHoverIndicator(bool isHoverIndicator)
 
     if (isHoverIndicator) {
         auto totalOffset = static_cast<MapScene*>(scene())->absolutePositionForLayer(*mObject->objectGroup());
-        setOpacity(0.5);
         setTransform(QTransform::fromTranslate(totalOffset.x(), totalOffset.y()));
     } else {
-        setOpacity(1.0);
         setTransform(QTransform());
     }
 
@@ -139,6 +137,10 @@ void MapObjectItem::paint(QPainter *painter,
 {
     const qreal scale = static_cast<MapView*>(widget->parent())->zoomable()->scale();
     const QColor color = mIsHoveredIndicator ? mColor.lighter() : mColor;
+    const qreal previousOpacity = painter->opacity();
+
+    if (mIsHoveredIndicator)
+        painter->setOpacity(0.4);
 
     painter->translate(-pos());
     mMapDocument->renderer()->setPainterScale(scale);
@@ -146,6 +148,8 @@ void MapObjectItem::paint(QPainter *painter,
     painter->translate(pos());
 
     if (mIsHoveredIndicator) {
+        painter->setOpacity(0.6);
+
         // TODO: Code mostly duplicated in MapObjectOutline
         const QPointF pixelPos = mMapDocument->renderer()->pixelToScreenCoords(mObject->position());
         QRectF bounds = mObject->screenBounds(*mMapDocument->renderer());
@@ -174,6 +178,8 @@ void MapObjectItem::paint(QPainter *painter,
         pen.setDashPattern({dashLength, dashLength});
         painter->setPen(pen);
         painter->drawLines(lines, 4);
+
+        painter->setOpacity(previousOpacity);
     }
 }
 

--- a/src/tiled/objectreferenceitem.cpp
+++ b/src/tiled/objectreferenceitem.cpp
@@ -102,7 +102,7 @@ ObjectReferenceItem::ObjectReferenceItem(MapObject *source,
     , mArrowHead(new ArrowHead(this))
     , mProperty(property)
 {
-    setZValue(-0.5); // below labels but above hover
+    setZValue(-0.5); // below labels
     updateColor();
 }
 

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -269,6 +269,8 @@ ObjectSelectionItem::ObjectSelectionItem(MapDocument *mapDocument,
             this, &ObjectSelectionItem::propertyChanged);
     connect(mapDocument, &Document::propertiesChanged,
             this, &ObjectSelectionItem::propertiesChanged);
+    
+    // TODO: add components?
 
     connect(mapDocument, &MapDocument::selectedObjectsChanged,
             this, &ObjectSelectionItem::selectedObjectsChanged);

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -45,8 +45,11 @@
 
 namespace Tiled {
 
-static const qreal labelMargin = 2;
-static const qreal labelDistance = 4;
+static constexpr qreal labelMargin = 2;
+static constexpr qreal labelDistance = 4;
+
+static constexpr qreal selectionZValue = 1.0;   // selection outlines above labels
+static constexpr qreal hoverZValue = 0.5;       // hover below selection
 
 static Preferences::ObjectLabelVisiblity objectLabelVisibility()
 {
@@ -69,12 +72,12 @@ public:
 
         switch (role) {
         case SelectionIndicator:
-            setZValue(1);       // makes sure outlines are above labels
+            setZValue(selectionZValue);
             mUpdateTimer = startTimer(100);
             break;
         case HoverIndicator:
-            setZValue(-1.0);    // show below selection outlines
-            setOpacity(0.5);
+            setZValue(hoverZValue);
+            setOpacity(0.6);
             break;
         }
     }
@@ -327,7 +330,7 @@ void ObjectSelectionItem::updateItemPositions()
     for (MapObjectOutline *outline : qAsConst(mObjectOutlines))
         outline->syncWithMapObject(renderer);
 
-    for (const auto &items : mReferencesBySourceObject) {
+    for (const auto &items : qAsConst(mReferencesBySourceObject)) {
         for (ObjectReferenceItem *item : items) {
             item->syncWithSourceObject(renderer);
             item->syncWithTargetObject(renderer);
@@ -455,7 +458,7 @@ void ObjectSelectionItem::hoveredMapObjectChanged(MapObject *object,
         mHoveredMapObjectItem = std::make_unique<MapObjectItem>(object, mMapDocument, this);
         mHoveredMapObjectItem->setEnabled(false);
         mHoveredMapObjectItem->setIsHoverIndicator(true);
-        mHoveredMapObjectItem->setZValue(-1.0);     // show below selection outlines
+        mHoveredMapObjectItem->setZValue(hoverZValue);  // show below selection outlines
     } else {
         mHoveredMapObjectItem.reset();
     }
@@ -587,7 +590,7 @@ void ObjectSelectionItem::updateItemColors() const
     for (MapObjectLabel *label : mObjectLabels)
         label->updateColor();
 
-    for (const auto &referenceItems : mReferencesBySourceObject)
+    for (const auto &referenceItems : qAsConst(mReferencesBySourceObject))
         for (ObjectReferenceItem *item : referenceItems)
             item->updateColor();
 }
@@ -705,7 +708,7 @@ void ObjectSelectionItem::showObjectReferencesChanged()
 void ObjectSelectionItem::objectLineWidthChanged()
 {
     // Object reference items should redraw when line width is changed
-    for (const auto &items : mReferencesBySourceObject)
+    for (const auto &items : qAsConst(mReferencesBySourceObject))
         for (ObjectReferenceItem *item : items)
             item->update();
 }
@@ -904,7 +907,7 @@ void ObjectSelectionItem::addRemoveObjectReferences(MapObject *object)
     }
 
     // Delete remaining existing items, also removing them from mReferencesByTargetObject
-    for (ObjectReferenceItem *item : existingItems) {
+    for (ObjectReferenceItem *item : qAsConst(existingItems)) {
         auto &itemsByTarget = mReferencesByTargetObject[item->targetObject()];
         itemsByTarget.removeOne(item);
         if (itemsByTarget.isEmpty())

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -164,6 +164,11 @@ int Preferences::gridFine() const
     return get<int>("Interface/GridFine", 4);
 }
 
+int Preferences::gridMajor() const
+{
+    return get<int>("Interface/GridMajor", 10);
+}
+
 qreal Preferences::objectLineWidth() const
 {
     return get<qreal>("Interface/ObjectLineWidth", 2.0);
@@ -313,6 +318,12 @@ void Preferences::setGridFine(int gridFine)
 {
     setValue(QLatin1String("Interface/GridFine"), gridFine);
     emit gridFineChanged(gridFine);
+}
+
+void Preferences::setGridMajor(int gridMajor)
+{
+    setValue(QLatin1String("Interface/GridMajor"), gridMajor);
+    emit gridMajorChanged(gridMajor);
 }
 
 void Preferences::setObjectLineWidth(qreal lineWidth)

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -63,6 +63,7 @@ public:
     bool snapToPixels() const;
     QColor gridColor() const;
     int gridFine() const;
+    int gridMajor() const;
     qreal objectLineWidth() const;
 
     bool highlightCurrentLayer() const;
@@ -187,6 +188,7 @@ public slots:
     void setSnapToPixels(bool snapToPixels);
     void setGridColor(QColor gridColor);
     void setGridFine(int gridFine);
+    void setGridMajor(int gridMajor);
     void setObjectLineWidth(qreal lineWidth);
     void setHighlightCurrentLayer(bool highlight);
     void setHighlightHoveredObject(bool highlight);
@@ -210,6 +212,7 @@ signals:
     void snapToPixelsChanged(bool snapToPixels);
     void gridColorChanged(QColor gridColor);
     void gridFineChanged(int gridFine);
+    void gridMajorChanged(int gridMajor);
     void objectLineWidthChanged(qreal lineWidth);
     void highlightCurrentLayerChanged(bool highlight);
     void highlightHoveredObjectChanged(bool highlight);

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -125,6 +125,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             preferences, &Preferences::setGridColor);
     connect(mUi->gridFine, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged),
             preferences, &Preferences::setGridFine);
+    connect(mUi->gridMajor, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            preferences, &Preferences::setGridMajor);
     connect(mUi->objectLineWidth, static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
             preferences, &Preferences::setObjectLineWidth);
     connect(mUi->openGL, &QCheckBox::toggled,
@@ -222,6 +224,7 @@ void PreferencesDialog::fromPreferences()
     mUi->languageCombo->setCurrentIndex(languageIndex);
     mUi->gridColor->setColor(prefs->gridColor());
     mUi->gridFine->setValue(prefs->gridFine());
+    mUi->gridMajor->setValue(prefs->gridMajor());
     mUi->objectLineWidth->setValue(prefs->objectLineWidth());
 
     // Updates

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -178,32 +178,13 @@
           <string>Interface</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="4">
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Grid color:</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="4" column="3">
-           <widget class="QDoubleSpinBox" name="objectLineWidth">
-            <property name="suffix">
-             <string> pixels</string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>2.000000000000000</double>
+            <property name="buddy">
+             <cstring>gridColor</cstring>
             </property>
            </widget>
           </item>
@@ -220,13 +201,39 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="label_6">
             <property name="text">
              <string>Object selection behavior:</string>
             </property>
             <property name="buddy">
              <cstring>objectSelectionBehaviorCombo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Object line width:</string>
+            </property>
+            <property name="buddy">
+             <cstring>objectLineWidth</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="3">
+           <widget class="QDoubleSpinBox" name="objectLineWidth">
+            <property name="suffix">
+             <string> pixels</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>2.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -240,37 +247,37 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0" colspan="5">
-           <widget class="QCheckBox" name="wheelZoomsByDefault">
+          <item row="0" column="3">
+           <widget class="QComboBox" name="languageCombo"/>
+          </item>
+          <item row="11" column="0" colspan="5">
+           <widget class="QCheckBox" name="smoothScrolling">
             <property name="text">
-             <string>Mouse wheel &amp;zooms by default</string>
+             <string>Use s&amp;mooth scrolling</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0" colspan="5">
+          <item row="0" column="4">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="8" column="0" colspan="5">
            <widget class="QCheckBox" name="openGL">
             <property name="text">
              <string>Hardware &amp;accelerated drawing (OpenGL)</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="3">
-           <widget class="QComboBox" name="languageCombo"/>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Grid color:</string>
-            </property>
-            <property name="buddy">
-             <cstring>gridColor</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="3">
-           <widget class="QComboBox" name="objectSelectionBehaviorCombo"/>
-          </item>
-          <item row="9" column="0" colspan="5">
+          <item row="10" column="0" colspan="5">
            <widget class="QCheckBox" name="autoScrolling">
             <property name="text">
              <string>Middle mouse button uses auto-&amp;scrolling</string>
@@ -287,20 +294,27 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label">
+          <item row="9" column="0" colspan="5">
+           <widget class="QCheckBox" name="wheelZoomsByDefault">
             <property name="text">
-             <string>Object line width:</string>
-            </property>
-            <property name="buddy">
-             <cstring>objectLineWidth</cstring>
+             <string>Mouse wheel &amp;zooms by default</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="0" colspan="5">
-           <widget class="QCheckBox" name="smoothScrolling">
+          <item row="6" column="3">
+           <widget class="QComboBox" name="objectSelectionBehaviorCombo"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_7">
             <property name="text">
-             <string>Use s&amp;mooth scrolling</string>
+             <string>Major grid every:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QSpinBox" name="gridMajor">
+            <property name="suffix">
+             <string> tiles</string>
             </property>
            </widget>
           </item>
@@ -534,6 +548,7 @@
   <tabstop>languageCombo</tabstop>
   <tabstop>gridColor</tabstop>
   <tabstop>gridFine</tabstop>
+  <tabstop>gridMajor</tabstop>
   <tabstop>objectLineWidth</tabstop>
   <tabstop>objectSelectionBehaviorCombo</tabstop>
   <tabstop>openGL</tabstop>

--- a/src/tiled/projectmodel.cpp
+++ b/src/tiled/projectmodel.cpp
@@ -171,6 +171,7 @@ void ProjectModel::addFolder(const QString &folder)
 
     mProject.addFolder(folder);
     mFolders.push_back(std::make_unique<FolderEntry>(folder));
+    mWatcher.addPath(folder);
     scheduleFolderScan(folder);
 
     endInsertRows();
@@ -182,9 +183,14 @@ void ProjectModel::removeFolder(int row)
 {
     const QString folder = mFolders.at(row)->filePath;
 
+    QStringList watchedFilePaths;
+    watchedFilePaths.append(folder);
+    collectDirectories(*mFolders.at(row), watchedFilePaths);
+
     beginRemoveRows(QModelIndex(), row, row);
     mProject.removeFolder(row);
     mFolders.erase(mFolders.begin() + row);
+    mWatcher.removePaths(watchedFilePaths);
     endRemoveRows();
 
     emit folderRemoved(folder);

--- a/src/tiled/propertiesdock.cpp
+++ b/src/tiled/propertiesdock.cpp
@@ -94,7 +94,7 @@ PropertiesDock::PropertiesDock(QWidget *parent)
     toolBar->addAction(mActionRemoveProperty);
     toolBar->addAction(mActionRenameProperty);
 
-    QWidget* spacer = new QWidget();
+    QWidget *spacer = new QWidget;
     spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     toolBar->addWidget(spacer);
     toolBar->addWidget(mButtonComponents);
@@ -190,17 +190,11 @@ void PropertiesDock::currentObjectChanged(Object *object)
     mActionAddProperty->setEnabled(enabled);
 
     // enable/disable components button
-    {
-        bool isMapObject = false;
+    const bool isMapObject = object && mDocument &&
+            mDocument->type() == Document::MapDocumentType &&
+            object->typeId() == Object::MapObjectType;
 
-        if (object) {
-            isMapObject = mDocument &&
-                    mDocument->type() == Document::MapDocumentType &&
-                    object->typeId() == Object::MapObjectType;
-        }
-
-        mButtonComponents->setEnabled(isMapObject);
-    }
+    mButtonComponents->setEnabled(isMapObject);
 }
 
 void PropertiesDock::updateActions()
@@ -533,30 +527,26 @@ void PropertiesDock::setupComponentMenu()
 
     componentMenu->clear();
 
-    if (!mDocument || !mDocument->currentObject()) {
+    if (!mDocument || !mDocument->currentObject())
         return;
-    }
 
-    if (mDocument->currentObject()->typeId() != Object::MapObjectType) {
+    if (mDocument->currentObject()->typeId() != Object::MapObjectType)
         return;
-    }
 
-    QSet<QString> listset;
+    QSet<QString> componentNames;
 
-    for (const QString &type : objectTypeNames()) {
-        listset.insert(type);
-    }
+    for (const QString &type : objectTypeNames())
+        componentNames.insert(type);
 
-    for (const QString &component : mDocument->currentObject()->components().keys()) {
-        listset.insert(component);
-    }
+    for (const QString &component : mDocument->currentObject()->components().keys())
+        componentNames.insert(component);
 
-    QSetIterator<QString> it(listset);
+    QSetIterator<QString> it(componentNames);
     while (it.hasNext()) {
         const QString &name = it.next();
 
-        QAction* addAction = componentMenu->addAction(name);
-        addAction->setData(QVariant(name));
+        QAction *addAction = componentMenu->addAction(name);
+        addAction->setData(name);
         connect(addAction, &QAction::triggered, this, &PropertiesDock::onComponentChecked);
 
         addAction->setCheckable(true);
@@ -581,10 +571,9 @@ void PropertiesDock::onComponentChecked(bool checked)
                                                 componentName));
         }
 
-        // only when holding shift down
-        if (QApplication::queryKeyboardModifiers().testFlag(Qt::ShiftModifier)) {
+        // Reopen the menu when holding Shift down
+        if (QApplication::queryKeyboardModifiers().testFlag(Qt::ShiftModifier))
             mButtonComponents->click();
-        }
     }
 }
 

--- a/src/tiled/propertiesdock.cpp
+++ b/src/tiled/propertiesdock.cpp
@@ -46,6 +46,8 @@
 #include <QFileInfo>
 #include <QApplication>
 
+#include <algorithm>
+
 namespace Tiled {
 
 PropertiesDock::PropertiesDock(QWidget *parent)
@@ -533,15 +535,19 @@ void PropertiesDock::setupComponentMenu()
     if (mDocument->currentObject()->typeId() != Object::MapObjectType)
         return;
 
-    QSet<QString> componentNames;
+    QStringList componentNames;
 
     for (const QString &type : objectTypeNames())
-        componentNames.insert(type);
+        componentNames << type;
 
-    for (const QString &component : mDocument->currentObject()->components().keys())
-        componentNames.insert(component);
+    for (const QString &componentName : mDocument->currentObject()->components().keys()) {
+        if (!componentNames.contains(componentName))
+            componentNames << componentName;
+    }
 
-    QSetIterator<QString> it(componentNames);
+    std::sort(componentNames.begin(), componentNames.end(), std::less<QString>());
+
+    QStringListIterator it(componentNames);
     while (it.hasNext()) {
         const QString &name = it.next();
 

--- a/src/tiled/propertiesdock.h
+++ b/src/tiled/propertiesdock.h
@@ -22,6 +22,7 @@
 
 #include <QDockWidget>
 #include <QVariant>
+#include <QToolButton>
 
 class QtBrowserItem;
 
@@ -67,6 +68,9 @@ private:
     void renamePropertyTo(const QString &name);
     void showContextMenu(const QPoint &pos);
 
+    void setupComponentMenu();
+    void onComponentChecked(bool checked = false);
+
     void retranslateUi();
 
     Document *mDocument;
@@ -74,6 +78,8 @@ private:
     QAction *mActionAddProperty;
     QAction *mActionRemoveProperty;
     QAction *mActionRenameProperty;
+
+    QToolButton *mButtonComponents;
 };
 
 } // namespace Tiled

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -228,7 +228,7 @@ private:
     MapDocument *mMapDocument = nullptr;
     TilesetDocument *mTilesetDocument = nullptr;
 
-    VariantEditorFactory *mVariantFactory;
+    VariantEditorFactory *mVariantEditorFactory;
 
     // manager owning the properties
     QtVariantPropertyManager *mVariantManager;

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -212,9 +212,9 @@ private:
     void addComponents();
     void removeComponents();
     void updateComponents();
+    bool isComponentProperty(QtProperty *propertry);
 
     void onComponentPropertyChanged(Object *object, const QString &componentName, const QString &propertyName, const QVariant &value);
-    void onComponentValueChanged(QtProperty *property, const QVariant &value);
 
     QVariant toDisplayValue(const QVariant &value) const;
     QVariant fromDisplayValue(const QVariant &value) const;
@@ -253,10 +253,6 @@ private:
     // component name -> property group
     // owns components properties
     QHash<QString, QtProperty *> mComponents;
-
-    // owns variant managers
-    // managers own components properites
-    QHash<QString, QtVariantPropertyManager *> mComponentVariantManagers;
 
     // component name -> (property name -> property)
     QHash<QString, QHash<QString, QtVariantProperty *>> mMapComponentPropertyField;

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -23,6 +23,7 @@
 #include "changeevents.h"
 #include "map.h"
 #include "properties.h"
+#include "varianteditorfactory.h"
 
 #include <QtTreePropertyBrowser>
 
@@ -85,6 +86,10 @@ private:
     void propertyRemoved(Object *object, const QString &name);
     void propertyChanged(Object *object, const QString &name);
     void propertiesChanged(Object *object);
+
+    void componentAdded(Object *object, const QString &name);
+    void removeComponent(Object *object, const QString &name);
+
     void selectedObjectsChanged();
     void selectedLayersChanged();
     void selectedTilesChanged();
@@ -183,6 +188,11 @@ private:
                                       int type,
                                       const QString &name);
 
+    QtVariantProperty *createPropertyInManager(QtVariantPropertyManager *manager,
+                                               PropertyId id,
+                                               int type,
+                                               const QString &name);
+
     using QtTreePropertyBrowser::addProperty;
     QtVariantProperty *addProperty(PropertyId id,
                                    int type,
@@ -199,6 +209,13 @@ private:
     void updateCustomProperties();
     void updateCustomPropertyColor(const QString &name);
 
+    void addComponents();
+    void removeComponents();
+    void updateComponents();
+
+    void onComponentPropertyChanged(Object *object, const QString &componentName, const QString &propertyName, const QVariant &value);
+    void onComponentValueChanged(QtProperty *property, const QVariant &value);
+
     QVariant toDisplayValue(const QVariant &value) const;
     QVariant fromDisplayValue(const QVariant &value) const;
 
@@ -211,15 +228,38 @@ private:
     MapDocument *mMapDocument = nullptr;
     TilesetDocument *mTilesetDocument = nullptr;
 
+    VariantEditorFactory *mVariantFactory;
+
+    // manager owning the properties
     QtVariantPropertyManager *mVariantManager;
+
+    // stores property groups
     QtGroupPropertyManager *mGroupManager;
+
+    // custom properties
     QtProperty *mCustomPropertiesGroup;
 
     QHash<QtProperty *, PropertyId> mPropertyToId;
     QHash<PropertyId, QtVariantProperty *> mIdToProperty;
+
+    // maps property name to property value
     QHash<QString, QtVariantProperty *> mNameToProperty;
 
-    Properties mCombinedProperties;
+    // components
+
+    // property -> componentName
+    QHash<QtProperty *, QString> mMapComponentProperty;
+
+    // component name -> property group
+    // owns components properties
+    QHash<QString, QtProperty *> mComponents;
+
+    // owns variant managers
+    // managers own components properites
+    QHash<QString, QtVariantPropertyManager *> mComponentVariantManagers;
+
+    // component name -> (property name -> property)
+    QHash<QString, QHash<QString, QtVariantProperty *>> mMapComponentPropertyField;
 
     QStringList mStaggerAxisNames;
     QStringList mStaggerIndexNames;

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -23,7 +23,6 @@
 #include "changeevents.h"
 #include "map.h"
 #include "properties.h"
-#include "varianteditorfactory.h"
 
 #include <QtTreePropertyBrowser>
 
@@ -146,6 +145,7 @@ private:
         WangColorProbabilityProperty,
         WangSetTypeProperty,
         CustomProperty,
+        ComponentProperty,
         InfiniteProperty,
         TemplateProperty,
         CompressionLevelProperty,
@@ -188,11 +188,6 @@ private:
                                       int type,
                                       const QString &name);
 
-    QtVariantProperty *createPropertyInManager(QtVariantPropertyManager *manager,
-                                               PropertyId id,
-                                               int type,
-                                               const QString &name);
-
     using QtTreePropertyBrowser::addProperty;
     QtVariantProperty *addProperty(PropertyId id,
                                    int type,
@@ -210,9 +205,7 @@ private:
     void updateCustomPropertyColor(const QString &name);
 
     void addComponents();
-    void removeComponents();
     void updateComponents();
-    bool isComponentProperty(QtProperty *propertry);
 
     void onComponentPropertyChanged(Object *object, const QString &componentName, const QString &propertyName, const QVariant &value);
 
@@ -227,8 +220,6 @@ private:
     Document *mDocument = nullptr;
     MapDocument *mMapDocument = nullptr;
     TilesetDocument *mTilesetDocument = nullptr;
-
-    VariantEditorFactory *mVariantEditorFactory;
 
     // manager owning the properties
     QtVariantPropertyManager *mVariantManager;

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -94,6 +94,7 @@ SOURCES += aboutdialog.cpp \
     changetilewangid.cpp \
     changewangcolordata.cpp \
     changewangsetdata.cpp \
+    changecomponents.cpp \
     clickablelabel.cpp \
     issuescounter.cpp \
     issuesdock.cpp \
@@ -329,6 +330,7 @@ HEADERS += aboutdialog.h \
     changetilewangid.h \
     changewangcolordata.h \
     changewangsetdata.h \
+    changecomponents.h \
     clickablelabel.h \
     issuescounter.h \
     issuesdock.h \

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -77,6 +77,7 @@ SOURCES += aboutdialog.cpp \
     brushitem.cpp \
     bucketfilltool.cpp \
     capturestamphelper.cpp \
+    changecomponents.cpp \
     changeimagelayerproperties.cpp \
     changelayer.cpp \
     changemapobject.cpp \
@@ -94,7 +95,6 @@ SOURCES += aboutdialog.cpp \
     changetilewangid.cpp \
     changewangcolordata.cpp \
     changewangsetdata.cpp \
-    changecomponents.cpp \
     clickablelabel.cpp \
     issuescounter.cpp \
     issuesdock.cpp \
@@ -312,6 +312,7 @@ HEADERS += aboutdialog.h \
     brushitem.h \
     bucketfilltool.h \
     capturestamphelper.h \
+    changecomponents.h \
     changeevents.h \
     changeimagelayerproperties.h \
     changelayer.h \
@@ -330,7 +331,6 @@ HEADERS += aboutdialog.h \
     changetilewangid.h \
     changewangcolordata.h \
     changewangsetdata.h \
-    changecomponents.h \
     clickablelabel.h \
     issuescounter.h \
     issuesdock.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -131,6 +131,8 @@ QtGuiApplication {
         "bucketfilltool.h",
         "capturestamphelper.cpp",
         "capturestamphelper.h",
+        "changecomponents.cpp",
+        "changecomponents.h",
         "changeevents.h",
         "changeimagelayerproperties.cpp",
         "changeimagelayerproperties.h",

--- a/src/tiled/tilesetdocument.cpp
+++ b/src/tiled/tilesetdocument.cpp
@@ -76,6 +76,8 @@ TilesetDocument::TilesetDocument(const SharedTileset &tileset)
     connect(this, &TilesetDocument::propertiesChanged,
             this, &TilesetDocument::onPropertiesChanged);
 
+    // TODO: add components?
+
     connect(mWangSetModel, &TilesetWangSetModel::wangSetRemoved,
             this, &TilesetDocument::onWangSetRemoved);
 }

--- a/translations/tiled_bg.ts
+++ b/translations/tiled_bg.ts
@@ -807,7 +807,7 @@
     <message>
         <location line="+8"/>
         <source>Show &amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>Показване на &amp;света</translation>
     </message>
     <message>
         <location line="-248"/>
@@ -902,12 +902,12 @@
     <message>
         <location line="+33"/>
         <source>&amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Свят</translation>
     </message>
     <message>
         <location line="+30"/>
         <source>&amp;Open File or Project...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Отваряне на файл или проект…</translation>
     </message>
     <message>
         <location line="+79"/>
@@ -1686,17 +1686,17 @@ Line %1, column %2</source>
     <message>
         <location line="-133"/>
         <source>Crash Reporting</source>
-        <translation type="unfinished"></translation>
+        <translation>Докладване на сривове</translation>
     </message>
     <message>
         <location line="+9"/>
         <source>Enable sending anonymous crash reports</source>
-        <translation type="unfinished"></translation>
+        <translation>Включване на изпращането на анонимни доклади за сривове</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;)</source>
-        <translation type="unfinished"></translation>
+        <translation>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;още информация&lt;/a&gt;)</translation>
     </message>
     <message>
         <location line="+97"/>
@@ -2771,32 +2771,32 @@ Line %1, column %2</source>
         <location filename="../src/tiled/scriptprocess.cpp" line="+38"/>
         <location line="+10"/>
         <source>Error running %1: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Грешка при изпълнението на %1: %2</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Error running &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Грешка при изпълнението на „%1“: %2</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Process &apos;%1 %2&apos; finished with exit code %3.</source>
-        <translation type="unfinished"></translation>
+        <translation>Процесът „%1 %2“ завърши с код %3.</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>The standard output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>На стандартния изход имаше:</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>The standard error output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>На стандартния изход за грешки имаше:</translation>
     </message>
     <message>
         <location line="+118"/>
         <source>Access to Process object that was already closed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Достъп до процес, който вече е приключил.</translation>
     </message>
 </context>
 <context>
@@ -4217,7 +4217,7 @@ Please select specific format.</source>
         <location line="-1513"/>
         <location line="+1514"/>
         <source>Lock Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Заключване на оформлението</translation>
     </message>
     <message>
         <location line="-1503"/>
@@ -4323,17 +4323,17 @@ Please select specific format.</source>
     <message>
         <location line="+140"/>
         <source>&lt;html&gt;Enable anonymous crash reporting? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;Искате ли да включите анонимното докладване на сривове? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;още информация&lt;/a&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>&amp;Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Да</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>&amp;No</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Не</translation>
     </message>
     <message>
         <location line="+241"/>
@@ -4973,7 +4973,7 @@ Please select specific format.</source>
     <message>
         <location filename="../src/tiled/wangdock.cpp" line="+72"/>
         <source>&lt;p&gt;No tileset with Terrain Sets available.&lt;/p&gt;&lt;p&gt;Open a tileset with a Terrain Set or set up a new Terrain Set to be able to use the Terrain Brush or the Terrain Fill Mode.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;Няма налични плочни набори съдържащи теренен набор.&lt;/p&gt;&lt;p&gt;Отворете плочен набор с теренен набор, или създайте нов теренен набор, за да можете да използвате Теренната четка или Режима за запълване на терен.&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
@@ -5029,12 +5029,12 @@ Please select specific format.</source>
     <message>
         <location line="+166"/>
         <source>Select Touched Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Избиране на докосваните обекти</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Select Enclosed Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Избиране на заградените обекти</translation>
     </message>
     <message numerus="yes">
         <location line="+599"/>
@@ -5827,7 +5827,7 @@ Please select specific format.</source>
     <message>
         <location line="+14"/>
         <source>Error decoding file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Грешка при декодирането на файл: %1</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -7299,7 +7299,7 @@ Please select specific format.</source>
     <message>
         <location filename="../src/plugins/yy/yyplugin.cpp" line="+163"/>
         <source>GameMaker Studio 2 files (*.yy)</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлове на GameMaker Studio 2 (*.yy)</translation>
     </message>
 </context>
 <context>
@@ -7442,7 +7442,7 @@ Please select specific format.</source>
     <message>
         <location line="+8"/>
         <source>Fit Map In View</source>
-        <translation type="unfinished"></translation>
+        <translation>Побиране на картата в изгледа</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -7452,7 +7452,7 @@ Please select specific format.</source>
     <message>
         <location line="+6"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Изглед</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/translations/tiled_bg.ts
+++ b/translations/tiled_bg.ts
@@ -616,12 +616,12 @@
     <message>
         <location line="+95"/>
         <source>&amp;Unload World</source>
-        <translation type="unfinished">Отзареждане на света</translation>
+        <translation>&amp;Отзареждане на света</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>&amp;Save World</source>
-        <translation type="unfinished">Запазване на света</translation>
+        <translation>&amp;Запазване на света</translation>
     </message>
     <message>
         <location line="-86"/>
@@ -731,12 +731,12 @@
     <message>
         <location line="+5"/>
         <source>&amp;Load World...</source>
-        <translation type="unfinished">Зареждане на света…</translation>
+        <translation>&amp;Зареждане на света…</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>&amp;New World...</source>
-        <translation type="unfinished">Нов свят…</translation>
+        <translation>&amp;Нов свят…</translation>
     </message>
     <message>
         <location line="+8"/>

--- a/translations/tiled_fr.ts
+++ b/translations/tiled_fr.ts
@@ -353,7 +353,7 @@
     <message>
         <location line="+13"/>
         <source>&amp;Browse...</source>
-        <translation>Parcourir... (&amp;B)</translation>
+        <translation>&amp;Parcourir ...</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -616,12 +616,12 @@
     <message>
         <location line="+95"/>
         <source>&amp;Unload World</source>
-        <translation type="unfinished">Décharger le Monde</translation>
+        <translation>&amp;Décharger le Monde</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>&amp;Save World</source>
-        <translation type="unfinished">Sauvegarder le Monde</translation>
+        <translation>&amp;Sauvegarder le Monde</translation>
     </message>
     <message>
         <location line="-86"/>
@@ -731,12 +731,12 @@
     <message>
         <location line="+5"/>
         <source>&amp;Load World...</source>
-        <translation type="unfinished">Charger le Monde...</translation>
+        <translation>&amp;Charger le Monde...</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>&amp;New World...</source>
-        <translation type="unfinished">Nouveau Monde...</translation>
+        <translation>&amp;Nouveau Monde ...</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -807,7 +807,7 @@
     <message>
         <location line="+8"/>
         <source>Show &amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher le &amp;Monde</translation>
     </message>
     <message>
         <location line="-248"/>
@@ -857,7 +857,7 @@
     <message>
         <location line="+5"/>
         <source>&amp;Offset Map...</source>
-        <translation>Décaler la Carte... (&amp;O)</translation>
+        <translation>&amp;Décaler la Carte ...</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -902,12 +902,12 @@
     <message>
         <location line="+33"/>
         <source>&amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Monde</translation>
     </message>
     <message>
         <location line="+30"/>
         <source>&amp;Open File or Project...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Ouvrir un fichier ou un projet ...</translation>
     </message>
     <message>
         <location line="+79"/>
@@ -1276,7 +1276,7 @@ Ligne %1, colonne %2</translation>
     <message>
         <location line="+25"/>
         <source>&amp;Browse...</source>
-        <translation>Parcourir.. (&amp;B)</translation>
+        <translation>&amp;Parcourir ...</translation>
     </message>
     <message>
         <location line="+20"/>
@@ -1686,17 +1686,17 @@ Ligne %1, colonne %2</translation>
     <message>
         <location line="-133"/>
         <source>Crash Reporting</source>
-        <translation type="unfinished"></translation>
+        <translation>Rapport de plantage</translation>
     </message>
     <message>
         <location line="+9"/>
         <source>Enable sending anonymous crash reports</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer l&apos;envoi de rapport de plantage anonymes</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;)</source>
-        <translation type="unfinished"></translation>
+        <translation>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;Plus d&apos;informations&lt;/a&gt;)</translation>
     </message>
     <message>
         <location line="+97"/>
@@ -2771,32 +2771,32 @@ Ligne %1, colonne %2</translation>
         <location filename="../src/tiled/scriptprocess.cpp" line="+38"/>
         <location line="+10"/>
         <source>Error running %1: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de l&apos;exécution de %1 : %2</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Error running &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de l&apos;exécution de &apos;%1&apos; : %2</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Process &apos;%1 %2&apos; finished with exit code %3.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le processus &apos;%1 %2&apos; s&apos;est terminé avec le code d&apos;erreur %3.</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>The standard output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>Le contenu de la sortie standard était :</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>The standard error output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>Le contenu de la sortie d&apos;erreur était :</translation>
     </message>
     <message>
         <location line="+118"/>
         <source>Access to Process object that was already closed.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;accès au processus objet était déjà fermé.</translation>
     </message>
 </context>
 <context>
@@ -3083,7 +3083,7 @@ Ligne %1, colonne %2</translation>
     <message>
         <location line="+1"/>
         <source>Intersect Selection</source>
-        <translation>Intersectionner la Sélection</translation>
+        <translation>Recouper la Sélection</translation>
     </message>
 </context>
 <context>
@@ -4217,7 +4217,7 @@ Veuillez sélectionner un format spécifique.</translation>
         <location line="-1513"/>
         <location line="+1514"/>
         <source>Lock Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Figer la disposition</translation>
     </message>
     <message>
         <location line="-1503"/>
@@ -4323,17 +4323,17 @@ Veuillez sélectionner un format spécifique.</translation>
     <message>
         <location line="+140"/>
         <source>&lt;html&gt;Enable anonymous crash reporting? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;Activer le rapport de plantage anonyme ? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;Plus d&apos;informations&lt;/a&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>&amp;Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Oui</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>&amp;No</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Non</translation>
     </message>
     <message>
         <location line="+241"/>
@@ -4973,7 +4973,7 @@ Veuillez sélectionner un format spécifique.</translation>
     <message>
         <location filename="../src/tiled/wangdock.cpp" line="+72"/>
         <source>&lt;p&gt;No tileset with Terrain Sets available.&lt;/p&gt;&lt;p&gt;Open a tileset with a Terrain Set or set up a new Terrain Set to be able to use the Terrain Brush or the Terrain Fill Mode.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;Aucun Jeu de Tuile disponible pour le Terrain donné.&lt;/p&gt;&lt;p&gt;Veuillez ouvrir un Jeu de Tuile avec un Jeu de Terrain ou créez un nouveau Jeu de Terrain afin de pouvoir utiliser la Brosse de Terrain ou le mode de Remplissage de Terrain.&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
@@ -5029,12 +5029,12 @@ Veuillez sélectionner un format spécifique.</translation>
     <message>
         <location line="+166"/>
         <source>Select Touched Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionnez les objets modifiés</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Select Enclosed Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner les objets inclus</translation>
     </message>
     <message numerus="yes">
         <location line="+599"/>
@@ -5827,7 +5827,7 @@ Veuillez sélectionner un format spécifique.</translation>
     <message>
         <location line="+14"/>
         <source>Error decoding file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors du décodage du fichier : %1</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -7299,7 +7299,7 @@ Veuillez sélectionner un format spécifique.</translation>
     <message>
         <location filename="../src/plugins/yy/yyplugin.cpp" line="+163"/>
         <source>GameMaker Studio 2 files (*.yy)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fichiers GameMaker Studio 2 (*.yy)</translation>
     </message>
 </context>
 <context>
@@ -7442,7 +7442,7 @@ Veuillez sélectionner un format spécifique.</translation>
     <message>
         <location line="+8"/>
         <source>Fit Map In View</source>
-        <translation type="unfinished"></translation>
+        <translation>Recentrer la Carte dans la vue courante</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -7452,7 +7452,7 @@ Veuillez sélectionner un format spécifique.</translation>
     <message>
         <location line="+6"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/translations/tiled_pt_PT.ts
+++ b/translations/tiled_pt_PT.ts
@@ -621,12 +621,12 @@
     <message>
         <location line="+95"/>
         <source>&amp;Unload World</source>
-        <translation type="unfinished">Descarregar Mundo</translation>
+        <translation>Descarregar M&amp;undo</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>&amp;Save World</source>
-        <translation type="unfinished">Guardar Mundo</translation>
+        <translation>Gu&amp;ardar Mundo</translation>
     </message>
     <message>
         <location line="-86"/>
@@ -706,7 +706,7 @@
     <message>
         <location line="+354"/>
         <source>&amp;New World...</source>
-        <translation type="unfinished">Novo Mundo...</translation>
+        <translation>&amp;Novo Mundo...</translation>
     </message>
     <message>
         <location line="+16"/>
@@ -787,7 +787,7 @@
     <message>
         <location line="+8"/>
         <source>Show &amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>M&amp;ostrar Mundo</translation>
     </message>
     <message>
         <location line="-269"/>
@@ -802,7 +802,7 @@
     <message>
         <location line="+5"/>
         <source>&amp;Load World...</source>
-        <translation type="unfinished">Carregar Mundo...</translation>
+        <translation>&amp;Carregar Mundo...</translation>
     </message>
     <message>
         <location line="+13"/>
@@ -947,12 +947,12 @@
     <message>
         <location line="+160"/>
         <source>&amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Mundo</translation>
     </message>
     <message>
         <location line="+30"/>
         <source>&amp;Open File or Project...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Abrir Ficheiro ou Projeto...</translation>
     </message>
     <message>
         <location line="+95"/>
@@ -1686,17 +1686,17 @@ Linha %1, coluna %2</translation>
     <message>
         <location line="-133"/>
         <source>Crash Reporting</source>
-        <translation type="unfinished"></translation>
+        <translation>Relatório de Falha</translation>
     </message>
     <message>
         <location line="+9"/>
         <source>Enable sending anonymous crash reports</source>
-        <translation type="unfinished"></translation>
+        <translation>Permitir o envio de relatórios de falha anónimos</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;)</source>
-        <translation type="unfinished"></translation>
+        <translation>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;mais informação&lt;/a&gt;)</translation>
     </message>
     <message>
         <location line="+97"/>
@@ -2771,32 +2771,32 @@ Linha %1, coluna %2</translation>
         <location filename="../src/tiled/scriptprocess.cpp" line="+38"/>
         <location line="+10"/>
         <source>Error running %1: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro ao executar %1: %2</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Error running &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro ao executar &apos;%1&apos;: %2</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Process &apos;%1 %2&apos; finished with exit code %3.</source>
-        <translation type="unfinished"></translation>
+        <translation>Processo &apos;%1 %2&apos; terminou com código de saída %3.</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>The standard output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>A saída padrão foi:</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>The standard error output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>O erro de saída padrão foi:</translation>
     </message>
     <message>
         <location line="+118"/>
         <source>Access to Process object that was already closed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Acesso a objeto de Processo já fechado.</translation>
     </message>
 </context>
 <context>
@@ -4217,7 +4217,7 @@ Por favor, selecione um formato específico.</translation>
         <location line="-1513"/>
         <location line="+1514"/>
         <source>Lock Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Trancar Layout</translation>
     </message>
     <message>
         <location line="-1503"/>
@@ -4323,17 +4323,17 @@ Por favor, selecione um formato específico.</translation>
     <message>
         <location line="+140"/>
         <source>&lt;html&gt;Enable anonymous crash reporting? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;Permitir relatório de falha anónimo? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;mais informação&lt;/a&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>&amp;Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Sim</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>&amp;No</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Não</translation>
     </message>
     <message>
         <location line="+241"/>
@@ -4973,7 +4973,7 @@ Por favor, selecione um formato específico.</translation>
     <message>
         <location filename="../src/tiled/wangdock.cpp" line="+72"/>
         <source>&lt;p&gt;No tileset with Terrain Sets available.&lt;/p&gt;&lt;p&gt;Open a tileset with a Terrain Set or set up a new Terrain Set to be able to use the Terrain Brush or the Terrain Fill Mode.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;Tileset com Conjunto Terreno não disponível.&lt;/p&gt;&lt;p&gt;Abra um tileset com um Conjunto Terreno ou prepare um novo Conjunto Terreno para ser capaz de usar o Pincel de Terreno ou o Modo de Preenchimento de Terreno.&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
@@ -5029,12 +5029,12 @@ Por favor, selecione um formato específico.</translation>
     <message>
         <location line="+166"/>
         <source>Select Touched Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecionar Objetos Tocados</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Select Enclosed Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecionar Objetos Fechados</translation>
     </message>
     <message numerus="yes">
         <location line="+599"/>
@@ -5827,7 +5827,7 @@ Por favor, selecione um formato específico.</translation>
     <message>
         <location line="+14"/>
         <source>Error decoding file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro ao descodificar ficheiro: %1</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -6004,7 +6004,7 @@ Por favor, selecione um formato específico.</translation>
     <message>
         <location line="+1"/>
         <source>Terrain Fill Mode</source>
-        <translation>Modo de Preenchimento do Terreno</translation>
+        <translation>Modo de Preenchimento de Terreno</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -6558,12 +6558,12 @@ Por favor, selecione um formato específico.</translation>
         <location filename="../src/tiled/wangbrush.cpp" line="+111"/>
         <location line="+96"/>
         <source>Terrain Brush</source>
-        <translation>Pincel do Terreno</translation>
+        <translation>Pincel de Terreno</translation>
     </message>
     <message>
         <location line="+202"/>
         <source>Missing terrain transition</source>
-        <translation>Transições do terreno em falta</translation>
+        <translation>Transições de terreno em falta</translation>
     </message>
 </context>
 <context>
@@ -7299,7 +7299,7 @@ Por favor, selecione um formato específico.</translation>
     <message>
         <location filename="../src/plugins/yy/yyplugin.cpp" line="+163"/>
         <source>GameMaker Studio 2 files (*.yy)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ficheiros GameMaker Studio 2 (*.yy)</translation>
     </message>
 </context>
 <context>
@@ -7442,7 +7442,7 @@ Por favor, selecione um formato específico.</translation>
     <message>
         <location line="+8"/>
         <source>Fit Map In View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajustar Mapa à Vista</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -7452,7 +7452,7 @@ Por favor, selecione um formato específico.</translation>
     <message>
         <location line="+6"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Vista</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/translations/tiled_sv.ts
+++ b/translations/tiled_sv.ts
@@ -616,12 +616,12 @@
     <message>
         <location line="+95"/>
         <source>&amp;Unload World</source>
-        <translation type="unfinished">Ta bort värld</translation>
+        <translation>&amp;Avlasta Värld</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>&amp;Save World</source>
-        <translation type="unfinished">Rädda världen</translation>
+        <translation>&amp;Spara Värld</translation>
     </message>
     <message>
         <location line="-86"/>
@@ -631,7 +631,7 @@
     <message>
         <location line="+4"/>
         <source>Show Object &amp;Names</source>
-        <translation>Visa objekt&amp;namn</translation>
+        <translation>Visa objekt &amp;namn</translation>
     </message>
     <message>
         <location line="+46"/>
@@ -646,7 +646,7 @@
     <message>
         <location line="+58"/>
         <source>&amp;Save</source>
-        <translation>S&amp;para</translation>
+        <translation>&amp;Spara</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -661,7 +661,7 @@
     <message>
         <location line="+12"/>
         <source>&amp;Paste</source>
-        <translation>K&amp;listra in</translation>
+        <translation>&amp;Klistra in</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -691,7 +691,7 @@
     <message>
         <location line="+12"/>
         <source>Save &amp;As...</source>
-        <translation>Spara s&amp;om...</translation>
+        <translation>Spara &amp;som...</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -701,7 +701,7 @@
     <message>
         <location line="+9"/>
         <source>&amp;Close</source>
-        <translation>S&amp;täng</translation>
+        <translation>&amp;Stäng</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -731,12 +731,12 @@
     <message>
         <location line="+5"/>
         <source>&amp;Load World...</source>
-        <translation type="unfinished">Läs in värld...</translation>
+        <translation>&amp;Läs in värld...</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>&amp;New World...</source>
-        <translation type="unfinished">Ny värld...</translation>
+        <translation>&amp;Ny värld...</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -807,7 +807,7 @@
     <message>
         <location line="+8"/>
         <source>Show &amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>Visa &amp;Värld</translation>
     </message>
     <message>
         <location line="-248"/>
@@ -902,12 +902,12 @@
     <message>
         <location line="+33"/>
         <source>&amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Värld</translation>
     </message>
     <message>
         <location line="+30"/>
         <source>&amp;Open File or Project...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Öppna Fil eller Projekt...</translation>
     </message>
     <message>
         <location line="+79"/>
@@ -1686,17 +1686,17 @@ Rad %1, kolumn %2</translation>
     <message>
         <location line="-133"/>
         <source>Crash Reporting</source>
-        <translation type="unfinished"></translation>
+        <translation>Kraschrapportering</translation>
     </message>
     <message>
         <location line="+9"/>
         <source>Enable sending anonymous crash reports</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktivera sändning av anonyma kraschrapporter</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;)</source>
-        <translation type="unfinished"></translation>
+        <translation>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;mer information&lt;/a&gt;)</translation>
     </message>
     <message>
         <location line="+97"/>
@@ -2771,32 +2771,32 @@ Rad %1, kolumn %2</translation>
         <location filename="../src/tiled/scriptprocess.cpp" line="+38"/>
         <location line="+10"/>
         <source>Error running %1: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Fel vid körning av %1: %2</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Error running &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Fel vid körning av &apos;%1&apos;: %2</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Process &apos;%1 %2&apos; finished with exit code %3.</source>
-        <translation type="unfinished"></translation>
+        <translation>Processen &apos;%1 %2&apos; avslutades med avslutningskoden %3.</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>The standard output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>Standardutmatningen var:</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>The standard error output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>Standardfelutmatningen var:</translation>
     </message>
     <message>
         <location line="+118"/>
         <source>Access to Process object that was already closed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Åtkomst till Process-objekt som redan var stängt.</translation>
     </message>
 </context>
 <context>
@@ -4217,7 +4217,7 @@ Var god ange det specifika formatet.</translation>
         <location line="-1513"/>
         <location line="+1514"/>
         <source>Lock Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Låslayout</translation>
     </message>
     <message>
         <location line="-1503"/>
@@ -4323,17 +4323,17 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+140"/>
         <source>&lt;html&gt;Enable anonymous crash reporting? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;Aktivera anonym kraschrapportering? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;mer information&lt;/a&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>&amp;Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Ja</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>&amp;No</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Nej</translation>
     </message>
     <message>
         <location line="+241"/>
@@ -4973,7 +4973,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location filename="../src/tiled/wangdock.cpp" line="+72"/>
         <source>&lt;p&gt;No tileset with Terrain Sets available.&lt;/p&gt;&lt;p&gt;Open a tileset with a Terrain Set or set up a new Terrain Set to be able to use the Terrain Brush or the Terrain Fill Mode.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;Ingen brickuppsättning med terränguppsättningar tillgänglig.&lt;/p&gt;&lt;p&gt;Öppna en brickuppsättning med en terränguppsättning eller ställ in en ny terränguppsättning för att kunna använda terrängpenseln eller läget för terrängfyllning.&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
@@ -5029,12 +5029,12 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+166"/>
         <source>Select Touched Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Välj rörda objekt</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Select Enclosed Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Välj slutna objekt</translation>
     </message>
     <message numerus="yes">
         <location line="+599"/>
@@ -5413,12 +5413,12 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+5"/>
         <source>Output Chunk Width</source>
-        <translation type="unfinished">Bredd på output chunk</translation>
+        <translation>Bredd på utdatasegment</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Output Chunk Height</source>
-        <translation type="unfinished">Höjd på output chunk</translation>
+        <translation>Höjd för utdatasegment</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -5605,7 +5605,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+14"/>
         <source>Object Alignment</source>
-        <translation type="unfinished">Objektgruppering</translation>
+        <translation>Objektinriktning</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -5827,7 +5827,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+14"/>
         <source>Error decoding file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fel vid avkodning av fil: %1</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -6300,7 +6300,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+1"/>
         <source>Dynamically Wrap Tiles</source>
-        <translation type="unfinished">Vikna rutor dynamiskt</translation>
+        <translation>Radbryt dynamiskt rutor</translation>
     </message>
     <message>
         <location line="+252"/>
@@ -6368,7 +6368,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+1"/>
         <source>Dynamically Wrap Tiles</source>
-        <translation type="unfinished">Vikna rutor dynamiskt</translation>
+        <translation>Radbryt dynamiskt rutor</translation>
     </message>
     <message>
         <location line="+47"/>
@@ -6895,7 +6895,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+59"/>
         <source>Change Object Alignment</source>
-        <translation type="unfinished">Ändra objektjustering</translation>
+        <translation>Ändra objektjustering</translation>
     </message>
     <message>
         <location line="+18"/>
@@ -7103,7 +7103,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+10"/>
         <source>Change Chunk Size</source>
-        <translation type="unfinished">Ändra storlek på chunk</translation>
+        <translation>Ändra bitstorlek</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -7291,7 +7291,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+7"/>
         <source>Open with System Editor</source>
-        <translation type="unfinished">Öppna med Systemsredigeraren</translation>
+        <translation>Öppna med systemredigeraren</translation>
     </message>
 </context>
 <context>
@@ -7299,7 +7299,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location filename="../src/plugins/yy/yyplugin.cpp" line="+163"/>
         <source>GameMaker Studio 2 files (*.yy)</source>
-        <translation type="unfinished"></translation>
+        <translation>GameMaker Studio 2-filer (*.yy)</translation>
     </message>
 </context>
 <context>
@@ -7442,7 +7442,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+8"/>
         <source>Fit Map In View</source>
-        <translation type="unfinished"></translation>
+        <translation>Anpassa kartan i vyn</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -7452,7 +7452,7 @@ Var god ange det specifika formatet.</translation>
     <message>
         <location line="+6"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Visa</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/translations/tiled_tr.ts
+++ b/translations/tiled_tr.ts
@@ -616,12 +616,12 @@
     <message>
         <location line="+95"/>
         <source>&amp;Unload World</source>
-        <translation type="unfinished">Dünyayı Boşalt</translation>
+        <translation>Dünyayı &amp;Boşalt</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>&amp;Save World</source>
-        <translation type="unfinished">Dünyayı Kaydet</translation>
+        <translation>Dünyayı &amp;Kaydet</translation>
     </message>
     <message>
         <location line="-86"/>
@@ -731,12 +731,12 @@
     <message>
         <location line="+5"/>
         <source>&amp;Load World...</source>
-        <translation type="unfinished">Dünya Yükle...</translation>
+        <translation>Dünya &amp;Yükle...</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>&amp;New World...</source>
-        <translation type="unfinished">Yeni Dünya...</translation>
+        <translation>Yeni &amp;Dünya...</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -751,7 +751,7 @@
     <message>
         <location line="+5"/>
         <source>&amp;Close Project</source>
-        <translation>Projeyi &amp;Kapa</translation>
+        <translation>Projeyi &amp;Kapat</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -807,7 +807,7 @@
     <message>
         <location line="+8"/>
         <source>Show &amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>Dünyayı &amp;Göster</translation>
     </message>
     <message>
         <location line="-248"/>
@@ -903,12 +903,12 @@
     <message>
         <location line="+33"/>
         <source>&amp;World</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Dünya</translation>
     </message>
     <message>
         <location line="+30"/>
         <source>&amp;Open File or Project...</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya veya Proje &amp;Aç...</translation>
     </message>
     <message>
         <location line="+79"/>
@@ -1689,17 +1689,17 @@ Satır %1, sütun %2</translation>
     <message>
         <location line="-133"/>
         <source>Crash Reporting</source>
-        <translation type="unfinished"></translation>
+        <translation>Çökme Bildirimi</translation>
     </message>
     <message>
         <location line="+9"/>
         <source>Enable sending anonymous crash reports</source>
-        <translation type="unfinished"></translation>
+        <translation>Anonim çökme bildirimleri göndermeyi etkinleştir</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;)</source>
-        <translation type="unfinished"></translation>
+        <translation>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;daha fazla bilgi&lt;/a&gt;)</translation>
     </message>
     <message>
         <location line="+97"/>
@@ -2774,32 +2774,32 @@ Satır %1, sütun %2</translation>
         <location filename="../src/tiled/scriptprocess.cpp" line="+38"/>
         <location line="+10"/>
         <source>Error running %1: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 çalıştırılırken hata oluştu: %2</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Error running &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; çalıştırılırken hata oluştu: %2</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Process &apos;%1 %2&apos; finished with exit code %3.</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1 %2&apos; işlemi %3 çıkış koduyla tamamlandı.</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>The standard output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>Standart çıktı şuydu:</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>The standard error output was:</source>
-        <translation type="unfinished"></translation>
+        <translation>Standart hata çıktısı şuydu:</translation>
     </message>
     <message>
         <location line="+118"/>
         <source>Access to Process object that was already closed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaten kapatılmış olan İşlem nesnesine erişim.</translation>
     </message>
 </context>
 <context>
@@ -2971,12 +2971,14 @@ Satır %1, sütun %2</translation>
         <source>Duplicate %n Object(s)</source>
         <translation>
             <numerusform>%n Nesneyi Çoğalt</numerusform>
+            <numerusform>%n Nesneyi Çoğalt</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+2"/>
         <source>Remove %n Object(s)</source>
         <translation>
+            <numerusform>%n Nesneyi Kaldır</numerusform>
             <numerusform>%n Nesneyi Kaldır</numerusform>
         </translation>
     </message>
@@ -3054,6 +3056,7 @@ Satır %1, sütun %2</translation>
         <location line="+6"/>
         <source>Move %n Object(s) to Layer</source>
         <translation>
+            <numerusform>%n Nesneyi Katmana Taşı</numerusform>
             <numerusform>%n Nesneyi Katmana Taşı</numerusform>
         </translation>
     </message>
@@ -3768,6 +3771,7 @@ Satır %1, sütun %2</translation>
         <source>Move %n Point(s)</source>
         <translation>
             <numerusform>%n Noktayı Taşı</numerusform>
+            <numerusform>%n Noktayı Taşı</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -3775,6 +3779,7 @@ Satır %1, sütun %2</translation>
         <location line="+94"/>
         <source>Delete %n Node(s)</source>
         <translation>
+            <numerusform>%n Boğumu Sil</numerusform>
             <numerusform>%n Boğumu Sil</numerusform>
         </translation>
     </message>
@@ -3912,12 +3917,14 @@ Onu değiştirmek istiyor musunuz?</translation>
         <source>%n error(s)</source>
         <translation>
             <numerusform>%n hata</numerusform>
+            <numerusform>%n hata</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+1"/>
         <source>%n warning(s)</source>
         <translation>
+            <numerusform>%n uyarı</numerusform>
             <numerusform>%n uyarı</numerusform>
         </translation>
     </message>
@@ -3984,7 +3991,8 @@ Onu değiştirmek istiyor musunuz?</translation>
         <location line="+86"/>
         <source>Drag Layer(s)</source>
         <translation>
-            <numerusform>%n Katmanı Sürükle</numerusform>
+            <numerusform>Katmanı Sürükle</numerusform>
+            <numerusform>Katmanları Sürükle</numerusform>
         </translation>
     </message>
     <message>
@@ -4212,7 +4220,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <location line="-1513"/>
         <location line="+1514"/>
         <source>Lock Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Düzeni Kilitle</translation>
     </message>
     <message>
         <location line="-1503"/>
@@ -4318,17 +4326,17 @@ Lütfen belirli bir biçim seçin.</translation>
     <message>
         <location line="+140"/>
         <source>&lt;html&gt;Enable anonymous crash reporting? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;Anonim çökme bildirimi etkinleştirilsin mi? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;daha fazla bilgi&lt;/a&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>&amp;Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Evet</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>&amp;No</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Hayır</translation>
     </message>
     <message>
         <location line="+241"/>
@@ -4419,6 +4427,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Rotate %n Object(s)</source>
         <translation>
             <numerusform>%n Nesneyi Döndür</numerusform>
+            <numerusform>%n Nesneyi Döndür</numerusform>
         </translation>
     </message>
     <message>
@@ -4448,6 +4457,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Group %n Layer(s)</source>
         <translation>
             <numerusform>%n Katmanı Grupla</numerusform>
+            <numerusform>%n Katmanı Grupla</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -4455,12 +4465,14 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Ungroup %n Layer(s)</source>
         <translation>
             <numerusform>%n Katmanı Gruptan Çıkar</numerusform>
+            <numerusform>%n Katmanı Gruptan Çıkar</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+46"/>
         <source>Duplicate %n Layer(s)</source>
         <translation>
+            <numerusform>%n Katmanı Çoğalt</numerusform>
             <numerusform>%n Katmanı Çoğalt</numerusform>
         </translation>
     </message>
@@ -4479,6 +4491,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <location line="+98"/>
         <source>Remove %n Layer(s)</source>
         <translation>
+            <numerusform>%n Katmanı Kaldır</numerusform>
             <numerusform>%n Katmanı Kaldır</numerusform>
         </translation>
     </message>
@@ -4507,12 +4520,14 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Duplicate %n Object(s)</source>
         <translation>
             <numerusform>%n Nesneyi Çoğalt</numerusform>
+            <numerusform>%n Nesneyi Çoğalt</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+13"/>
         <source>Remove %n Object(s)</source>
         <translation>
+            <numerusform>%n Nesneyi Kaldır</numerusform>
             <numerusform>%n Nesneyi Kaldır</numerusform>
         </translation>
     </message>
@@ -4521,6 +4536,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Move %n Object(s) to Layer</source>
         <translation>
             <numerusform>%n Nesneyi Katmana Taşı</numerusform>
+            <numerusform>%n Nesneyi Katmana Taşı</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -4528,12 +4544,14 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Move %n Object(s) Up</source>
         <translation>
             <numerusform>%n Nesneyi Yukarı Taşı</numerusform>
+            <numerusform>%n Nesneyi Yukarı Taşı</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+36"/>
         <source>Move %n Object(s) Down</source>
         <translation>
+            <numerusform>%n Nesneyi Aşağı Taşı</numerusform>
             <numerusform>%n Nesneyi Aşağı Taşı</numerusform>
         </translation>
     </message>
@@ -4692,12 +4710,14 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Duplicate %n Object(s)</source>
         <translation>
             <numerusform>%n Nesneyi Çoğalt</numerusform>
+            <numerusform>%n Nesneyi Çoğalt</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+1"/>
         <source>Remove %n Object(s)</source>
         <translation>
+            <numerusform>%n Nesneyi Kaldır</numerusform>
             <numerusform>%n Nesneyi Kaldır</numerusform>
         </translation>
     </message>
@@ -4739,6 +4759,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <location line="+17"/>
         <source>Add %n Tileset(s)</source>
         <translation>
+            <numerusform>%n Desen Seti Ekle</numerusform>
             <numerusform>%n Desen Seti Ekle</numerusform>
         </translation>
     </message>
@@ -4955,7 +4976,7 @@ Lütfen belirli bir biçim seçin.</translation>
     <message>
         <location filename="../src/tiled/wangdock.cpp" line="+72"/>
         <source>&lt;p&gt;No tileset with Terrain Sets available.&lt;/p&gt;&lt;p&gt;Open a tileset with a Terrain Set or set up a new Terrain Set to be able to use the Terrain Brush or the Terrain Fill Mode.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;Zemin Setlerine sahip desen seti yok.&lt;/p&gt;&lt;p&gt;Zemin Fırçası veya Zemin Dolgu Modunu kullanabilmek için bir Zemin Seti ile bir desen seti açın veya yeni bir Zemin Seti kurun.&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
@@ -4985,6 +5006,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Move %n Object(s)</source>
         <translation>
             <numerusform>%n Nesneyi Taşı</numerusform>
+            <numerusform>%n Nesneyi Taşı</numerusform>
         </translation>
     </message>
     <message>
@@ -5010,17 +5032,18 @@ Lütfen belirli bir biçim seçin.</translation>
     <message>
         <location line="+166"/>
         <source>Select Touched Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Dokunulan Nesneleri Seç</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Select Enclosed Objects</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapalı Nesneleri Seç</translation>
     </message>
     <message numerus="yes">
         <location line="+599"/>
         <source>Rotate %n Object(s)</source>
         <translation>
+            <numerusform>%n Nesneyi Döndür</numerusform>
             <numerusform>%n Nesneyi Döndür</numerusform>
         </translation>
     </message>
@@ -5028,6 +5051,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <location line="+275"/>
         <source>Resize %n Object(s)</source>
         <translation>
+            <numerusform>%n Nesneyi Boyutlandır</numerusform>
             <numerusform>%n Nesneyi Boyutlandır</numerusform>
         </translation>
     </message>
@@ -5144,6 +5168,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Move %n Object(s) to Layer</source>
         <translation>
             <numerusform>%n Nesneyi Katmana Taşı</numerusform>
+            <numerusform>%n Nesneyi Katmana Taşı</numerusform>
         </translation>
     </message>
 </context>
@@ -5242,14 +5267,16 @@ Lütfen belirli bir biçim seçin.</translation>
         <location filename="../src/tiled/propertiesdock.cpp" line="+247"/>
         <source>Paste Property/Properties</source>
         <translation>
-            <numerusform>%n Özelliği Yapıştır</numerusform>
+            <numerusform>Özelliği/Özellikleri Yapıştır</numerusform>
+            <numerusform>Özelliği/Özellikleri Yapıştır</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+50"/>
         <source>Remove Property/Properties</source>
         <translation>
-            <numerusform>%n Özelliği Kaldır</numerusform>
+            <numerusform>Özelliği/Özellikleri Kaldır</numerusform>
+            <numerusform>Özelliği/Özellikleri Kaldır</numerusform>
         </translation>
     </message>
     <message>
@@ -5302,7 +5329,8 @@ Lütfen belirli bir biçim seçin.</translation>
         <location line="-62"/>
         <source>Convert Property/Properties</source>
         <translation>
-            <numerusform>%n Özelliği Dönüştür</numerusform>
+            <numerusform>Özelliği/Özellikleri Dönüştür</numerusform>
+            <numerusform>Özelliği/Özellikleri Dönüştür</numerusform>
         </translation>
     </message>
     <message>
@@ -5802,7 +5830,7 @@ Lütfen belirli bir biçim seçin.</translation>
     <message>
         <location line="+14"/>
         <source>Error decoding file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyanın kodu çözülürken hata oluştu: %1</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -6969,12 +6997,14 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Change %n Object/s Tile</source>
         <translation>
             <numerusform>%n Nesnenin Desenini Değiştir</numerusform>
+            <numerusform>%n Nesnenin Desenini Değiştir</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+69"/>
         <source>Detach %n Template Instance(s)</source>
         <translation>
+            <numerusform>%n Şablon Örneğini Ayır</numerusform>
             <numerusform>%n Şablon Örneğini Ayır</numerusform>
         </translation>
     </message>
@@ -6983,12 +7013,14 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Reset %n Instances</source>
         <translation>
             <numerusform>%n Örneği Sıfırla</numerusform>
+            <numerusform>%n Örneği Sıfırla</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+53"/>
         <source>Replace %n Object(s) With Template</source>
         <translation>
+            <numerusform>%n Nesneyi Şablonla Değiştir</numerusform>
             <numerusform>%n Nesneyi Şablonla Değiştir</numerusform>
         </translation>
     </message>
@@ -7130,6 +7162,7 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Flip %n Object(s)</source>
         <translation>
             <numerusform>%n Nesneyi Çevir</numerusform>
+            <numerusform>%n Nesneyi Çevir</numerusform>
         </translation>
     </message>
     <message>
@@ -7162,12 +7195,14 @@ Lütfen belirli bir biçim seçin.</translation>
         <source>Raise %n Layer(s)</source>
         <translation>
             <numerusform>%n Katmanı Yükselt</numerusform>
+            <numerusform>%n Katmanı Yükselt</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location line="+27"/>
         <source>Lower %n Layer(s)</source>
         <translation>
+            <numerusform>%n Katmanı Alçalt</numerusform>
             <numerusform>%n Katmanı Alçalt</numerusform>
         </translation>
     </message>
@@ -7267,7 +7302,7 @@ Lütfen belirli bir biçim seçin.</translation>
     <message>
         <location filename="../src/plugins/yy/yyplugin.cpp" line="+163"/>
         <source>GameMaker Studio 2 files (*.yy)</source>
-        <translation type="unfinished"></translation>
+        <translation>GameMaker Studio 2 dosyaları (*.yy)</translation>
     </message>
 </context>
 <context>
@@ -7410,7 +7445,7 @@ Lütfen belirli bir biçim seçin.</translation>
     <message>
         <location line="+8"/>
         <source>Fit Map In View</source>
-        <translation type="unfinished"></translation>
+        <translation>Haritayı Görünüme Sığdır</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -7420,7 +7455,7 @@ Lütfen belirli bir biçim seçin.</translation>
     <message>
         <location line="+6"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Görünüm</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/translations/translations.pro
+++ b/translations/translations.pro
@@ -29,6 +29,7 @@ LANGUAGES = \
     pt_PT \
     ru \
     sv \
+    th \
     tr \
     uk \
     zh_CN \

--- a/translations/translations.qbs
+++ b/translations/translations.qbs
@@ -10,7 +10,6 @@ Product {
         "tiled_hi.ts",
         "tiled_lv.ts",
         "tiled_mr.ts",
-        "tiled_th.ts",
     ]
 
     Depends { name: "Qt.core" }


### PR DESCRIPTION
Add the ability to use object types as components on an object.

Implemented:

- [x] Add/remove components in Property Dock/Browser
- [x] Use Shift to add/remove multiple components in sequence
- [x] Undo/redo adding components
- [x] Change component's properties
- [x] Undo/redo changing component's properties
- [x] Only map objects supported for now
- [x] Save/Load components to the map file
- [x] History view change component property label
- [x] Being able to load & remove object components that are not defined as object types
- [x] Consolidate add/remove component menus into one
- [x] Accidentally remove the component, undo the action, modified component properties should be correct
- [x] Add support for objects in the collision editor
- [x] Support for tileset tile collision objects
- [x] Component properties of an object type cannot select objects

Future work (in sub-branches):
- Support tile objects and inheritance?
- Scripting/API support
- Support object templates
- Remember the order of components
- A different tool button menu icon
- Make components menu not flicker when holding shift
- Add components to multiple objects
- Modify components for multiple objects
- Add ObjectReferenceItem support
- When adding a component add it into an alphabetically sorted place in the property browser
- Review & Test this & all sub-features
- ~Use the object type color as the property browser bar color (cannot be implemented)~

PR status:
- [x] Initial review
- [x] Working on TODOs
- [x] Code style check
- [x] Fine-tuning
- [x] Testing