### PR TITLE
docs: Extended TypeScript API definitions

### DIFF
--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1176,7 +1176,6 @@ interface frame {
    */
   duration : number
 }
-interface Image {}
 
 declare class Tile extends TiledObject{
   /**
@@ -1240,7 +1239,7 @@ declare class Tile extends TiledObject{
    * Warning: This function has no undo and does not affect the saved tileset!
    * @param image
    */
-  setImage(image : Image) : void
+  setImage(image : TiledImage) : void
 }
 
 declare class Layer extends TiledObject {
@@ -1939,7 +1938,7 @@ declare class Tileset extends Asset {
    *
    * Warning: This function has no undo!
    */
-  public loadFromImage(image : Image, source?: string) : void
+  public loadFromImage(image : TiledImage, source?: string) : void
 
   /**
    * Adds a new tile to this tileset and returns it. Only works for image collection tilesets.

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -889,7 +889,7 @@ interface AspectRatio {}
 
 interface TransformationMode {}
 
-declare namespace TiledImage {
+declare namespace Image {
   const Format_Invalid: number;
   const Format_Mono: number;
   const Format_MonoLSB: number;
@@ -929,7 +929,7 @@ declare namespace TiledImage {
  * writing an importer, where the image can be set on a tileset or its
  * tiles ({@see Tileset.loadFromImage} and {@see Tile.setImage}.
  */
-declare class TiledImage {
+declare class Image {
   /**
    * Width of the image in pixels.
    */
@@ -1074,19 +1074,19 @@ declare class TiledImage {
   /**
    * Copies the given rectangle to a new image object.
    */
-  copy(x: number, y: number, width: number, height: number) : TiledImage;
+  copy(x: number, y: number, width: number, height: number) : Image;
 
   /**
    * Returns a scaled copy of this image. Default `aspectRatioMode`
    * behavior is to ignore the aspect ratio. Default `mode` is a fast
    * transformation.
    */
-  scaled(width: number, height: number, aspectRatioMode: AspectRatio, transformationMode: TransformationMode): TiledImage;
+  scaled(width: number, height: number, aspectRatioMode: AspectRatio, transformationMode: TransformationMode): Image;
 
   /**
    * Returns a mirrored copy of this image.
    */
-  mirrored(horizontal: boolean, vertical: boolean) : TiledImage;
+  mirrored(horizontal: boolean, vertical: boolean) : Image;
 
   readonly IgnoreAspectRatio: number;
   readonly KeepAspectRatio: number;
@@ -1113,7 +1113,7 @@ interface ImageLayer extends Layer {
    *
    * *Warning: This function has no undo!*
    */
-  loadFromImage(image: TiledImage, source?: string) : void;
+  loadFromImage(image: Image, source?: string) : void;
 }
 
 interface MapFormat {
@@ -1165,7 +1165,6 @@ interface TilesetsView {
 }
 
 interface frame {}
-interface Image {}
 
 declare class Tile extends TiledObject{
   /**

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -890,7 +890,7 @@ interface AspectRatio {}
 
 interface TransformationMode {}
 
-declare namespace Image {
+declare namespace TiledImage {
   const Format_Invalid: number;
   const Format_Mono: number;
   const Format_MonoLSB: number;
@@ -930,7 +930,7 @@ declare namespace Image {
  * writing an importer, where the image can be set on a tileset or its
  * tiles ({@see Tileset.loadFromImage} and {@see Tile.setImage}.
  */
-declare class Image {
+declare class TiledImage {
   /**
    * Width of the image in pixels.
    */
@@ -1075,19 +1075,19 @@ declare class Image {
   /**
    * Copies the given rectangle to a new image object.
    */
-  copy(x: number, y: number, width: number, height: number) : Image;
+  copy(x: number, y: number, width: number, height: number) : TiledImage;
 
   /**
    * Returns a scaled copy of this image. Default `aspectRatioMode`
    * behavior is to ignore the aspect ratio. Default `mode` is a fast
    * transformation.
    */
-  scaled(width: number, height: number, aspectRatioMode: AspectRatio, transformationMode: TransformationMode): Image;
+  scaled(width: number, height: number, aspectRatioMode: AspectRatio, transformationMode: TransformationMode): TiledImage;
 
   /**
    * Returns a mirrored copy of this image.
    */
-  mirrored(horizontal: boolean, vertical: boolean) : Image;
+  mirrored(horizontal: boolean, vertical: boolean) : TiledImage;
 
   readonly IgnoreAspectRatio: number;
   readonly KeepAspectRatio: number;
@@ -1114,7 +1114,7 @@ interface ImageLayer extends Layer {
    *
    * *Warning: This function has no undo!*
    */
-  loadFromImage(image: Image, source?: string) : void;
+  loadFromImage(image: TiledImage, source?: string) : void;
 }
 
 interface MapFormat {
@@ -1176,6 +1176,7 @@ interface frame {
    */
   duration : number
 }
+interface Image {}
 
 declare class Tile extends TiledObject{
   /**

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1747,32 +1747,7 @@ interface TileLayerEdit {
   apply() : void
 }
 
-declare class WangSet {
-  /**
-   * Name of the Wang set.
-   */
-  name : string
-
-  /**
-   * Type of the Wang set.
-   */
-  type : Type
-
-  /**
-   * The tile used to represent the Wang set.
-   */
-  imageTile : Tile
-
-  /**
-   * The number of colors used by this Wang set.
-   */
-  colorCount : number
-
-  /**
-   * The tileset to which this Wang set belongs.
-   */
-  readonly tileset : Tileset
-
+declare namespace WangSet {
   type Type = number
 
   /**
@@ -1789,20 +1764,51 @@ declare class WangSet {
    * Wang set uses both corners and edges.
    */
   const Mixed: Type
+}
+
+declare class WangSet {
+  /**
+   * Name of the Wang set.
+   */
+  name : string
 
   /**
-   * Returns the current Wang ID associated with the given tile. The Wang ID is given by an array of 8 numbers, indicating the colors associated with each index in the following order: [Top, TopRight, Right, BottomRight, Bottom, BottomLeft, Left, TopLeft].
+   * Type of the Wang set.
+   */
+  type : WangSet.Type
+
+  /**
+   * The tile used to represent the Wang set.
+   */
+  imageTile : Tile
+
+  /**
+   * The number of colors used by this Wang set.
+   */
+  colorCount : number
+
+  /**
+   * The tileset to which this Wang set belongs.
+   */
+  readonly tileset : Tileset
+
+  /**
+   * Returns the current Wang ID associated with the given tile.
    *
+   * The Wang ID is given by an array of 8 numbers, indicating the colors associated with each index in the following order: [Top, TopRight, Right, BottomRight, Bottom, BottomLeft, Left, TopLeft].
    * A value of 0 indicates that no color is associated with a given index.
    */
-  public wangId(tile : Tile) : number[8]
+  public wangId(tile : Tile) : number[]
 
   /**
    * Sets the Wang ID associated with the given tile.
    *
+   * The Wang ID is given by an array of 8 numbers, indicating the colors associated with each index in the following order: [Top, TopRight, Right, BottomRight, Bottom, BottomLeft, Left, TopLeft].
+   * A value of 0 indicates that no color is associated with a given index.
+   *
    * Make sure the Wang set color count is set before calling this function, because it will raise an error when the Wang ID refers to non-existing colors.
    */
-  public setWangId(tile : Tile, wangId : number[8]) : void
+  public setWangId(tile : Tile, wangId : number[]) : void
 }
 
 declare namespace Tileset {

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1632,7 +1632,7 @@ interface cell {
   /**
    * The local tile ID of the tile, or -1 if the cell is empty.
    */
-  tileId : int
+  tileId : number
 
   /**
    * Whether the cell is empty.
@@ -1766,7 +1766,7 @@ declare class WangSet {
   /**
    * The number of colors used by this Wang set.
    */
-  colorCount : int
+  colorCount : number
 
   /**
    * The tileset to which this Wang set belongs.
@@ -1795,14 +1795,14 @@ declare class WangSet {
    *
    * A value of 0 indicates that no color is associated with a given index.
    */
-  public wangId(tile : Tile) : int[8]
+  public wangId(tile : Tile) : number[8]
 
   /**
    * Sets the Wang ID associated with the given tile.
    *
    * Make sure the Wang set color count is set before calling this function, because it will raise an error when the Wang ID refers to non-existing colors.
    */
-  public setWangId(tile : Tile, wangId : int[8]) : void
+  public setWangId(tile : Tile, wangId : number[8]) : void
 }
 
 declare namespace Tileset {
@@ -1924,12 +1924,12 @@ declare class Tileset extends Asset {
    *
    * Note that the tiles in a tileset are only guaranteed to have consecutive IDs for tileset-image based tilesets. For image collection tilesets there will be gaps when tiles have been removed from the tileset.
    */
-  public tile(id : int) : Tile
+  public tile(id : number) : Tile
 
   /**
    * Sets the tile size for this tileset. If an image has been specified as well, the tileset will be (re)loaded. Can’t be used on image collection tilesets.
    */
-  public setTileSize(width : int, height : int) : void
+  public setTileSize(width : number, height : number) : void
 
   /**
    * Creates the tiles in this tileset by cutting them out of the given image, using the current tile size, tile spacing and margin parameters. These values should be set before calling this function.
@@ -1953,7 +1953,7 @@ declare class Tileset extends Asset {
   /**
    * Add a new Wang set to this tileset with the given name and type.
    */
-  public addWangSet(name : string, type : int) : WangSet
+  public addWangSet(name : string, type : number) : WangSet
 
   /**
    * Removes the given Wang set from this tileset.

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -92,6 +92,7 @@ declare namespace Qt {
     width: number,
     height: number
   ): rect;
+  export function size(width: number, height: number): size;
 
   type Alignment = number;
 
@@ -1164,7 +1165,17 @@ interface TilesetsView {
   selectedTiles: Tile[]
 }
 
-interface frame {}
+interface frame {
+  /**
+   * The local tile ID used to represent the frame.
+   */
+  tileId : number
+
+  /**
+   * Duration of the frame in milliseconds.
+   */
+  duration : number
+}
 
 declare class Tile extends TiledObject{
   /**
@@ -1229,7 +1240,6 @@ declare class Tile extends TiledObject{
    * @param image
    */
   setImage(image : Image) : void
-
 }
 
 declare class Layer extends TiledObject {
@@ -1310,7 +1320,54 @@ declare namespace TileMap {
   interface StaggerIndex {}
 }
 
-interface SelectedArea {}
+interface SelectedArea {
+  readonly boundingRect: rect;
+
+  /**
+   * Returns the selected region.
+   */
+  get() : region
+
+  /**
+   * Sets the selected area to the given rectangle.
+   */
+  set(rect : rect) : void
+
+  /**
+   * Sets the selected area to the given region.
+   */
+  set(region : region) : void
+
+  /**
+   * Adds the given rectangle to the selected area.
+   */
+  add(rect : rect) : void
+
+  /**
+   * Adds the given region to the selected area.
+   */
+  add(region : region) : void
+
+  /**
+   * Subtracts the given rectangle from the selected area.
+   */
+  subtract(rect : rect) : void
+
+  /**
+   * Subtracts the given region from the selected area.
+   */
+  subtract(region : region) : void
+
+  /**
+   * Sets the selected area to the intersection of the current selected area and the given rectangle.
+   */
+  intersect(rect : rect) : void
+
+  /**
+   * Sets the selected area to the intersection of the current selected area and the given region.
+   */
+  intersect(region : region) : void
+}
 
 declare class TileMap extends Asset {
   /**
@@ -1410,24 +1467,113 @@ declare class TileMap extends Asset {
 
   constructor();
 
+  /**
+   * Applies Automapping using the given rules file, or using the default rules file is none is given.
+   *
+   * This operation can only be applied to maps loaded from a file.
+   */
   public autoMap(rulesFule?: string): void;
+
+  /**
+   * Applies Automapping in the given region using the given rules file, or using the default rules file is none is given.
+   *
+   * This operation can only be applied to maps loaded from a file.
+   */
   public autoMap(region: region | rect, rulesFile?: string): void;
+
+  /**
+   * Sets the size of the map in tiles. This does not affect the contents of the map.
+   *
+   * See also resize.
+   */
   public setSize(width: number, height: number): void;
+
+  /**
+   * Sets the tile size of the map in pixels. This affects the rendering of all tile layers.
+   */
   public setTileSize(width: number, height: number): void;
+
+  /**
+   * Returns a reference to the top-level layer at the given index. When the layer gets removed from the map, the reference changes to a standalone copy of the layer.
+   */
   public layerAt(index: number): Layer;
+
+  /**
+   * Removes the top-level layer at the given index. When a reference to the layer still exists, that reference becomes a standalone copy of the layer.
+   */
   public removeLayerAt(index: number): void;
+
+  /**
+   * Removes the given layer from the map. The reference to the layer becomes a standalone copy.
+   */
   public removeLayer(layer: Layer): void;
+
+  /**
+   * Inserts the layer at the given index. The layer can’t already be part of a map.
+   */
   public insertLayerAt(index: number, layer: Layer): void;
+
+  /**
+   * Adds the layer to the map, above all existing layers. The layer can’t already be part of a map.
+   */
   public addLayer(layer: Layer): void;
+
+  /**
+   * Adds the given tileset to the list of tilesets referenced by this map. Returns true if the tileset was added, or false if the tileset was already referenced by this map.
+   */
   public addTileset(tileset: Tileset): boolean;
+
+  /**
+   * Replaces all occurrences of oldTileset with newTileset. Returns true on success, or false when either the old tileset was not referenced by the map, or when the new tileset was already referenced by the map.
+   */
   public replaceTileset(oldTileset: Tileset, newTileset: Tileset): boolean;
+
+  /**
+   * Removes the given tileset from the list of tilesets referenced by this map. Returns true on success, or false when the given tileset was not referenced by this map or when the tileset was still in use by a tile layer or tile object.
+   */
   public removeTileset(tileset: Tileset): boolean;
+
+  /**
+   * Returns the list of tilesets actually used by this map. This is generally a subset of the tilesets referenced by the map (the TileMap.tilesets property).
+   */
   public usedTilesets(): Tileset[];
+
+  /**
+   * Merges the tile layers in the given map with this one. If only a single tile layer exists in the given map, it will be merged with the currentLayer.
+   *
+   * This operation can currently only be applied to maps loaded from a file.
+   *
+   * @param canJoin If true, the operation joins with the previous one on the undo stack when possible. Useful for reducing the amount of undo commands.
+   */
   public merge(map: TileMap, canJoin?: boolean): void;
+
+  /**
+   * Resizes the map to the given size, optionally applying an offset (in tiles).
+   *
+   * This operation can currently only be applied to maps loaded from a file.
+   *
+   * See also setSize.
+   */
   public resize(size: size, offset?: point, removeObjects?: boolean): void;
+
+  /**
+   * Converts the given position from screen to tile coordinates.
+   */
   public screenToTile(x: number, y: number): point;
+
+  /**
+   * Converts the given position from screen to tile coordinates.
+   */
   public screenToTile(position: point): point;
+
+  /**
+   * Converts the given position from tile to screen coordinates.
+   */
   public tileToScreen(x: number, y: number): point;
+
+  /**
+   * Converts the given position from tile to screen coordinates.
+   */
   public tileToScreen(position: point): point;
 
   /**
@@ -1482,7 +1628,37 @@ declare class TileMap extends Asset {
   public tileToPixel(position: point): point;
 }
 
-interface cell {}
+interface cell {
+  /**
+   * The local tile ID of the tile, or -1 if the cell is empty.
+   */
+  tileId : int
+
+  /**
+   * Whether the cell is empty.
+   */
+  empty : bool
+
+  /**
+   * Whether the tile is flipped horizontally.
+   */
+  flippedHorizontally : bool
+
+  /**
+   * Whether the tile is flipped vertically.
+   */
+  flippedVertically : bool
+
+  /**
+   * Whether the tile is flipped anti-diagonally.
+   */
+  flippedAntiDiagonally : bool
+
+  /**
+   * Whether the tile is rotated by 120 degrees (for hexagonal maps, the anti-diagonal flip is interpreted as a 60-degree rotation).
+   */
+  rotatedHexagonal120 : bool
+}
 
 declare class TileLayer extends Layer {
   /**
@@ -1543,7 +1719,6 @@ declare class TileLayer extends Layer {
    * Returns an object that enables making modifications to the tile layer.
    */
   edit() : TileLayerEdit
-
 }
 
 interface TileLayerEdit {
@@ -1570,11 +1745,65 @@ interface TileLayerEdit {
    * Applies all changes made through this object. This object can be reused to make further
    */
   apply() : void
-
-
 }
 
-interface WangSet {}
+declare class WangSet {
+  /**
+   * Name of the Wang set.
+   */
+  name : string
+
+  /**
+   * Type of the Wang set.
+   */
+  type : Type
+
+  /**
+   * The tile used to represent the Wang set.
+   */
+  imageTile : Tile
+
+  /**
+   * The number of colors used by this Wang set.
+   */
+  colorCount : int
+
+  /**
+   * The tileset to which this Wang set belongs.
+   */
+  readonly tileset : Tileset
+
+  type Type = number
+
+  /**
+   * Wang set only uses edges.
+   */
+  const Edge: Type
+
+  /**
+   * Wang set only uses corners.
+   */
+  const Corner: Type
+
+  /**
+   * Wang set uses both corners and edges.
+   */
+  const Mixed: Type
+
+  /**
+   * Returns the current Wang ID associated with the given tile. The Wang ID is given by an array of 8 numbers, indicating the colors associated with each index in the following order: [Top, TopRight, Right, BottomRight, Bottom, BottomLeft, Left, TopLeft].
+   *
+   * A value of 0 indicates that no color is associated with a given index.
+   */
+  public wangId(tile : Tile) : int[8]
+
+  /**
+   * Sets the Wang ID associated with the given tile.
+   *
+   * Make sure the Wang set color count is set before calling this function, because it will raise an error when the Wang ID refers to non-existing colors.
+   */
+  public setWangId(tile : Tile, wangId : int[8]) : void
+}
 
 declare namespace Tileset {
   interface Orientation {}
@@ -1684,7 +1913,52 @@ declare class Tileset extends Asset {
    */
   selectedTiles : Tile[]
 
-  // Functions missing.
+  /**
+   * Constructs a new Tileset.
+   * @param name
+   */
+  constructor(name? : string)
+
+  /**
+   * Returns a reference to the tile with the given ID. Raises an error if no such tile exists. When the tile gets removed from the tileset, the reference changes to a standalone copy of the tile.
+   *
+   * Note that the tiles in a tileset are only guaranteed to have consecutive IDs for tileset-image based tilesets. For image collection tilesets there will be gaps when tiles have been removed from the tileset.
+   */
+  public tile(id : int) : Tile
+
+  /**
+   * Sets the tile size for this tileset. If an image has been specified as well, the tileset will be (re)loaded. Can’t be used on image collection tilesets.
+   */
+  public setTileSize(width : int, height : int) : void
+
+  /**
+   * Creates the tiles in this tileset by cutting them out of the given image, using the current tile size, tile spacing and margin parameters. These values should be set before calling this function.
+   *
+   * Optionally sets the source file of the image. This may be useful, but be careful since Tiled will try to reload the tileset from that source when the tileset parameters are changed.
+   *
+   * Warning: This function has no undo!
+   */
+  public loadFromImage(image : Image, source?: string) : void
+
+  /**
+   * Adds a new tile to this tileset and returns it. Only works for image collection tilesets.
+   */
+  public addTile() : Tile
+
+  /**
+   * Removes the given tiles from this tileset. Only works for image collection tilesets.
+   */
+  public removeTiles(tiles : Tile[]) : void
+
+  /**
+   * Add a new Wang set to this tileset with the given name and type.
+   */
+  public addWangSet(name : string, type : int) : WangSet
+
+  /**
+   * Removes the given Wang set from this tileset.
+   */
+  public removeWangSet(wangSet : WangSet) : void
 }
 
 interface TilesetFormat {
@@ -1714,7 +1988,41 @@ interface TilesetFormat {
   write?: (tileset: Tileset, fileName: string) => string | undefined;
 }
 
-interface TilesetEditor {}
+interface MapView {
+  /**
+   * The scale of the view.
+   */
+  scale : number
+
+  /**
+   * The center of the view.
+   */
+  center : point
+
+  /**
+   * Centers the view at the given location in screen coordinates. Same as assigning to the center property.
+   */
+  centerOn(x : number, y : number) : void
+}
+
+interface TileCollisionEditor {
+  /**
+   * Selected objects.
+   */
+  selectedObjects : MapObject[]
+
+  /**
+   * The map view used by the Collision Editor.
+   */
+  view : MapView
+}
+
+interface TilesetEditor {
+  /**
+   * Access the collision editor within the tileset editor.
+   */
+  collisionEditor : TileCollisionEditor
+}
 
 interface Tool {
   /**
@@ -2141,7 +2449,7 @@ declare namespace tiled {
    *
    * @example
    * Example that produces a simple JSON representation of a map:
-   * ``` js
+   * ```js
    * var customMapFormat = {
    *     name: "Custom map format",
    *     extension: "custom",
@@ -2333,5 +2641,4 @@ declare class Process {
    * @param text
    */
   writeLine(text : string) : void
-
 }

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1637,27 +1637,27 @@ interface cell {
   /**
    * Whether the cell is empty.
    */
-  empty : bool
+  empty : boolean
 
   /**
    * Whether the tile is flipped horizontally.
    */
-  flippedHorizontally : bool
+  flippedHorizontally : boolean
 
   /**
    * Whether the tile is flipped vertically.
    */
-  flippedVertically : bool
+  flippedVertically : boolean
 
   /**
    * Whether the tile is flipped anti-diagonally.
    */
-  flippedAntiDiagonally : bool
+  flippedAntiDiagonally : boolean
 
   /**
    * Whether the tile is rotated by 120 degrees (for hexagonal maps, the anti-diagonal flip is interpreted as a 60-degree rotation).
    */
-  rotatedHexagonal120 : bool
+  rotatedHexagonal120 : boolean
 }
 
 declare class TileLayer extends Layer {


### PR DESCRIPTION
@MrMasterplan, I noticed there was a "TiledImage" class and namespace being defined, but actually Tiled registers this class as just `Image`:
```c++
globalObject.setProperty(QStringLiteral("Image"), mEngine->newQMetaObject<ScriptImage>());
```
It could be that "TiledImage" was chosen on purpose, so I've opened a PR for this. Do you see any issues with this change?
