### PR TITLE
Render fine grid over main grid with thicker lines

### DIFF
--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -138,7 +138,7 @@ QRect HexagonalRenderer::boundingRect(const QRect &rect) const
 }
 
 void HexagonalRenderer::drawGrid(QPainter *painter, const QRectF &exposed,
-                                 QColor gridColor) const
+                                 QColor gridColor, const int _gridFine) const
 {
     QRect rect = exposed.toAlignedRect();
     if (rect.isNull())

--- a/src/libtiled/hexagonalrenderer.h
+++ b/src/libtiled/hexagonalrenderer.h
@@ -78,7 +78,7 @@ public:
     QRect boundingRect(const QRect &rect) const override;
 
     void drawGrid(QPainter *painter, const QRectF &exposed,
-                  QColor gridColor) const override;
+                  QColor gridColor, const int gridFine = 0) const override;
 
     using MapRenderer::drawTileLayer;
     void drawTileLayer(const RenderTileCallback &renderTile,

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -226,7 +226,7 @@ QPainterPath IsometricRenderer::interactionShape(const MapObject *object) const
 }
 
 void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect,
-                                 QColor gridColor) const
+                                 QColor gridColor, const int gridFine) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -248,16 +248,23 @@ void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect,
     }
 
     QPen gridPen = makeGridPen(painter->device(), gridColor);
+    QPen finePen = makeGridPen(painter->device(), gridColor.darker());
+    finePen.setWidth(gridPen.width() * 2);
+
     painter->setPen(gridPen);
 
     for (int y = startY; y <= endY; ++y) {
         const QPointF start = tileToScreenCoords(startX, y);
         const QPointF end = tileToScreenCoords(endX, y);
+
+        painter->setPen(gridFine != 0 && y % gridFine == 0 ? finePen : gridPen);
         painter->drawLine(start, end);
     }
     for (int x = startX; x <= endX; ++x) {
         const QPointF start = tileToScreenCoords(x, startY);
         const QPointF end = tileToScreenCoords(x, endY);
+
+        painter->setPen(gridFine != 0 && x % gridFine == 0 ? finePen : gridPen);
         painter->drawLine(start, end);
     }
 }

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -52,7 +52,7 @@ public:
     QPainterPath shape(const MapObject *object) const override;
     QPainterPath interactionShape(const MapObject *object) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &rect, QColor grid) const override;
+    void drawGrid(QPainter *painter, const QRectF &rect, QColor grid, const int gridFine) const override;
 
     using MapRenderer::drawTileLayer;
     void drawTileLayer(const RenderTileCallback &renderTile,

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -133,7 +133,7 @@ public:
      * \a painter.
      */
     virtual void drawGrid(QPainter *painter, const QRectF &rect,
-                          QColor gridColor = Qt::black) const = 0;
+                          QColor gridColor = Qt::black, const int gridFine = 0) const = 0;
 
     typedef std::function<void(QPoint, const QPointF &)> RenderTileCallback;
 

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -224,7 +224,7 @@ QPainterPath OrthogonalRenderer::interactionShape(const MapObject *object) const
 }
 
 void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect,
-                                  QColor gridColor) const
+                                  QColor gridColor, const int gridFine) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -245,19 +245,35 @@ void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect,
     }
 
     QPen gridPen = makeGridPen(painter->device(), gridColor);
+    QPen finePen = makeGridPen(painter->device(), gridColor);
+    finePen.setWidth(gridPen.width() * 2);
 
     if (startY < endY) {
         gridPen.setDashOffset(startY);
+        finePen.setDashOffset(startY);
         painter->setPen(gridPen);
+        int tick = 0;
+
         for (int x = startX; x < endX; x += tileWidth)
+        {
+            painter->setPen(gridFine != 0 && tick % gridFine == 0 ? finePen : gridPen);
             painter->drawLine(x, startY, x, endY - 1);
+            tick++;
+        }
     }
 
     if (startX < endX) {
         gridPen.setDashOffset(startX);
+        finePen.setDashOffset(startX);
         painter->setPen(gridPen);
+        int tick = 0;
+
         for (int y = startY; y < endY; y += tileHeight)
+        {
+            painter->setPen(gridFine != 0 && tick % gridFine == 0 ? finePen : gridPen);
             painter->drawLine(startX, y, endX - 1, y);
+            tick++;
+        }
     }
 }
 

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -50,7 +50,7 @@ public:
     QPainterPath interactionShape(const MapObject *object) const override;
 
     void drawGrid(QPainter *painter, const QRectF &rect,
-                  QColor gridColor) const override;
+                  QColor gridColor, const int gridFine = 0) const override;
 
     using MapRenderer::drawTileLayer;
     void drawTileLayer(const RenderTileCallback &renderTile,

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -107,7 +107,7 @@ public:
         Preferences *prefs = Preferences::instance();
         mMapDocument->renderer()->drawGrid(painter,
                                            option->exposedRect.translated(-mOffset),
-                                           prefs->gridColor());
+                                           prefs->gridColor(), prefs->gridFine());
     }
 
     void updateOffset()


### PR DESCRIPTION
This patch should be mostly considered as a feature request and proposal. Because it doesn't feel right for me and I don't really know how to improve it. Although we use this for a while and it fits our needs perfectly. 

The thing we need is a second grid over the main grid to see major cells. We call them sectors. There is a fine grid setting in Preferences but I'm honestly tried to find its meaning and found nothing except "Snapping to Fine Grid". So my first idea is to use this value to draw a "major" grid over the main grid. There is "main grid" and "fine grid" why not draw them both? 

I'm almost sure this is a valid topic for discussion on the forum yet I wanted to show how it affects the current codebase. Because at this point things come a little bit dirty for my taste. 

`MapRednerer` has method `drawGrid` which defined as

```
irtual void drawGrid(QPainter *painter, const QRectF &rect, QColor gridColor = Qt::black) const = 0;
```

The only "visual" option here is `gridColor` which seems fine. But when I add another one like `int gridFine` it doesn't look well. Because probably now it would be better to add `fineGridColor` as well. At this point, I started to think maybe it is better to pass drawing options to the `*Render` constructors but not into methods directly. But this looks like massive structural changes for the minor feature. 

So I kept things as simple as I could.

Added `gridFine` - new argument to `drawGrid` method in MapRenderer. For `drawGrid` this value acts in sense of "major ticks". When `gridFine` set to non-zero value Orthogonal and Isometric renderers will draw thicker lines with this step.

HexagonalRenderer does not support this because it's unclear what exactly we need to render here as the fine grid.

### Some screenshots
![photo_2021-04-22 13 47 50](https://user-images.githubusercontent.com/3934589/115702267-62d9b980-a371-11eb-9731-3713c0ed797d.jpeg)
![photo_2021-04-22 13 47 53](https://user-images.githubusercontent.com/3934589/115702272-64a37d00-a371-11eb-86aa-387d4945cc30.jpeg)
