### PR TITLE
Fix inherited parallax values causing layers to display incorrectly

### DIFF
--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -266,14 +266,7 @@ void MapItem::updateLayerPositions()
 
     for (LayerItem *layerItem : qAsConst(mLayerItems)) {
         const Layer &layer = *layerItem->layer();
-        QPointF parallaxOffset = mapScene->parallaxOffset(layer);
-
-        // If this is a group layer, we don't want to apply any parallax -- that'll be
-        // taken care of by the effective parallax offset calculated for the leaf layers.
-        // If we don't do this, it doubles up bad.
-        if (layer.layerType() == Layer::GroupLayerType) parallaxOffset = QPointF(0, 0);
-
-        layerItem->setPos(layer.offset() + parallaxOffset);
+        layerItem->setPos(mapScene->layerItemPosition(layer));
     }
 
     if (mDisplayMode == Editable) {
@@ -487,10 +480,8 @@ void MapItem::layerChanged(const LayerChangeEvent &change)
             multiplier = opacityFactor;
     }
 
-    const QPointF parallaxOffset = static_cast<MapScene*>(scene())->parallaxOffset(*layer);
-
     layerItem->setOpacity(layer->opacity() * multiplier);
-    layerItem->setPos(layer->offset() + parallaxOffset);
+    layerItem->setPos(static_cast<MapScene*>(scene())->layerItemPosition(*layer));
 
     updateBoundingRect();   // possible layer offset change
 }
@@ -727,7 +718,7 @@ LayerItem *MapItem::createLayerItem(Layer *layer)
     // MapItem constructor and the layer will be positioned by a call to
     // updateLayerPositions from the MapScene.
     if (const MapScene *mapScene = static_cast<MapScene*>(scene()))
-        layerItem->setPos(layer->offset() + mapScene->parallaxOffset(*layer));
+        layerItem->setPos(mapScene->layerItemPosition(*layer));
 
     layerItem->setVisible(layer->isVisible());
     layerItem->setEnabled(mDisplayMode == Editable);

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -266,7 +266,14 @@ void MapItem::updateLayerPositions()
 
     for (LayerItem *layerItem : qAsConst(mLayerItems)) {
         const Layer &layer = *layerItem->layer();
-        layerItem->setPos(layer.offset() + mapScene->parallaxOffset(layer));
+        QPointF parallaxOffset = mapScene->parallaxOffset(layer);
+
+        // If this is a group layer, we don't want to apply any parallax -- that'll be
+        // taken care of by the effective parallax offset calculated for the leaf layers.
+        // If we don't do this, it doubles up bad.
+        if (layer.layerType() == Layer::GroupLayerType) parallaxOffset = QPointF(0, 0);
+
+        layerItem->setPos(layer.offset() + parallaxOffset);
     }
 
     if (mDisplayMode == Editable) {

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -198,6 +198,22 @@ QPointF MapScene::absolutePositionForLayer(const Layer &layer) const
 }
 
 /**
+ * Returns the position for a layer item.
+ *
+ * Since layer items are in a hierarchy where translation of the parent layer
+ * item affects the child layer items, the local offset is used instead of the
+ * total offset.
+ *
+ * Similarly, since the effective parallax factor is applied, this factor is
+ * ignored for group layers.
+ */
+QPointF MapScene::layerItemPosition(const Layer &layer) const
+{
+    return layer.offset() + (layer.isGroupLayer() ? QPointF()
+                                                  : parallaxOffset(layer));
+}
+
+/**
  * Returns the parallax offset of the given layer, taking into account its
  * parallax factor in combination with the current view rect.
  */

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -77,6 +77,7 @@ public:
     void setViewRect(const QRectF &rect);
 
     QPointF absolutePositionForLayer(const Layer &layer) const;
+    QPointF layerItemPosition(const Layer &layer) const;
     QPointF parallaxOffset(const Layer &layer) const;
 
     static SessionOption<bool> enableWorlds;


### PR DESCRIPTION
Fixes #3124.

Before, parallax was causing group layers to be offset as well as non-group layers. Now, only non-group layers have the parallax offset, so that they can properly use their effective inherited parallax value.

Visually tested on the scene I included in the issue. Also, tested with a 2-layer inheritance: 0.8 * 0.5 * 0.5 = 0.2. 