### PR TITLE
Moved object types into the project

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -1038,7 +1038,6 @@ void MainWindow::initializeSession()
     bool projectLoaded = !session.project.isEmpty() && project.load(session.project);
 
     if (projectLoaded) {
-        Preferences::instance()->setObjectTypesFile(project.mObjectTypesFile);
         ProjectManager::instance()->setProject(std::move(project));
         updateWindowTitle();
         updateActions();
@@ -1522,7 +1521,6 @@ bool MainWindow::switchProject(Project project)
         prefs->addRecentProject(project.fileName());
     }
 
-    prefs->setObjectTypesFile(project.mObjectTypesFile);
     ProjectManager::instance()->setProject(std::move(project));
 
     restoreSession();
@@ -1558,8 +1556,6 @@ void MainWindow::projectProperties()
 
     if (ProjectPropertiesDialog(project, this).exec() == QDialog::Accepted) {
         project.save();
-        Preferences::instance()->setObjectTypesFile(project.mObjectTypesFile);
-
         ScriptManager::instance().refreshExtensionsPaths();
     }
 }

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -86,18 +86,12 @@ void Preferences::initialize()
     if (!dataDir.exists())
         dataDir.mkpath(QStringLiteral("."));
 
-    connect(&mWatcher, &FileSystemWatcher::fileChanged,
-            this, &Preferences::objectTypesFileChangedOnDisk);
-
     SaveFile::setSafeSavingEnabled(safeSavingEnabled());
 
     // Backwards compatibility check since 'FusionStyle' was removed from the
     // preferences dialog.
     if (applicationStyle() == FusionStyle)
         setApplicationStyle(TiledStyle);
-
-    // Read object types from the default location (custom location moved to project)
-    setObjectTypesFile(QString());
 
     TilesetManager *tilesetManager = TilesetManager::instance();
     tilesetManager->setReloadTilesetsOnChange(reloadTilesetsOnChange());
@@ -755,47 +749,6 @@ QString Preferences::startupProject()
 void Preferences::setStartupProject(const QString &filePath)
 {
     mStartupProject = filePath;
-}
-
-QString Preferences::objectTypesFile() const
-{
-    return mObjectTypesFile;
-}
-
-void Preferences::setObjectTypesFile(const QString &fileName)
-{
-    QString newObjectTypesFile = fileName;
-    if (newObjectTypesFile.isEmpty())
-        newObjectTypesFile = dataLocation() + QLatin1String("/objecttypes.xml");
-
-    if (mObjectTypesFile == newObjectTypesFile)
-        return;
-
-    if (!mObjectTypesFile.isEmpty())
-        mWatcher.removePath(mObjectTypesFile);
-
-    mObjectTypesFile = newObjectTypesFile;
-    mWatcher.addPath(newObjectTypesFile);
-
-    ObjectTypes objectTypes;
-    ObjectTypesSerializer().readObjectTypes(mObjectTypesFile, objectTypes);
-    setObjectTypes(objectTypes);
-}
-
-void Preferences::setObjectTypesFileLastSaved(const QDateTime &time)
-{
-    mObjectTypesFileLastSaved = time;
-}
-
-void Preferences::objectTypesFileChangedOnDisk()
-{
-    const QFileInfo fileInfo { objectTypesFile() };
-    if (fileInfo.lastModified() == mObjectTypesFileLastSaved)
-        return;
-
-    ObjectTypes objectTypes;
-    if (ObjectTypesSerializer().readObjectTypes(fileInfo.filePath(), objectTypes))
-        setObjectTypes(objectTypes);
 }
 
 #include "moc_preferences.cpp"

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -26,7 +26,6 @@
 #include <QObject>
 #include <QSettings>
 
-#include "filesystemwatcher.h"
 #include "map.h"
 #include "objecttypes.h"
 
@@ -136,10 +135,6 @@ public:
 
     void setObjectTypes(const ObjectTypes &objectTypes);
     void setPropertyTypes(const PropertyTypes &propertyTypes);
-
-    QString objectTypesFile() const;
-    void setObjectTypesFile(const QString &filePath);
-    void setObjectTypesFileLastSaved(const QDateTime &time);
 
     QDate firstRun() const;
     int runCount() const;
@@ -252,9 +247,6 @@ signals:
 private:
     void addToRecentFileList(const QString &fileName, QStringList &files);
 
-    void objectTypesFileChangedOnDisk();
-
-    FileSystemWatcher mWatcher;
     bool mPortable = false;
 
     QString mObjectTypesFile;

--- a/src/tiled/project.h
+++ b/src/tiled/project.h
@@ -21,8 +21,9 @@
 #pragma once
 
 #include "command.h"
-#include "propertytype.h"
+#include "objecttypes.h"
 #include "properties.h"
+#include "propertytype.h"
 
 #include <QDateTime>
 #include <QStringList>
@@ -47,10 +48,10 @@ public:
     const QDateTime &lastSaved() const;
 
     QString mExtensionsPath;
-    QString mObjectTypesFile;
     QString mAutomappingRulesFile;
     QVector<Command> mCommands;
     PropertyTypes mPropertyTypes;
+    ObjectTypes mObjectTypes;
 
 private:
     QDateTime mLastSaved;

--- a/src/tiled/projectmanager.cpp
+++ b/src/tiled/projectmanager.cpp
@@ -20,6 +20,7 @@
 
 #include "projectmanager.h"
 
+#include "preferences.h"
 #include "projectmodel.h"
 
 namespace Tiled {
@@ -40,6 +41,11 @@ ProjectManager::ProjectManager(QObject *parent)
 void ProjectManager::setProject(Project project)
 {
     mProjectModel->setProject(std::move(project));
+
+    Preferences *prefs = Preferences::instance();
+    prefs->setPropertyTypes(mProjectModel->project().mPropertyTypes);
+    prefs->setObjectTypes(mProjectModel->project().mObjectTypes);
+
     emit projectChanged();
 }
 

--- a/src/tiled/projectpropertiesdialog.cpp
+++ b/src/tiled/projectpropertiesdialog.cpp
@@ -53,12 +53,6 @@ ProjectPropertiesDialog::ProjectPropertiesDialog(Project &project, QWidget *pare
 
     auto filesGroupProperty = groupPropertyManager->addProperty(tr("Files"));
 
-    mObjectTypesFileProperty = variantPropertyManager->addProperty(filePathTypeId(), tr("Object types"));
-    mObjectTypesFileProperty->setValue(project.mObjectTypesFile);
-    mObjectTypesFileProperty->setAttribute(QStringLiteral("filter"),
-                                           QCoreApplication::translate("File Types", "Object Types files (*.xml *.json)"));
-    filesGroupProperty->addSubProperty(mObjectTypesFileProperty);
-
     mAutomappingRulesFileProperty = variantPropertyManager->addProperty(filePathTypeId(), tr("Automapping rules"));
     mAutomappingRulesFileProperty->setValue(project.mAutomappingRulesFile);
     mAutomappingRulesFileProperty->setAttribute(QStringLiteral("filter"),
@@ -76,7 +70,6 @@ ProjectPropertiesDialog::~ProjectPropertiesDialog()
 void ProjectPropertiesDialog::accept()
 {
     mProject.mExtensionsPath = mExtensionPathProperty->value().toString();
-    mProject.mObjectTypesFile = mObjectTypesFileProperty->value().toString();
     mProject.mAutomappingRulesFile = mAutomappingRulesFileProperty->value().toString();
 
     QDialog::accept();

--- a/src/tiled/projectpropertiesdialog.h
+++ b/src/tiled/projectpropertiesdialog.h
@@ -47,7 +47,6 @@ private:
 
     Project &mProject;
     QtVariantProperty *mExtensionPathProperty;
-    QtVariantProperty *mObjectTypesFileProperty;
     QtVariantProperty *mAutomappingRulesFileProperty;
 };
 


### PR DESCRIPTION
This change moves the storage of object types from a separate file into the project. The main advantage being to simplify the user experience (avoiding the need to manage an additional file, as well as getting rid of the the "global" vs. "overridden by project file" distinction).

When a loaded project referred to an object types file, its types are now automatically imported to the project. This is not done for the global object types file however, so instructions are probably needed for those who need to import the file manually (documenting the location of this file).

When the object types file was changed outside of Tiled, it was automatically reloaded. Automatic reloading still needs to be implemented for the project.

The new setup is not ideal for those who were generating the object types file. A potential solution would be to add a scripting API for registering object types.

Feedback welcome!