### PR TITLE
Refactor Map constructor

### DIFF
--- a/src/libtiled/map.cpp
+++ b/src/libtiled/map.cpp
@@ -42,29 +42,26 @@
 using namespace Tiled;
 
 Map::Map()
+    : Map(Parameters())
+{
+}
+
+Map::Map(const Parameters &parameters)
     : Object(MapType)
+    , mParameters(parameters)
 {
 }
 
 Map::Map(Orientation orientation,
-         int width, int height, int tileWidth, int tileHeight, bool infinite)
-    : Object(MapType)
-    , mOrientation(orientation)
-    , mWidth(width)
-    , mHeight(height)
-    , mTileWidth(tileWidth)
-    , mTileHeight(tileHeight)
-    , mInfinite(infinite)
+         int width, int height,
+         int tileWidth, int tileHeight)
+    : Map()
 {
-}
-
-Map::Map(Orientation orientation,
-         QSize size, QSize tileSize, bool infinite)
-    : Map(orientation,
-          size.width(), size.height(),
-          tileSize.width(), tileSize.height(),
-          infinite)
-{
+    mParameters.orientation = orientation;
+    mParameters.width = width;
+    mParameters.height = height;
+    mParameters.tileWidth = tileWidth;
+    mParameters.tileHeight = tileHeight;
 }
 
 Map::~Map()
@@ -133,8 +130,8 @@ void Map::recomputeDrawMargins() const
     // We subtract the tile size of the map, since that part does not
     // contribute to additional margin.
     mDrawMargins = QMargins(offsetMargins.left(),
-                            offsetMargins.top() + maxTileSize - mTileHeight,
-                            offsetMargins.right() + maxTileSize - mTileWidth,
+                            offsetMargins.top() + maxTileSize - tileHeight(),
+                            offsetMargins.right() + maxTileSize - tileWidth(),
                             offsetMargins.bottom());
 
     mDrawMarginsDirty = false;
@@ -347,17 +344,11 @@ bool Map::isTilesetUsed(const Tileset *tileset) const
 
 std::unique_ptr<Map> Map::clone() const
 {
-    auto o = std::make_unique<Map>(mOrientation, mWidth, mHeight, mTileWidth, mTileHeight, mInfinite);
+    auto o = std::make_unique<Map>(mParameters);
     o->fileName = fileName;
     o->exportFileName = exportFileName;
     o->exportFormat = exportFormat;
-    o->mRenderOrder = mRenderOrder;
-    o->mCompressionLevel = mCompressionLevel;
-    o->mHexSideLength = mHexSideLength;
-    o->mStaggerAxis = mStaggerAxis;
-    o->mStaggerIndex = mStaggerIndex;
-    o->mBackgroundColor = mBackgroundColor;
-    o->mChunkSize = mChunkSize;
+    o->mEditorSettings = mEditorSettings;
     o->mDrawMargins = mDrawMargins;
     o->mDrawMarginsDirty = mDrawMarginsDirty;
     for (const Layer *layer : mLayers) {
@@ -366,7 +357,6 @@ std::unique_ptr<Map> Map::clone() const
         o->mLayers.append(clone);
     }
     o->mTilesets = mTilesets;
-    o->mLayerDataFormat = mLayerDataFormat;
     o->mNextLayerId = mNextLayerId;
     o->mNextObjectId = mNextObjectId;
     o->setProperties(properties());
@@ -538,12 +528,11 @@ QString Tiled::renderOrderToString(Map::RenderOrder renderOrder)
 Map::RenderOrder Tiled::renderOrderFromString(const QString &string)
 {
     Map::RenderOrder renderOrder = Map::RightDown;
-    if (string == QLatin1String("right-up")) {
+    if (string == QLatin1String("right-up"))
         renderOrder = Map::RightUp;
-    } else if (string == QLatin1String("left-down")) {
+    else if (string == QLatin1String("left-down"))
         renderOrder = Map::LeftDown;
-    } else if (string == QLatin1String("left-up")) {
+    else if (string == QLatin1String("left-up"))
         renderOrder = Map::LeftUp;
-    }
     return renderOrder;
 }

--- a/src/libtiled/map.h
+++ b/src/libtiled/map.h
@@ -147,22 +147,43 @@ public:
         StaggerEven = 1
     };
 
+    struct Parameters
+    {
+        Orientation orientation = Orthogonal;
+        RenderOrder renderOrder = RightDown;
+        int width = 0;
+        int height = 0;
+        int tileWidth = 0;
+        int tileHeight = 0;
+        bool infinite = false;
+        int hexSideLength = 0;
+        StaggerAxis staggerAxis = StaggerY;
+        StaggerIndex staggerIndex = StaggerOdd;
+        QColor backgroundColor;
+    };
+
+    struct EditorSettings
+    {
+        int compressionLevel = -1;
+        QSize chunkSize = QSize(CHUNK_SIZE, CHUNK_SIZE);
+        LayerDataFormat layerDataFormat = Base64Zlib;
+    };
+
     Map();
+    Map(const Parameters &parameters);
 
     /**
      * Constructor taking map orientation, size and tile size as parameters.
+     *
+     * @deprecated Only kept around for the Python API!
      */
     Map(Orientation orientation,
         int width, int height,
-        int tileWidth, int tileHeight,
-        bool infinite = false);
-
-    Map(Orientation orientation,
-        QSize size,
-        QSize tileSize,
-        bool infinite = false);
+        int tileWidth, int tileHeight);
 
     ~Map();
+
+    const Parameters &parameters() const;
 
     Orientation orientation() const;
     void setOrientation(Orientation orientation);
@@ -292,47 +313,43 @@ private:
 
     void recomputeDrawMargins() const;
 
-    Orientation mOrientation = Orthogonal;
-    RenderOrder mRenderOrder = RightDown;
-    int mCompressionLevel = -1;
-    int mWidth = 0;
-    int mHeight = 0;
-    int mTileWidth = 0;
-    int mTileHeight = 0;
-    bool mInfinite = false;
-    int mHexSideLength = 0;
-    StaggerAxis mStaggerAxis = StaggerY;
-    StaggerIndex mStaggerIndex = StaggerOdd;
-    QColor mBackgroundColor;
-    QSize mChunkSize = QSize(CHUNK_SIZE, CHUNK_SIZE);
+    Parameters mParameters;
+    EditorSettings mEditorSettings;
+
     mutable QMargins mDrawMargins;
     mutable bool mDrawMarginsDirty = true;
+
     QList<Layer*> mLayers;
     QVector<SharedTileset> mTilesets;
-    LayerDataFormat mLayerDataFormat = Base64Zlib;
+
     int mNextLayerId = 1;
     int mNextObjectId = 1;
 };
 
 
+inline const Map::Parameters &Map::parameters() const
+{
+    return mParameters;
+}
+
 inline Map::Orientation Map::orientation() const
 {
-    return mOrientation;
+    return mParameters.orientation;
 }
 
 inline void Map::setOrientation(Map::Orientation orientation)
 {
-    mOrientation = orientation;
+    mParameters.orientation = orientation;
 }
 
 inline Map::RenderOrder Map::renderOrder() const
 {
-    return mRenderOrder;
+    return mParameters.renderOrder;
 }
 
 inline void Map::setRenderOrder(Map::RenderOrder renderOrder)
 {
-    mRenderOrder = renderOrder;
+    mParameters.renderOrder = renderOrder;
 }
 
 /**
@@ -340,12 +357,12 @@ inline void Map::setRenderOrder(Map::RenderOrder renderOrder)
  */
 inline int Map::compressionLevel() const
 {
-    return mCompressionLevel;
+    return mEditorSettings.compressionLevel;
 }
 
 inline void Map::setCompressionLevel(int compressionLevel)
 {
-    mCompressionLevel = compressionLevel;
+    mEditorSettings.compressionLevel = compressionLevel;
 }
 
 /**
@@ -353,7 +370,7 @@ inline void Map::setCompressionLevel(int compressionLevel)
  */
 inline int Map::width() const
 {
-    return mWidth;
+    return mParameters.width;
 }
 
 /**
@@ -361,7 +378,7 @@ inline int Map::width() const
  */
 inline void Map::setWidth(int width)
 {
-    mWidth = width;
+    mParameters.width = width;
 }
 
 /**
@@ -369,7 +386,7 @@ inline void Map::setWidth(int width)
  */
 inline int Map::height() const
 {
-    return mHeight;
+    return mParameters.height;
 }
 
 /**
@@ -377,7 +394,7 @@ inline int Map::height() const
  */
 inline void Map::setHeight(int height)
 {
-    mHeight = height;
+    mParameters.height = height;
 }
 
 /**
@@ -385,7 +402,7 @@ inline void Map::setHeight(int height)
  */
 inline QSize Map::size() const
 {
-    return QSize(mWidth, mHeight);
+    return QSize(mParameters.width, mParameters.height);
 }
 
 /**
@@ -393,7 +410,7 @@ inline QSize Map::size() const
  */
 inline int Map::tileWidth() const
 {
-    return mTileWidth;
+    return mParameters.tileWidth;
 }
 
 /**
@@ -401,7 +418,7 @@ inline int Map::tileWidth() const
  */
 inline void Map::setTileWidth(int width)
 {
-    mTileWidth = width;
+    mParameters.tileWidth = width;
 }
 
 /**
@@ -409,7 +426,7 @@ inline void Map::setTileWidth(int width)
  */
 inline int Map::tileHeight() const
 {
-    return mTileHeight;
+    return mParameters.tileHeight;
 }
 
 /**
@@ -417,7 +434,7 @@ inline int Map::tileHeight() const
  */
 inline void Map::setTileHeight(int height)
 {
-    mTileHeight = height;
+    mParameters.tileHeight = height;
 }
 
 /**
@@ -425,52 +442,52 @@ inline void Map::setTileHeight(int height)
  */
 inline QSize Map::tileSize() const
 {
-    return QSize(mTileWidth, mTileHeight);
+    return QSize(mParameters.tileWidth, mParameters.tileHeight);
 }
 
 inline bool Map::infinite() const
 {
-    return mInfinite;
+    return mParameters.infinite;
 }
 
 inline void Map::setInfinite(bool infinite)
 {
-    mInfinite = infinite;
+    mParameters.infinite = infinite;
 }
 
 inline int Map::hexSideLength() const
 {
-    return mHexSideLength;
+    return mParameters.hexSideLength;
 }
 
 inline void Map::setHexSideLength(int hexSideLength)
 {
-    mHexSideLength = hexSideLength;
+    mParameters.hexSideLength = hexSideLength;
 }
 
 inline Map::StaggerAxis Map::staggerAxis() const
 {
-    return mStaggerAxis;
+    return mParameters.staggerAxis;
 }
 
 inline void Map::setStaggerAxis(StaggerAxis staggerAxis)
 {
-    mStaggerAxis = staggerAxis;
+    mParameters.staggerAxis = staggerAxis;
 }
 
 inline Map::StaggerIndex Map::staggerIndex() const
 {
-    return mStaggerIndex;
+    return mParameters.staggerIndex;
 }
 
 inline void Map::setStaggerIndex(StaggerIndex staggerIndex)
 {
-    mStaggerIndex = staggerIndex;
+    mParameters.staggerIndex = staggerIndex;
 }
 
 inline void Map::invertStaggerIndex()
 {
-    mStaggerIndex = static_cast<StaggerIndex>(!mStaggerIndex);
+    mParameters.staggerIndex = static_cast<StaggerIndex>(!mParameters.staggerIndex);
 }
 
 inline void Map::invalidateDrawMargins()
@@ -584,12 +601,12 @@ inline const QVector<SharedTileset> &Map::tilesets() const
  */
 inline const QColor &Map::backgroundColor() const
 {
-    return mBackgroundColor;
+    return mParameters.backgroundColor;
 }
 
 inline void Map::setBackgroundColor(QColor color)
 {
-    mBackgroundColor = color;
+    mParameters.backgroundColor = color;
 }
 
 /**
@@ -597,12 +614,12 @@ inline void Map::setBackgroundColor(QColor color)
  */
 inline QSize Map::chunkSize() const
 {
-    return mChunkSize;
+    return mEditorSettings.chunkSize;
 }
 
 inline void Map::setChunkSize(QSize size)
 {
-    mChunkSize = size;
+    mEditorSettings.chunkSize = size;
 }
 
 /**
@@ -615,12 +632,12 @@ inline bool Map::isStaggered() const
 
 inline Map::LayerDataFormat Map::layerDataFormat() const
 {
-    return mLayerDataFormat;
+    return mEditorSettings.layerDataFormat;
 }
 
 inline void Map::setLayerDataFormat(Map::LayerDataFormat format)
 {
-    mLayerDataFormat = format;
+    mEditorSettings.layerDataFormat = format;
 }
 
 /**

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -479,9 +479,11 @@ void CellRenderer::paintTileCollisionShapes()
 {
     const Tileset *tileset = mTile->tileset();
     const bool isIsometric = tileset->orientation() == Tileset::Isometric;
-    const Map map(isIsometric ? Map::Isometric : Map::Orthogonal,
-                  QSize(1, 1),
-                  tileset->gridSize());
+    Map::Parameters mapParameters;
+    mapParameters.orientation = isIsometric ? Map::Isometric : Map::Orthogonal;
+    mapParameters.tileWidth = tileset->gridSize().width();
+    mapParameters.tileHeight = tileset->gridSize().height();
+    const Map map(mapParameters);
     const auto renderer = MapRenderer::create(&map);
 
     const qreal lineWidth = mRenderer->objectLineWidth();

--- a/src/plugins/droidcraft/droidcraftplugin.cpp
+++ b/src/plugins/droidcraft/droidcraftplugin.cpp
@@ -60,7 +60,12 @@ std::unique_ptr<Tiled::Map> DroidcraftPlugin::read(const QString &fileName)
     // Build 48 x 48 map
     // Create a Map -> Create a Tileset -> Add Tileset to map
     // -> Create a TileLayer -> Fill layer -> Add TileLayer to Map
-    std::unique_ptr<Map> map { new Map(Map::Orthogonal, 48, 48, 32, 32) };
+    Map::Parameters mapParameters;
+    mapParameters.width = 48;
+    mapParameters.height = 48;
+    mapParameters.tileWidth = 32;
+    mapParameters.tileHeight = 32;
+    auto map = std::make_unique<Map>(mapParameters);
 
     SharedTileset mapTileset(Tileset::create("tileset", 32, 32));
     mapTileset->loadFromImage(QImage(":/tileset.png"), QUrl("qrc://tileset.png"));

--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -61,7 +61,14 @@ std::unique_ptr<Tiled::Map> FlarePlugin::read(const QString &fileName)
     }
 
     // default to values of the original Flare alpha game.
-    auto map = std::make_unique<Map>(Map::Isometric, 256, 256, 64, 32);
+    Map::Parameters mapParameters;
+    mapParameters.orientation = Map::Isometric;
+    mapParameters.width = 256;
+    mapParameters.height = 256;
+    mapParameters.tileWidth = 64;
+    mapParameters.tileHeight = 32;
+
+    auto map = std::make_unique<Map>(mapParameters);
 
     QTextStream stream (&file);
     QString line;

--- a/src/plugins/replicaisland/replicaislandplugin.cpp
+++ b/src/plugins/replicaisland/replicaislandplugin.cpp
@@ -71,8 +71,11 @@ std::unique_ptr<Tiled::Map> ReplicaIslandPlugin::read(const QString &fileName)
         return nullptr;
     }
 
-    // Create our map, setting width and height to 0 until we load a layer.
-    std::unique_ptr<Map> map { new Map(Map::Orthogonal, 0, 0, 32, 32) };
+    // Create our map, leaving width and height to 0 until we load a layer.
+    Map::Parameters mapParameters;
+    mapParameters.tileWidth = 32;
+    mapParameters.tileHeight = 32;
+    auto map = std::make_unique<Map>(mapParameters);
     map->setProperty("background_index", QString::number(backgroundIndex));
 
     // Load our Tilesets.

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -150,9 +150,13 @@ std::unique_ptr<Tiled::Map> TbinMapFormat::read(const QString &fileName)
 
         auto &firstLayer = tmap.layers[0];
 
-        map = std::make_unique<Tiled::Map>(Tiled::Map::Orthogonal,
-                                           QSize(firstLayer.layerSize.x, firstLayer.layerSize.y),
-                                           QSize(firstLayer.tileSize.x, firstLayer.tileSize.y));
+        Tiled::Map::Parameters mapParameters;
+        mapParameters.width = firstLayer.layerSize.x;
+        mapParameters.height = firstLayer.layerSize.y;
+        mapParameters.tileWidth = firstLayer.tileSize.x;
+        mapParameters.tileHeight = firstLayer.tileSize.y;
+
+        map = std::make_unique<Tiled::Map>(mapParameters);
 
         tbinToTiledProperties(tmap.props, *map);
 

--- a/src/tiled/abstracttilefilltool.cpp
+++ b/src/tiled/abstracttilefilltool.cpp
@@ -184,9 +184,7 @@ void AbstractTileFillTool::updatePreview(const QRegion &fillRegion)
     }
 
     mFillBounds = fillRegion.boundingRect();
-    auto preview = SharedMap::create(mapDocument()->map()->orientation(),
-                                     mapDocument()->map()->size(),
-                                     mapDocument()->map()->tileSize());
+    auto preview = SharedMap::create(mapDocument()->map()->parameters());
 
     switch (mFillMethod) {
     case TileFill:

--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -147,13 +147,11 @@ bool ClipboardManager::copySelection(const MapDocument &mapDocument)
     const QRect selectionBounds = selectedArea.boundingRect();
 
     // Create a temporary map to write to the clipboard
-    Map copyMap(map->orientation(),
-                selectionBounds.width(),
-                selectionBounds.height(),
-                map->tileWidth(), map->tileHeight());
-    copyMap.setRenderOrder(map->renderOrder());
-    copyMap.setStaggerAxis(map->staggerAxis());
-    copyMap.setStaggerIndex(map->staggerIndex());
+    Map::Parameters mapParameters = map->parameters();
+    mapParameters.width = selectionBounds.width();
+    mapParameters.height = selectionBounds.height();
+    mapParameters.infinite = false;
+    Map copyMap(mapParameters);
 
     bool tileLayerSelected = std::any_of(selectedLayers.begin(), selectedLayers.end(),
                                          [] (Layer *layer) { return layer->isTileLayer(); });

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -197,11 +197,14 @@ void MapObjectItem::expandBoundsToCoverTileCollisionObjects(QRectF &bounds)
         return;
 
     const Tileset *tileset = cell.tileset();
-    const Map map(tileset->orientation() == Tileset::Orthogonal ? Map::Orthogonal
-                                                                : Map::Isometric,
-                  QSize(1, 1),
-                  tileset->gridSize());
 
+    Map::Parameters mapParameters;
+    mapParameters.orientation = tileset->orientation() == Tileset::Orthogonal ? Map::Orthogonal
+                                                                              : Map::Isometric;
+    mapParameters.tileWidth = tileset->gridSize().width();
+    mapParameters.tileHeight = tileset->gridSize().height();
+
+    const Map map(mapParameters);
     const auto renderer = MapRenderer::create(&map);
     const QTransform tileTransform = tileCollisionObjectsTransform(*tile);
 

--- a/src/tiled/newmapdialog.cpp
+++ b/src/tiled/newmapdialog.cpp
@@ -150,10 +150,15 @@ MapDocumentPtr NewMapDialog::createMap()
     session::mapTileWidth = mUi->tileWidth->value();
     session::mapTileHeight = mUi->tileHeight->value();
 
-    std::unique_ptr<Map> map { new Map(session::mapOrientation,
-                                       session::mapWidth, session::mapHeight,
-                                       session::mapTileWidth, session::mapTileHeight,
-                                       !session::fixedSize) };
+    Map::Parameters mapParameters;
+    mapParameters.orientation = session::mapOrientation;
+    mapParameters.width = session::mapWidth;
+    mapParameters.height = session::mapHeight;
+    mapParameters.tileWidth = session::mapTileWidth;
+    mapParameters.tileHeight = session::mapTileHeight;
+    mapParameters.infinite = !session::fixedSize;
+
+    auto map = std::make_unique<Map>(mapParameters);
 
     map->setLayerDataFormat(session::layerDataFormat);
     map->setRenderOrder(session::renderOrder);
@@ -187,11 +192,14 @@ MapDocumentPtr NewMapDialog::createMap()
 
 void NewMapDialog::refreshPixelSize()
 {
-    const Map map(comboBoxValue<Map::Orientation>(mUi->orientation),
-                  mUi->mapWidth->value(),
-                  mUi->mapHeight->value(),
-                  mUi->tileWidth->value(),
-                  mUi->tileHeight->value());
+    Map::Parameters mapParameters;
+    mapParameters.orientation = comboBoxValue<Map::Orientation>(mUi->orientation);
+    mapParameters.width = mUi->mapWidth->value();
+    mapParameters.height = mUi->mapHeight->value();
+    mapParameters.tileWidth = mUi->tileWidth->value();
+    mapParameters.tileHeight = mUi->tileHeight->value();
+
+    const Map map(mapParameters);
     const QSize size = MapRenderer::create(&map)->mapBoundingRect().size();
 
     mUi->pixelSizeLabel->setText(tr("%1 x %2 pixels")

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -422,9 +422,11 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
         for (const QPoint &p : points)
             bounds |= QRect(p, p);
 
-        SharedMap preview = SharedMap::create(mapDocument()->map()->orientation(),
-                                              bounds.size(),
-                                              mapDocument()->map()->tileSize());
+        Map::Parameters mapParameters = mapDocument()->map()->parameters();
+        mapParameters.width = bounds.width();
+        mapParameters.height = bounds.height();
+        mapParameters.infinite = false;
+        SharedMap preview = SharedMap::create(mapParameters);
 
         std::unique_ptr<TileLayer> previewLayer {
             new TileLayer(QString(), bounds.topLeft(), bounds.size())
@@ -453,9 +455,12 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
             paintedRegion += QRect(p, p);
 
         const QRect bounds = paintedRegion.boundingRect();
-        SharedMap preview = SharedMap::create(mapDocument()->map()->orientation(),
-                                              bounds.size(),
-                                              mapDocument()->map()->tileSize());
+
+        Map::Parameters mapParameters = mapDocument()->map()->parameters();
+        mapParameters.width = bounds.width();
+        mapParameters.height = bounds.height();
+        mapParameters.infinite = false;
+        SharedMap preview = SharedMap::create(mapParameters);
 
         std::unique_ptr<TileLayer> previewLayer {
             new TileLayer(QString(), bounds.topLeft(), bounds.size())
@@ -544,9 +549,12 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
         }
 
         const QRect bounds = paintedRegion.boundingRect();
-        SharedMap preview = SharedMap::create(mapDocument()->map()->orientation(),
-                                              bounds.size(),
-                                              mapDocument()->map()->tileSize());
+
+        Map::Parameters mapParameters = mapDocument()->map()->parameters();
+        mapParameters.width = bounds.width();
+        mapParameters.height = bounds.height();
+        mapParameters.infinite = false;
+        SharedMap preview = SharedMap::create(mapParameters);
 
         for (const PaintOperation &op : operations) {
             LayerIterator layerIterator(op.stamp, Layer::TileLayerType);

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -237,8 +237,17 @@ void TemplatesDock::refreshDummyObject()
         mDummyMapDocument = ourDummyDocuments.value(mObjectTemplate);
 
         if (!mDummyMapDocument) {
-            Map::Orientation orientation = Map::Orthogonal;
-            std::unique_ptr<Map> map { new Map(orientation, 1, 1, 1, 1) };
+            // TODO: Isometric template objects are currently not supported
+            Map::Parameters mapParameters;
+
+            // Setting sizes to 1 makes it render a one-pixel square (the map
+            // border), which serves as a somewhat hacky origin indicator.
+            mapParameters.width = 1;
+            mapParameters.height = 1;
+            mapParameters.tileWidth = 1;
+            mapParameters.tileHeight = 1;
+
+            auto map = std::make_unique<Map>(mapParameters);
 
             MapObject *dummyObject = mObjectTemplate->object()->clone();
             dummyObject->markAsTemplateBase();

--- a/src/tiled/tilecollisiondock.cpp
+++ b/src/tiled/tilecollisiondock.cpp
@@ -388,15 +388,20 @@ void TileCollisionDock::setTile(Tile *tile)
     mActionAutoDetectMask->setEnabled(tile);
 
     if (tile) {
-        Map::Orientation orientation = Map::Orthogonal;
-        QSize tileSize = tile->size();
+        Map::Parameters mapParameters;
+        mapParameters.width = 1;
+        mapParameters.height = 1;
 
         if (tile->tileset()->orientation() == Tileset::Isometric) {
-            orientation = Map::Isometric;
-            tileSize = tile->tileset()->gridSize();
+            mapParameters.orientation = Map::Isometric;
+            mapParameters.tileWidth = tile->tileset()->gridSize().width();
+            mapParameters.tileHeight = tile->tileset()->gridSize().height();
+        } else {
+            mapParameters.tileWidth = tile->width();
+            mapParameters.tileHeight = tile->height();
         }
 
-        std::unique_ptr<Map> map { new Map(orientation, 1, 1, tileSize.width(), tileSize.height()) };
+        auto map = std::make_unique<Map>(mapParameters);
         map->addTileset(tile->sharedTileset());
 
         TileLayer *tileLayer = new TileLayer(QString(), 0, 0, 1, 1);

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -796,10 +796,12 @@ void TilesetDock::setCurrentTiles(std::unique_ptr<TileLayer> tiles)
 
     if (mCurrentTiles && mMapDocument) {
         // Create a tile stamp with these tiles
-        Map *map = mMapDocument->map();
-        std::unique_ptr<Map> stamp { new Map(map->orientation(),
-                                             mCurrentTiles->size(),
-                                             map->tileSize()) };
+        Map::Parameters mapParameters = mMapDocument->map()->parameters();
+        mapParameters.width = mCurrentTiles->width();
+        mapParameters.height = mCurrentTiles->height();
+        mapParameters.infinite = false;
+
+        auto stamp = std::make_unique<Map>(mapParameters);
         stamp->addLayer(mCurrentTiles->clone());
         stamp->addTilesets(mCurrentTiles->usedTilesets());
 

--- a/src/tiled/tilestampmanager.cpp
+++ b/src/tiled/tilestampmanager.cpp
@@ -101,14 +101,14 @@ static TileStamp stampFromContext(AbstractTool *selectedTool)
             return stamp;
 
         const Map *map = mapDocument->map();
-        std::unique_ptr<Map> copyMap { new Map(map->orientation(),
-                                               copy->width(), copy->height(),
-                                               map->tileWidth(), map->tileHeight()) };
 
-        // Add tileset references to map
+        Map::Parameters mapParameters = map->parameters();
+        mapParameters.width = copy->width();
+        mapParameters.height = copy->height();
+        mapParameters.infinite = false;
+
+        auto copyMap = std::make_unique<Map>(mapParameters);
         copyMap->addTilesets(copy->usedTilesets());
-
-        copyMap->setRenderOrder(map->renderOrder());
         copyMap->addLayer(std::move(copy));
 
         stamp.addVariation(std::move(copyMap));

--- a/tests/staggeredrenderer/test_staggeredrenderer.cpp
+++ b/tests/staggeredrenderer/test_staggeredrenderer.cpp
@@ -35,7 +35,14 @@ private:
 
 void test_StaggeredRenderer::initTestCase()
 {
-    mMap = new Map(Map::Staggered, 10, 10, 64, 32);
+    Map::Parameters mapParameters;
+    mapParameters.orientation = Map::Staggered;
+    mapParameters.width = 10;
+    mapParameters.height = 10;
+    mapParameters.tileWidth = 64;
+    mapParameters.tileHeight = 32;
+
+    mMap = new Map(mapParameters);
     TileLayer *tileLayer = new TileLayer(QString(),
                                          0, 0,
                                          mMap->width(), mMap->height());


### PR DESCRIPTION
This way, it should be less error-prone to add new parameters, since they will be automatically included in copy constructor and in various other places where they are copied.

Related to issue #2874.

This refactor was rather more work than I had expected, due to the huge amount of places in the source code that are constructing a Map instance. It might be worth looking for ways to reduce that, but creating maps just kind of happens to be what Tiled does.