### PR TITLE
[WIP] Set collision editor bg color to tileset bg color

### DIFF
--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -292,6 +292,11 @@ void MapScene::refreshScene()
 
 void MapScene::updateDefaultBackgroundColor()
 {
+    if(mOverrideBackgroundColor.isValid()){
+        setBackgroundBrush(mOverrideBackgroundColor);
+        return;
+    }
+
     mDefaultBackgroundColor = QGuiApplication::palette().dark().color();
 
     if (!mMapDocument || !mMapDocument->map()->backgroundColor().isValid())
@@ -307,6 +312,16 @@ void MapScene::updateSceneRect()
 
     setSceneRect(sceneRect);
 }
+
+void MapScene::setOverrideBackgroundColor(QColor backgroundColor)
+{
+    if(mOverrideBackgroundColor == backgroundColor)
+        return;
+
+    mOverrideBackgroundColor = backgroundColor;
+
+    updateDefaultBackgroundColor();
+};
 
 void MapScene::setWorldsEnabled(bool enabled)
 {

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -188,6 +188,15 @@ void MapScene::setViewRect(const QRectF &rect)
         emit parallaxParametersChanged();
 }
 
+void MapScene::setOverrideBackgroundColor(QColor backgroundColor)
+{
+    if (mOverrideBackgroundColor == backgroundColor)
+        return;
+
+    mOverrideBackgroundColor = backgroundColor;
+    updateBackgroundColor();
+};
+
 /**
  * Returns the position the given layer is supposed to have, taking into
  * account its offset and the parallax factor along with the current view rect.
@@ -278,29 +287,37 @@ void MapScene::refreshScene()
     mMapItems.swap(mapItems);
     qDeleteAll(mapItems);       // delete all map items that didn't get reused
 
+    updateBackgroundColor();
     updateSceneRect();
-
-    const Map *map = mMapDocument->map();
-
-    if (map->backgroundColor().isValid())
-        setBackgroundBrush(map->backgroundColor());
-    else
-        setBackgroundBrush(mDefaultBackgroundColor);
 
     emit sceneRefreshed();
 }
 
 void MapScene::updateDefaultBackgroundColor()
 {
-    if(mOverrideBackgroundColor.isValid()){
+    const QColor darkColor = QGuiApplication::palette().dark().color();
+    if (mDefaultBackgroundColor != darkColor) {
+        mDefaultBackgroundColor = darkColor;
+        updateBackgroundColor();
+    }
+}
+
+void MapScene::updateBackgroundColor()
+{
+    if (mOverrideBackgroundColor.isValid()) {
         setBackgroundBrush(mOverrideBackgroundColor);
         return;
     }
 
-    mDefaultBackgroundColor = QGuiApplication::palette().dark().color();
+    if (mMapDocument) {
+        const QColor &backgroundColor = mMapDocument->map()->backgroundColor();
+        if (backgroundColor.isValid()) {
+            setBackgroundBrush(backgroundColor);
+            return;
+        }
+    }
 
-    if (!mMapDocument || !mMapDocument->map()->backgroundColor().isValid())
-        setBackgroundBrush(mDefaultBackgroundColor);
+    setBackgroundBrush(mDefaultBackgroundColor);
 }
 
 void MapScene::updateSceneRect()
@@ -312,16 +329,6 @@ void MapScene::updateSceneRect()
 
     setSceneRect(sceneRect);
 }
-
-void MapScene::setOverrideBackgroundColor(QColor backgroundColor)
-{
-    if(mOverrideBackgroundColor == backgroundColor)
-        return;
-
-    mOverrideBackgroundColor = backgroundColor;
-
-    updateDefaultBackgroundColor();
-};
 
 void MapScene::setWorldsEnabled(bool enabled)
 {
@@ -356,11 +363,7 @@ MapItem *MapScene::takeOrCreateMapItem(const MapDocumentPtr &mapDocument, MapIte
  */
 void MapScene::mapChanged()
 {
-    const Map *map = mMapDocument->map();
-    if (map->backgroundColor().isValid())
-        setBackgroundBrush(map->backgroundColor());
-    else
-        setBackgroundBrush(mDefaultBackgroundColor);
+    updateBackgroundColor();
 }
 
 void MapScene::repaintTileset(Tileset *tileset)

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -76,6 +76,8 @@ public:
     const QRectF &viewRect() const;
     void setViewRect(const QRectF &rect);
 
+    void setOverrideBackgroundColor(QColor backgroundColor);
+
     QPointF absolutePositionForLayer(const Layer &layer) const;
     QPointF layerItemPosition(const Layer &layer) const;
     QPointF parallaxOffset(const Layer &layer) const;
@@ -134,6 +136,7 @@ private:
     QPointF mLastMousePos;
     QRectF mViewRect;
     QColor mDefaultBackgroundColor;
+    QColor mOverrideBackgroundColor = QColor::Invalid;
 };
 
 /**

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -114,6 +114,7 @@ private:
     void tilesetReplaced(int index, Tileset *tileset, Tileset *oldTileset);
 
     void updateDefaultBackgroundColor();
+    void updateBackgroundColor();
     void updateSceneRect();
 
     void setWorldsEnabled(bool enabled);
@@ -136,7 +137,7 @@ private:
     QPointF mLastMousePos;
     QRectF mViewRect;
     QColor mDefaultBackgroundColor;
-    QColor mOverrideBackgroundColor = QColor::Invalid;
+    QColor mOverrideBackgroundColor;
 };
 
 /**

--- a/src/tiled/tilecollisiondock.cpp
+++ b/src/tiled/tilecollisiondock.cpp
@@ -547,10 +547,7 @@ void TileCollisionDock::tilesetTileOffsetChanged(Tileset *tileset)
 
 void TileCollisionDock::tilesetBackgroundChanged(Tileset *tileset)
 {
-    if (!mMapScene)
-        return;
-
-    mMapScene->setBackgroundBrush(tileset->backgroundColor());
+    mMapScene->setOverrideBackgroundColor(tileset->backgroundColor());
 }
 
 void TileCollisionDock::cut()

--- a/src/tiled/tilecollisiondock.cpp
+++ b/src/tiled/tilecollisiondock.cpp
@@ -292,6 +292,8 @@ void TileCollisionDock::setTilesetDocument(TilesetDocument *tilesetDocument)
                 this, &TileCollisionDock::tileObjectGroupChanged);
         connect(mTilesetDocument, &TilesetDocument::tilesetTileOffsetChanged,
                 this, &TileCollisionDock::tilesetTileOffsetChanged);
+        connect(mTilesetDocument, &TilesetDocument::tilesetChanged,
+                this, &TileCollisionDock::tilesetBackgroundChanged);
     }
 }
 
@@ -400,6 +402,8 @@ void TileCollisionDock::setTile(Tile *tile)
             mapParameters.tileWidth = tile->width();
             mapParameters.tileHeight = tile->height();
         }
+
+        mapParameters.backgroundColor = tile->tileset()->backgroundColor();
 
         auto map = std::make_unique<Map>(mapParameters);
         map->addTileset(tile->sharedTileset());
@@ -539,6 +543,16 @@ void TileCollisionDock::tilesetTileOffsetChanged(Tileset *tileset)
     tileLayer->setOffset(-tileOffset);
 
     emit mDummyMapDocument->changed(LayerChangeEvent(tileLayer, LayerChangeEvent::OffsetProperty));
+}
+
+void TileCollisionDock::tilesetBackgroundChanged(Tileset *tileset)
+{
+    if (!mDummyMapDocument)
+        return;
+
+    mDummyMapDocument->map()->setBackgroundColor(tileset->backgroundColor());
+
+    emit mDummyMapDocument->changed(MapChangeEvent(Map::BackgroundColorProperty));
 }
 
 void TileCollisionDock::cut()

--- a/src/tiled/tilecollisiondock.cpp
+++ b/src/tiled/tilecollisiondock.cpp
@@ -293,7 +293,11 @@ void TileCollisionDock::setTilesetDocument(TilesetDocument *tilesetDocument)
         connect(mTilesetDocument, &TilesetDocument::tilesetTileOffsetChanged,
                 this, &TileCollisionDock::tilesetTileOffsetChanged);
         connect(mTilesetDocument, &TilesetDocument::tilesetChanged,
-                this, &TileCollisionDock::tilesetBackgroundChanged);
+                this, &TileCollisionDock::tilesetChanged);
+
+        mMapScene->setOverrideBackgroundColor(mTilesetDocument->tileset()->backgroundColor());
+    } else {
+        mMapScene->setOverrideBackgroundColor(QColor());
     }
 }
 
@@ -402,8 +406,6 @@ void TileCollisionDock::setTile(Tile *tile)
             mapParameters.tileWidth = tile->width();
             mapParameters.tileHeight = tile->height();
         }
-
-        mapParameters.backgroundColor = tile->tileset()->backgroundColor();
 
         auto map = std::make_unique<Map>(mapParameters);
         map->addTileset(tile->sharedTileset());
@@ -545,7 +547,7 @@ void TileCollisionDock::tilesetTileOffsetChanged(Tileset *tileset)
     emit mDummyMapDocument->changed(LayerChangeEvent(tileLayer, LayerChangeEvent::OffsetProperty));
 }
 
-void TileCollisionDock::tilesetBackgroundChanged(Tileset *tileset)
+void TileCollisionDock::tilesetChanged(Tileset *tileset)
 {
     mMapScene->setOverrideBackgroundColor(tileset->backgroundColor());
 }

--- a/src/tiled/tilecollisiondock.cpp
+++ b/src/tiled/tilecollisiondock.cpp
@@ -547,12 +547,10 @@ void TileCollisionDock::tilesetTileOffsetChanged(Tileset *tileset)
 
 void TileCollisionDock::tilesetBackgroundChanged(Tileset *tileset)
 {
-    if (!mDummyMapDocument)
+    if (!mMapScene)
         return;
 
-    mDummyMapDocument->map()->setBackgroundColor(tileset->backgroundColor());
-
-    emit mDummyMapDocument->changed(MapChangeEvent(Map::BackgroundColorProperty));
+    mMapScene->setBackgroundBrush(tileset->backgroundColor());
 }
 
 void TileCollisionDock::cut()

--- a/src/tiled/tilecollisiondock.h
+++ b/src/tiled/tilecollisiondock.h
@@ -105,6 +105,7 @@ private:
     void documentChanged(const ChangeEvent &change);
     void tileObjectGroupChanged(Tile*);
     void tilesetTileOffsetChanged(Tileset *tileset);
+    void tilesetBackgroundChanged(Tileset *tileset);
 
     void selectedObjectsChanged();
     void setHasSelectedObjects(bool hasSelectedObjects);

--- a/src/tiled/tilecollisiondock.h
+++ b/src/tiled/tilecollisiondock.h
@@ -105,7 +105,7 @@ private:
     void documentChanged(const ChangeEvent &change);
     void tileObjectGroupChanged(Tile*);
     void tilesetTileOffsetChanged(Tileset *tileset);
-    void tilesetBackgroundChanged(Tileset *tileset);
+    void tilesetChanged(Tileset *tileset);
 
     void selectedObjectsChanged();
     void setHasSelectedObjects(bool hasSelectedObjects);


### PR DESCRIPTION
Setting collision editor background color from tileset background color is working. However, when changing the tileset background color, the collision editor stays the same color until a new tile is opened.

Something I noticed is that when you change the tileset background, the tile that is open on the collision is unselected, and the collision editor stays open without a tile, which I'm thinking might be the reason the background is not updated.

Fixes #3070