### PR TITLE
Fix copy tool failing on some staggered maps

### DIFF
--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -152,6 +152,8 @@ bool ClipboardManager::copySelection(const MapDocument &mapDocument)
                 selectionBounds.height(),
                 map->tileWidth(), map->tileHeight());
     copyMap.setRenderOrder(map->renderOrder());
+    copyMap.setStaggerAxis(map->staggerAxis());
+    copyMap.setStaggerIndex(map->staggerIndex());
 
     bool tileLayerSelected = std::any_of(selectedLayers.begin(), selectedLayers.end(),
                                          [] (Layer *layer) { return layer->isTileLayer(); });


### PR DESCRIPTION
Fix https://github.com/mapeditor/tiled/issues/2874

Stamp tool has code that handles staggered maps, however it doesn't trigger if the stamp and the map have mismatch in their stagger index. In the case of copying it was always initialized to the default values instead of the values of the map copied from.

In my opinion some refactoring should take place, like forcing these parameters to be in the constructor, to avoid this same issue in other places.