### PR TITLE
Update Translation Korean

### DIFF
--- a/translations/tiled_ko.ts
+++ b/translations/tiled_ko.ts
@@ -2,24 +2,474 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ko_KR">
 <context>
+    <name>QtPointFPropertyManager</name>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <source>(%1, %2)</source>
+        <translation>(%1, %2)</translation>
+    </message>
+</context>
+<context>
+    <name>QtPointPropertyManager</name>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <source>(%1, %2)</source>
+        <translation>(%1, %2)</translation>
+    </message>
+</context>
+<context>
+    <name>QtRectFPropertyManager</name>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation>너비</translation>
+    </message>
+    <message>
+        <source>[(%1, %2), %3 x %4]</source>
+        <translation>[(%1, %2), %3 x %4]</translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation>높이</translation>
+    </message>
+</context>
+<context>
+    <name>QtRectPropertyManager</name>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation>너비</translation>
+    </message>
+    <message>
+        <source>[(%1, %2), %3 x %4]</source>
+        <translation>[(%1, %2), %3 x %4]</translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation>높이</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::PropertyBrowser</name>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Map</source>
+        <translation>맵</translation>
+    </message>
+    <message>
+        <source>Odd</source>
+        <translation>홀수</translation>
+    </message>
+    <message>
+        <source>Top</source>
+        <translation>상단</translation>
+    </message>
+    <message>
+        <source>Edge</source>
+        <translation>모서리</translation>
+    </message>
+    <message>
+        <source>Even</source>
+        <translation>짝수</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation>폰트</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>왼쪽</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>이름</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>텍스트</translation>
+    </message>
+    <message>
+        <source>Tile</source>
+        <translation>타일</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>타입</translation>
+    </message>
+    <message>
+        <source>Filename</source>
+        <translation>파일명</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>색상</translation>
+    </message>
+    <message>
+        <source>Image</source>
+        <translation>이미지</translation>
+    </message>
+    <message>
+        <source>Mixed</source>
+        <translation>혼합된</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>오른쪽</translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation>너비</translation>
+    </message>
+    <message>
+        <source>Horizontal</source>
+        <translation>수평</translation>
+    </message>
+    <message>
+        <source>Tile Render Order</source>
+        <translation>타일 렌더링 순서</translation>
+    </message>
+    <message>
+        <source>Change Infinite Property</source>
+        <translation>무한 속성 변경</translation>
+    </message>
+    <message>
+        <source>Tile Layer Format</source>
+        <translation>타일 레이어 형식</translation>
+    </message>
+    <message>
+        <source>Group Layer</source>
+        <translation>레이어 그룹화</translation>
+    </message>
+    <message>
+        <source>Top Right</source>
+        <translation>오른쪽 위</translation>
+    </message>
+    <message>
+        <source>Drawing Order</source>
+        <translation>그리기 순서</translation>
+    </message>
+    <message>
+        <source>Flip Horizontally</source>
+        <translation>가로로 뒤집기</translation>
+    </message>
+    <message>
+        <source>Flipping</source>
+        <translation>뒤집기</translation>
+    </message>
+    <message>
+        <source>Object Layer</source>
+        <translation>오브젝트 레이어</translation>
+    </message>
+    <message>
+        <source>Relative chance this tile will be picked</source>
+        <translation>이 타일이 선택될 상대적인 확률</translation>
+    </message>
+    <message>
+        <source>Custom Properties</source>
+        <translation>사용자 정의 속성</translation>
+    </message>
+    <message>
+        <source>Error Reading Tileset</source>
+        <translation>타일셋 읽기 오류</translation>
+    </message>
+    <message>
+        <source>Object Alignment</source>
+        <translation>오브젝트 정렬</translation>
+    </message>
+    <message>
+        <source>Bottom</source>
+        <translation>하단</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation>중앙</translation>
+    </message>
+    <message>
+        <source>Grid Height</source>
+        <translation>격자 높이</translation>
+    </message>
+    <message>
+        <source>Corner</source>
+        <translation>코너</translation>
+    </message>
+    <message>
+        <source>Tile Height</source>
+        <translation>타일 높이</translation>
+    </message>
+    <message>
+        <source>Infinite</source>
+        <translation>무한</translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation>높이</translation>
+    </message>
+    <message>
+        <source>Locked</source>
+        <translation>잠금</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation>수동으로</translation>
+    </message>
+    <message>
+        <source>Margin</source>
+        <translation>여백</translation>
+    </message>
+    <message>
+        <source>Object</source>
+        <translation>오브젝트</translation>
+    </message>
+    <message>
+        <source>Rotate</source>
+        <translation>회전하기</translation>
+    </message>
+    <message>
+        <source>Source</source>
+        <translation>소스</translation>
+    </message>
+    <message>
+        <source>Bottom Left</source>
+        <translation>왼쪽 하단</translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation>구도</translation>
+    </message>
+    <message>
+        <source>Top Down</source>
+        <translation>위에서 아래로</translation>
+    </message>
+    <message>
+        <source>Top Left</source>
+        <translation>왼쪽 위</translation>
+    </message>
+    <message>
+        <source>Tint Color</source>
+        <translation>색조 색상</translation>
+    </message>
+    <message>
+        <source>Grid Width</source>
+        <translation>격자 너비</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>불투명도</translation>
+    </message>
+    <message>
+        <source>Horizontal Offset</source>
+        <translation>수평 Offset</translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation>회전</translation>
+    </message>
+    <message>
+        <source>Output Chunk Height</source>
+        <translation>덩어리 길이 출력</translation>
+    </message>
+    <message>
+        <source>Image Layer</source>
+        <translation>이미지 레이어</translation>
+    </message>
+    <message>
+        <source>Tile Layer</source>
+        <translation>타일 레이어</translation>
+    </message>
+    <message>
+        <source>Tile Width</source>
+        <translation>타일 너비</translation>
+    </message>
+    <message>
+        <source>Background Color</source>
+        <translation>배경색</translation>
+    </message>
+    <message>
+        <source>Terrain Set</source>
+        <translation>지형셋</translation>
+    </message>
+    <message>
+        <source>Probability</source>
+        <translation>확률</translation>
+    </message>
+    <message>
+        <source>Allowed Transformations</source>
+        <translation>허락된 변형</translation>
+    </message>
+    <message>
+        <source>Word Wrap</source>
+        <translation>단어 감싸기</translation>
+    </message>
+    <message>
+        <source>Compression Level</source>
+        <translation>압축 수준</translation>
+    </message>
+    <message>
+        <source>Stagger Axis</source>
+        <translation>Stagger 축</translation>
+    </message>
+    <message>
+        <source>Columns</source>
+        <translation>열</translation>
+    </message>
+    <message>
+        <source>Spacing</source>
+        <translation>간격</translation>
+    </message>
+    <message>
+        <source>Terrain Count</source>
+        <translation>지형 수</translation>
+    </message>
+    <message>
+        <source>Terrain</source>
+        <translation>지형</translation>
+    </message>
+    <message>
+        <source>Flip Vertically</source>
+        <translation>세로로 뒤집기</translation>
+    </message>
+    <message>
+        <source>Tileset</source>
+        <translation>타일셋</translation>
+    </message>
+    <message>
+        <source>Prefer Untransformed Tiles</source>
+        <translation>변형되지 않은 타일 선호</translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <translation>정의되지 않은</translation>
+    </message>
+    <message>
+        <source>Bottom Right</source>
+        <translation>오른쪽 하단</translation>
+    </message>
+    <message>
+        <source>Parallax Factor</source>
+        <translation>시차 요소</translation>
+    </message>
+    <message>
+        <source>Template</source>
+        <translation>템플릿</translation>
+    </message>
+    <message>
+        <source>Transparent Color</source>
+        <translation>투명색</translation>
+    </message>
+    <message>
+        <source>Vertical</source>
+        <translation>수직</translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation>표시됨</translation>
+    </message>
+    <message>
+        <source>Drawing Offset</source>
+        <translation>그리기 Offset</translation>
+    </message>
+    <message>
+        <source>Tile Side Length (Hex)</source>
+        <translation>육각타일 모서리 길이</translation>
+    </message>
+    <message>
+        <source>Output Chunk Width</source>
+        <translation>덩어리 너비 출력</translation>
+    </message>
+    <message>
+        <source>Stagger Index</source>
+        <translation>Stagger 인덱스</translation>
+    </message>
+    <message>
+        <source>Vertical Offset</source>
+        <translation>수직 Offset</translation>
+    </message>
+    <message>
+        <source>Alignment</source>
+        <translation>정렬</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::MapObjectModel</name>
+    <message>
+        <source>ID</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>이름</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>타입</translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation>위치</translation>
+    </message>
+    <message>
+        <source>Change Object Type</source>
+        <translation>오브젝트 타입 변경</translation>
+    </message>
+    <message>
+        <source>Change Object Name</source>
+        <translation>오브젝트 이름 변경</translation>
+    </message>
+</context>
+<context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../src/tiled/aboutdialog.ui" line="+14"/>
-        <source>About Tiled</source>
-        <translation>Tiled에 대해서</translation>
-    </message>
-    <message>
-        <location line="+96"/>
-        <source>Donate ↗</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
         <source>OK</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../src/tiled/aboutdialog.cpp" line="+49"/>
+        <source>About Tiled</source>
+        <translation>Tiled에 대해서</translation>
+    </message>
+    <message>
+        <source>Donate ↗</source>
+        <translation>기부하기 ↗</translation>
+    </message>
+    <message>
         <source>&lt;p align=&quot;center&quot;&gt;&lt;font size=&quot;+2&quot;&gt;&lt;b&gt;Tiled Map Editor&lt;/b&gt;&lt;/font&gt;&lt;br&gt;&lt;i&gt;Version %1&lt;/i&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot;&gt;Copyright 2008-2021 Thorbj&amp;oslash;rn Lindeijer&lt;br&gt;(see the AUTHORS file for a full list of contributors)&lt;/p&gt;
 &lt;p align=&quot;center&quot;&gt;You may modify and redistribute this program under the terms of the GPL (version 2 or later). A copy of the GPL is contained in the &apos;COPYING&apos; file distributed with Tiled.&lt;/p&gt;
@@ -33,1826 +483,1951 @@
     </message>
 </context>
 <context>
-    <name>AddPropertyDialog</name>
-    <message>
-        <location filename="../src/tiled/addpropertydialog.ui" line="+14"/>
-        <source>Add Property</source>
-        <translation>속성 추가</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Property name</source>
-        <translation>속성 이름</translation>
-    </message>
-</context>
-<context>
-    <name>Command line</name>
-    <message>
-        <location filename="../src/tiled/main.cpp" line="+166"/>
-        <source>Format not recognized (see --export-formats)</source>
-        <translation>읽을 수 없는 형식입니다 (--export-formats를 참조하십시오)</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Non-unique file extension. Can&apos;t determine correct export format.</source>
-        <translation>확장자가 한 개가 아닙니다. 올바른 내보내기 형식을 결정할 수 없습니다.</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>No exporter found for target file.</source>
-        <translation>대상 파일에 대한 내보내기가 없습니다.</translation>
-    </message>
-    <message>
-        <location line="+226"/>
-        <source>Export syntax is --export-map [format] &lt;source&gt; &lt;target&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <source>Failed to load source map.</source>
-        <translation>소스 맵을 로드하지 못했습니다.</translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>Failed to export map to target file.</source>
-        <translation>맵 내보내기에 실패하였습니다.</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Export syntax is --export-tileset [format] &lt;source&gt; &lt;target&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <source>Failed to load source tileset.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Failed to export tileset to target file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Project file &apos;%1&apos; not found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CommandDialog</name>
-    <message>
-        <location filename="../src/tiled/commanddialog.ui" line="+14"/>
-        <source>Edit Commands</source>
-        <translation type="unfinished">Command 수정</translation>
-    </message>
-    <message>
-        <location line="+43"/>
-        <source>Close</source>
-        <translation>닫기</translation>
-    </message>
-</context>
-<context>
-    <name>CommandLineHandler</name>
-    <message>
-        <location filename="../src/tiled/main.cpp" line="-301"/>
-        <source>Display the version</source>
-        <translation>버전 표시</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Only check validity of arguments</source>
-        <translation>인수의 유효함만 확인</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Disable hardware accelerated rendering</source>
-        <translation>하드웨어 가속 렌더링 사용하지 않음</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Export the specified map file to target</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Export the specified tileset file to target</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Print a list of supported export formats</source>
-        <translation>지원되는 내보내기 형식 목록 출력</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Export the map with tilesets embedded</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Export the map or tileset with template instances detached</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Export the map or tileset with types and properties resolved</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Minimize the exported file by omitting unnecessary whitespace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Start a new instance, even if an instance is already running</source>
-        <translation>인스턴스가 이미 실행중인 경우에도 새 인스턴스 시작</translation>
-    </message>
-    <message>
-        <location line="+65"/>
-        <source>Map export formats:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Tileset export formats:</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CommandLineParser</name>
-    <message>
-        <location filename="../src/tiled/commandlineparser.cpp" line="+76"/>
-        <source>Bad argument %1: lonely hyphen</source>
-        <translation>잘못된 인수 %1: 하이픈(&apos;-&apos;)만 존재합니다</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Unknown long argument %1: %2</source>
-        <translation>알 수 없는 긴 인수 %1: %2</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Unknown short argument %1.%2: %3</source>
-        <translation>알 수 없는 짧은 인수 %1.%2: %3</translation>
-    </message>
-    <message>
-        <location line="+17"/>
-        <source>Usage:
-  %1 [options] [files...]</source>
-        <translation>사용법:
-  %1 [옵션] [파일...]</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Options:</source>
-        <translation>옵션:</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Display this help</source>
-        <translation>이 도움말 표시</translation>
-    </message>
-</context>
-<context>
-    <name>CommandsEdit</name>
-    <message>
-        <location filename="../src/tiled/commandsedit.ui" line="+50"/>
-        <source>Executable:</source>
-        <translation type="unfinished">실행 파일:</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <location line="+74"/>
-        <source>Browse...</source>
-        <translation type="unfinished">찾아보기...</translation>
-    </message>
-    <message>
-        <location line="-61"/>
-        <source>Shortcut:</source>
-        <translation type="unfinished">단축키:</translation>
-    </message>
-    <message>
-        <location line="+17"/>
-        <source>Clear</source>
-        <translation type="unfinished">지우기</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>&amp;Save before executing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Arguments:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Working Directory:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+17"/>
-        <source>Show output in Console view</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Csv::CsvPlugin</name>
-    <message>
-        <location filename="../src/plugins/csv/csvplugin.cpp" line="+158"/>
-        <source>CSV files (*.csv)</source>
-        <translation>CSV 파일 (*.csv)</translation>
-    </message>
-</context>
-<context>
-    <name>Defold::DefoldPlugin</name>
-    <message>
-        <location filename="../src/plugins/defold/defoldplugin.cpp" line="+79"/>
-        <source>Defold files (*.tilemap)</source>
-        <translation>Defold 파일 (*.tilemap)</translation>
-    </message>
-</context>
-<context>
-    <name>DefoldCollection::DefoldCollectionPlugin</name>
-    <message>
-        <location filename="../src/plugins/defoldcollection/defoldcollectionplugin.cpp" line="+137"/>
-        <source>Defold collection (*.collection)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DonationDialog</name>
-    <message>
-        <location filename="../src/tiled/donationpopup.cpp" line="+42"/>
-        <source>Please consider supporting Tiled development with a small monthly donation.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>&amp;Donate ↗</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>I&apos;m a &amp;supporter!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Maybe later</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Droidcraft::DroidcraftPlugin</name>
-    <message>
-        <location filename="../src/plugins/droidcraft/droidcraftplugin.cpp" line="+56"/>
-        <source>This is not a valid Droidcraft map file!</source>
-        <translation>유효한 Droidcraft map 파일이 아닙니다!</translation>
-    </message>
-    <message>
-        <location line="+45"/>
-        <source>The map needs to have exactly one tile layer!</source>
-        <translation>맵은 하나의 타일 레이어만 갖고 있어야 합니다!</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>The layer must have a size of 48 x 48 tiles!</source>
-        <translation>레이어 크기는 48 x 48 타일이여야 합니다!</translation>
-    </message>
-    <message>
-        <location line="+38"/>
-        <source>Droidcraft map files (*.dat)</source>
-        <translation>Droidcraft 맵 파일 (*.dat)</translation>
-    </message>
-</context>
-<context>
-    <name>ExportAsImageDialog</name>
-    <message>
-        <location filename="../src/tiled/exportasimagedialog.ui" line="+14"/>
-        <source>Export As Image</source>
-        <translation>이미지로 내보내기</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Location</source>
-        <translation>위치</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Name:</source>
-        <translation>이름:</translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>&amp;Browse...</source>
-        <translation>찾아보기(&amp;B)...</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Settings</source>
-        <translation>설정</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Only include &amp;visible layers</source>
-        <translation>표시된 레이어만 포함(&amp;V)</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Use current &amp;zoom level</source>
-        <translation>현재 보이는 크기로(&amp;Z)</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>&amp;Draw tile grid</source>
-        <translation>타일 격자 그리기(&amp;D)</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Draw object &amp;names</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>&amp;Include background color</source>
-        <translation>배경색 포함(&amp;I)</translation>
-    </message>
-</context>
-<context>
-    <name>File Errors</name>
-    <message>
-        <location filename="../src/libtiled/mapwriter.cpp" line="+110"/>
-        <location filename="../src/plugins/csv/csvplugin.cpp" line="-97"/>
-        <location filename="../src/plugins/defold/defoldplugin.cpp" line="+53"/>
-        <location filename="../src/plugins/defoldcollection/defoldcollectionplugin.cpp" line="+159"/>
-        <location line="+106"/>
-        <location line="+29"/>
-        <location filename="../src/plugins/droidcraft/droidcraftplugin.cpp" line="-16"/>
-        <location filename="../src/plugins/flare/flareplugin.cpp" line="+311"/>
-        <location filename="../src/plugins/gmx/gmxplugin.cpp" line="+110"/>
-        <location filename="../src/plugins/json/jsonplugin.cpp" line="+97"/>
-        <location line="+173"/>
-        <location line="+102"/>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="+97"/>
-        <location line="+173"/>
-        <location line="+102"/>
-        <location filename="../src/plugins/lua/luaplugin.cpp" line="+116"/>
-        <location line="+45"/>
-        <location filename="../src/plugins/replicaisland/replicaislandplugin.cpp" line="+242"/>
-        <location filename="../src/plugins/tengine/tengineplugin.cpp" line="+57"/>
-        <location filename="../src/plugins/yy/yyplugin.cpp" line="+1272"/>
-        <location filename="../src/tiled/shortcutsettingspage.cpp" line="+724"/>
-        <source>Could not open file for writing.</source>
-        <translation type="unfinished">쓰기용으로 파일을 열 수 없습니다.</translation>
-    </message>
-    <message>
-        <location filename="../src/libtiled/worldmanager.cpp" line="+135"/>
-        <location filename="../src/plugins/flare/flareplugin.cpp" line="-252"/>
-        <location filename="../src/plugins/json/jsonplugin.cpp" line="-315"/>
-        <location line="+161"/>
-        <location line="+109"/>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="-315"/>
-        <location line="+161"/>
-        <location line="+109"/>
-        <location filename="../src/plugins/tbin/tbinplugin.cpp" line="+138"/>
-        <location filename="../src/tiled/shortcutsettingspage.cpp" line="-53"/>
-        <source>Could not open file for reading.</source>
-        <translation type="unfinished">읽기용으로 파일을 열 수 없습니다.</translation>
-    </message>
-</context>
-<context>
-    <name>File Types</name>
-    <message>
-        <location filename="../src/tiled/objecttypeseditor.cpp" line="+355"/>
-        <location line="+43"/>
-        <location filename="../src/tiled/projectpropertiesdialog.cpp" line="+59"/>
-        <source>Object Types files (*.xml *.json)</source>
-        <translation type="unfinished">오브젝트 타입 파일 (*.xml *.json)</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/projectpropertiesdialog.cpp" line="+6"/>
-        <source>Automapping Rules files (*.txt)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Flare::FlarePlugin</name>
-    <message>
-        <location filename="../src/plugins/flare/flareplugin.cpp" line="+99"/>
-        <source>Error loading tileset %1, which expands to %2. Path not found!</source>
-        <translation>%2로 확장되는 타일셋 %1을 불러오는 중 오류가 발생했습니다. 경로를 찾을 수 없습니다!</translation>
-    </message>
-    <message>
-        <location line="+18"/>
-        <source>No tilesets section found before layer section.</source>
-        <translation>레이어 영역 선택 전에 타일셋 영역을 선택하지 않았습니다.</translation>
-    </message>
-    <message>
-        <location line="+29"/>
-        <source>Error mapping tile id %1.</source>
-        <translation>타일 ID %1을 매핑하는 중 오류가 발생했습니다.</translation>
-    </message>
-    <message>
-        <location line="+70"/>
-        <source>This seems to be no valid flare map. A Flare map consists of at least a header section, a tileset section and one tile layer.</source>
-        <translation>유효한 Flare 맵이 아닌 것 같습니다. Flare 맵은 적어도 하나 이상의 헤더 영역, 타일셋 영역 선택, 하나의 타일 레이어로 구성됩니다.</translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Flare map files (*.txt)</source>
-        <translation>Flare 맵 파일 (*.txt)</translation>
-    </message>
-</context>
-<context>
-    <name>Gmx::GmxPlugin</name>
-    <message>
-        <location filename="../src/plugins/gmx/gmxplugin.cpp" line="+384"/>
-        <source>GameMaker room files (*.room.gmx)</source>
-        <translation>GameMaker room 파일 (*.room.gmx)</translation>
-    </message>
-</context>
-<context>
-    <name>Json::JsonMapFormat</name>
-    <message>
-        <location filename="../src/plugins/json/jsonplugin.cpp" line="-250"/>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="-250"/>
-        <source>Error parsing file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+58"/>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="+58"/>
-        <source>Error while writing file:
-%1</source>
-        <translation>파일을 작성하는 도중 에러가 발생했습니다:
-%1</translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>JSON map files (*.json)</source>
-        <translation>JSON 맵 파일 (*.json)</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>JavaScript map files (*.js)</source>
-        <translation>JavaScript 맵 파일 (*.js)</translation>
-    </message>
-    <message>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="+15"/>
-        <source>JSON map files [Tiled 1.1] (*.json)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>JavaScript map files [Tiled 1.1] (*.js)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Json::JsonObjectTemplateFormat</name>
-    <message>
-        <location filename="../src/plugins/json/jsonplugin.cpp" line="+183"/>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="+183"/>
-        <source>Error parsing file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+57"/>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="+57"/>
-        <source>Error while writing file:
-%1</source>
-        <translation type="unfinished">파일을 작성하는 도중 에러가 발생했습니다:
-%1</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>JSON template files (*.json)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="+14"/>
-        <source>JSON template files [Tiled 1.1] (*.json)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Json::JsonTilesetFormat</name>
-    <message>
-        <location filename="../src/plugins/json/jsonplugin.cpp" line="-180"/>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="-180"/>
-        <source>Error parsing file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+64"/>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="+64"/>
-        <source>Error while writing file:
-%1</source>
-        <translation>파일을 작성하는 도중 에러가 발생했습니다:
-%1</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>JSON tileset files (*.json)</source>
-        <translation>JSON 타일셋 파일 (*.json)</translation>
-    </message>
-    <message>
-        <location filename="../src/plugins/json1/jsonplugin.cpp" line="+14"/>
-        <source>JSON tileset files [Tiled 1.1] (*.json)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Lua::LuaMapFormat</name>
-    <message>
-        <location filename="../src/plugins/lua/luaplugin.cpp" line="-20"/>
-        <source>Lua files (*.lua)</source>
-        <translation type="unfinished">Lua 파일 (*.lua)</translation>
-    </message>
-</context>
-<context>
-    <name>Lua::LuaTilesetFormat</name>
-    <message>
-        <location line="+45"/>
-        <source>Lua files (*.lua)</source>
-        <translation type="unfinished">Lua 파일 (*.lua)</translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/tiled/mainwindow.ui" line="+46"/>
-        <source>&amp;File</source>
-        <translation>파일(&amp;F)</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>&amp;Recent Files</source>
-        <translation>최근 파일 목록(&amp;R)</translation>
-    </message>
-    <message>
-        <location line="+47"/>
-        <source>&amp;Edit</source>
-        <translation>편집(&amp;E)</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>&amp;Help</source>
-        <translation>도움말(&amp;H)</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>&amp;Map</source>
-        <translation>맵(&amp;M)</translation>
-    </message>
-    <message>
-        <location line="+95"/>
-        <source>&amp;Unload World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;Save World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-86"/>
-        <source>&amp;View</source>
-        <translation>보기(&amp;V)</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Show Object &amp;Names</source>
-        <translation>오브젝트 이름 표시(&amp;N)</translation>
-    </message>
-    <message>
-        <location line="+46"/>
-        <source>&amp;Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>&amp;Recent Projects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+58"/>
-        <source>&amp;Save</source>
-        <translation>저장(&amp;S)</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>&amp;Quit</source>
-        <translation>종료(&amp;Q)</translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>&amp;Copy</source>
-        <translation>복사(&amp;C)</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>&amp;Paste</source>
-        <translation>붙여넣기(&amp;P)</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>&amp;About Tiled</source>
-        <translation>Tiled에 대해(&amp;A)</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>About Qt</source>
-        <translation>Qt에 대해</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>&amp;Resize Map...</source>
-        <translation>맵 크기 조정(&amp;R)...</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>AutoMap</source>
-        <translation>오토맵</translation>
-    </message>
-    <message>
-        <location line="+344"/>
-        <source>For Hovered Object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;Load World...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;New World...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Highlight Hovered Object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Show Tile Collision Shapes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Fit Map in View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Community Forum ↗</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;Open Project...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;Close Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Clear Recent Projects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Add Folder to Project...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Save Project As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Refresh Folders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Show Object &amp;References</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Reopen Closed File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <location line="+3"/>
-        <source>Move Map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Project &amp;Properties...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Open File in &amp;Project...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Enable Parallax</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Show &amp;World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-470"/>
-        <source>Show &amp;Grid</source>
-        <translation>격자 표시(&amp;G)</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Save &amp;As...</source>
-        <translation>다른 이름으로 저장(&amp;A)...</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>New &amp;Tileset...</source>
-        <translation>새로운 타일셋(&amp;T)...</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>&amp;Close</source>
-        <translation>닫기(&amp;C)</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Zoom In</source>
-        <translation>확대</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Zoom Out</source>
-        <translation>축소</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Normal Size</source>
-        <translation>원래 크기</translation>
-    </message>
-    <message>
-        <location line="+147"/>
-        <source>Save All</source>
-        <translation>모두 저장</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>User Manual ↗</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>&amp;Never</source>
-        <translation>표시하지 않음(&amp;N)</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>For &amp;Selected Objects</source>
-        <translation>선택한 오브젝트만(&amp;S)</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>For &amp;All Objects</source>
-        <translation>모든 오브젝트(&amp;A)</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>AutoMap While Drawing</source>
-        <translation>그리는 중 오토맵 사용</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>New Map...</source>
-        <translation>새로운 맵...</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Paste &amp;in Place</source>
-        <translation>같은 위치에 붙여넣기(&amp;I)</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Full Screen</source>
-        <translation>전체 화면</translation>
-    </message>
-    <message>
-        <location line="-194"/>
-        <source>Cu&amp;t</source>
-        <translation>잘라내기(&amp;T)</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>&amp;Offset Map...</source>
-        <translation>맵 Offset(&amp;O)...</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Pre&amp;ferences...</source>
-        <translation>설정(&amp;F)...</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Clear Recent Files</source>
-        <translation>최근 파일 목록 지우기</translation>
-    </message>
-    <message>
-        <location line="+92"/>
-        <source>&amp;Export</source>
-        <translation>내보내기(&amp;E)</translation>
-    </message>
-    <message>
-        <location line="-79"/>
-        <source>&amp;Add External Tileset...</source>
-        <translation>외부 타일셋 추가(&amp;A)...</translation>
-    </message>
-    <message>
-        <location line="-384"/>
-        <source>&amp;New</source>
-        <translation>새로 만들기(&amp;N)</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Commands</source>
-        <translation>Command</translation>
-    </message>
-    <message>
-        <location line="+75"/>
-        <source>Snapping</source>
-        <translation>스냅</translation>
-    </message>
-    <message>
-        <location line="+30"/>
-        <source>Tileset</source>
-        <translation>타일셋</translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>&amp;World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+30"/>
-        <source>&amp;Open File or Project...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+79"/>
-        <source>Map &amp;Properties...</source>
-        <translation>맵 속성(&amp;P)...</translation>
-    </message>
-    <message>
-        <location line="+83"/>
-        <source>Export As &amp;Image...</source>
-        <translation>이미지로 내보내기(&amp;I)...</translation>
-    </message>
-    <message>
-        <location line="+39"/>
-        <source>E&amp;xport As...</source>
-        <translation>다른 형식으로 내보내기(&amp;X)...</translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>&amp;Snap to Grid</source>
-        <translation>격자에 스냅(&amp;S)</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>C&amp;lose All</source>
-        <translation>모두 닫기(&amp;L)</translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>&amp;Delete</source>
-        <translation>삭제(&amp;D)</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Delete</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>&amp;Highlight Current Layer</source>
-        <translation>현재 레이어만 강조(&amp;H)</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Show Tile Object &amp;Outlines</source>
-        <translation>타일 오브젝트 테두리 표시(&amp;O)</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Snap to &amp;Fine Grid</source>
-        <translation>정밀 격자에 스냅(&amp;F)</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Show Tile Animations</source>
-        <translation>타일 애니메이션 표시</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Reload</source>
-        <translation>다시 불러오기</translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Support Tiled Development ↗</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+83"/>
-        <source>Snap to &amp;Pixels</source>
-        <translation>픽셀에 스냅(&amp;P)</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Tileset &amp;Properties...</source>
-        <translation>타일셋 속성(&amp;P)...</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>No Snapping</source>
-        <translation>스냅 안함</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Edit Commands...</source>
-        <translation>Command 수정...</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Clear View</source>
-        <translation>선명한 보기</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+824"/>
-        <source>All Files (*)</source>
-        <translation>모든 파일 (*)</translation>
-    </message>
-</context>
-<context>
-    <name>MapDocument</name>
-    <message>
-        <location filename="../src/tiled/adjusttileindexes.cpp" line="+184"/>
-        <source>Tile</source>
-        <translation>타일</translation>
-    </message>
-</context>
-<context>
-    <name>MapReader</name>
-    <message>
-        <location filename="../src/libtiled/mapreader.cpp" line="+168"/>
-        <source>Not a map file.</source>
-        <translation>맵 파일이 아닙니다.</translation>
-    </message>
-    <message>
-        <location line="+19"/>
-        <source>Not a tileset file.</source>
-        <translation>타일셋 파일이 아닙니다.</translation>
-    </message>
-    <message>
-        <location line="+17"/>
-        <source>Not a template file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>%3
-
-Line %1, column %2</source>
-        <translation>%3
-
-%1 행 , %2 열</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>File not found: %1</source>
-        <translation>파일을 찾을 수 없습니다: %1</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Unable to read file: %1</source>
-        <translation>파일을 읽을 수 없습니다: %1</translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="+61"/>
-        <source>Unsupported map orientation: &quot;%1&quot;</source>
-        <translation>지원되지 않는 맵 구도 입니다: &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <location line="+124"/>
-        <location line="+40"/>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="+165"/>
-        <source>Invalid tileset parameters for tileset &apos;%1&apos;</source>
-        <translation>유효하지 않은 타일셋 &apos;%1&apos;의 타일셋 인수입니다</translation>
-    </message>
-    <message>
-        <location line="+64"/>
-        <source>Invalid tile ID: %1</source>
-        <translation>유효하지 않은 타일 ID 입니다: %1</translation>
-    </message>
-    <message>
-        <location line="+220"/>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="+65"/>
-        <source>Terrains</source>
-        <translation type="unfinished">지형</translation>
-    </message>
-    <message>
-        <location line="+260"/>
-        <source>Too many &lt;tile&gt; elements</source>
-        <translation>&lt;tile&gt; 요소가 너무 많습니다</translation>
-    </message>
-    <message>
-        <location line="+58"/>
-        <location line="+62"/>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="+662"/>
-        <source>Invalid tile: %1</source>
-        <translation>유효하지 않은 타일입니다: %1</translation>
-    </message>
-    <message>
-        <location line="-26"/>
-        <source>Unable to parse tile at (%1,%2) on layer &apos;%3&apos;: &quot;%4&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+52"/>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="-293"/>
-        <source>Invalid draw order: %1</source>
-        <translation>유효하지 않은 그리기 순서 입니다: %1</translation>
-    </message>
-    <message>
-        <location line="+183"/>
-        <source>Invalid points data for polygon</source>
-        <translation>유효하지 않은 폴리곤의 포인트 데이터 입니다</translation>
-    </message>
-    <message>
-        <location line="-358"/>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="-40"/>
-        <source>Unknown encoding: %1</source>
-        <translation>알 수 없는 인코딩 입니다: %1</translation>
-    </message>
-    <message>
-        <location line="-407"/>
-        <source>Error reading embedded image for tile %1</source>
-        <translation>내장된 타일 &apos;%1&apos; 의 이미지를 읽는 도중 오류가 발생했습니다</translation>
-    </message>
-    <message>
-        <location line="+402"/>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="-4"/>
-        <source>Compression method &apos;%1&apos; not supported</source>
-        <translation>압축 방식 &apos;%1&apos; 은 지원되지 않습니다</translation>
-    </message>
-    <message>
-        <location line="+86"/>
-        <location line="+23"/>
-        <location line="+30"/>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="+290"/>
-        <location line="+41"/>
-        <source>Corrupt layer data for layer &apos;%1&apos;</source>
-        <translation>레이어 &apos;%1&apos; 의 레이어 데이터가 손상되어 있습니다</translation>
-    </message>
-    <message>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="-30"/>
-        <source>Unable to parse tile at (%1,%2) on layer &apos;%3&apos;</source>
-        <translation>레이어 &apos;%3&apos; 의 (%1,%2) 타일을 파싱할 수 없습니다</translation>
-    </message>
-    <message>
-        <location filename="../src/libtiled/mapreader.cpp" line="-50"/>
-        <location line="+63"/>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="+33"/>
-        <source>Tile used but no tilesets specified</source>
-        <translation>타일에 사용될 타일셋이 지정되어 있지 않습니다</translation>
-    </message>
-    <message>
-        <location filename="../src/libtiled/varianttomapconverter.cpp" line="-566"/>
-        <location line="+27"/>
-        <source>Invalid (negative) tile id: %1</source>
-        <translation>유효하지 않은 타일 ID (음수)입니다: %1</translation>
-    </message>
-</context>
-<context>
-    <name>NewMapDialog</name>
-    <message>
-        <location filename="../src/tiled/newmapdialog.ui" line="+14"/>
-        <source>New Map</source>
-        <translation>새로운 맵</translation>
-    </message>
-    <message>
-        <location line="+64"/>
-        <source>Map size</source>
-        <translation>맵 크기</translation>
-    </message>
-    <message>
-        <location line="+34"/>
-        <location line="+77"/>
-        <source>Width:</source>
-        <translation>너비:</translation>
-    </message>
-    <message>
-        <location line="-93"/>
-        <location line="+26"/>
-        <source> tiles</source>
-        <extracomment>Remember starting with a space.</extracomment>
-        <translation> 타일</translation>
-    </message>
-    <message>
-        <location line="-38"/>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+54"/>
-        <location line="+77"/>
-        <source>Height:</source>
-        <translation>높이:</translation>
-    </message>
-    <message>
-        <location line="-42"/>
-        <source>Infinite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Tile size</source>
-        <translation>타일 크기</translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <location line="+26"/>
-        <source> px</source>
-        <extracomment>Remember starting with a space.</extracomment>
-        <translation> 픽셀</translation>
-    </message>
-    <message>
-        <location line="-202"/>
-        <source>Map</source>
-        <translation>맵</translation>
-    </message>
-    <message>
-        <location line="+42"/>
-        <source>Orientation:</source>
-        <translation>구도:</translation>
-    </message>
-    <message>
-        <location line="-20"/>
-        <source>Tile layer format:</source>
-        <translation>타일 레이어 형식:</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>Tile render order:</source>
-        <translation>타일 렌더링 순서:</translation>
-    </message>
-</context>
-<context>
-    <name>NewTilesetDialog</name>
-    <message>
-        <location filename="../src/tiled/newtilesetdialog.ui" line="+14"/>
-        <location filename="../src/tiled/newtilesetdialog.cpp" line="+259"/>
-        <source>New Tileset</source>
-        <translation>새 타일셋</translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Tileset</source>
-        <translation>타일셋</translation>
-    </message>
-    <message>
-        <location line="+40"/>
-        <source>Based on Tileset Image</source>
-        <translation>타일셋 이미지에 맞춤</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Collection of Images</source>
-        <translation>여러 이미지 가져옴</translation>
-    </message>
-    <message>
-        <location line="-19"/>
-        <source>Type:</source>
-        <translation>타입:</translation>
-    </message>
-    <message>
-        <location line="-20"/>
-        <source>&amp;Name:</source>
-        <translation>이름(&amp;N):</translation>
-    </message>
-    <message>
-        <location line="+60"/>
-        <source>Embed in map</source>
-        <translation>맵에 내장하기</translation>
-    </message>
-    <message>
-        <location line="+25"/>
-        <source>&amp;Browse...</source>
-        <translation>찾아보기(B)(&amp;B)...</translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Use transparent color:</source>
-        <translation>투명색 사용:</translation>
-    </message>
-    <message>
-        <location line="+129"/>
-        <source>Tile width:</source>
-        <translation>타일 너비:</translation>
-    </message>
-    <message>
-        <location line="+38"/>
-        <source>Pick color from image</source>
-        <translation>이미지에서 색상 선택</translation>
-    </message>
-    <message>
-        <location line="-138"/>
-        <location line="+42"/>
-        <location line="+26"/>
-        <location line="+16"/>
-        <source> px</source>
-        <extracomment>Remember starting with a space.</extracomment>
-        <translation> 픽셀</translation>
-    </message>
-    <message>
-        <location line="-142"/>
-        <source>Image</source>
-        <translation>이미지</translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <source>Source:</source>
-        <translation>소스:</translation>
-    </message>
-    <message>
-        <location line="+94"/>
-        <source>The space at the edges of the tileset.</source>
-        <translation>타일셋 가장자리 여백입니다.</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Margin:</source>
-        <translation>여백:</translation>
-    </message>
-    <message>
-        <location line="-45"/>
-        <source>Tile height:</source>
-        <translation>타일 높이:</translation>
-    </message>
-    <message>
-        <location line="+91"/>
-        <source>The space between the tiles.</source>
-        <translation>타일간의 간격입니다.</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Spacing:</source>
-        <translation>간격:</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/newtilesetdialog.cpp" line="-2"/>
-        <source>Edit Tileset</source>
-        <translation>타일셋 편집</translation>
-    </message>
-</context>
-<context>
-    <name>NoEditorWidget</name>
-    <message>
-        <location filename="../src/tiled/noeditorwidget.ui" line="+40"/>
-        <source>&lt;font size=&quot;+2&quot;&gt;No Open Files&lt;/font&gt;</source>
-        <translation type="unfinished">&lt;font size=&quot;+2&quot;&gt;열린 파일 없음 &lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location line="+110"/>
-        <source>Open File...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+27"/>
-        <source>New Map...</source>
-        <translation type="unfinished">새로운 맵...</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>New Tileset...</source>
-        <translation type="unfinished">새로운 타일셋...</translation>
-    </message>
-</context>
-<context>
-    <name>NoTilesetWidget</name>
-    <message>
-        <location filename="../src/tiled/tilesetdock.cpp" line="+88"/>
-        <source>New Tileset...</source>
-        <translation type="unfinished">새로운 타일셋...</translation>
-    </message>
-</context>
-<context>
-    <name>ObjectRefDialog</name>
-    <message>
-        <location filename="../src/tiled/objectrefdialog.ui" line="+14"/>
-        <source>Edit Object Reference</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Filter</source>
-        <translation type="unfinished">필터</translation>
-    </message>
-</context>
-<context>
-    <name>ObjectTypes</name>
-    <message>
-        <location filename="../src/libtiled/objecttypes.cpp" line="+251"/>
-        <source>Could not open file for writing.</source>
-        <translation>쓰기용으로 파일을 열 수 없습니다.</translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>Could not open file.</source>
-        <translation>파일을 열 수 없습니다.</translation>
-    </message>
-    <message>
-        <location line="-89"/>
-        <source>File doesn&apos;t contain object types.</source>
-        <translation>파일이 오브젝트 타입을 포함하고 있지 않습니다.</translation>
-    </message>
-    <message>
-        <location line="+27"/>
-        <source>%3
-
-Line %1, column %2</source>
-        <translation>%3
-
-%1 행 , %2 열</translation>
-    </message>
-</context>
-<context>
-    <name>ObjectTypesEditor</name>
-    <message>
-        <location filename="../src/tiled/objecttypeseditor.ui" line="+14"/>
-        <source>Object Types Editor</source>
-        <translation>오브젝트 타입 편집기</translation>
-    </message>
-    <message>
-        <location line="+56"/>
-        <source>Export...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Export Object Types</source>
-        <translation type="unfinished">오브젝트 타입 내보내기</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Import Object Types</source>
-        <translation type="unfinished">오브젝트 타입 가져오기</translation>
-    </message>
-</context>
-<context>
     <name>OffsetMapDialog</name>
     <message>
-        <location filename="../src/tiled/offsetmapdialog.ui" line="+17"/>
-        <source>Offset Map</source>
-        <translation>맵 Offset</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Offset Contents of Map</source>
-        <translation>맵의 Offset 내용</translation>
-    </message>
-    <message>
-        <location line="+6"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+46"/>
-        <source> tiles</source>
-        <translation> 타일</translation>
-    </message>
-    <message>
-        <location line="-30"/>
-        <location line="+46"/>
-        <source>Wrap</source>
-        <translation>감싸기</translation>
-    </message>
-    <message>
-        <location line="-39"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>Layers:</source>
-        <translation>레이어:</translation>
+        <source>Wrap</source>
+        <translation>감싸기</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>All Visible Layers</source>
         <translation>표시된 레이어</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source> tiles</source>
+        <translation> 타일</translation>
+    </message>
+    <message>
+        <source>Layers:</source>
+        <translation>레이어:</translation>
+    </message>
+    <message>
         <source>All Layers</source>
         <translation>모든 레이어</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Selected Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Bounds:</source>
-        <translation>범위:</translation>
-    </message>
-    <message>
-        <location line="+8"/>
         <source>Whole Map</source>
         <translation>전체 맵</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Selected Layers</source>
+        <translation>선택된 레이어</translation>
+    </message>
+    <message>
+        <source>Bounds:</source>
+        <translation>범위:</translation>
+    </message>
+    <message>
+        <source>Offset Map</source>
+        <translation>맵 Offset</translation>
+    </message>
+    <message>
+        <source>Offset Contents of Map</source>
+        <translation>맵의 Offset 내용</translation>
+    </message>
+    <message>
         <source>Current Selection</source>
         <translation>선택된 영역</translation>
     </message>
 </context>
 <context>
+    <name>ResizeDialog</name>
+    <message>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>크기</translation>
+    </message>
+    <message>
+        <source> tiles</source>
+        <translation> 타일</translation>
+    </message>
+    <message>
+        <source>Offset</source>
+        <translation>오프셋</translation>
+    </message>
+    <message>
+        <source>Resize</source>
+        <translation>크기 조정</translation>
+    </message>
+    <message>
+        <source>Width:</source>
+        <translation>너비:</translation>
+    </message>
+    <message>
+        <source>Remove objects outside of the map</source>
+        <translation>맵 바깥 오브젝트 제거</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>높이:</translation>
+    </message>
+</context>
+<context>
+    <name>TileAnimationEditor</name>
+    <message>
+        <source> ms</source>
+        <translation> ms</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>적용</translation>
+    </message>
+    <message>
+        <source>Tile Animation Editor</source>
+        <translation>타일 애니메이션 편집기</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation>미리보기</translation>
+    </message>
+    <message>
+        <source>Frame Duration: </source>
+        <translation>프레임 기간: </translation>
+    </message>
+</context>
+<context>
+    <name>NewMapDialog</name>
+    <message>
+        <source> px</source>
+        <translation> 픽셀</translation>
+    </message>
+    <message>
+        <source>Map</source>
+        <translation>맵</translation>
+    </message>
+    <message>
+        <source>Fixed</source>
+        <translation>고정된</translation>
+    </message>
+    <message>
+        <source>Tile size</source>
+        <translation>타일 크기</translation>
+    </message>
+    <message>
+        <source> tiles</source>
+        <translation> 타일</translation>
+    </message>
+    <message>
+        <source>New Map</source>
+        <translation>새로운 맵</translation>
+    </message>
+    <message>
+        <source>Infinite</source>
+        <translation>무한</translation>
+    </message>
+    <message>
+        <source>Width:</source>
+        <translation>너비:</translation>
+    </message>
+    <message>
+        <source>Map size</source>
+        <translation>맵 크기</translation>
+    </message>
+    <message>
+        <source>Tile layer format:</source>
+        <translation>타일 레이어 형식:</translation>
+    </message>
+    <message>
+        <source>Tile render order:</source>
+        <translation>타일 렌더링 순서:</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>높이:</translation>
+    </message>
+    <message>
+        <source>Orientation:</source>
+        <translation>구도:</translation>
+    </message>
+</context>
+<context>
+    <name>NewTilesetDialog</name>
+    <message>
+        <source> px</source>
+        <translation> 픽셀</translation>
+    </message>
+    <message>
+        <source>Image</source>
+        <translation>이미지</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>타입:</translation>
+    </message>
+    <message>
+        <source>Pick color from image</source>
+        <translation>이미지에서 색상 선택</translation>
+    </message>
+    <message>
+        <source>Embed in map</source>
+        <translation>맵에 내장하기</translation>
+    </message>
+    <message>
+        <source>&amp;Name:</source>
+        <translation>이름(&amp;N):</translation>
+    </message>
+    <message>
+        <source>Margin:</source>
+        <translation>여백:</translation>
+    </message>
+    <message>
+        <source>Spacing:</source>
+        <translation>거리:</translation>
+    </message>
+    <message>
+        <source>&amp;Browse...</source>
+        <translation>찾아보기(&amp;B)...</translation>
+    </message>
+    <message>
+        <source>Tile width:</source>
+        <translation>타일 너비:</translation>
+    </message>
+    <message>
+        <source>Use transparent color:</source>
+        <translation>투명색 사용:</translation>
+    </message>
+    <message>
+        <source>Based on Tileset Image</source>
+        <translation>타일셋 이미지에 맞춤</translation>
+    </message>
+    <message>
+        <source>The space at the edges of the tileset.</source>
+        <translation>타일셋 가장자리 여백입니다.</translation>
+    </message>
+    <message>
+        <source>Source:</source>
+        <translation>소스:</translation>
+    </message>
+    <message>
+        <source>New Tileset</source>
+        <translation>새 타일셋</translation>
+    </message>
+    <message>
+        <source>Tileset</source>
+        <translation>타일셋</translation>
+    </message>
+    <message>
+        <source>Tile height:</source>
+        <translation>타일 높이:</translation>
+    </message>
+    <message>
+        <source>The space between the tiles.</source>
+        <translation>타일사이의 거리입니다.</translation>
+    </message>
+    <message>
+        <source>Edit Tileset</source>
+        <translation>타일셋 편집</translation>
+    </message>
+    <message>
+        <source>Collection of Images</source>
+        <translation>여러 이미지 가져옴</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::NewTilesetDialog</name>
+    <message>
+        <source>&amp;OK</source>
+        <translation>확인(&amp;O)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>오류</translation>
+    </message>
+    <message>
+        <source>&amp;Save As...</source>
+        <translation>다른 이름으로 저장(&amp;S)...</translation>
+    </message>
+    <message>
+        <source>No tiles found in the tileset image when using the given tile size, margin and spacing!</source>
+        <translation>입력된 타일 크기, 여백, 간격을 사용시 타일셋 이미지에 타일이 없습니다!</translation>
+    </message>
+    <message>
+        <source>Tileset Image</source>
+        <translation>타일셋 이미지</translation>
+    </message>
+    <message>
+        <source>Failed to load tileset image &apos;%1&apos;.</source>
+        <translation>타일셋 이미지 &apos;%1&apos; 을 불러오는 데 실패하였습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::MainWindow</name>
+    <message>
+        <source>&amp;No</source>
+        <translation>아니오 (&amp;N)</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation>새로 만들기(&amp;N)</translation>
+    </message>
+    <message>
+        <source>&amp;Yes</source>
+        <translation>예 (&amp;Yes)</translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation>다시 실행</translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation>실행 취소</translation>
+    </message>
+    <message>
+        <source>Non-unique file extension.
+Please select specific format.</source>
+        <translation>확장자가 한 개가 아닙니다.
+명확한 형식을 지정해주세요.</translation>
+    </message>
+    <message>
+        <source>Error Exporting Map</source>
+        <translation>맵 내보내는 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Unsaved Changes</source>
+        <translation>변경 사항 저장되지 않음</translation>
+    </message>
+    <message>
+        <source>Error Saving File</source>
+        <translation>파일 저장중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Non-unique file extension</source>
+        <translation>확장자가 한 개가 아닙니다</translation>
+    </message>
+    <message>
+        <source>Export As...</source>
+        <translation>다른 형식으로 내보내기...</translation>
+    </message>
+    <message>
+        <source>Tiled may not automatically recognize your file when loading. Are you sure you want to save with this extension?</source>
+        <translation>Tiled는 불러오는 중 파일을 자동으로 인식하지 못할 수 있습니다. 이 확장자로 저장하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>&amp;Close</source>
+        <translation>닫기(&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Group</source>
+        <translation>그룹 (&amp;G)</translation>
+    </message>
+    <message>
+        <source>&amp;Layer</source>
+        <translation>레이어(&amp;L)</translation>
+    </message>
+    <message>
+        <source>Open Project</source>
+        <translation>프로젝트 열기</translation>
+    </message>
+    <message>
+        <source>Error Exporting Map!</source>
+        <translation>맵 내보내기 오류!</translation>
+    </message>
+    <message>
+        <source>Save Template</source>
+        <translation>템플릿 저장</translation>
+    </message>
+    <message>
+        <source>Object Types Editor</source>
+        <translation>오브젝트 타입 편집기</translation>
+    </message>
+    <message>
+        <source>Error Opening Project</source>
+        <translation>프로젝트 열기 오류</translation>
+    </message>
+    <message>
+        <source>Error Opening File</source>
+        <translation>파일 여는 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Lock Layout</source>
+        <translation>레이어 잠금</translation>
+    </message>
+    <message>
+        <source>The file extension does not match the chosen file type.</source>
+        <translation>파일 확장자가 선택된 파일의 타입과 맞지 않습니다.</translation>
+    </message>
+    <message>
+        <source>untitled</source>
+        <translation>untitled</translation>
+    </message>
+    <message>
+        <source>Tile Collision Editor</source>
+        <translation>타일 Collision 편집기</translation>
+    </message>
+    <message>
+        <source>There are unsaved changes to world &quot;%1&quot;. Do you want to save the world now?</source>
+        <translation>저장되지 않은 변경 사항이 있습니다 &quot;%1&quot; 지금 저장하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>Load World</source>
+        <translation>월드 불러오기</translation>
+    </message>
+    <message>
+        <source>Error Loading World</source>
+        <translation>월드 불러오기 오류</translation>
+    </message>
+    <message>
+        <source>Error Saving Project</source>
+        <translation>프로젝트 저장 오류</translation>
+    </message>
+    <message>
+        <source>Error Exporting Tileset</source>
+        <translation>타일셋 내보내기 오류</translation>
+    </message>
+    <message>
+        <source>Views and Toolbars</source>
+        <translation>보기 및 툴바</translation>
+    </message>
+    <message>
+        <source>Add External Tileset(s)</source>
+        <translation>외부 타일셋 추가</translation>
+    </message>
+    <message>
+        <source>Error Writing World File</source>
+        <translation>월드 파일 읽기 오류</translation>
+    </message>
+    <message>
+        <source>The current project contains &lt;a href=&quot;https://doc.mapeditor.org/en/stable/reference/scripting/&quot;&gt;scripted extensions&lt;/a&gt;.&lt;br&gt;&lt;i&gt;Make sure you trust those extensions before enabling them!&lt;/i&gt;</source>
+        <translation>현재 프로젝트는 &lt;a href=&quot;https://doc.mapeditor.org/en/stable/reference/scripting/&quot;&gt;개요 확장자를 포함하고 있다.확장을 활성화하기 전에 해당 확장을 신뢰하는지 확인하십시오!&lt;/i&gt;</translation>
+    </message>
+    <message>
+        <source>Error Saving World</source>
+        <translation>월드 저장 오류</translation>
+    </message>
+    <message>
+        <source>Error Creating World</source>
+        <translation>월드 생성 오류</translation>
+    </message>
+    <message>
+        <source>Automatic Mapping Warning</source>
+        <translation>오토맵 경고</translation>
+    </message>
+    <message>
+        <source>Unknown File Format</source>
+        <translation>알 수 없는 파일 형식</translation>
+    </message>
+    <message>
+        <source>Automatic Mapping Error</source>
+        <translation>오토맵 오류</translation>
+    </message>
+    <message>
+        <source>Exported to %1</source>
+        <translation>%1 로 내보냈습니다</translation>
+    </message>
+    <message>
+        <source>There are unsaved changes. Do you want to save now?</source>
+        <translation>저장되지 않은 변경 사항이 있습니다. 지금 저장하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>New World</source>
+        <translation>새로운 월드</translation>
+    </message>
+    <message>
+        <source>The given filename does not have any known file extension.</source>
+        <translation>입력된 파일명은 지원되는 확장자를 포함하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Some export files already exist:</source>
+        <translation>일부 내보낸 파일들이 이미 존재합니다:</translation>
+    </message>
+    <message>
+        <source>An error occurred while saving the project.</source>
+        <translation>프로젝트를 저장하는 동안 오류가 발생했습니다.</translation>
+    </message>
+    <message>
+        <source>Do you want to replace them?</source>
+        <translation>대체하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>Reset to Default Layout</source>
+        <translation>레이어 초기값 초기화</translation>
+    </message>
+    <message>
+        <source>All Files (*)</source>
+        <translation>모든 파일 (*)</translation>
+    </message>
+    <message>
+        <source>Error opening &apos;%1&apos;:
+%2</source>
+        <translation>열기 오류 &apos;%1&apos;::
+%2</translation>
+    </message>
+    <message>
+        <source>Unsaved Changes to World</source>
+        <translation>월드 변경 사항 저장되지 않음</translation>
+    </message>
+    <message>
+        <source>An error occurred while opening the project.</source>
+        <translation>프로젝트를 여는 동안 오류가 발생했습니다.</translation>
+    </message>
+    <message>
+        <source>All Files (*);;</source>
+        <translation>모든 파일 (*);;</translation>
+    </message>
+    <message>
+        <source>Overwrite Files</source>
+        <translation>파일 덮어쓰기</translation>
+    </message>
+    <message>
+        <source>Open File</source>
+        <translation>파일 ㅇㅕㄹ기</translation>
+    </message>
+    <message>
+        <source>Error Reloading Map</source>
+        <translation>맵 다시 불러오는 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>&amp;Enable Extensions</source>
+        <translation>확장 사용 (&amp;E)</translation>
+    </message>
+    <message>
+        <source>Save Project As</source>
+        <translation>다른 이름으로 프로젝트 저장</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;Enable anonymous crash reporting? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;익명의 오류 충돌 보고서를 사용하시겠습니까?  &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Extension Mismatch</source>
+        <translation>확장자 불일치</translation>
+    </message>
+    <message>
+        <source>Tiled Projects (*.tiled-project)</source>
+        <translation>타일 프로젝트 (*.tiled-project)</translation>
+    </message>
+    <message>
+        <source>[*]%1%2</source>
+        <translation>[*]%1%2</translation>
+    </message>
+    <message>
+        <source>World files (*.world)</source>
+        <translation>월드 파일 (*.world)</translation>
+    </message>
+    <message>
+        <source>Error Saving Template</source>
+        <translation>템플릿 저장 오류</translation>
+    </message>
+</context>
+<context>
+    <name>QtColorEditWidget</name>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+</context>
+<context>
+    <name>QtFontEditWidget</name>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Select Font</source>
+        <translation>폰트 선택</translation>
+    </message>
+</context>
+<context>
     <name>PreferencesDialog</name>
     <message>
-        <location filename="../src/tiled/preferencesdialog.ui" line="+14"/>
-        <source>Preferences</source>
-        <translation>설정</translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>General</source>
-        <translation>일반</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Saving and Loading</source>
-        <translation>저장 및 불러오기</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/newmapdialog.cpp" line="+85"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+1228"/>
-        <source>Base64 (uncompressed)</source>
-        <translation>Base64 (미압축)</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/propertybrowser.cpp" line="-1"/>
-        <source>XML (deprecated)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Base64 (gzip compressed)</source>
-        <translation>Base64 (gzip 압축)</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/newmapdialog.cpp" line="+1"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+1"/>
-        <source>Base64 (zlib compressed)</source>
-        <translation>Base64 (zlib 압축)</translation>
-    </message>
-    <message>
-        <location line="-2"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+4"/>
         <source>CSV</source>
         <translation>CSV</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="-2"/>
-        <source>Base64 (Zstandard compressed)</source>
-        <translation type="unfinished"></translation>
+        <source>Saving and Loading</source>
+        <translation>저장 및 불러오기</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+14"/>
-        <source>Right Down</source>
-        <translation>오른쪽 아래 방향으로</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+1"/>
-        <source>Right Up</source>
-        <translation>오른쪽 위 방향으로</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+1"/>
-        <source>Left Down</source>
-        <translation>왼쪽 아래 방향으로</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+1"/>
-        <source>Left Up</source>
-        <translation>왼쪽 위 방향으로</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/preferencesdialog.ui" line="+23"/>
-        <source>&amp;Reload tileset images when they change</source>
-        <translation>타일셋 이미지 변경시 다시 불러오기(&amp;R)</translation>
-    </message>
-    <message>
-        <location line="+116"/>
-        <location line="+6"/>
-        <source>Interface</source>
-        <translation>인터페이스</translation>
-    </message>
-    <message>
-        <location line="+26"/>
-        <source>&amp;Language:</source>
-        <translation>언어(&amp;L):</translation>
-    </message>
-    <message>
-        <location line="+113"/>
-        <source>Hardware &amp;accelerated drawing (OpenGL)</source>
-        <translation>하드웨어 가속 그리기 (OpenGL)(&amp;A)</translation>
-    </message>
-    <message>
-        <location line="-278"/>
-        <source>Turn this off if you&apos;re having trouble saving your files.</source>
-        <translation>파일 저장에 문제 발생시 이 옵션을 꺼주십시오.</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Use safe writing of files</source>
-        <translation>파일 안전 작성 사용</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Restore previous session on startup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Repeat last export on save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Export Options</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Resolve object types and properties</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Embed tilesets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Detach templates</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Omits unnecessary whitespace when supported by the output format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Minimize output</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Crash Reporting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Enable sending anonymous crash reports</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+85"/>
-        <source>Major grid every:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+63"/>
-        <source> tiles</source>
-        <translation type="unfinished"> 타일</translation>
-    </message>
-    <message>
-        <location line="+30"/>
-        <source>Object selection behavior:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-123"/>
-        <source>Grid color:</source>
-        <translation>그리드 색상:</translation>
-    </message>
-    <message>
-        <location line="+113"/>
-        <source>Fine grid divisions:</source>
-        <translation>정밀 그리드 분할:</translation>
-    </message>
-    <message>
-        <location line="+27"/>
-        <source>Background fade color:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+167"/>
-        <source>Extensions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Directory:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Open...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-280"/>
-        <source> pixels</source>
-        <translation> 픽셀</translation>
-    </message>
-    <message>
-        <location line="-37"/>
-        <source>Object line width:</source>
-        <translation>오브젝트 선 굵기:</translation>
-    </message>
-    <message>
-        <location line="+30"/>
-        <source>Mouse wheel &amp;zooms by default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+43"/>
-        <source>Middle mouse button uses auto-&amp;scrolling</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-20"/>
-        <source>Use s&amp;mooth scrolling</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+96"/>
-        <source>Display news in status bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Highlight new version in status bar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+24"/>
-        <source>Keyboard</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <location line="+6"/>
         <source>Theme</source>
         <translation>테마</translation>
     </message>
     <message>
-        <location filename="../src/tiled/preferencesdialog.cpp" line="+66"/>
-        <location line="+191"/>
-        <source>Native</source>
-        <translation>Native 스타일</translation>
+        <source>Background fade color:</source>
+        <translation>배경 투명 색상:</translation>
     </message>
     <message>
-        <location line="-190"/>
-        <location line="+191"/>
         <source>Tiled Fusion</source>
         <translation>Tiled Fusion 스타일</translation>
     </message>
     <message>
-        <location filename="../src/tiled/preferencesdialog.ui" line="+25"/>
-        <source>Selection color:</source>
-        <translation>선택 색상:</translation>
+        <source>Omits unnecessary whitespace when supported by the output format</source>
+        <translation>출력 형식에서 지원하는 경우 불필요한 공백을 생략합니다</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <source>Resolve object types and properties</source>
+        <translation>개체 유형 및 속성 확인</translation>
+    </message>
+    <message>
+        <source>Display news in status bar</source>
+        <translation>상태 표시줄에 뉴스 표시</translation>
+    </message>
+    <message>
+        <source>Use safe writing of files</source>
+        <translation>파일 안전 작성 사용</translation>
+    </message>
+    <message>
+        <source> tiles</source>
+        <translation> 타일</translation>
+    </message>
+    <message>
+        <source>Enabled Plugins</source>
+        <translation>내장 플러그인</translation>
+    </message>
+    <message>
+        <source>Left Up</source>
+        <translation>왼쪽 위 방향으로</translation>
+    </message>
+    <message>
+        <source>Turn this off if you&apos;re having trouble saving your files.</source>
+        <translation>파일 저장에 문제 발생시 이 옵션을 꺼주십시오.</translation>
+    </message>
+    <message>
+        <source>Major grid every:</source>
+        <translation>주 그리드 간격:</translation>
+    </message>
+    <message>
+        <source>Restore previous session on startup</source>
+        <translation>시작할 ㄸㅐ 이전 세션 복원</translation>
+    </message>
+    <message>
+        <source>Detach templates</source>
+        <translation>템플릿 분리</translation>
+    </message>
+    <message>
+        <source>Minimize output</source>
+        <translation>출력 최소화</translation>
+    </message>
+    <message>
+        <source>Object line width:</source>
+        <translation>오브젝트 선 굵기:</translation>
+    </message>
+    <message>
+        <source>&amp;Language:</source>
+        <translation>언어(&amp;L):</translation>
+    </message>
+    <message>
+        <source>Hardware &amp;accelerated drawing (OpenGL)</source>
+        <translation>하드웨어 가속 그리기 (OpenGL)(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Native</source>
+        <translation>Native 스타일</translation>
+    </message>
+    <message>
+        <source>Repeat last export on save</source>
+        <translation>저장 시 마지막 내보내기 반복</translation>
+    </message>
+    <message>
         <source>Style:</source>
         <translation>스타일:</translation>
     </message>
     <message>
-        <location line="+26"/>
+        <source>Open...</source>
+        <translation>열기...</translation>
+    </message>
+    <message>
+        <source>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;)</source>
+        <translation>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;더 많은정보&lt;/a&gt;)</translation>
+    </message>
+    <message>
+        <source>Grid color:</source>
+        <translation>그리드 색상:</translation>
+    </message>
+    <message>
         <source>Base color:</source>
         <translation>기본 색상:</translation>
     </message>
     <message>
-        <location line="-109"/>
-        <source>Updates</source>
-        <translation>업데이트</translation>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>Plugins</source>
         <translation>플러그인</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>Enabled Plugins</source>
-        <translation>내장 플러그인</translation>
+        <source> pixels</source>
+        <translation> 픽셀</translation>
+    </message>
+    <message>
+        <source>Mouse wheel &amp;zooms by default</source>
+        <translation>기본적으로 마우스 휠 &amp;확대/축소</translation>
+    </message>
+    <message>
+        <source>Base64 (gzip compressed)</source>
+        <translation>Base64 (gzip 압축)</translation>
+    </message>
+    <message>
+        <source>Export Options</source>
+        <translation>옵션 내보내기</translation>
+    </message>
+    <message>
+        <source>XML (deprecated)</source>
+        <translation>XML (사용되지않는)</translation>
+    </message>
+    <message>
+        <source>Middle mouse button uses auto-&amp;scrolling</source>
+        <translation>마우스 가운데 버튼은 자동&amp;스크롤 사용</translation>
+    </message>
+    <message>
+        <source>&amp;Reload tileset images when they change</source>
+        <translation>타일셋 이미지 변경시 다시 불러오기(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Highlight new version in status bar</source>
+        <translation>상태 표시줄에서 새 버전 강조 표시</translation>
+    </message>
+    <message>
+        <source>Use s&amp;mooth scrolling</source>
+        <translation>&amp;부드러운 스크롤 사용</translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation>인터페이스</translation>
+    </message>
+    <message>
+        <source>Base64 (uncompressed)</source>
+        <translation>Base64 (미압축)</translation>
+    </message>
+    <message>
+        <source>Directory:</source>
+        <translation>디렉토리:</translation>
+    </message>
+    <message>
+        <source>Extensions</source>
+        <translation>확장</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation>업데이트</translation>
+    </message>
+    <message>
+        <source>Preferences</source>
+        <translation>설정</translation>
+    </message>
+    <message>
+        <source>Keyboard</source>
+        <translation>키보드</translation>
+    </message>
+    <message>
+        <source>Selection color:</source>
+        <translation>선택 색상:</translation>
+    </message>
+    <message>
+        <source>Left Down</source>
+        <translation>왼쪽 아래 방향으로</translation>
+    </message>
+    <message>
+        <source>Embed tilesets</source>
+        <translation>숨겨진 타일셋</translation>
+    </message>
+    <message>
+        <source>Base64 (Zstandard compressed)</source>
+        <translation>Base64 (Zstandard 압축)</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>일반</translation>
+    </message>
+    <message>
+        <source>Base64 (zlib compressed)</source>
+        <translation>Base64 (zlib 압축)</translation>
+    </message>
+    <message>
+        <source>Object selection behavior:</source>
+        <translation>오브젝트 선택 동작:</translation>
+    </message>
+    <message>
+        <source>Enable sending anonymous crash reports</source>
+        <translation>익명으로 충돌 보고서 보내기 사용</translation>
+    </message>
+    <message>
+        <source>Right Down</source>
+        <translation>오른쪽 아래 방향으로</translation>
+    </message>
+    <message>
+        <source>Fine grid divisions:</source>
+        <translation>정밀 그리드 분할:</translation>
+    </message>
+    <message>
+        <source>Right Up</source>
+        <translation>오른쪽 위 방향으로</translation>
+    </message>
+    <message>
+        <source>Crash Reporting</source>
+        <translation>충돌 보고</translation>
     </message>
 </context>
 <context>
-    <name>ProjectPropertiesDialog</name>
+    <name>Tiled::MapDocumentActionHandler</name>
     <message>
-        <location filename="../src/tiled/projectpropertiesdialog.ui" line="+14"/>
-        <source>Project Properties</source>
-        <translation type="unfinished"></translation>
+        <source>Cut</source>
+        <translation>잘라내기</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation>새로 만들기(&amp;N)</translation>
+    </message>
+    <message>
+        <source>&amp;Lower Layers</source>
+        <translation>레이어 내리기(&amp;L)</translation>
+    </message>
+    <message numerus="yes">
+        <source>Duplicate %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 복제</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>&amp;Group Layer</source>
+        <translation>레이어 그룹화(&amp;G)</translation>
+    </message>
+    <message>
+        <source>&amp;Merge Layer Down</source>
+        <translation>아래 레이어와 병합(&amp;M)</translation>
+    </message>
+    <message>
+        <source>&amp;Ungroup Layers</source>
+        <translation>레이어 그룹 해제(&amp;U)</translation>
+    </message>
+    <message>
+        <source>R&amp;aise Layers</source>
+        <translation>레이어 올리기(&amp;a)</translation>
+    </message>
+    <message>
+        <source>&amp;Group</source>
+        <translation>그룹(&amp;G)</translation>
+    </message>
+    <message>
+        <source>Show/&amp;Hide Other Layers</source>
+        <translation>다른 레이어 표시/숨기기(&amp;H)</translation>
+    </message>
+    <message>
+        <source>Select &amp;None</source>
+        <translation>선택 해제(&amp;N)</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>삭제</translation>
+    </message>
+    <message>
+        <source>Layer &amp;Properties...</source>
+        <translation>레이어 속성(&amp;P)...</translation>
+    </message>
+    <message>
+        <source>&amp;Image Layer</source>
+        <translation>이미지 레이어(&amp;I)</translation>
+    </message>
+    <message>
+        <source>Select &amp;Next Layer</source>
+        <translation>다음 레이어 선택(&amp;N)</translation>
+    </message>
+    <message>
+        <source>Show/&amp;Hide Layers</source>
+        <translation>레이어 표시/숨기기(&amp;H)</translation>
+    </message>
+    <message>
+        <source>&amp;Tile Layer</source>
+        <translation>타일 레이어(&amp;T)</translation>
+    </message>
+    <message>
+        <source>&amp;Crop to Selection</source>
+        <translation>선택 영역 잘라내기(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Layer via Copy</source>
+        <translation>사본을 통한 레이어</translation>
+    </message>
+    <message>
+        <source>&amp;Duplicate Layers</source>
+        <translation>레이어 복제(&amp;D)</translation>
+    </message>
+    <message>
+        <source>Select Pre&amp;vious Layer</source>
+        <translation>이전 레이어 선택(&amp;V)</translation>
+    </message>
+    <message>
+        <source>Remove Objects</source>
+        <translation>오브젝트 삭제</translation>
+    </message>
+    <message>
+        <source>Select &amp;All</source>
+        <translation>모두 선택(&amp;A)</translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 삭제</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Duplicate Objects</source>
+        <translation>오브젝트 복제</translation>
+    </message>
+    <message>
+        <source>Lock/&amp;Unlock Other Layers</source>
+        <translation>다른 레이어 잠금/잠금 해제(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Invert S&amp;election</source>
+        <translation>선택 영역 반전(&amp;e)</translation>
+    </message>
+    <message>
+        <source>Autocrop</source>
+        <translation>자동 잘라내기</translation>
+    </message>
+    <message>
+        <source>&amp;Object Layer</source>
+        <translation>오브젝트 레이어(&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Remove Layers</source>
+        <translation>레이어 삭제(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Lock/&amp;Unlock Layers</source>
+        <translation>레이어 잠금/잠금 해제(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Layer via Cut</source>
+        <translation>잘라내기를 통한 레이어</translation>
+    </message>
+    <message>
+        <source>&amp;Group Layers</source>
+        <translation>레이어 그룹화(&amp;G)</translation>
     </message>
 </context>
 <context>
-    <name>Python::PythonMapFormat</name>
+    <name>Tiled::TileCollisionDock</name>
     <message>
-        <location filename="../src/plugins/python/pythonplugin.cpp" line="+274"/>
-        <source>-- Using script %1 to read %2</source>
-        <translation>-- %2를 읽기 위해 스크립트 %1을 사용합니다</translation>
+        <source>Cut</source>
+        <translation>잘라내기</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <source>-- Using script %1 to write %2</source>
-        <translation>-- %2를 쓰기 위해 스크립트 %1을 사용합니다</translation>
+        <source>Detect Bounding Box</source>
+        <translation>경계 상자 탐지</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>Uncaught exception in script. Please check console.</source>
-        <translation>스크립트에 캐치되지 않은 예외가 있습니다. 콘솔을 확인하여 주십시오.</translation>
+        <source>Delete</source>
+        <translation>삭제</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Script returned false. Please check console.</source>
-        <translation>스크립트가 false를 반환하였습니다. 콘솔을 확인하여 주십시오.</translation>
+        <source>Show Bottom</source>
+        <translation>하단 표시</translation>
+    </message>
+    <message>
+        <source>Hidden</source>
+        <translation>숨겨짐</translation>
+    </message>
+    <message>
+        <source>Move Objects Up</source>
+        <translation>오브젝트 위로 이동</translation>
+    </message>
+    <message>
+        <source>Show Right</source>
+        <translation>오른쪽 표시</translation>
+    </message>
+    <message>
+        <source>Remove Objects</source>
+        <translation>오브젝트 삭제</translation>
+    </message>
+    <message>
+        <source>Duplicate Objects</source>
+        <translation>오브젝트 복제</translation>
+    </message>
+    <message>
+        <source>Object Properties</source>
+        <translation>오브젝트 속성</translation>
+    </message>
+    <message>
+        <source>Objects list</source>
+        <translation>오브젝트 목록</translation>
+    </message>
+    <message>
+        <source>Move Objects Down</source>
+        <translation>오브젝트 아래로 이동</translation>
     </message>
 </context>
 <context>
-    <name>Python::PythonPlugin</name>
+    <name>Tiled::MainToolBar</name>
     <message>
-        <location line="-176"/>
-        <source>Reloading Python scripts</source>
-        <translation>Python 스크립트 다시 불러오는 중</translation>
+        <source>New</source>
+        <translation>새로운 파일</translation>
+    </message>
+    <message>
+        <source>Main Toolbar</source>
+        <translation>메인 툴바</translation>
+    </message>
+</context>
+<context>
+    <name>QtColorPropertyManager</name>
+    <message>
+        <source>Red</source>
+        <translation>적색</translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation>청색</translation>
+    </message>
+    <message>
+        <source>Alpha</source>
+        <translation>투명도</translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation>녹색</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::VariantPropertyManager</name>
+    <message>
+        <source>Top</source>
+        <translation>상단</translation>
+    </message>
+    <message>
+        <source>%1: </source>
+        <translation>%1: </translation>
+    </message>
+    <message>
+        <source>(%1)</source>
+        <translation>(%1)</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>왼쪽</translation>
+    </message>
+    <message>
+        <source> (%1)</source>
+        <translation> (%1)</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>오른쪽</translation>
+    </message>
+    <message>
+        <source>Unset</source>
+        <translation>셋취소</translation>
+    </message>
+    <message>
+        <source>Horizontal</source>
+        <translation>수평</translation>
+    </message>
+    <message>
+        <source>Justify</source>
+        <translation>가지런히</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <translation>%1, %2</translation>
+    </message>
+    <message>
+        <source>Unnamed object</source>
+        <translation>이름 없는 오브젝트</translation>
+    </message>
+    <message>
+        <source>Bottom</source>
+        <translation>하단</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation>중앙</translation>
+    </message>
+    <message>
+        <source>%1: Object not found</source>
+        <translation>%1: 오브젝트를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Vertical</source>
+        <translation>수직</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>&amp;Map</source>
+        <translation>맵 (&amp;M)</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation>새로 만들기 (&amp;N)</translation>
+    </message>
+    <message>
+        <source>Cu&amp;t</source>
+        <translation>&amp;잘라내기</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation>복사 (&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation>편집 (&amp;E)</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>파일 (&amp;F)</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>도움말 (&amp;H)</translation>
+    </message>
+    <message>
+        <source>&amp;Quit</source>
+        <translation>종료 (&amp;Q)</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <translation>저장 (&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation>보기 (&amp;V)</translation>
+    </message>
+    <message>
+        <source>&amp;Open File or Project...</source>
+        <translation>파일 또는 프로젝트 열기 (&amp;O)...</translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation>확대</translation>
+    </message>
+    <message>
+        <source>E&amp;xport As...</source>
+        <translation>다른 형식으로 내보내기(&amp;x)...</translation>
+    </message>
+    <message>
+        <source>Tileset &amp;Properties...</source>
+        <translation>타일셋 속성(&amp;P)...</translation>
+    </message>
+    <message>
+        <source>Edit Commands...</source>
+        <translation>Command 수정...</translation>
+    </message>
+    <message>
+        <source>Show Object &amp;Names</source>
+        <translation>오브젝트 이름 표시&amp;Names</translation>
+    </message>
+    <message>
+        <source>&amp;Recent Projects</source>
+        <translation>최근 프로젝트 (&amp;R)</translation>
+    </message>
+    <message>
+        <source>&amp;Close</source>
+        <translation>닫기 (&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Snap to Grid</source>
+        <translation>격자에 스냅(&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Never</source>
+        <translation>표시하지 않음 (&amp;N)</translation>
+    </message>
+    <message>
+        <source>&amp;Paste</source>
+        <translation>붙여넣기 (&amp;P)</translation>
+    </message>
+    <message>
+        <source>&amp;World</source>
+        <translation>월드 (&amp;W)</translation>
+    </message>
+    <message>
+        <source>Show &amp;World</source>
+        <translation>&amp;월드 보기</translation>
+    </message>
+    <message>
+        <source>Refresh Folders</source>
+        <translation>폴더 새로고침</translation>
+    </message>
+    <message>
+        <source>Save &amp;As...</source>
+        <translation>&amp;다른 이름으로 저장...</translation>
+    </message>
+    <message>
+        <source>&amp;Offset Map...</source>
+        <translation>맵 Offset (&amp;O)...</translation>
+    </message>
+    <message>
+        <source>Pre&amp;ferences...</source>
+        <translation>설정 (&amp;f)...</translation>
+    </message>
+    <message>
+        <source>Snap to &amp;Pixels</source>
+        <translation>픽셀에 스냅(&amp;P)</translation>
+    </message>
+    <message>
+        <source>Community Forum ↗</source>
+        <translation>커뮤니티 포럼 ↗</translation>
+    </message>
+    <message>
+        <source>Save Project As...</source>
+        <translation>다른 이름으로 프로젝트 저장...</translation>
+    </message>
+    <message>
+        <source>Snapping</source>
+        <translation>스냅</translation>
+    </message>
+    <message>
+        <source>Support Tiled Development ↗</source>
+        <translation>Tiled 개발을 지원 ↗</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>삭제</translation>
+    </message>
+    <message>
+        <source>Snap to &amp;Fine Grid</source>
+        <translation>정밀 격자에 스냅(&amp;F)</translation>
+    </message>
+    <message>
+        <source>No Snapping</source>
+        <translation>스냅 안함</translation>
+    </message>
+    <message>
+        <source>&amp;About Tiled</source>
+        <translation>Tiled에 대해 (&amp;A)</translation>
+    </message>
+    <message>
+        <source>&amp;Add External Tileset...</source>
+        <translation>외부 타일셋 추가 (&amp;A)...</translation>
+    </message>
+    <message>
+        <source>New Map...</source>
+        <translation>새로운 맵...</translation>
+    </message>
+    <message>
+        <source>Show Tile Collision Shapes</source>
+        <translation>타일 충돌 모양 표시</translation>
+    </message>
+    <message>
+        <source>Reload</source>
+        <translation>다시 불러오기</translation>
+    </message>
+    <message>
+        <source>New &amp;Tileset...</source>
+        <translation>&amp;새로운 타일셋...</translation>
+    </message>
+    <message>
+        <source>Full Screen</source>
+        <translation>전체 화면</translation>
+    </message>
+    <message>
+        <source>&amp;Load World...</source>
+        <translation>월드를 로드 중입니다 (&amp;L)...</translation>
+    </message>
+    <message>
+        <source>Commands</source>
+        <translation>Command</translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation>축소</translation>
+    </message>
+    <message>
+        <source>C&amp;lose All</source>
+        <translation>모두 닫기(&amp;L)</translation>
+    </message>
+    <message>
+        <source>Move Map</source>
+        <translation>맵으로 이동</translation>
+    </message>
+    <message>
+        <source>For &amp;All Objects</source>
+        <translation>모든 오브젝트 (&amp;A)</translation>
+    </message>
+    <message>
+        <source>User Manual ↗</source>
+        <translation>사용자 메뉴얼 ↗</translation>
+    </message>
+    <message>
+        <source>For Hovered Object</source>
+        <translation>Hovered 객체를 위해</translation>
+    </message>
+    <message>
+        <source>Clear Recent Files</source>
+        <translation>최근 파일 목록 지우기</translation>
+    </message>
+    <message>
+        <source>&amp;Save World</source>
+        <translation>월드 저장 (&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Project</source>
+        <translation>프로젝트 (&amp;P)</translation>
+    </message>
+    <message>
+        <source>Normal Size</source>
+        <translation>원래 크기</translation>
+    </message>
+    <message>
+        <source>Map &amp;Properties...</source>
+        <translation>&amp;맵 속성...</translation>
+    </message>
+    <message>
+        <source>Clear View</source>
+        <translation>선명한 보기</translation>
+    </message>
+    <message>
+        <source>Save All</source>
+        <translation>모두 저장</translation>
+    </message>
+    <message>
+        <source>AutoMap</source>
+        <translation>오토맵</translation>
+    </message>
+    <message>
+        <source>Show &amp;Grid</source>
+        <translation>&amp;격자 표시</translation>
+    </message>
+    <message>
+        <source>Open File in &amp;Project...</source>
+        <translation>파일을 &amp;프로젝트에서 열기...</translation>
+    </message>
+    <message>
+        <source>About Qt</source>
+        <translation>Qt에 대해</translation>
+    </message>
+    <message>
+        <source>Add Folder to Project...</source>
+        <translation>프로젝트에 폴더를 추가...</translation>
+    </message>
+    <message>
+        <source>For &amp;Selected Objects</source>
+        <translation>선택한 오브젝트만 (&amp;S)</translation>
+    </message>
+    <message>
+        <source>Show Tile Object &amp;Outlines</source>
+        <translation>타일 오브젝트 테두리 표시(&amp;O)</translation>
+    </message>
+    <message>
+        <source>Fit Map in View</source>
+        <translation>보기에 적절히 맵을 맞춤</translation>
+    </message>
+    <message>
+        <source>Highlight Hovered Object</source>
+        <translation>Hovered 객체 중요부분</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>삭제(&amp;D)</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation>내보내기 (&amp;E)</translation>
+    </message>
+    <message>
+        <source>All Files (*)</source>
+        <translation>모든 파일 (*)</translation>
+    </message>
+    <message>
+        <source>Paste &amp;in Place</source>
+        <translation>&amp;같은 위치에 붙여넣기</translation>
+    </message>
+    <message>
+        <source>Tileset</source>
+        <translation>타일셋</translation>
+    </message>
+    <message>
+        <source>Export As &amp;Image...</source>
+        <translation>이미지로 내보내기(&amp;I)...</translation>
+    </message>
+    <message>
+        <source>Clear Recent Projects</source>
+        <translation>최근 프로젝트들을 지우기</translation>
+    </message>
+    <message>
+        <source>&amp;Open Project...</source>
+        <translation>프로젝트 열기 (&amp;O)...</translation>
+    </message>
+    <message>
+        <source>&amp;Highlight Current Layer</source>
+        <translation>현재 레이어만 강조(&amp;H)</translation>
+    </message>
+    <message>
+        <source>AutoMap While Drawing</source>
+        <translation>그리는 중 오토맵 사용</translation>
+    </message>
+    <message>
+        <source>&amp;Unload World</source>
+        <translation>로드되지 않은 월드 (&amp;U)</translation>
+    </message>
+    <message>
+        <source>Project &amp;Properties...</source>
+        <translation>프로젝트 속성(&amp;P)...</translation>
+    </message>
+    <message>
+        <source>&amp;Close Project</source>
+        <translation>프로젝트 닫기 (&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Recent Files</source>
+        <translation>최근 파일 목록 (&amp;R)</translation>
+    </message>
+    <message>
+        <source>&amp;New World...</source>
+        <translation>새로운 월드 생성 (&amp;N)...</translation>
+    </message>
+    <message>
+        <source>&amp;Resize Map...</source>
+        <translation>맵 크기 조정 (&amp;R)...</translation>
+    </message>
+    <message>
+        <source>Show Tile Animations</source>
+        <translation>타일 애니메이션 표시</translation>
+    </message>
+    <message>
+        <source>Reopen Closed File</source>
+        <translation>닫힌 파일 다시 열기</translation>
+    </message>
+    <message>
+        <source>Enable Parallax</source>
+        <translation>시차 활성화</translation>
+    </message>
+    <message>
+        <source>Show Object &amp;References</source>
+        <translation>객체 보기&amp;참조</translation>
+    </message>
+</context>
+<context>
+    <name>QtFontPropertyManager</name>
+    <message>
+        <source>Bold</source>
+        <translation>진하게</translation>
+    </message>
+    <message>
+        <source>Kerning</source>
+        <translation>글자 엇물리기</translation>
+    </message>
+    <message>
+        <source>Family</source>
+        <translation>집합</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation>기울임</translation>
+    </message>
+    <message>
+        <source>Strikeout</source>
+        <translation>취소선</translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation>밑줄</translation>
+    </message>
+    <message>
+        <source>Pixel Size</source>
+        <translation>픽셀 크기</translation>
+    </message>
+</context>
+<context>
+    <name>QtCursorDatabase</name>
+    <message>
+        <source>Busy</source>
+        <translation>바쁜</translation>
+    </message>
+    <message>
+        <source>Wait</source>
+        <translation>대기</translation>
+    </message>
+    <message>
+        <source>Arrow</source>
+        <translation>화살표</translation>
+    </message>
+    <message>
+        <source>Blank</source>
+        <translation>공백</translation>
+    </message>
+    <message>
+        <source>Cross</source>
+        <translation>십자가</translation>
+    </message>
+    <message>
+        <source>IBeam</source>
+        <translation>I광선</translation>
+    </message>
+    <message>
+        <source>Size All</source>
+        <translation>모든 크기</translation>
+    </message>
+    <message>
+        <source>Split Horizontal</source>
+        <translation>가로 나누기</translation>
+    </message>
+    <message>
+        <source>Size Horizontal</source>
+        <translation>가로 크기</translation>
+    </message>
+    <message>
+        <source>Up Arrow</source>
+        <translation>위 화살표</translation>
+    </message>
+    <message>
+        <source>Pointing Hand</source>
+        <translation>포인팅 핸드</translation>
+    </message>
+    <message>
+        <source>Size Vertical</source>
+        <translation>세로 크기</translation>
+    </message>
+    <message>
+        <source>Size Slash</source>
+        <translation>슬래시(/) 크기</translation>
+    </message>
+    <message>
+        <source>Forbidden</source>
+        <translation>금지됨</translation>
+    </message>
+    <message>
+        <source>Size Backslash</source>
+        <translation>백슬래시(\) 크기</translation>
+    </message>
+    <message>
+        <source>Closed Hand</source>
+        <translation>클로즈드 핸드</translation>
+    </message>
+    <message>
+        <source>Split Vertical</source>
+        <translation>세로 나누기</translation>
+    </message>
+    <message>
+        <source>Open Hand</source>
+        <translation>오픈 핸드</translation>
+    </message>
+    <message>
+        <source>What&apos;s This</source>
+        <translation>이것이 무엇인가요</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::PropertiesDock</name>
+    <message>
+        <source>Cu&amp;t</source>
+        <translation>잘라내기(&amp;T)</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation>복사(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>이름:</translation>
+    </message>
+    <message>
+        <source>Go to Object</source>
+        <translation>오브젝트로 가기</translation>
+    </message>
+    <message>
+        <source>&amp;Paste</source>
+        <translation>붙여넣기(&amp;P)</translation>
+    </message>
+    <message>
+        <source>Rename...</source>
+        <translation>이름 변경...</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>제거</translation>
+    </message>
+    <message>
+        <source>Remove Property/Properties</source>
+        <translation>%n개 속성 제거</translation>
+    </message>
+    <message>
+        <source>Properties</source>
+        <translation>속성</translation>
+    </message>
+    <message>
+        <source>Paste Property/Properties</source>
+        <translation>%n개 속성 붙여넣기</translation>
+    </message>
+    <message>
+        <source>Convert To</source>
+        <translation>다음으로 변환하기</translation>
+    </message>
+    <message>
+        <source>Remove Property</source>
+        <translation>속성 삭제</translation>
+    </message>
+    <message>
+        <source>Add Property</source>
+        <translation>속성 추가</translation>
+    </message>
+    <message>
+        <source>Rename Property</source>
+        <translation>속성 이름 변경</translation>
+    </message>
+    <message>
+        <source>Convert Property/Properties</source>
+        <translation>%n개 속성 변환</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <source>Exit</source>
+        <translation>종료</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>파일</translation>
+    </message>
+    <message>
+        <source>Help</source>
+        <translation>도움</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>보기</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation>이름</translation>
+    </message>
+    <message>
+        <source>size</source>
+        <translation>크기</translation>
+    </message>
+    <message>
+        <source>About Tiled Quick</source>
+        <translation>Tiled Quick에 대해</translation>
+    </message>
+    <message>
+        <source>scale</source>
+        <translation>scale</translation>
+    </message>
+    <message>
+        <source>No map file loaded</source>
+        <translation>맵 파일이 로드되지 않았습니다</translation>
+    </message>
+    <message>
+        <source>Image file to output.</source>
+        <translation>출력할 이미지 파일입니다.</translation>
+    </message>
+    <message>
+        <source>Renders a Tiled map or world to an image.</source>
+        <translation>Tiled map ㄸㅗ는 월드를 이미지로 렌더링합니다.</translation>
+    </message>
+    <message>
+        <source>Antialias edges of primitives.</source>
+        <translation>원시 요소의 Antialias 가장자리 입니다.</translation>
+    </message>
+    <message>
+        <source>Invalid size specified: &quot;%1&quot;</source>
+        <translation>유효하지 않은 사이즈 지정입니다: &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Tiled Quick</source>
+        <translation>Tiled Quick</translation>
+    </message>
+    <message>
+        <source>The scale of the output image (default: 1).</source>
+        <translation>출력 이미지의 스케일 입니다(기본값: 1).</translation>
+    </message>
+    <message>
+        <source>Open...</source>
+        <translation>열기...</translation>
+    </message>
+    <message>
+        <source>Ignore all layer visibility flags in the map file, and render all layers in the output (default is to omit invisible layers).</source>
+        <translation>지도 파일의 모든 레이어 가시성 플래그를 무시하고 출력의 모든 레이어를 렌더링합니다(기본적으로 보이지 않는 레이어는 생략합니다).</translation>
+    </message>
+    <message>
+        <source>If used tile animations are advanced by the specified duration.</source>
+        <translation>사용된 타일 애니메이션이 지정된 기간만큼 앞당겨지는 경우.</translation>
+    </message>
+    <message>
+        <source>Displays a Tiled map (TMX format).</source>
+        <translation>타일 맵을 표시합니다 (TMX 형식).</translation>
+    </message>
+    <message>
+        <source>Use nearest neighbour instead of smooth blending of pixels.</source>
+        <translation>픽셀을 부드럽게 혼합하는 대신 가장 갂ㅏ운 neighbour를 사용합니다.</translation>
+    </message>
+    <message>
+        <source>Fit Map In View</source>
+        <translation>보기에 맵을 맞추기</translation>
+    </message>
+    <message>
+        <source>Map or world file to render.</source>
+        <translation>렌더링할 맵 또는 월드 파일입니다.</translation>
+    </message>
+    <message>
+        <source>The output image fits within a SIZE x SIZE square (overrides the --scale and --tilesize options).</source>
+        <translation>출력 이미지는 SIZE x SIZE 정사각형 안에 맞습니다(--scale 및 --tilesize 옵션을 재정의함).</translation>
+    </message>
+    <message>
+        <source>Invalid scale specified: &quot;%1&quot;</source>
+        <translation>유효하지 않은 scale 지정입니다: &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Invalid tile size specified: &quot;%1&quot;</source>
+        <translation>유효하지 않은 타일 사이즈 지정입니다: &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>duration</source>
+        <translation>기간</translation>
+    </message>
+    <message>
+        <source>If used only specified layers are shown. Can be repeated to show multiple specified layers only.</source>
+        <translation>지정된 레이어만 사용된게 보여진 경우 여러 개의 지정된 레이어만 표시되도록 반복할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Invalid advance-animations specified: &quot;%1&quot;</source>
+        <translation>유효하지 않은 애니메이션 지정입니다: &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Specifies a layer to omit from the output image. Can be repeated to hide multiple layers.</source>
+        <translation>출력 이미지에서 생략할 레이어를 지정합니다. 여러 레이어를 숨기기 위해 반복할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>The requested size in pixels at which a tile is rendered (overrides the --scale option).</source>
+        <translation>타일을 렌더링할 때 요청된 픽셀의 크기입니다(--scale 옵션을 무시하고).</translation>
+    </message>
+    <message>
+        <source>Map file to display.</source>
+        <translation>맵 파일을 보여줍니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CommandDataModel</name>
+    <message>
+        <source>Name</source>
+        <translation>이름</translation>
+    </message>
+    <message>
+        <source>%1 (copy)</source>
+        <translation>%1 (복사)</translation>
+    </message>
+    <message>
+        <source>Move Up</source>
+        <translation>위로 이동</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>삭제</translation>
+    </message>
+    <message>
+        <source>Enable</source>
+        <translation>사용</translation>
+    </message>
+    <message>
+        <source>Execute in Terminal</source>
+        <translation>터미널에서 실행</translation>
+    </message>
+    <message>
+        <source>&lt;new command&gt;</source>
+        <translation>&lt;새로운 명령어&gt;</translation>
+    </message>
+    <message>
+        <source>New command</source>
+        <translation>새로운 Command</translation>
+    </message>
+    <message>
+        <source>Show or hide this command in the command list</source>
+        <translation>이 Command를 목록에서 표시 또는 표시 안함</translation>
+    </message>
+    <message>
+        <source>Add a new command</source>
+        <translation>새로운 명령어 추가</translation>
+    </message>
+    <message>
+        <source>Move Down</source>
+        <translation>아래로 이동</translation>
+    </message>
+    <message>
+        <source>Shortcut for this command</source>
+        <translation>이 Command 단축키</translation>
+    </message>
+    <message>
+        <source>Execute</source>
+        <translation>실행</translation>
+    </message>
+    <message>
+        <source>Set a name for this command</source>
+        <translation>이 명령어 이름을 설정</translation>
+    </message>
+    <message>
+        <source>Shortcut</source>
+        <translation>단축키</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::NewsButton</name>
+    <message>
+        <source>News</source>
+        <translation>소식</translation>
+    </message>
+    <message>
+        <source>View All Posts</source>
+        <translation>모든 게시글 보기</translation>
+    </message>
+    <message>
+        <source>Devlog</source>
+        <translation>Devlog</translation>
+    </message>
+    <message>
+        <source>News Archive</source>
+        <translation>소식 아카이브</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ActionsModel</name>
+    <message>
+        <source>Text</source>
+        <translation>텍스트</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>동작</translation>
+    </message>
+    <message>
+        <source>Shortcut</source>
+        <translation>단축키</translation>
+    </message>
+</context>
+<context>
+    <name>MapDocument</name>
+    <message>
+        <source>Tile</source>
+        <translation>타일</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::MapDocument</name>
+    <message>
+        <source>Tile</source>
+        <translation>타일</translation>
+    </message>
+    <message numerus="yes">
+        <source>Duplicate %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 복제</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Resize Map</source>
+        <translation>맵 크기 조정</translation>
+    </message>
+    <message>
+        <source>Merge Layer Down</source>
+        <translation>아래 레이어와 병합</translation>
+    </message>
+    <message>
+        <source>Tile Layer %1</source>
+        <translation>타일 레이어 %1</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n Object(s) to Layer</source>
+        <translation>
+            <numerusform>%n개 오브젝트 레이어로 이동</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Failed to load template &apos;%1&apos;</source>
+        <translation>&apos;%1&apos; 템플릿 불러오기 실패</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n Object(s) Up</source>
+        <translation>
+            <numerusform>%n개 레이어를 위로 옮기기</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>untitled.tmx</source>
+        <translation>untitled.tmx</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n Object(s) Down</source>
+        <translation>
+            <numerusform>%n개 레이어를 아래로 이동</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Map format &apos;%s&apos; not found</source>
+        <translation>맵 형식 %s를 찾을 수 없습니다</translation>
+    </message>
+    <message numerus="yes">
+        <source>Ungroup %n Layer(s)</source>
+        <translation>
+            <numerusform>%n개 레이어(s) 그룹 해제</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Object Layer %1</source>
+        <translation>오브젝트 레이어 %1</translation>
+    </message>
+    <message numerus="yes">
+        <source>Duplicate %n Layer(s)</source>
+        <translation>
+            <numerusform>%n개 Layer(s) 복제</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Group %1</source>
+        <translation>그룹 %1</translation>
+    </message>
+    <message>
+        <source>Offset Map</source>
+        <translation>맵 Offset</translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 삭제</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n Layer(s)</source>
+        <translation>
+            <numerusform>%n개 레이어(s) 삭제</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Failed to load tileset &apos;%1&apos;</source>
+        <translation>&apos;%1&apos;타일셋 불러오기 실패</translation>
+    </message>
+    <message numerus="yes">
+        <source>Group %n Layer(s)</source>
+        <translation>
+            <numerusform>%n개 레이어(s) ㄱㅡ룹</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Tileset Changes</source>
+        <translation>타일셋 변경</translation>
+    </message>
+    <message numerus="yes">
+        <source>Rotate %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 회전</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Copy of %1</source>
+        <translation>%1의 사본</translation>
+    </message>
+    <message>
+        <source>Image Layer %1</source>
+        <translation>이미지 레이어 %1</translation>
     </message>
 </context>
 <context>
     <name>QtBoolEdit</name>
     <message>
-        <location filename="../src/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="+243"/>
-        <location line="+10"/>
-        <location line="+25"/>
         <source>True</source>
         <translation>True</translation>
     </message>
     <message>
-        <location line="-25"/>
-        <location line="+25"/>
         <source>False</source>
         <translation>False</translation>
     </message>
@@ -1860,5606 +2435,3459 @@ Line %1, column %2</source>
 <context>
     <name>QtBoolPropertyManager</name>
     <message>
-        <location filename="../src/qtpropertybrowser/src/qtpropertymanager.cpp" line="+1705"/>
         <source>True</source>
         <translation>True</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>False</source>
         <translation>False</translation>
     </message>
 </context>
 <context>
-    <name>QtCharEdit</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qteditorfactory.cpp" line="+1712"/>
-        <source>Clear Char</source>
-        <translation>문자 지우기</translation>
-    </message>
-</context>
-<context>
-    <name>QtColorEditWidget</name>
-    <message>
-        <location line="+614"/>
-        <source>...</source>
-        <translation>...</translation>
-    </message>
-</context>
-<context>
-    <name>QtColorPropertyManager</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qtpropertymanager.cpp" line="+4740"/>
-        <source>Red</source>
-        <translation>적색</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Green</source>
-        <translation>녹색</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Blue</source>
-        <translation>청색</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Alpha</source>
-        <translation>투명도</translation>
-    </message>
-</context>
-<context>
-    <name>QtCursorDatabase</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="-220"/>
-        <source>Arrow</source>
-        <translation>화살표</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Up Arrow</source>
-        <translation>위 화살표</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Cross</source>
-        <translation>십자가</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Wait</source>
-        <translation>대기</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>IBeam</source>
-        <translation>I광선</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Size Vertical</source>
-        <translation>세로 크기</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Size Horizontal</source>
-        <translation>가로 크기</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Size Backslash</source>
-        <translation>백슬래시(\) 크기</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Size Slash</source>
-        <translation>슬래시(/) 크기</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Size All</source>
-        <translation>모든 크기</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Blank</source>
-        <translation>공백</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Split Vertical</source>
-        <translation>세로 나누기</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Split Horizontal</source>
-        <translation>가로 나누기</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Pointing Hand</source>
-        <translation>포인팅 핸드</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Forbidden</source>
-        <translation>금지됨</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Open Hand</source>
-        <translation>오픈 핸드</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Closed Hand</source>
-        <translation>클로즈드 핸드</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>What&apos;s This</source>
-        <translation>이것이 무엇인가요</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Busy</source>
-        <translation>바쁜</translation>
-    </message>
-</context>
-<context>
-    <name>QtFontEditWidget</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qteditorfactory.cpp" line="+209"/>
-        <source>...</source>
-        <translation>...</translation>
-    </message>
-    <message>
-        <location line="+28"/>
-        <source>Select Font</source>
-        <translation>폰트 선택</translation>
-    </message>
-</context>
-<context>
-    <name>QtFontPropertyManager</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qtpropertymanager.cpp" line="-362"/>
-        <source>Family</source>
-        <translation>집합</translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>Pixel Size</source>
-        <translation>픽셀 크기</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Bold</source>
-        <translation>진하게</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Italic</source>
-        <translation>기울임</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Underline</source>
-        <translation>밑줄</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Strikeout</source>
-        <translation>취소선</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Kerning</source>
-        <translation>글자 엇물리기</translation>
-    </message>
-</context>
-<context>
-    <name>QtKeySequenceEdit</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="+244"/>
-        <source>Clear Shortcut</source>
-        <translation>단축키 지우기</translation>
-    </message>
-</context>
-<context>
-    <name>QtLocalePropertyManager</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qtpropertymanager.cpp" line="-3537"/>
-        <source>%1, %2</source>
-        <translation>%1, %2</translation>
-    </message>
-    <message>
-        <location line="+53"/>
-        <source>Language</source>
-        <translation>언어</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Country</source>
-        <translation>국가</translation>
-    </message>
-</context>
-<context>
-    <name>QtPointFPropertyManager</name>
-    <message>
-        <location line="+409"/>
-        <source>(%1, %2)</source>
-        <translation>(%1, %2)</translation>
-    </message>
-    <message>
-        <location line="+71"/>
-        <source>X</source>
-        <translation>X</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>QtPointPropertyManager</name>
-    <message>
-        <location line="-319"/>
-        <source>(%1, %2)</source>
-        <translation>(%1, %2)</translation>
-    </message>
-    <message>
-        <location line="+37"/>
-        <source>X</source>
-        <translation>X</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-</context>
-<context>
-    <name>QtPropertyBrowserUtils</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="-150"/>
-        <source>[%1, %2, %3] (%4)</source>
-        <translation>[%1, %2, %3] (%4)</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Not set</source>
-        <translation>설정되어 있지 않음</translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>[%1, %2]</source>
-        <translation>[%1, %2]</translation>
-    </message>
-</context>
-<context>
-    <name>QtRectFPropertyManager</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qtpropertymanager.cpp" line="+1701"/>
-        <source>[(%1, %2), %3 x %4]</source>
-        <translation>[(%1, %2), %3 x %4]</translation>
-    </message>
-    <message>
-        <location line="+156"/>
-        <source>X</source>
-        <translation>X</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Width</source>
-        <translation>너비</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Height</source>
-        <translation>높이</translation>
-    </message>
-</context>
-<context>
-    <name>QtRectPropertyManager</name>
-    <message>
-        <location line="-611"/>
-        <source>[(%1, %2), %3 x %4]</source>
-        <translation>[(%1, %2), %3 x %4]</translation>
-    </message>
-    <message>
-        <location line="+120"/>
-        <source>X</source>
-        <translation>X</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Width</source>
-        <translation>너비</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Height</source>
-        <translation>높이</translation>
-    </message>
-</context>
-<context>
-    <name>QtSizeFPropertyManager</name>
-    <message>
-        <location line="-534"/>
-        <source>%1 x %2</source>
-        <translation>%1 x %2</translation>
-    </message>
-    <message>
-        <location line="+130"/>
-        <source>Width</source>
-        <translation>너비</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Height</source>
-        <translation>높이</translation>
-    </message>
-</context>
-<context>
-    <name>QtSizePolicyPropertyManager</name>
-    <message>
-        <location line="+1704"/>
-        <location line="+1"/>
-        <source>&lt;Invalid&gt;</source>
-        <translation>&lt;무효&gt;</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>[%1, %2, %3, %4]</source>
-        <translation>[%1, %2, %3, %4]</translation>
-    </message>
-    <message>
-        <location line="+45"/>
-        <source>Horizontal Policy</source>
-        <translation>수평 정책</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Vertical Policy</source>
-        <translation>수직 정책</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Horizontal Stretch</source>
-        <translation>수평 늘이기</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Vertical Stretch</source>
-        <translation>수직 늘이기</translation>
-    </message>
-</context>
-<context>
-    <name>QtSizePropertyManager</name>
-    <message>
-        <location line="-2280"/>
-        <source>%1 x %2</source>
-        <translation>%1 x %2</translation>
-    </message>
-    <message>
-        <location line="+96"/>
-        <source>Width</source>
-        <translation>너비</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Height</source>
-        <translation>높이</translation>
-    </message>
-</context>
-<context>
-    <name>QtTreePropertyBrowser</name>
-    <message>
-        <location filename="../src/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="+513"/>
-        <source>Property</source>
-        <translation>속성</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Value</source>
-        <translation>값</translation>
-    </message>
-</context>
-<context>
-    <name>ReplicaIsland::ReplicaIslandPlugin</name>
-    <message>
-        <location filename="../src/plugins/replicaisland/replicaislandplugin.cpp" line="-183"/>
-        <source>Cannot open Replica Island map file!</source>
-        <translation>Replica Island 맵 파일을 열 수 없습니다!</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Can&apos;t parse file header!</source>
-        <translation>파일 헤더를 파싱할 수 없습니다!</translation>
-    </message>
-    <message>
-        <location line="+21"/>
-        <source>Can&apos;t parse layer header!</source>
-        <translation>레이어 헤더를 파싱할 수 없습니다!</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Inconsistent layer sizes!</source>
-        <translation>레이어 크기가 동일하지 않습니다!</translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>File ended in middle of layer!</source>
-        <translation>레이어 중간에서 파일이 끝났습니다!</translation>
-    </message>
-    <message>
-        <location line="+19"/>
-        <source>Unexpected data at end of file!</source>
-        <translation>파일 끝에 예상치 못한 데이터가 있습니다!</translation>
-    </message>
-    <message>
-        <location line="+64"/>
-        <source>Replica Island map files (*.bin)</source>
-        <translation>Replica Island 맵 파일 (*.bin)</translation>
-    </message>
-    <message>
-        <location line="+53"/>
-        <source>You must define a background_index property on the map!</source>
-        <translation>모든 맵에 background_index 속성을 정의해야 합니다!</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Can&apos;t save non-tile layer!</source>
-        <translation>타일 레이어가 아닌 것은 저장할 수 없습니다!</translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <source>You must define a type property on each layer!</source>
-        <translation>모든 레이어에 type 속성을 정의해야 합니다!</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>You must define a tile_index property on each layer!</source>
-        <translation>모든 레이어에 type_index 속성을 정의해야 합니다!</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>You must define a scroll_speed property on each layer!</source>
-        <translation>모든 레이어에 scroll_speed 속성을 정의해야 합니다!</translation>
-    </message>
-</context>
-<context>
-    <name>ResizeDialog</name>
-    <message>
-        <location filename="../src/tiled/resizedialog.ui" line="+14"/>
-        <source>Resize</source>
-        <translation>크기 조정</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Size</source>
-        <translation>크기</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <location line="+33"/>
-        <location line="+32"/>
-        <location line="+23"/>
-        <source> tiles</source>
-        <translation> 타일</translation>
-    </message>
-    <message>
-        <location line="-75"/>
-        <source>Width:</source>
-        <translation>너비:</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Height:</source>
-        <translation>높이:</translation>
-    </message>
-    <message>
-        <location line="+26"/>
-        <source>Offset</source>
-        <translation>오프셋</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>X:</source>
-        <translation>X:</translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <source>Y:</source>
-        <translation>Y:</translation>
-    </message>
-    <message>
-        <location line="+47"/>
-        <source>Remove objects outside of the map</source>
-        <translation>맵 바깥 오브젝트 제거</translation>
-    </message>
-</context>
-<context>
-    <name>RpMap::RpMapPlugin</name>
-    <message>
-        <location filename="../src/plugins/rpmap/rpmapplugin.cpp" line="+93"/>
-        <source>RpTool MapTool files (*.rpmap)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Script Errors</name>
-    <message>
-        <location filename="../src/tiled/editableasset.cpp" line="+92"/>
-        <source>Invalid callback</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <location line="+8"/>
-        <source>Undo system not available for this asset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/editablegrouplayer.cpp" line="+45"/>
-        <location line="+11"/>
-        <location line="+29"/>
-        <location filename="../src/tiled/editablemap.cpp" line="+157"/>
-        <location line="+11"/>
-        <location line="+31"/>
-        <location filename="../src/tiled/editableobjectgroup.cpp" line="+57"/>
-        <location line="+11"/>
-        <location line="+36"/>
-        <source>Index out of range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-16"/>
-        <location line="+21"/>
-        <location filename="../src/tiled/editablemap.cpp" line="+65"/>
-        <source>Invalid argument</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-15"/>
-        <location filename="../src/tiled/editablemap.cpp" line="-75"/>
-        <source>Layer not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Layer is in use</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/editablemap.cpp" line="+20"/>
-        <source>Layer already part of a map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+128"/>
-        <source>Merge is currently not supported for detached maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+27"/>
-        <source>Resize is currently not supported for detached maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Invalid size</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>AutoMapping is currently not supported for detached maps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+185"/>
-        <source>Not a layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Layer not from this map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+21"/>
-        <location filename="../src/tiled/tilecollisiondock.cpp" line="+354"/>
-        <source>Not an object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Object not from this map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/editablemapobject.cpp" line="+196"/>
-        <location filename="../src/tiled/editabletile.cpp" line="+193"/>
-        <source>Array expected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>Invalid coordinate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/editableobject.cpp" line="+82"/>
-        <source>Asset is read-only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/editableobjectgroup.cpp" line="-14"/>
-        <location filename="../src/tiled/tilecollisiondock.cpp" line="+16"/>
-        <source>Object not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+19"/>
-        <source>Object already part of an object layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/editablewangset.cpp" line="+84"/>
-        <source>Wang ID must be an array of length 8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Invalid Wang ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+31"/>
-        <source>Tile not from the same tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/editabletile.cpp" line="-51"/>
-        <source>Tileset needs to be an image collection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+28"/>
-        <source>ObjectGroup is in use</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+41"/>
-        <source>Invalid value (negative)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/editabletileset.cpp" line="+84"/>
-        <source>Invalid tile ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+55"/>
-        <source>Can only add tiles to an image collection tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+19"/>
-        <source>Can only remove tiles from an image collection tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+64"/>
-        <source>Can&apos;t set the image of an image collection tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Can&apos;t set tile size on an image collection tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+69"/>
-        <location filename="../src/tiled/tilesetdock.cpp" line="+903"/>
-        <source>Not a tile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Tile not from this tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/scriptedfileformat.cpp" line="+102"/>
-        <source>Invalid return value for &apos;write&apos; (string or undefined expected)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+40"/>
-        <source>Invalid file format object (requires string &apos;name&apos; property)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Invalid file format object (requires string &apos;extension&apos; property)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Invalid file format object (requires a &apos;write&apos; and/or &apos;read&apos; function property)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-22"/>
-        <source>Invalid return value for &apos;outputFiles&apos; (string or array expected)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/scriptedtool.cpp" line="+214"/>
-        <source>Invalid tool object (requires string &apos;name&apos; property)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/scriptmodule.cpp" line="+162"/>
-        <location line="+48"/>
-        <source>Editor not available</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+29"/>
-        <location line="+22"/>
-        <source>Not an open asset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Can&apos;t reload an embedded tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+21"/>
-        <source>Invalid ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Invalid callback function</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Reserved ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <source>Invalid shortName</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+77"/>
-        <source>Unknown menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Separators can&apos;t have actions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Unknown action: &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Non-separator item without action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+26"/>
-        <source>Unknown action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Unknown command</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/tilecollisiondock.cpp" line="-12"/>
-        <source>Object not from this asset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/scriptfile.cpp" line="+47"/>
-        <source>BinaryFile constructor needs path of file to be opened.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+18"/>
-        <location line="+164"/>
-        <source>Unable to open file &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-122"/>
-        <source>Could not resize &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Could not seek &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <location line="+15"/>
-        <source>Could not read from &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+156"/>
-        <source>Could not write to &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-135"/>
-        <source>Access to BinaryFile object that was already closed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>TextFile constructor needs path of file to be opened.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+58"/>
-        <location filename="../src/tiled/scriptprocess.cpp" line="+142"/>
-        <location line="+6"/>
-        <source>Unsupported encoding: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+89"/>
-        <source>Access to TextFile object that was already closed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/scriptfileformatwrappers.cpp" line="+59"/>
-        <source>File format doesn&apos;t support `read`</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>File format doesn&apos;t support `write`</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+17"/>
-        <source>Error reading tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+35"/>
-        <source>Error reading map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/scriptmanager.cpp" line="+293"/>
-        <source>Argument %1 is undefined or the wrong type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/scriptimage.cpp" line="+95"/>
-        <source>Invalid color name: &apos;%2&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Invalid color value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/scriptprocess.cpp" line="+38"/>
-        <location line="+10"/>
-        <source>Error running %1: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Error running &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Process &apos;%1 %2&apos; finished with exit code %3.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>The standard output was:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>The standard error output was:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+118"/>
-        <source>Access to Process object that was already closed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tbin::TbinMapFormat</name>
-    <message>
-        <location filename="../src/plugins/tbin/tbinplugin.cpp" line="+11"/>
-        <source>Map contains no layers.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+18"/>
-        <source>Tilesheet must have equal spacings.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Tilesheet must have equal margins.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
-        <source>Different tile sizes per layer are not supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+21"/>
-        <source>Invalid animation frame.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+132"/>
-        <source>Only object and tile layers supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+50"/>
-        <source>Could not open file for writing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Exception: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Tbin map files (*.tbin)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>TbinMapFormat</name>
-    <message>
-        <location filename="../src/plugins/tbin/tbin/Map.cpp" line="+99"/>
-        <location line="+23"/>
-        <source>Bad property type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+69"/>
-        <location line="+68"/>
-        <source>Bad layer tile data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+72"/>
-        <source>Failed to open file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>File is not a tbin file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+35"/>
-        <source>Failed to open file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/plugins/tbin/tbinplugin.cpp" line="-309"/>
-        <source>Unsupported property type</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tengine::TenginePlugin</name>
-    <message>
-        <location filename="../src/plugins/tengine/tengineplugin.cpp" line="+248"/>
-        <source>T-Engine4 map files (*.lua)</source>
-        <translation>T-Engine4 맵 파일 (*.lua)</translation>
-    </message>
-</context>
-<context>
-    <name>TextEditorDialog</name>
-    <message>
-        <location filename="../src/tiled/texteditordialog.ui" line="+14"/>
-        <source>Edit Text</source>
-        <translation>텍스트 수정</translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <source>Monospace</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>TileAnimationEditor</name>
-    <message>
-        <location filename="../src/tiled/tileanimationeditor.ui" line="+14"/>
-        <source>Tile Animation Editor</source>
-        <translation>타일 애니메이션 편집기</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Frame Duration: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source> ms</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+19"/>
-        <source>Apply</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+98"/>
-        <location filename="../src/tiled/tileanimationeditor.cpp" line="+550"/>
-        <source>Preview</source>
-        <translation>미리보기</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::AbstractObjectTool</name>
-    <message>
-        <location filename="../src/tiled/abstractobjecttool.cpp" line="+187"/>
-        <location line="+501"/>
-        <source>Flip Horizontally</source>
-        <translation type="unfinished">가로로 뒤집기</translation>
-    </message>
-    <message>
-        <location line="-500"/>
-        <location line="+501"/>
-        <source>Flip Vertically</source>
-        <translation type="unfinished">세로로 뒤집기</translation>
-    </message>
-    <message>
-        <location line="-363"/>
-        <source>Apply Collision Shapes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+50"/>
-        <location line="+249"/>
-        <source>Reset Tile Size</source>
-        <translation type="unfinished">타일 크기 리셋</translation>
-    </message>
-    <message>
-        <location line="-214"/>
-        <location line="+228"/>
-        <source>Convert to Polygon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location line="-40"/>
-        <source>Duplicate %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 복제</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+2"/>
-        <source>Remove %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 삭제</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Apply Collision(s) to Selected Tiles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Replace Existing Objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Add Objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Replace Tile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Replace With Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Replace With Template &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Save As Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Can&apos;t create template with embedded tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Detach</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Reset Template Instance(s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>Raise Object</source>
-        <translation type="unfinished">오브젝트 올리기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Lower Object</source>
-        <translation type="unfinished">오브젝트 내리기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Raise Object to Top</source>
-        <translation type="unfinished">오브젝트 맨 위로 올리기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Lower Object to Bottom</source>
-        <translation type="unfinished">오브젝트 맨 아래로 내리기</translation>
-    </message>
-    <message numerus="yes">
-        <location line="+6"/>
-        <source>Move %n Object(s) to Layer</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>Object &amp;Properties...</source>
-        <translation type="unfinished">오브젝트 속성(&amp;P)...</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::AbstractTileSelectionTool</name>
-    <message>
-        <location filename="../src/tiled/abstracttileselectiontool.cpp" line="+139"/>
-        <source>Replace Selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Add Selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Subtract Selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Intersect Selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::AbstractTileTool</name>
-    <message>
-        <location filename="../src/tiled/abstracttiletool.cpp" line="+177"/>
-        <source>empty</source>
-        <translation type="unfinished">비어있음</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::AbstractWorldTool</name>
-    <message>
-        <location filename="../src/tiled/abstractworldtool.cpp" line="+198"/>
-        <source>Add another map to the current world</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Add the current map to a loaded world</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Remove the current map from the current world</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+72"/>
-        <source>Add a Map to World &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Remove &quot;%1&quot; from World &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <location line="+106"/>
-        <source>Add &quot;%1&quot; to World &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-78"/>
-        <source>All Files (*)</source>
-        <translation type="unfinished">모든 파일 (*)</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Load Map</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Error Opening File</source>
-        <translation type="unfinished">파일 여는 중 오류 발생</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Error opening &apos;%1&apos;:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ActionsModel</name>
-    <message>
-        <location filename="../src/tiled/shortcutsettingspage.cpp" line="-400"/>
-        <source>Action</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Text</source>
-        <translation type="unfinished">텍스트</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Shortcut</source>
-        <translation type="unfinished">단축키</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::AutoMapper</name>
-    <message>
-        <location filename="../src/tiled/automapper.cpp" line="+143"/>
-        <source>Ignoring unknown property &apos;%2&apos; = &apos;%3&apos; (rule map &apos;%1&apos;)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+40"/>
-        <source>Ignoring unknown property &apos;%2&apos; = &apos;%3&apos; on layer &apos;%4&apos; (rule map &apos;%1&apos;)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+29"/>
-        <source>&apos;regions_input&apos; layer must not occur more than once.</source>
-        <translation type="unfinished">&apos;regions_input&apos; 레이어는 둘 이상 존재할 수 없습니다.</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <location line="+13"/>
-        <source>&apos;regions_*&apos; layers must be tile layers.</source>
-        <translation type="unfinished">&apos;regions_*&apos; 레이어는 타일 레이어여야 합니다.</translation>
-    </message>
-    <message>
-        <location line="-6"/>
-        <source>&apos;regions_output&apos; layer must not occur more than once.</source>
-        <translation type="unfinished">&apos;regions_output&apos; 레이어는 둘 이상 존재할 수 없습니다.</translation>
-    </message>
-    <message>
-        <location line="+19"/>
-        <source>Did you forget an underscore in layer &apos;%1&apos;?</source>
-        <translation type="unfinished">레이어 &apos;%1&apos;의 밑줄 표시를 잊으셨습니까?</translation>
-    </message>
-    <message>
-        <location line="+21"/>
-        <source>&apos;input_*&apos; and &apos;inputnot_*&apos; layers must be tile layers.</source>
-        <translation type="unfinished">&apos;input_*&apos; 와 &apos;inputnot_*&apos; 레이어는 타일 레이어여야 합니다.</translation>
-    </message>
-    <message>
-        <location line="+45"/>
-        <source>Layer &apos;%1&apos; is not recognized as a valid layer for Automapping.</source>
-        <translation type="unfinished">&apos;%1&apos; 레이어는 유효한 오토맵 레이어로 인식되지 않습니다.</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>No &apos;regions&apos; or &apos;regions_input&apos; layer found.</source>
-        <translation type="unfinished">&apos;regions&apos; 또는 &apos;regions_input&apos; 레이어가 발견되지 않았습니다.</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>No &apos;regions&apos; or &apos;regions_output&apos; layer found.</source>
-        <translation type="unfinished">&apos;regions&apos; 또는 &apos;regions_output&apos; 레이어가 발견되지 않았습니다.</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>No input_&lt;name&gt; layer found!</source>
-        <translation type="unfinished">input_&lt;name&gt; 레이어가 발견되지 않았습니다!</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>No output_&lt;name&gt; layer found!</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::AutomappingManager</name>
-    <message>
-        <location filename="../src/tiled/automappingmanager.cpp" line="+133"/>
-        <source>Apply AutoMap rules</source>
-        <translation type="unfinished">오토맵 규칙 적용</translation>
-    </message>
-    <message>
-        <location line="+24"/>
-        <source>No rules file found at &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Error opening rules file &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+28"/>
-        <source>File not found: &apos;%1&apos; (referenced by &apos;%2&apos;)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Opening rules map &apos;%1&apos; failed: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Tiled::BrokenLinksModel</name>
     <message>
-        <location filename="../src/tiled/brokenlinks.cpp" line="+269"/>
-        <source>Tileset</source>
-        <translation type="unfinished">타일셋</translation>
+        <source>Type</source>
+        <translation>타입</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Template tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Tileset image</source>
-        <translation type="unfinished">타일셋 이미지</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Tile image</source>
-        <translation type="unfinished">타일 이미지</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+22"/>
         <source>File name</source>
-        <translation type="unfinished">파일명</translation>
+        <translation>파일명</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Location</source>
-        <translation type="unfinished">위치</translation>
+        <translation>위치</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Type</source>
-        <translation type="unfinished">타입</translation>
+        <source>Tile image</source>
+        <translation>타일 이미지</translation>
     </message>
-</context>
-<context>
-    <name>Tiled::BrokenLinksWidget</name>
     <message>
-        <location line="+89"/>
-        <source>Some files could not be found</source>
-        <translation type="unfinished">일부 파일이 발견되지 않을 수 있습니다</translation>
+        <source>Tileset</source>
+        <translation>타일셋</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>One or more referenced files could not be found. You can help locate them below.</source>
-        <translation type="unfinished">하나 이상의 참조된 파일이 발견되지 않을 수 있습니다. 하단에서 위치를 찾을 수 있습니다.</translation>
+        <source>Template</source>
+        <translation>템플릿</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+84"/>
-        <location line="+8"/>
-        <source>Locate File...</source>
-        <translation type="unfinished">파일 위치 찾기...</translation>
+        <source>Tileset image</source>
+        <translation>타일셋 이미지</translation>
     </message>
     <message>
-        <location line="-5"/>
-        <source>Open Template...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Open Tileset...</source>
-        <translation type="unfinished">타일셋 열기...</translation>
-    </message>
-    <message>
-        <location line="+36"/>
-        <source>Locate Directory for Files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+90"/>
-        <source>Error Loading Image</source>
-        <translation type="unfinished">이미지를 불러오는 중 오류 발생</translation>
-    </message>
-    <message>
-        <location line="+40"/>
-        <source>Locate File</source>
-        <translation type="unfinished">파일 위치 찾기</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <location line="+17"/>
-        <source>All Files (*)</source>
-        <translation type="unfinished">모든 파일 (*)</translation>
-    </message>
-    <message>
-        <location line="-12"/>
-        <source>Locate External Tileset</source>
-        <translation type="unfinished">외부 타일셋 위치 찾기</translation>
-    </message>
-    <message>
-        <location line="+17"/>
-        <source>Locate Object Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>Error Reading Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+24"/>
-        <source>Error Reading Object Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::BucketFillTool</name>
-    <message>
-        <location filename="../src/tiled/bucketfilltool.cpp" line="+44"/>
-        <location line="+137"/>
-        <source>Bucket Fill Tool</source>
-        <translation type="unfinished">페인트 통 도구</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ClipboardManager</name>
-    <message>
-        <location filename="../src/tiled/clipboardmanager.cpp" line="+266"/>
-        <source>Paste Objects</source>
-        <translation type="unfinished">오브젝트 붙여넣기</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CommandButton</name>
-    <message>
-        <location filename="../src/tiled/commandbutton.cpp" line="+55"/>
-        <source>Error Executing Command</source>
-        <translation type="unfinished">Command 실행 중 오류 발생</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>You do not have any commands setup.</source>
-        <translation type="unfinished">Command 설정이 없습니다.</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Edit Commands...</source>
-        <translation type="unfinished">Command 수정...</translation>
-    </message>
-    <message>
-        <location line="+25"/>
-        <source>Execute Command</source>
-        <translation type="unfinished">Command 실행</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CommandDataModel</name>
-    <message>
-        <location filename="../src/tiled/commanddatamodel.cpp" line="+127"/>
-        <location line="+69"/>
-        <source>&lt;new command&gt;</source>
-        <translation type="unfinished">&lt;새로운 명령어&gt;</translation>
-    </message>
-    <message>
-        <location line="-61"/>
-        <source>Set a name for this command</source>
-        <translation type="unfinished">이 명령어 이름을 설정</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Shortcut for this command</source>
-        <translation type="unfinished">이 Command 단축키</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Show or hide this command in the command list</source>
-        <translation type="unfinished">이 Command를 목록에서 표시 또는 표시 안함</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Add a new command</source>
-        <translation type="unfinished">새로운 명령어 추가</translation>
-    </message>
-    <message>
-        <location line="+114"/>
-        <source>Name</source>
-        <translation type="unfinished">이름</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Shortcut</source>
-        <translation type="unfinished">단축키</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Enable</source>
-        <translation type="unfinished">사용</translation>
-    </message>
-    <message>
-        <location line="+18"/>
-        <source>Move Up</source>
-        <translation type="unfinished">위로 이동</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Move Down</source>
-        <translation type="unfinished">아래로 이동</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Execute</source>
-        <translation type="unfinished">실행</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Execute in Terminal</source>
-        <translation type="unfinished">터미널에서 실행</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Delete</source>
-        <translation type="unfinished">삭제</translation>
-    </message>
-    <message>
-        <location line="+92"/>
-        <source>%1 (copy)</source>
-        <translation type="unfinished">%1 (복사)</translation>
-    </message>
-    <message>
-        <location line="+18"/>
-        <source>New command</source>
-        <translation type="unfinished">새로운 Command</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CommandDialog</name>
-    <message>
-        <location filename="../src/tiled/commanddialog.cpp" line="+53"/>
-        <source>Global Commands</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Project Commands</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CommandManager</name>
-    <message>
-        <location filename="../src/tiled/commandmanager.cpp" line="+68"/>
-        <source>Open in text editor</source>
-        <translation type="unfinished">텍스트 편집기에서 열기</translation>
-    </message>
-    <message>
-        <location line="+142"/>
-        <source>Edit Commands...</source>
-        <translation type="unfinished">Command 수정...</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CommandProcess</name>
-    <message>
-        <location filename="../src/tiled/command.cpp" line="+245"/>
-        <source>Unable to create/open %1</source>
-        <translation type="unfinished">%1 을 생성하거나 열 수 없습니다</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Unable to add executable permissions to %1</source>
-        <translation type="unfinished">%1 에 실행 권한을 추가할 수 없습니다</translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Executing: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
-        <source>The command failed to start.</source>
-        <translation type="unfinished">Command를 시작하지 못했습니다.</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>The command crashed.</source>
-        <translation type="unfinished">Command가 충돌하였습니다.</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>The command timed out.</source>
-        <translation type="unfinished">Command가 시간 초과 되었습니다.</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>An unknown error occurred.</source>
-        <translation type="unfinished">알 수 없는 오류가 발생하였습니다.</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Error Executing %1</source>
-        <translation type="unfinished">%1 실행중 오류 발생</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CommandsEdit</name>
-    <message>
-        <location filename="../src/tiled/commandsedit.cpp" line="+165"/>
-        <source>Select Executable</source>
-        <translation type="unfinished">실행 파일 선택</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Select Working Directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ConsoleDock</name>
-    <message>
-        <location filename="../src/tiled/consoledock.cpp" line="+59"/>
-        <location line="+36"/>
-        <location line="+118"/>
-        <source>Clear Console</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-2"/>
-        <source>Console</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Execute script</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CreateEllipseObjectTool</name>
-    <message>
-        <location filename="../src/tiled/createellipseobjecttool.cpp" line="+48"/>
-        <source>Insert Ellipse</source>
-        <translation type="unfinished">타원형 삽입</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CreatePointObjectTool</name>
-    <message>
-        <location filename="../src/tiled/createpointobjecttool.cpp" line="+51"/>
-        <source>Insert Point</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CreatePolygonObjectTool</name>
-    <message>
-        <location filename="../src/tiled/createpolygonobjecttool.cpp" line="+167"/>
-        <source>Insert Polygon</source>
-        <translation type="unfinished">다각형 삽입</translation>
-    </message>
-    <message>
-        <location line="+125"/>
-        <source>Connect Polylines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+208"/>
-        <source>Create Polygon</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CreateRectangleObjectTool</name>
-    <message>
-        <location filename="../src/tiled/createrectangleobjecttool.cpp" line="+47"/>
-        <source>Insert Rectangle</source>
-        <translation type="unfinished">직사각형 삽입</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CreateTemplateTool</name>
-    <message>
-        <location filename="../src/tiled/createtemplatetool.cpp" line="+53"/>
-        <source>Insert Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CreateTextObjectTool</name>
-    <message>
-        <location filename="../src/tiled/createtextobjecttool.cpp" line="+70"/>
-        <source>Insert Text</source>
-        <translation type="unfinished">텍스트 삽입</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Hello World</source>
-        <translation type="unfinished">Hello World</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::CreateTileObjectTool</name>
-    <message>
-        <location filename="../src/tiled/createtileobjecttool.cpp" line="+72"/>
-        <source>Insert Tile</source>
-        <translation type="unfinished">타일 삽입</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::Document</name>
-    <message>
-        <location filename="../src/tiled/document.cpp" line="+91"/>
-        <source>Custom property &apos;%1&apos; refers to non-existing file &apos;%2&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::DocumentManager</name>
-    <message>
-        <location filename="../src/tiled/documentmanager.cpp" line="+652"/>
-        <source>Unrecognized file format.</source>
-        <translation type="unfinished">인식할 수 없는 파일 형식.</translation>
-    </message>
-    <message>
-        <location line="+67"/>
-        <source>Save File As</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+214"/>
-        <location line="+20"/>
-        <source>%1:
-
-%2</source>
-        <translation type="unfinished">%1:
-
-%2</translation>
-    </message>
-    <message>
-        <location line="+112"/>
-        <source>Close</source>
-        <translation type="unfinished">닫기</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Close Other Tabs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Close Tabs to the Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+311"/>
-        <source>Tileset Columns Changed</source>
-        <translation type="unfinished">타일셋 열이 변경됨</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The number of tile columns in the tileset &apos;%1&apos; appears to have changed from %2 to %3. Do you want to adjust tile references?</source>
-        <translation type="unfinished">&apos;%1&apos; 타일셋 열의 수가 &apos;%2&apos; 에서 &apos;%3&apos; 으로 변경되었습니다. 타일에 대한 참조를 조정하시겠습니까?</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::DonationDialog</name>
-    <message>
-        <location filename="../src/tiled/donationpopup.cpp" line="+4"/>
-        <source>Remind me next week</source>
-        <translation type="unfinished">다음 주에 다시 알려주세요</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Remind me next month</source>
-        <translation type="unfinished">다음 달에 다시 알려주세요</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Don&apos;t remind me</source>
-        <translation type="unfinished">다시 알려주지 마세요</translation>
-    </message>
-    <message>
-        <location line="+27"/>
-        <source>Thanks!</source>
-        <translation type="unfinished">감사합니다!</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Thanks a lot for your support! With your help Tiled will keep getting better.</source>
-        <translation type="unfinished">지원에 매우 감사드립니다! 당신의 도움으로 Tiled 는 계속 나아질 것입니다.</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::EditPolygonTool</name>
-    <message>
-        <location filename="../src/tiled/editpolygontool.cpp" line="+59"/>
-        <location line="+272"/>
-        <source>Edit Polygons</source>
-        <translation type="unfinished">다각형 편집</translation>
-    </message>
-    <message>
-        <location line="-22"/>
-        <source>Split Segment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location line="+268"/>
-        <source>Move %n Point(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n 포인트 이동</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+58"/>
-        <location line="+94"/>
-        <source>Delete %n Node(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n 노드 삭제</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="-89"/>
-        <location line="+295"/>
-        <source>Join Nodes</source>
-        <translation type="unfinished">노드 병합</translation>
-    </message>
-    <message>
-        <location line="-294"/>
-        <location line="+330"/>
-        <source>Split Segments</source>
-        <translation type="unfinished">선을 분할</translation>
-    </message>
-    <message>
-        <location line="-329"/>
-        <location line="+396"/>
-        <source>Delete Segment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-365"/>
-        <source>Extend Polyline</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::Eraser</name>
-    <message>
-        <location filename="../src/tiled/eraser.cpp" line="+35"/>
-        <location line="+62"/>
-        <source>Eraser</source>
-        <translation type="unfinished">지우개</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ExportAsImageDialog</name>
-    <message>
-        <location filename="../src/tiled/exportasimagedialog.cpp" line="+70"/>
-        <source>Export</source>
-        <translation type="unfinished">내보내기</translation>
-    </message>
-    <message>
-        <location line="+58"/>
-        <source>Export as Image</source>
-        <translation type="unfinished">이미지로 내보내기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>%1 already exists.
-Do you want to replace it?</source>
-        <translation type="unfinished">%1 는 이미 존재합니다.
-덮어쓰시겠습니까?</translation>
-    </message>
-    <message>
-        <location line="+71"/>
-        <source>Image too Big</source>
-        <translation type="unfinished">이미지가 너무 큽니다</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The resulting image would be %1 x %2 pixels and take %3 GB of memory. Tiled is unable to create such an image. Try reducing the zoom level.</source>
-        <translation type="unfinished">생성된 이미지는 %1 x %2 픽셀이며, %3 GB의 메모리를 사용합니다. Tiled가 이미지를 생성할 수 없습니다. 확대 레벨을 낮춰보세요.</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Out of Memory</source>
-        <translation type="unfinished">메모리 부족</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Could not allocate sufficient memory for the image. Try reducing the zoom level or using a 64-bit version of Tiled.</source>
-        <translation type="unfinished">이미지에 충분한 메모리를 할당할 수 없습니다. 줌 레벨을 낮추거나 64비트 버전의 Tiled를 써보십시오.</translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Image</source>
-        <translation type="unfinished">이미지</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::FileChangedWarning</name>
-    <message>
-        <location filename="../src/tiled/filechangedwarning.cpp" line="+39"/>
-        <source>File change detected. Discard changes and reload the file?</source>
-        <translation type="unfinished">파일 변경이 감지되었습니다. 변경 사항들을 무시하고 다시 불러오시겠습니까?</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Reload</source>
-        <translation type="unfinished">다시 불러오기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Ignore</source>
-        <translation type="unfinished">무시</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::FileEdit</name>
-    <message>
-        <location filename="../src/tiled/fileedit.cpp" line="+50"/>
-        <source>Choose</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+81"/>
-        <source>Choose a Folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Choose a File</source>
-        <translation type="unfinished">파일을 선택하십시오</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ImageCache</name>
-    <message>
-        <location filename="../src/libtiled/imagecache.cpp" line="+221"/>
-        <source>Recursive metatile map detected: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Failed to read metatile map %1: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::IssuesCounter</name>
-    <message numerus="yes">
-        <location filename="../src/tiled/issuescounter.cpp" line="+110"/>
-        <source>%n error(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+1"/>
-        <source>%n warning(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::IssuesDock</name>
-    <message>
-        <location filename="../src/tiled/issuesdock.cpp" line="+176"/>
-        <source>Show warnings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Clear</source>
-        <translation type="unfinished">지우기</translation>
-    </message>
-    <message>
-        <location line="+46"/>
-        <source>Issues</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Filter</source>
-        <translation type="unfinished">필터</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::LayerDock</name>
-    <message>
-        <location filename="../src/tiled/layerdock.cpp" line="+237"/>
-        <source>Layers</source>
-        <translation type="unfinished">레이어</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Opacity:</source>
-        <translation type="unfinished">불투명도:</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>New Layer</source>
-        <translation type="unfinished">새로운 레이어</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::LayerModel</name>
-    <message>
-        <location filename="../src/tiled/layermodel.cpp" line="+236"/>
-        <source>Layer</source>
-        <translation type="unfinished">레이어</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Visible</source>
-        <translation type="unfinished">표시됨</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Locked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location line="+86"/>
-        <source>Drag Layer(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n 레이어 드래그</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+142"/>
-        <source>Show Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Hide Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <source>Lock Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Unlock Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+61"/>
-        <source>Show Other Layers</source>
-        <translation type="unfinished">다른 레이어 표시</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Hide Other Layers</source>
-        <translation type="unfinished">다른 레이어 표시 안함</translation>
-    </message>
-    <message>
-        <location line="+26"/>
-        <source>Lock Other Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Unlock Other Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::LayerOffsetTool</name>
-    <message>
-        <location filename="../src/tiled/layeroffsettool.cpp" line="+44"/>
-        <location line="+97"/>
-        <source>Offset Layers</source>
-        <translation type="unfinished">레이어 Offset</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::LocatorWidget</name>
-    <message>
-        <location filename="../src/tiled/locatorwidget.cpp" line="+327"/>
-        <source>Filename</source>
-        <translation type="unfinished">파일명</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::MagicWandTool</name>
-    <message>
-        <location filename="../src/tiled/magicwandtool.cpp" line="+33"/>
-        <location line="+22"/>
-        <source>Magic Wand</source>
-        <translation type="unfinished">자동 선택 도구</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::MainToolBar</name>
-    <message>
-        <location filename="../src/tiled/maintoolbar.cpp" line="+41"/>
-        <source>Main Toolbar</source>
-        <translation type="unfinished">메인 툴바</translation>
-    </message>
-    <message>
-        <location line="+62"/>
-        <source>New</source>
-        <translation type="unfinished">새로운 파일</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::MainWindow</name>
-    <message>
-        <location filename="../src/tiled/abstractobjecttool.cpp" line="-286"/>
-        <location filename="../src/tiled/documentmanager.cpp" line="-630"/>
-        <location line="+26"/>
-        <location filename="../src/tiled/mainwindow.cpp" line="+1444"/>
-        <source>untitled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Save Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Error Saving Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/documentmanager.cpp" line="-96"/>
-        <source>Error Saving File</source>
-        <translation type="unfinished">파일 저장중 오류 발생</translation>
-    </message>
-    <message>
-        <location line="+41"/>
-        <source>Extension Mismatch</source>
-        <translation type="unfinished">확장자 불일치</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The file extension does not match the chosen file type.</source>
-        <translation type="unfinished">파일 확장자가 선택된 파일의 타입과 맞지 않습니다.</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Tiled may not automatically recognize your file when loading. Are you sure you want to save with this extension?</source>
-        <translation type="unfinished">Tiled는 불러오는 중 파일을 자동으로 인식하지 못할 수 있습니다. 이 확장자로 저장하시겠습니까?</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/mainwindow.cpp" line="-1298"/>
-        <location line="+963"/>
-        <location line="+757"/>
-        <source>All Files (*)</source>
-        <translation type="unfinished">모든 파일 (*)</translation>
-    </message>
-    <message>
-        <location line="-1698"/>
-        <source>Export As...</source>
-        <translation type="unfinished">다른 형식으로 내보내기...</translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Non-unique file extension</source>
-        <translation type="unfinished">확장자가 한 개가 아닙니다</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Non-unique file extension.
-Please select specific format.</source>
-        <translation type="unfinished">확장자가 한 개가 아닙니다.
-명확한 형식을 지정해주세요.</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Unknown File Format</source>
-        <translation type="unfinished">알 수 없는 파일 형식</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The given filename does not have any known file extension.</source>
-        <translation type="unfinished">입력된 파일명은 지원되는 확장자를 포함하지 않습니다.</translation>
-    </message>
-    <message>
-        <location line="+156"/>
-        <source>Undo</source>
-        <translation type="unfinished">실행 취소</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Redo</source>
-        <translation type="unfinished">다시 실행</translation>
-    </message>
-    <message>
-        <location line="+152"/>
-        <location line="+1817"/>
-        <source>&amp;Layer</source>
-        <translation type="unfinished">레이어(&amp;L)</translation>
-    </message>
-    <message>
-        <location line="-1730"/>
-        <location line="+35"/>
-        <source>All Files (*);;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-34"/>
-        <location line="+35"/>
-        <location line="+490"/>
-        <source>World files (*.world)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-523"/>
-        <source>Load World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <location line="+453"/>
-        <source>Error Loading World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-424"/>
-        <source>New World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>Error Creating World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Error Writing World File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+120"/>
-        <location line="+1546"/>
-        <source>Views and Toolbars</source>
-        <translation type="unfinished">보기 및 툴바</translation>
-    </message>
-    <message>
-        <location line="-1543"/>
-        <location line="+1544"/>
-        <source>Reset to Default Layout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-1543"/>
-        <location line="+1544"/>
-        <source>Lock Layout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-1533"/>
-        <location line="+1534"/>
-        <source>Object Types Editor</source>
-        <translation type="unfinished">오브젝트 타입 편집기</translation>
-    </message>
-    <message>
-        <location line="-1240"/>
-        <source>Error Opening File</source>
-        <translation type="unfinished">파일 여는 중 오류 발생</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Error opening &apos;%1&apos;:
-%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>Open File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+105"/>
-        <source>Error Saving World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Unsaved Changes</source>
-        <translation type="unfinished">변경 사항 저장되지 않음</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>There are unsaved changes. Do you want to save now?</source>
-        <translation type="unfinished">저장되지 않은 변경 사항이 있습니다. 지금 저장하시겠습니까?</translation>
-    </message>
-    <message>
-        <location line="+35"/>
-        <source>Unsaved Changes to World</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>There are unsaved changes to world &quot;%1&quot;. Do you want to save the world now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+47"/>
-        <location line="+14"/>
-        <source>Exported to %1</source>
-        <translation type="unfinished">%1 로 내보냈습니다</translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>Error Exporting Map</source>
-        <translation type="unfinished">맵 내보내는 중 오류 발생</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Error Exporting Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-225"/>
-        <location line="+281"/>
-        <location line="+46"/>
-        <source>Tiled Projects (*.tiled-project)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-44"/>
-        <source>Open Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Error Opening Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>An error occurred while opening the project.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+31"/>
-        <source>Save Project As</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Error Saving Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>An error occurred while saving the project.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+135"/>
-        <source>&lt;html&gt;Enable anonymous crash reporting? &lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>&amp;Yes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;No</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+38"/>
-        <source>The current project contains &lt;a href=&quot;https://doc.mapeditor.org/en/stable/reference/scripting/&quot;&gt;scripted extensions&lt;/a&gt;.&lt;br&gt;&lt;i&gt;Make sure you trust those extensions before enabling them!&lt;/i&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>&amp;Enable Extensions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Close</source>
-        <translation type="unfinished">닫기(&amp;C)</translation>
-    </message>
-    <message>
-        <location line="+231"/>
-        <source>Add External Tileset(s)</source>
-        <translation type="unfinished">외부 타일셋 추가</translation>
-    </message>
-    <message>
-        <location line="+115"/>
-        <source>Automatic Mapping Error</source>
-        <translation type="unfinished">오토맵 오류</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Automatic Mapping Warning</source>
-        <translation type="unfinished">오토맵 경고</translation>
-    </message>
-    <message>
-        <location line="+292"/>
-        <source>[*]%1%2</source>
-        <translation type="unfinished">[*]%1%2</translation>
-    </message>
-    <message>
-        <location line="+28"/>
-        <source>&amp;New</source>
-        <translation type="unfinished">새로 만들기(&amp;N)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>Some export files already exist:</source>
-        <translation type="unfinished">일부 내보낸 파일들이 이미 존재합니다:</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Do you want to replace them?</source>
-        <translation type="unfinished">대체하시겠습니까?</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Overwrite Files</source>
-        <translation type="unfinished">파일 덮어쓰기</translation>
-    </message>
-    <message>
-        <location line="+19"/>
-        <location line="+39"/>
-        <source>Error Exporting Map!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+81"/>
-        <source>Error Reloading Map</source>
-        <translation type="unfinished">맵 다시 불러오는 중 오류 발생</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/tilecollisiondock.cpp" line="+349"/>
-        <source>Tile Collision Editor</source>
-        <translation type="unfinished">타일 Collision 편집기</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::MapDocument</name>
-    <message>
-        <location filename="../src/tiled/mapdocument.cpp" line="+131"/>
-        <source>Map format &apos;%s&apos; not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+104"/>
-        <source>untitled.tmx</source>
-        <translation type="unfinished">untitled.tmx</translation>
-    </message>
-    <message>
-        <location line="+109"/>
-        <source>Resize Map</source>
-        <translation type="unfinished">맵 크기 조정</translation>
-    </message>
-    <message>
-        <location line="+75"/>
-        <source>Offset Map</source>
-        <translation type="unfinished">맵 Offset</translation>
-    </message>
-    <message numerus="yes">
-        <location line="+27"/>
-        <source>Rotate %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 회전</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+36"/>
-        <location filename="../src/tiled/newmapdialog.cpp" line="+83"/>
-        <source>Tile Layer %1</source>
-        <translation type="unfinished">타일 레이어 %1</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Object Layer %1</source>
-        <translation type="unfinished">오브젝트 레이어 %1</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Image Layer %1</source>
-        <translation type="unfinished">이미지 레이어 %1</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <location line="+33"/>
-        <source>Group %1</source>
-        <translation type="unfinished">그룹 %1</translation>
-    </message>
-    <message numerus="yes">
-        <location line="+2"/>
-        <source>Group %n Layer(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+16"/>
-        <source>Ungroup %n Layer(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+46"/>
-        <source>Duplicate %n Layer(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+28"/>
-        <location filename="../src/tiled/tileseteditor.cpp" line="+968"/>
-        <source>Copy of %1</source>
-        <translation type="unfinished">%1의 사본</translation>
-    </message>
-    <message>
-        <location line="+38"/>
-        <source>Merge Layer Down</source>
-        <translation type="unfinished">아래 레이어와 병합</translation>
-    </message>
-    <message numerus="yes">
-        <location line="+98"/>
-        <source>Remove %n Layer(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+358"/>
-        <source>Tile</source>
-        <translation type="unfinished">타일</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Tileset Changes</source>
-        <translation type="unfinished">타일셋 변경</translation>
-    </message>
-    <message>
-        <location line="+179"/>
-        <source>Failed to load tileset &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+19"/>
-        <source>Failed to load template &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location line="+85"/>
-        <source>Duplicate %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 복제</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+13"/>
-        <source>Remove %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 삭제</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+11"/>
-        <source>Move %n Object(s) to Layer</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+38"/>
-        <source>Move %n Object(s) Up</source>
-        <translation type="unfinished">
-            <numerusform>%n개 레이어를 위로 옮기기</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+36"/>
-        <source>Move %n Object(s) Down</source>
-        <translation type="unfinished">
-            <numerusform>%n개 레이어를 아래로 이동</numerusform>
-        </translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::MapDocumentActionHandler</name>
-    <message>
-        <location filename="../src/tiled/mapdocumentactionhandler.cpp" line="+241"/>
-        <source>Select &amp;All</source>
-        <translation type="unfinished">모두 선택(&amp;A)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Invert S&amp;election</source>
-        <translation type="unfinished">선택 영역 반전(&amp;E)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Select &amp;None</source>
-        <translation type="unfinished">선택 해제(&amp;N)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Crop to Selection</source>
-        <translation type="unfinished">선택 영역 잘라내기(&amp;C)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Autocrop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>&amp;Tile Layer</source>
-        <translation type="unfinished">타일 레이어(&amp;T)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Object Layer</source>
-        <translation type="unfinished">오브젝트 레이어(&amp;O)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Image Layer</source>
-        <translation type="unfinished">이미지 레이어(&amp;I)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Group Layer</source>
-        <translation type="unfinished">레이어 그룹화(&amp;G)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location line="+340"/>
-        <source>Layer via Copy</source>
-        <translation type="unfinished">사본을 통한 레이어</translation>
-    </message>
-    <message>
-        <location line="-339"/>
-        <location line="+339"/>
-        <source>Layer via Cut</source>
-        <translation type="unfinished">잘라내기를 통한 레이어</translation>
-    </message>
-    <message>
-        <location line="-338"/>
-        <source>&amp;Group Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Ungroup Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>&amp;Duplicate Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Merge Layer Down</source>
-        <translation type="unfinished">아래 레이어와 병합(&amp;M)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Remove Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Select Pre&amp;vious Layer</source>
-        <translation type="unfinished">이전 레이어 선택(&amp;V)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Select &amp;Next Layer</source>
-        <translation type="unfinished">다음 레이어 선택(&amp;N)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>R&amp;aise Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Lower Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Show/&amp;Hide Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Lock/&amp;Unlock Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Show/&amp;Hide Other Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Lock/&amp;Unlock Other Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Layer &amp;Properties...</source>
-        <translation type="unfinished">레이어 속성(&amp;P)...</translation>
-    </message>
-    <message>
-        <location line="+37"/>
-        <source>&amp;New</source>
-        <translation type="unfinished">새로 만들기(&amp;N)</translation>
-    </message>
-    <message>
-        <location line="+18"/>
-        <source>&amp;Group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>Cut</source>
-        <translation type="unfinished">잘라내기</translation>
-    </message>
-    <message>
-        <location line="+67"/>
-        <source>Delete</source>
-        <translation type="unfinished">삭제</translation>
-    </message>
-    <message numerus="yes">
-        <location line="+426"/>
-        <source>Duplicate %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 복제</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+1"/>
-        <source>Remove %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 삭제</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Duplicate Objects</source>
-        <translation type="unfinished">오브젝트 복제</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Remove Objects</source>
-        <translation type="unfinished">오브젝트 삭제</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::MapEditor</name>
-    <message>
-        <location filename="../src/tiled/mapeditor.cpp" line="+723"/>
-        <source>Paste in Place</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+193"/>
-        <source>Unrecognized tileset format.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <location line="+5"/>
-        <source>Error Reading Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>%1: %2</source>
-        <translation type="unfinished">%1: %2</translation>
-    </message>
-    <message numerus="yes">
-        <location line="+17"/>
-        <source>Add %n Tileset(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 타일셋 추가</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+56"/>
-        <source>Tools</source>
-        <translation type="unfinished">도구</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Tool Options</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::MapObjectModel</name>
-    <message>
-        <location filename="../src/tiled/mapobjectmodel.cpp" line="+240"/>
-        <source>Change Object Name</source>
-        <translation type="unfinished">오브젝트 이름 변경</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Change Object Type</source>
-        <translation type="unfinished">오브젝트 타입 변경</translation>
-    </message>
-    <message>
-        <location line="+55"/>
-        <source>Name</source>
-        <translation type="unfinished">이름</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Type</source>
-        <translation type="unfinished">타입</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>ID</source>
-        <translation type="unfinished">ID</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Position</source>
-        <translation type="unfinished">위치</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::MiniMapDock</name>
-    <message>
-        <location filename="../src/tiled/minimapdock.cpp" line="+59"/>
-        <source>Mini-map</source>
-        <translation type="unfinished">미니맵</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::NewMapDialog</name>
-    <message>
-        <location filename="../src/tiled/newmapdialog.cpp" line="-95"/>
-        <source>Save As...</source>
-        <translation type="unfinished">다른 이름으로 저장...</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="-34"/>
-        <source>Orthogonal</source>
-        <translation type="unfinished">직교</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+1"/>
-        <source>Isometric</source>
-        <translation type="unfinished">아이소메트릭</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+1"/>
-        <source>Isometric (Staggered)</source>
-        <translation type="unfinished">아이소메트릭 (비틀거림)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="+1"/>
-        <source>Hexagonal (Staggered)</source>
-        <translation type="unfinished">육각형 (비틀거림)</translation>
-    </message>
-    <message>
-        <location line="+83"/>
-        <source>Memory Usage Warning</source>
-        <translation type="unfinished">메모리 사용량 경고</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Tile layers for this map will consume %L1 GB of memory each. Not creating one by default.</source>
-        <translation type="unfinished">이 맵의 타일 레이어는 각각 %L1 GB 의 메모리를 소모합니다. 기본설정으로 만들지 마십시오.</translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>%1 x %2 pixels</source>
-        <translation type="unfinished">%1 x %2 픽셀</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::NewTilesetDialog</name>
-    <message>
-        <location filename="../src/tiled/newtilesetdialog.cpp" line="-43"/>
-        <location line="+7"/>
-        <source>Error</source>
-        <translation type="unfinished">오류</translation>
-    </message>
-    <message>
-        <location line="-6"/>
-        <source>Failed to load tileset image &apos;%1&apos;.</source>
-        <translation type="unfinished">타일셋 이미지 &apos;%1&apos; 을 불러오는 데 실패하였습니다.</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>No tiles found in the tileset image when using the given tile size, margin and spacing!</source>
-        <translation type="unfinished">입력된 타일 크기, 여백, 간격을 사용시 타일셋 이미지에 타일이 없습니다!</translation>
-    </message>
-    <message>
-        <location line="+47"/>
-        <source>Tileset Image</source>
-        <translation type="unfinished">타일셋 이미지</translation>
-    </message>
-    <message>
-        <location line="+31"/>
-        <location line="+2"/>
-        <source>&amp;OK</source>
-        <translation type="unfinished">확인(&amp;O)</translation>
-    </message>
-    <message>
-        <location line="-2"/>
-        <source>&amp;Save As...</source>
-        <translation type="unfinished">다른 이름으로 저장(&amp;S)...</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::NewVersionButton</name>
-    <message>
-        <location filename="../src/tiled/newversionbutton.cpp" line="+43"/>
-        <source>Up to date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+30"/>
-        <source>Update Available</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>%1 %2 is available</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Error checking for updates</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::NewVersionDialog</name>
-    <message>
-        <location filename="../src/tiled/newversiondialog.ui" line="+14"/>
-        <source>Update Available</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+30"/>
-        <source>Download ↗</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Release Notes ↗</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+48"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Tiled 1.2.5&lt;/span&gt; is available!&lt;br/&gt;&lt;br/&gt;Current version is Tiled 1.2.3.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/newversiondialog.cpp" line="+47"/>
-        <source>&lt;p&gt;&lt;b&gt;%1 %2&lt;/b&gt; is available!&lt;br/&gt;&lt;br/&gt;Current version is %1 %3.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::NewsButton</name>
-    <message>
-        <location filename="../src/tiled/newsbutton.cpp" line="+155"/>
-        <source>Devlog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>News</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-22"/>
-        <source>View All Posts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>News Archive</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::NoWangSetWidget</name>
-    <message>
-        <location filename="../src/tiled/wangdock.cpp" line="+72"/>
-        <source>&lt;p&gt;No tileset with Terrain Sets available.&lt;/p&gt;&lt;p&gt;Open a tileset with a Terrain Set or set up a new Terrain Set to be able to use the Terrain Brush or the Terrain Fill Mode.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ObjectRefEdit</name>
-    <message>
-        <location filename="../src/tiled/objectrefedit.cpp" line="+54"/>
-        <source>Search Object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Select Object on Map</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ObjectSelectionTool</name>
-    <message>
-        <location filename="../src/tiled/objectselectiontool.cpp" line="+321"/>
-        <location line="+438"/>
-        <source>Select Objects</source>
-        <translation type="unfinished">오브젝트 선택</translation>
-    </message>
-    <message numerus="yes">
-        <location line="-296"/>
-        <location line="+802"/>
-        <source>Move %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 옮기기</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="-674"/>
-        <source>Unnamed object</source>
-        <translation type="unfinished">이름 없는 오브젝트</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Instance of %1</source>
-        <translation type="unfinished">%1의 instance</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>&amp;%1) %2</source>
-        <translation type="unfinished">&amp;%1) %2</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>%1) %2</source>
-        <translation type="unfinished">%1) %2</translation>
-    </message>
-    <message>
-        <location line="+166"/>
-        <source>Select Touched Objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Select Enclosed Objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message numerus="yes">
-        <location line="+599"/>
-        <source>Rotate %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 회전</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+275"/>
-        <source>Resize %n Object(s)</source>
-        <translation type="unfinished">
-            <numerusform>%n개 오브젝트 크기 조정</numerusform>
-        </translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ObjectTypesEditor</name>
-    <message>
-        <location filename="../src/tiled/objecttypeseditor.cpp" line="-159"/>
-        <source>Add Object Type</source>
-        <translation type="unfinished">오브젝트 타입 추가</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Remove Object Type</source>
-        <translation type="unfinished">오브젝트 타입 삭제</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Add Property</source>
-        <translation type="unfinished">속성 추가</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Remove Property</source>
-        <translation type="unfinished">속성 삭제</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location line="+299"/>
-        <source>Rename Property</source>
-        <translation type="unfinished">속성 이름 변경</translation>
-    </message>
-    <message>
-        <location line="-242"/>
-        <location line="+105"/>
-        <source>Error Writing Object Types</source>
-        <translation type="unfinished">오브젝트 타입 쓰는중 오류 발생</translation>
-    </message>
-    <message>
-        <location line="-104"/>
-        <source>Error writing to %1:
-%2</source>
-        <translation type="unfinished">%1 에 쓰기 실패:
-%2</translation>
-    </message>
-    <message>
-        <location line="+80"/>
-        <source>Error Reading Object Types</source>
-        <translation type="unfinished">오브젝트 타입을 읽어오는 중 오류 발생</translation>
-    </message>
-    <message>
-        <location line="-29"/>
-        <source>Import Object Types</source>
-        <translation type="unfinished">오브젝트 타입 가져오기</translation>
-    </message>
-    <message>
-        <location line="+43"/>
-        <source>Export Object Types</source>
-        <translation type="unfinished">오브젝트 타입 내보내기</translation>
-    </message>
-    <message>
-        <location line="+145"/>
-        <source>Name:</source>
-        <translation type="unfinished">이름:</translation>
+        <source>Template tileset</source>
+        <translation>템플릿 타일셋</translation>
     </message>
 </context>
 <context>
     <name>Tiled::ObjectTypesModel</name>
     <message>
-        <location filename="../src/tiled/objecttypesmodel.cpp" line="+64"/>
         <source>Type</source>
-        <translation type="unfinished">타입</translation>
+        <translation>타입</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Color</source>
-        <translation type="unfinished">색상</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ObjectsDock</name>
-    <message>
-        <location filename="../src/tiled/objectsdock.cpp" line="+171"/>
-        <source>Objects</source>
-        <translation type="unfinished">오브젝트</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Filter</source>
-        <translation type="unfinished">필터</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Add Object Layer</source>
-        <translation type="unfinished">오브젝트 레이어 추가</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Object Properties</source>
-        <translation type="unfinished">오브젝트 속성</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Move Objects Up</source>
-        <translation type="unfinished">오브젝트 위로 이동</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Move Objects Down</source>
-        <translation type="unfinished">오브젝트 아래로 이동</translation>
-    </message>
-    <message numerus="yes">
-        <location line="+17"/>
-        <source>Move %n Object(s) to Layer</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::PreferencesDialog</name>
-    <message>
-        <location filename="../src/tiled/preferencesdialog.cpp" line="-194"/>
-        <location line="+191"/>
-        <source>System default</source>
-        <translation type="unfinished">시스템 기본 설정</translation>
-    </message>
-    <message>
-        <location line="-183"/>
-        <location line="+188"/>
-        <source>Select From Any Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-187"/>
-        <location line="+188"/>
-        <source>Prefer Selected Layers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-187"/>
-        <location line="+188"/>
-        <source>Selected Layers Only</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ProjectDock</name>
-    <message>
-        <location filename="../src/tiled/projectdock.cpp" line="+126"/>
-        <source>Choose Folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+51"/>
-        <source>Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ProjectModel</name>
-    <message>
-        <location filename="../src/tiled/projectmodel.cpp" line="+283"/>
-        <source>(Refreshing)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ProjectPropertiesDialog</name>
-    <message>
-        <location filename="../src/tiled/projectpropertiesdialog.cpp" line="-18"/>
-        <source>Extensions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Directory</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Object types</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Automapping rules</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ProjectView</name>
-    <message>
-        <location filename="../src/tiled/projectdock.cpp" line="+91"/>
-        <source>Select Template Instances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>&amp;Remove Folder from Project</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::PropertiesDock</name>
-    <message numerus="yes">
-        <location filename="../src/tiled/propertiesdock.cpp" line="+247"/>
-        <source>Paste Property/Properties</source>
-        <translation type="unfinished">
-            <numerusform>%n개 속성 붙여넣기</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+50"/>
-        <source>Remove Property/Properties</source>
-        <translation type="unfinished">
-            <numerusform>%n개 속성 제거</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <source>Name:</source>
-        <translation type="unfinished">이름:</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <location line="+209"/>
-        <source>Rename Property</source>
-        <translation type="unfinished">속성 이름 변경</translation>
-    </message>
-    <message>
-        <location line="-150"/>
-        <source>Go to Object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>Cu&amp;t</source>
-        <translation type="unfinished">잘라내기(&amp;T)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Copy</source>
-        <translation type="unfinished">복사(&amp;C)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Paste</source>
-        <translation type="unfinished">붙여넣기(&amp;P)</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Convert To</source>
-        <translation type="unfinished">다음으로 변환하기</translation>
-    </message>
-    <message>
-        <location line="+129"/>
-        <source>Rename...</source>
-        <translation type="unfinished">이름 변경...</translation>
-    </message>
-    <message>
-        <location line="-3"/>
-        <source>Remove</source>
-        <translation type="unfinished">제거</translation>
-    </message>
-    <message numerus="yes">
-        <location line="-62"/>
-        <source>Convert Property/Properties</source>
-        <translation type="unfinished">
-            <numerusform>%n개 속성 변환</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location line="+58"/>
-        <source>Properties</source>
-        <translation type="unfinished">속성</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Add Property</source>
-        <translation type="unfinished">속성 추가</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Remove Property</source>
-        <translation type="unfinished">속성 삭제</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::PropertyBrowser</name>
-    <message>
-        <location filename="../src/tiled/propertybrowser.cpp" line="-1435"/>
-        <source>Map</source>
-        <translation type="unfinished">맵</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <location line="+238"/>
-        <source>Orientation</source>
-        <translation type="unfinished">구도</translation>
-    </message>
-    <message>
-        <location line="-233"/>
-        <location line="+103"/>
-        <location line="+194"/>
-        <source>Width</source>
-        <translation type="unfinished">너비</translation>
-    </message>
-    <message>
-        <location line="-296"/>
-        <location line="+103"/>
-        <location line="+194"/>
-        <source>Height</source>
-        <translation type="unfinished">높이</translation>
-    </message>
-    <message>
-        <location line="-296"/>
-        <location line="+267"/>
-        <source>Tile Width</source>
-        <translation type="unfinished">타일 너비</translation>
-    </message>
-    <message>
-        <location line="-266"/>
-        <location line="+267"/>
-        <source>Tile Height</source>
-        <translation type="unfinished">타일 높이</translation>
-    </message>
-    <message>
-        <location line="-266"/>
-        <source>Infinite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Tile Side Length (Hex)</source>
-        <translation type="unfinished">육각타일 모서리 길이</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Stagger Axis</source>
-        <translation type="unfinished">Stagger 축</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Stagger Index</source>
-        <translation type="unfinished">Stagger 인덱스</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Tile Layer Format</source>
-        <translation type="unfinished">타일 레이어 형식</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Output Chunk Width</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Output Chunk Height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Tile Render Order</source>
-        <translation type="unfinished">타일 렌더링 순서</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Compression Level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <location line="+176"/>
-        <source>Background Color</source>
-        <translation type="unfinished">배경색</translation>
-    </message>
-    <message>
-        <location line="-144"/>
-        <source>Object</source>
-        <translation type="unfinished">오브젝트</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <location line="+46"/>
-        <location line="+159"/>
-        <source>ID</source>
-        <translation type="unfinished">ID</translation>
-    </message>
-    <message>
-        <location line="-204"/>
-        <source>Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location line="+45"/>
-        <location line="+81"/>
-        <location line="+112"/>
-        <location line="+24"/>
-        <source>Name</source>
-        <translation type="unfinished">이름</translation>
-    </message>
-    <message>
-        <location line="-259"/>
-        <location line="+203"/>
-        <location line="+35"/>
-        <source>Type</source>
-        <translation type="unfinished">타입</translation>
-    </message>
-    <message>
-        <location line="-234"/>
-        <location line="+39"/>
-        <source>Visible</source>
-        <translation type="unfinished">표시됨</translation>
-    </message>
-    <message>
-        <location line="-37"/>
-        <location line="+1318"/>
-        <source>X</source>
-        <translation type="unfinished">X</translation>
-    </message>
-    <message>
-        <location line="-1317"/>
-        <location line="+1318"/>
-        <source>Y</source>
-        <translation type="unfinished">Y</translation>
-    </message>
-    <message>
-        <location line="-1307"/>
-        <source>Rotation</source>
-        <translation type="unfinished">회전</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Flipping</source>
-        <translation type="unfinished">뒤집기</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Text</source>
-        <translation type="unfinished">텍스트</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Alignment</source>
-        <translation type="unfinished">정렬</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Font</source>
-        <translation type="unfinished">폰트</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Word Wrap</source>
-        <translation type="unfinished">단어 감싸기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location line="+38"/>
-        <location line="+192"/>
-        <source>Color</source>
-        <translation type="unfinished">색상</translation>
-    </message>
-    <message>
-        <location line="-219"/>
-        <source>Locked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Opacity</source>
-        <translation type="unfinished">불투명도</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Tint Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Horizontal Offset</source>
-        <translation type="unfinished">수평 Offset</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Vertical Offset</source>
-        <translation type="unfinished">수직 Offset</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Parallax Factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Tile Layer</source>
-        <translation type="unfinished">타일 레이어</translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Object Layer</source>
-        <translation type="unfinished">오브젝트 레이어</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Drawing Order</source>
-        <translation type="unfinished">그리기 순서</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Image Layer</source>
-        <translation type="unfinished">이미지 레이어</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <location line="+83"/>
-        <location line="+48"/>
-        <source>Image</source>
-        <translation type="unfinished">이미지</translation>
-    </message>
-    <message>
-        <location line="-126"/>
-        <location line="+87"/>
-        <source>Transparent Color</source>
-        <translation type="unfinished">투명색</translation>
-    </message>
-    <message>
-        <location line="-80"/>
-        <source>Group Layer</source>
-        <translation type="unfinished">레이어 그룹화</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Tileset</source>
-        <translation type="unfinished">타일셋</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Filename</source>
-        <translation type="unfinished">파일명</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Object Alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Drawing Offset</source>
-        <translation type="unfinished">그리기 Offset</translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Grid Width</source>
-        <translation type="unfinished">격자 너비</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Grid Height</source>
-        <translation type="unfinished">격자 높이</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Columns</source>
-        <translation type="unfinished">열</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Allowed Transformations</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Flip Horizontally</source>
-        <translation type="unfinished">가로로 뒤집기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Flip Vertically</source>
-        <translation type="unfinished">세로로 뒤집기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Rotate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Prefer Untransformed Tiles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Source</source>
-        <translation type="unfinished">소스</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Margin</source>
-        <translation type="unfinished">여백</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Spacing</source>
-        <translation type="unfinished">간격</translation>
-    </message>
-    <message>
-        <location line="+17"/>
-        <source>Tile</source>
-        <translation type="unfinished">타일</translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <location line="+55"/>
-        <source>Probability</source>
-        <translation type="unfinished">확률</translation>
-    </message>
-    <message>
-        <location line="-52"/>
-        <source>Relative chance this tile will be picked</source>
-        <translation type="unfinished">이 타일이 선택될 상대적인 확률</translation>
-    </message>
-    <message>
-        <location line="+19"/>
-        <source>Terrain Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Terrain Count</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1133"/>
-        <source>Corner</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Edge</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Mixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-1095"/>
-        <source>Change Infinite Property</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+340"/>
-        <source>Error Reading Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+330"/>
-        <source>Custom Properties</source>
-        <translation type="unfinished">사용자 정의 속성</translation>
-    </message>
-    <message>
-        <location line="+362"/>
-        <source>Odd</source>
-        <translation type="unfinished">홀수</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Even</source>
-        <translation type="unfinished">짝수</translation>
-    </message>
-    <message>
-        <location line="+40"/>
-        <source>Unspecified</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Top Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Top</source>
-        <translation type="unfinished">상단</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Top Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Left</source>
-        <translation type="unfinished">왼쪽</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Center</source>
-        <translation type="unfinished">중앙</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Right</source>
-        <translation type="unfinished">오른쪽</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Bottom Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Bottom</source>
-        <translation type="unfinished">하단</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Bottom Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Horizontal</source>
-        <translation type="unfinished">수평</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Vertical</source>
-        <translation type="unfinished">수직</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Top Down</source>
-        <translation type="unfinished">위에서 아래로</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Manual</source>
-        <translation type="unfinished">수동으로</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ResetWidget</name>
-    <message>
-        <location filename="../src/tiled/varianteditorfactory.cpp" line="+66"/>
-        <source>Reset</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ScriptManager</name>
-    <message>
-        <location filename="../src/tiled/scriptmanager.cpp" line="-114"/>
-        <source>Error opening file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>Error decoding file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Evaluating &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+63"/>
-        <source>Stack traceback:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>At line %1: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+26"/>
-        <source>Resetting script engine</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+45"/>
-        <source>Script files changed: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+38"/>
-        <source>Extensions paths changed: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::SelectSameTileTool</name>
-    <message>
-        <location filename="../src/tiled/selectsametiletool.cpp" line="+31"/>
-        <location line="+36"/>
-        <source>Select Same Tile</source>
-        <translation type="unfinished">동일한 타일 선택</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ShapeFillTool</name>
-    <message>
-        <location filename="../src/tiled/shapefilltool.cpp" line="+41"/>
-        <location line="+91"/>
-        <source>Shape Fill Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Rectangle Fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Circle Fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>%1, %2 - %3: (%4 x %5)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Rectangle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+0"/>
-        <source>Circle</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ShortcutEditor</name>
-    <message>
-        <location filename="../src/tiled/shortcutsettingspage.cpp" line="+103"/>
-        <source>Remove shortcut</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Reset shortcut to default</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::ShortcutSettingsPage</name>
-    <message>
-        <location filename="../src/tiled/shortcutsettingspage.ui" line="+17"/>
-        <source>Keyboard Shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Filter</source>
-        <translation type="unfinished">필터</translation>
-    </message>
-    <message>
-        <location line="+41"/>
-        <source>&amp;Import...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Potential conflicts!&lt;/span&gt; &lt;a href=&quot;#show-conflicts&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Set Filter&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>&amp;Export...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>&amp;Reset All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/shortcutsettingspage.cpp" line="+275"/>
-        <location line="+52"/>
-        <source>Keyboard Mapping Scheme (*.kms)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-51"/>
-        <source>Import Shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <location line="+9"/>
-        <source>Error Loading Shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Invalid shortcuts file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>Export Shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <location line="+41"/>
-        <source>Error Saving Shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::StampActions</name>
-    <message>
-        <location filename="../src/tiled/abstractobjecttool.cpp" line="-260"/>
-        <location filename="../src/tiled/stampactions.cpp" line="+86"/>
-        <source>Rotate Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <location filename="../src/tiled/stampactions.cpp" line="+1"/>
-        <source>Rotate Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/stampactions.cpp" line="-5"/>
-        <source>Random Mode</source>
-        <translation type="unfinished">랜덤 모드</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Terrain Fill Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Flip Horizontally</source>
-        <translation type="unfinished">가로로 뒤집기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Flip Vertically</source>
-        <translation type="unfinished">세로로 뒤집기</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::StampBrush</name>
-    <message>
-        <location filename="../src/tiled/stampbrush.cpp" line="+49"/>
-        <location line="+183"/>
-        <source>Stamp Brush</source>
-        <translation type="unfinished">스탬프 브러쉬</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TemplateManager</name>
-    <message>
-        <location filename="../src/libtiled/templatemanager.cpp" line="+106"/>
-        <source>Unable to reload template file: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TemplatesDock</name>
-    <message>
-        <location filename="../src/tiled/templatesdock.cpp" line="+300"/>
-        <source>Open Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <location line="+9"/>
-        <source>%1: Couldn&apos;t find &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-4"/>
-        <source>Locate Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+76"/>
-        <source>Template Editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+27"/>
-        <source>All Files (*)</source>
-        <translation type="unfinished">모든 파일 (*)</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Locate External Tileset</source>
-        <translation type="unfinished">외부 타일셋 위치 찾기</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Error Reading Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TileAnimationEditor</name>
-    <message>
-        <location filename="../src/tiled/tileanimationeditor.cpp" line="-49"/>
-        <source>Delete Frames</source>
-        <translation type="unfinished">프레임 삭제</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TileCollisionDock</name>
-    <message>
-        <location filename="../src/tiled/tilecollisiondock.cpp" line="-538"/>
-        <source>Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Show Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Show Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Objects list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+403"/>
-        <source>Delete</source>
-        <translation type="unfinished">삭제</translation>
-    </message>
-    <message>
-        <location line="+0"/>
-        <source>Cut</source>
-        <translation type="unfinished">잘라내기</translation>
-    </message>
-    <message>
-        <location line="+108"/>
-        <source>Detect Bounding Box</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Duplicate Objects</source>
-        <translation type="unfinished">오브젝트 복제</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Remove Objects</source>
-        <translation type="unfinished">오브젝트 삭제</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Move Objects Up</source>
-        <translation type="unfinished">오브젝트 위로 이동</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Move Objects Down</source>
-        <translation type="unfinished">오브젝트 아래로 이동</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Object Properties</source>
-        <translation type="unfinished">오브젝트 속성</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TileSelectionTool</name>
-    <message>
-        <location filename="../src/tiled/tileselectiontool.cpp" line="+36"/>
-        <location line="+111"/>
-        <source>Rectangular Select</source>
-        <translation type="unfinished">사각형 선택</translation>
-    </message>
-    <message>
-        <location line="-85"/>
-        <source>%1, %2 - Rectangle: (%3 x %4)</source>
-        <translation type="unfinished">%1, %2 - 직사각형: (%3 x %4)</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TileStampModel</name>
-    <message>
-        <location filename="../src/tiled/tilestampmodel.cpp" line="+77"/>
-        <source>Stamp</source>
-        <translation type="unfinished">스탬프</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Probability</source>
-        <translation type="unfinished">확률</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TileStampsDock</name>
-    <message>
-        <location filename="../src/tiled/tilestampsdock.cpp" line="+200"/>
-        <source>Delete Stamp</source>
-        <translation type="unfinished">스탬프 삭제</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Remove Variation</source>
-        <translation type="unfinished">변동 사항 삭제</translation>
-    </message>
-    <message>
-        <location line="+68"/>
-        <source>Choose the Stamps Folder</source>
-        <translation type="unfinished">스탬프 폴더 선택</translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Tile Stamps</source>
-        <translation type="unfinished">타일 스탬프</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Add New Stamp</source>
-        <translation type="unfinished">새로운 스탬프 추가</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Add Variation</source>
-        <translation type="unfinished">변동 사항 추가</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Duplicate Stamp</source>
-        <translation type="unfinished">스탬프 복제</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Delete Selected</source>
-        <translation type="unfinished">선택 사항 제거</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Set Stamps Folder</source>
-        <translation type="unfinished">스탬프 폴더 설정</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Filter</source>
-        <translation type="unfinished">필터</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TilesetDock</name>
-    <message>
-        <location filename="../src/tiled/tilesetdock.cpp" line="-300"/>
-        <source>All Files (*)</source>
-        <translation type="unfinished">모든 파일 (*)</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <location line="+135"/>
-        <source>Replace Tileset</source>
-        <translation type="unfinished">타일셋 교체</translation>
-    </message>
-    <message>
-        <location line="-120"/>
-        <source>Error Reading Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+42"/>
-        <source>Remove Tileset</source>
-        <translation type="unfinished">타일셋 삭제</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>The tileset &quot;%1&quot; is still in use by the map!</source>
-        <translation type="unfinished">타일셋 &quot;%1&quot; 은 아직 맵에서 사용되고 있습니다!</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Remove this tileset and all references to the tiles in this tileset?</source>
-        <translation type="unfinished">이 타일셋과 참조된 모든 타일을 삭제하시겠습니까?</translation>
-    </message>
-    <message>
-        <location line="+67"/>
-        <source>Tilesets</source>
-        <translation type="unfinished">타일셋</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>New Tileset</source>
-        <translation type="unfinished">새 타일셋</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Embed Tileset</source>
-        <translation type="unfinished">타일셋 내장(&amp;E)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;Export Tileset As...</source>
-        <translation type="unfinished">타일셋 내보내기(&amp;E)...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Edit Tile&amp;set</source>
-        <translation type="unfinished">타일셋 편집(S)(&amp;S)</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>&amp;Remove Tileset</source>
-        <translation type="unfinished">타일셋 삭제(&amp;R)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Select Next Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Select Previous Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Dynamically Wrap Tiles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+252"/>
-        <location line="+17"/>
-        <source>Export Tileset</source>
-        <translation type="unfinished">타일셋 내보내기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Error saving tileset: %1</source>
-        <translation type="unfinished">타일셋 저장하는 중 오류 발생: %1</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TilesetDocument</name>
-    <message>
-        <location filename="../src/tiled/tilesetdocument.cpp" line="+102"/>
-        <location line="+38"/>
-        <source>Tileset format &apos;%s&apos; not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+83"/>
-        <source>untitled.tsx</source>
-        <translation type="unfinished">untitled.tsx</translation>
-    </message>
-    <message>
-        <location line="+220"/>
-        <source>Failed to load tileset image &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Failed to load tile image &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TilesetEditor</name>
-    <message>
-        <location filename="../src/tiled/tileseteditor.cpp" line="-789"/>
-        <location line="+480"/>
-        <source>Tileset</source>
-        <translation type="unfinished">타일셋</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <location line="+24"/>
-        <location line="+29"/>
-        <location line="+19"/>
-        <source>Add Tiles</source>
-        <translation type="unfinished">타일 추가</translation>
-    </message>
-    <message>
-        <location line="-71"/>
-        <location line="+191"/>
-        <source>Remove Tiles</source>
-        <translation type="unfinished">타일 삭제</translation>
-    </message>
-    <message>
-        <location line="-190"/>
-        <source>Rearrange Tiles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Tile Animation Editor</source>
-        <translation type="unfinished">타일 애니메이션 편집기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Dynamically Wrap Tiles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+47"/>
-        <source>Apply this action to all tiles</source>
-        <translation type="unfinished">모든 타일에 이 작업 적용</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Tile &quot;%1&quot; already exists in the tileset!</source>
-        <translation type="unfinished">타일 &quot;%1&quot; 이 이미 타일셋에 존재합니다!</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Add anyway?</source>
-        <translation type="unfinished">그래도 추가하시겠습니까?</translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Could not load &quot;%1&quot;!</source>
-        <translation type="unfinished">&quot;%1&quot; 을 불러올 수 없습니다!</translation>
-    </message>
-    <message>
-        <location line="+120"/>
-        <source>Tiles to be removed are in use by open maps!</source>
-        <translation type="unfinished">삭제될 타일들이 아직 열린 맵에서 사용되고 있습니다!</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Remove all references to these tiles?</source>
-        <translation type="unfinished">이 타일에 대한 모든 참조를 삭제하시겠습니까?</translation>
-    </message>
-    <message>
-        <location line="+90"/>
-        <source>Unnamed Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TilesetParametersEdit</name>
-    <message>
-        <location filename="../src/tiled/tilesetparametersedit.cpp" line="+47"/>
-        <source>Edit...</source>
-        <translation type="unfinished">편집...</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TilesetView</name>
-    <message>
-        <location filename="../src/tiled/tilesetview.cpp" line="+769"/>
-        <source>Use as Terrain Set Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Use as Terrain Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Tile &amp;Properties...</source>
-        <translation type="unfinished">타일 속성(P)(&amp;P)...</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>&amp;Swap Tiles</source>
-        <translation type="unfinished">타일 바꾸기(S)(&amp;S)</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Show &amp;Grid</source>
-        <translation type="unfinished">격자 표시(&amp;G)</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TmxMapFormat</name>
-    <message>
-        <location filename="../src/tiled/tmxmapformat.h" line="+65"/>
-        <source>Tiled map files (*.tmx *.xml)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::TsxTilesetFormat</name>
-    <message>
-        <location line="+28"/>
-        <source>Tiled tileset files (*.tsx *.xml)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::UndoDock</name>
-    <message>
-        <location filename="../src/tiled/undodock.cpp" line="+68"/>
-        <source>History</source>
-        <translation type="unfinished">히스토리</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>&lt;empty&gt;</source>
-        <translation type="unfinished">&lt;비어있음&gt;</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::VariantPropertyManager</name>
-    <message>
-        <location filename="../src/tiled/variantpropertymanager.cpp" line="+171"/>
-        <source>%1: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source> (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>(%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Unnamed object</source>
-        <translation type="unfinished">이름 없는 오브젝트</translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>Unset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>%1: Object not found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+25"/>
-        <source>%1, %2</source>
-        <translation type="unfinished">%1, %2</translation>
-    </message>
-    <message>
-        <location line="+139"/>
-        <source>Horizontal</source>
-        <translation type="unfinished">수평</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Vertical</source>
-        <translation type="unfinished">수직</translation>
-    </message>
-    <message>
-        <location line="+115"/>
-        <location line="+6"/>
-        <source>Left</source>
-        <translation type="unfinished">왼쪽</translation>
-    </message>
-    <message>
-        <location line="-5"/>
-        <location line="+12"/>
-        <location line="+4"/>
-        <source>Center</source>
-        <translation type="unfinished">중앙</translation>
-    </message>
-    <message>
-        <location line="-15"/>
-        <source>Right</source>
-        <translation type="unfinished">오른쪽</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Justify</source>
-        <translation type="unfinished">가지런히</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Top</source>
-        <translation type="unfinished">상단</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Bottom</source>
-        <translation type="unfinished">하단</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::WangBrush</name>
-    <message>
-        <location filename="../src/tiled/wangbrush.cpp" line="+111"/>
-        <location line="+96"/>
-        <source>Terrain Brush</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+202"/>
-        <source>Missing terrain transition</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::WangColorView</name>
-    <message>
-        <location filename="../src/tiled/wangcolorview.cpp" line="+144"/>
-        <source>Pick Custom Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::WangDock</name>
-    <message>
-        <location filename="../src/tiled/wangdock.cpp" line="+197"/>
-        <location line="+363"/>
-        <source>Terrains</source>
-        <translation type="unfinished">지형</translation>
-    </message>
-    <message>
-        <location line="-362"/>
-        <location line="+363"/>
-        <source>Patterns</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-13"/>
-        <source>Terrain Sets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Erase Terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Add Terrain Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>New Corner Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>New Edge Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>New Mixed Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Duplicate Terrain Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Remove Terrain Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Add Terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Remove Terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::WangSetView</name>
-    <message>
-        <location filename="../src/tiled/wangsetview.cpp" line="+116"/>
-        <source>Terrain Set &amp;Properties...</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::WorldDocument</name>
-    <message>
-        <location filename="../src/tiled/worlddocument.cpp" line="+43"/>
-        <source>untitled.world</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::WorldManager</name>
-    <message>
-        <location filename="../src/libtiled/worldmanager.cpp" line="+8"/>
-        <source>JSON parse error at offset %1:
-%2.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+37"/>
-        <source>World: Invalid number of captures in &apos;%1&apos;, 2 captures expected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>World: Invalid multiplierX: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>World: Invalid multiplierY: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>World: Invalid mapWidth: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>World: Invalid mapHeight: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>World contained no valid maps or patterns: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+91"/>
-        <source>World doesn&apos;t support saving</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+32"/>
-        <source>Could not open file for reading.</source>
-        <translation type="unfinished">읽기용으로 파일을 열 수 없습니다.</translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::WorldMoveMapTool</name>
-    <message>
-        <location filename="../src/tiled/worldmovemaptool.cpp" line="+84"/>
-        <location line="+170"/>
-        <source>World Tool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-46"/>
-        <source>Move map to %1, %2 (offset: %3, %4)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Tiled::XmlObjectTemplateFormat</name>
-    <message>
-        <location filename="../src/tiled/tmxmapformat.h" line="+27"/>
-        <source>Tiled template files (*.tx)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>TmxViewer</name>
-    <message>
-        <location filename="../src/tmxviewer/tmxviewer.cpp" line="+180"/>
-        <source>TMX Viewer</source>
-        <translation>TMX 뷰어</translation>
+        <translation>색상</translation>
     </message>
 </context>
 <context>
     <name>Undo Commands</name>
     <message>
-        <location filename="../src/tiled/addremovelayer.cpp" line="+65"/>
-        <source>Add Layer</source>
-        <translation>레이어 추가</translation>
-    </message>
-    <message>
-        <location line="+17"/>
-        <source>Remove Layer</source>
-        <translation>레이어 삭제</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/addremovemapobject.cpp" line="+88"/>
-        <source>Add Object</source>
-        <translation>오브젝트 추가</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Add Objects</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+58"/>
-        <source>Remove Object</source>
-        <translation>오브젝트 삭제</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Remove Objects</source>
-        <translation type="unfinished">오브젝트 삭제</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/addremovetileset.cpp" line="+61"/>
-        <source>Add Tileset</source>
-        <translation>타일셋 추가</translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>Remove Tileset</source>
-        <translation>타일셋 삭제</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changemapobject.cpp" line="+38"/>
-        <source>Change Object</source>
-        <translation>오브젝트 변경</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changeobjectgroupproperties.cpp" line="+36"/>
-        <source>Change Object Layer Properties</source>
-        <translation>오브젝트 레이어 속성 변경</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changeproperties.cpp" line="+40"/>
-        <source>Change Properties</source>
-        <translation>속성 변경</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Change %1 Properties</source>
-        <translation>%1 속성 변경</translation>
-    </message>
-    <message>
-        <location line="+42"/>
-        <source>Set Property</source>
-        <translation>속성 설정</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Add Property</source>
-        <translation>속성 추가</translation>
-    </message>
-    <message>
-        <location line="+33"/>
-        <source>Remove Property</source>
-        <translation>속성 삭제</translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <source>Rename Property</source>
-        <translation>속성 이름 변경</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changeselectedarea.cpp" line="+32"/>
-        <source>Change Selection</source>
-        <translation>선택 영역 변경</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/erasetiles.cpp" line="+36"/>
-        <source>Erase</source>
-        <translation>지우기</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/bucketfilltool.cpp" line="-18"/>
-        <source>Fill Area</source>
-        <translation>영역 채우기</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/movemapobject.cpp" line="+54"/>
-        <source>Move Object</source>
-        <translation>오브젝트 이동</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/movemapobjecttogroup.cpp" line="+33"/>
-        <source>Move Object to Layer</source>
-        <translation>오브젝트를 레이어로 이동</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/offsetlayer.cpp" line="+52"/>
-        <source>Offset Layer</source>
-        <translation>레이어 Offset</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/painttilelayer.cpp" line="+67"/>
-        <source>Paint</source>
-        <translation>페인트</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changelayer.cpp" line="+39"/>
-        <source>Rename Layer</source>
-        <translation>레이어 이름 변경</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/resizetilelayer.cpp" line="+37"/>
-        <source>Resize Layer</source>
-        <translation>레이어 크기 조정</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/resizemap.cpp" line="+33"/>
-        <source>Resize Map</source>
-        <translation>맵 크기 조정</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/resizemapobject.cpp" line="+51"/>
-        <source>Resize Object</source>
-        <translation>오브젝트 크기 조정</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/tilesetchanges.cpp" line="+33"/>
-        <source>Change Tileset Name</source>
-        <translation>타일셋 이름 변경</translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Change Drawing Offset</source>
-        <translation>그리기 오프셋 변경</translation>
-    </message>
-    <message>
-        <location line="+48"/>
-        <source>Edit Tileset</source>
-        <translation>타일셋 편집</translation>
-    </message>
-    <message>
-        <location line="+36"/>
-        <source>Change Columns</source>
-        <translation>열 변경</translation>
-    </message>
-    <message>
-        <location line="+59"/>
-        <source>Change Object Alignment</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+18"/>
-        <source>Change Grid Size</source>
-        <translation>격자 크기 변경</translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Change Tileset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/movelayer.cpp" line="+41"/>
-        <source>Lower Layer</source>
-        <translation>레이어 내리기</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Raise Layer</source>
-        <translation>레이어 올리기</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changepolygon.cpp" line="+41"/>
-        <location line="+13"/>
-        <source>Change Polygon</source>
-        <translation>다각형 변경</translation>
-    </message>
-    <message>
-        <location line="+28"/>
-        <source>Split Polyline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changeimagelayerproperties.cpp" line="+38"/>
-        <source>Change Image Layer Properties</source>
-        <translation>이미지 레이어 속성 변경</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changelayer.cpp" line="+31"/>
-        <source>Show Layer</source>
-        <translation>레이어 표시</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Hide Layer</source>
-        <translation>레이어 표시 안함</translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <source>Lock Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Unlock Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <source>Change Layer Tint Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+30"/>
-        <source>Change Layer Opacity</source>
-        <translation>레이어 불투명도 변경</translation>
-    </message>
-    <message>
-        <location line="+32"/>
-        <location filename="../src/tiled/layeroffsettool.cpp" line="+93"/>
-        <source>Change Layer Offset</source>
-        <translation>레이어 Offset 변경</translation>
-    </message>
-    <message>
-        <location line="+21"/>
-        <source>Change Layer Parallax Factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Change Tile Layer Size</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changemapobject.cpp" line="+12"/>
-        <source>Show Object</source>
-        <translation>오브젝트 표시</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <source>Hide Object</source>
-        <translation>오브젝트 표시 안함</translation>
-    </message>
-    <message numerus="yes">
-        <location line="+61"/>
-        <source>Change %n Object/s Tile</source>
-        <translation>
-            <numerusform>%n개 오프젝트 타일 변경</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+69"/>
-        <source>Detach %n Template Instance(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+39"/>
-        <source>Reset %n Instances</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+53"/>
-        <source>Replace %n Object(s) With Template</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/addremovetiles.cpp" line="+62"/>
-        <source>Add Tiles</source>
-        <translation>타일 추가</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <location filename="../src/tiled/tileseteditor.cpp" line="-159"/>
-        <source>Remove Tiles</source>
-        <translation>타일 삭제</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changemapobjectsorder.cpp" line="+45"/>
-        <location filename="../src/tiled/raiselowerhelper.cpp" line="+68"/>
-        <source>Raise Object</source>
-        <translation>오브젝트 올리기</translation>
-    </message>
-    <message>
-        <location line="+2"/>
-        <location filename="../src/tiled/raiselowerhelper.cpp" line="+29"/>
-        <source>Lower Object</source>
-        <translation>오브젝트 내리기</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changetileanimation.cpp" line="+34"/>
-        <source>Change Tile Animation</source>
-        <translation>타일 애니메이션 변경</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changetileobjectgroup.cpp" line="+35"/>
-        <source>Change Tile Collision</source>
-        <translation>타일 충돌 변경</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/raiselowerhelper.cpp" line="+43"/>
-        <source>Raise Object To Top</source>
-        <translation>오브젝트 맨 위로 올리기</translation>
-    </message>
-    <message>
-        <location line="+37"/>
-        <source>Lower Object To Bottom</source>
-        <translation>오브젝트 맨 아래로 내리기</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/rotatemapobject.cpp" line="+51"/>
-        <source>Rotate Object</source>
-        <translation>오브젝트 회전</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changemapproperty.cpp" line="+41"/>
-        <source>Change Tile Width</source>
-        <translation>타일 너비 변경</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Change Tile Height</source>
-        <translation>타일 높이 변경</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Change Infinite Property</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Change Hex Side Length</source>
-        <translation>육각 타일 모서리 길이 변경</translation>
-    </message>
-    <message>
-        <location line="+4"/>
-        <source>Change Compression Level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <location filename="../src/tiled/tilesetchanges.cpp" line="-78"/>
-        <source>Change Background Color</source>
-        <translation>배경색 변경</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Change Chunk Size</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
         <source>Change Stagger Axis</source>
         <translation>Stagger 축 변경</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <source>Change Tileset Name</source>
+        <translation>타일셋 이름 변경</translation>
+    </message>
+    <message>
+        <source>Erase</source>
+        <translation>지우기</translation>
+    </message>
+    <message>
+        <source>Paint</source>
+        <translation>페인트</translation>
+    </message>
+    <message>
         <source>Change Stagger Index</source>
         <translation>Stagger 인덱스 변경</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location filename="../src/tiled/tilesetchanges.cpp" line="+20"/>
-        <source>Change Orientation</source>
-        <translation>구도 변경</translation>
+        <source>Change %1 Properties</source>
+        <translation>%1 속성 변경</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>Change Render Order</source>
-        <translation>렌더링 순서 변경</translation>
+        <source>Resize Map</source>
+        <translation>맵 크기 조정</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <source>Add Terrain Set</source>
+        <translation>지형 셋 추가</translation>
+    </message>
+    <message>
+        <source>Change Infinite Property</source>
+        <translation>무한 속성 변경</translation>
+    </message>
+    <message>
+        <source>Swap Tiles</source>
+        <translation>타일 바꾸기</translation>
+    </message>
+    <message>
+        <source>Lower Object</source>
+        <translation>오브젝트 내리기</translation>
+    </message>
+    <message>
+        <source>Relocate Tile</source>
+        <translation>타일 위치 다시 찾기</translation>
+    </message>
+    <message>
+        <source>Raise Object</source>
+        <translation>오브젝트 올리기</translation>
+    </message>
+    <message>
+        <source>Remove Tiles</source>
+        <translation>타일 삭제</translation>
+    </message>
+    <message>
+        <source>Resize Layer</source>
+        <translation>레이어 크기 조정</translation>
+    </message>
+    <message>
+        <source>Rename Layer</source>
+        <translation>레이어 이름 변경</translation>
+    </message>
+    <message>
+        <source>Remove Layer</source>
+        <translation>레이어 삭제</translation>
+    </message>
+    <message>
+        <source>Fill Area</source>
+        <translation>영역 채우기</translation>
+    </message>
+    <message>
+        <source>Split Polyline</source>
+        <translation>폴리선 분리</translation>
+    </message>
+    <message>
+        <source>Change Object Layer Properties</source>
+        <translation>오브젝트 레이어 속성 변경</translation>
+    </message>
+    <message>
+        <source>Offset Layer</source>
+        <translation>레이어 Offset</translation>
+    </message>
+    <message>
         <source>Change Layer Data Format</source>
         <translation>레이어 데이터 형식 변경</translation>
     </message>
     <message>
-        <location filename="../src/tiled/changetileprobability.cpp" line="+40"/>
-        <location line="+14"/>
-        <source>Change Tile Probability</source>
-        <translation>타일 확률 변경</translation>
+        <source>Lower Object To Bottom</source>
+        <translation>오브젝트 맨 아래로 내리기</translation>
     </message>
     <message>
-        <location filename="../src/tiled/adjusttileindexes.cpp" line="-137"/>
-        <location line="+92"/>
-        <source>Adjust Tile Indexes</source>
-        <translation>타일 인덱스 조정</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changetileimagesource.cpp" line="+39"/>
-        <source>Change Tile Image</source>
-        <translation>타일 이미지 변경</translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/replacetileset.cpp" line="+33"/>
-        <source>Replace Tileset</source>
-        <translation>타일셋 교체</translation>
+        <source>Change Terrain Probability</source>
+        <translation>지형 확률 변경</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/tiled/flipmapobjects.cpp" line="+39"/>
-        <location filename="../src/tiled/propertybrowser.cpp" line="-946"/>
         <source>Flip %n Object(s)</source>
         <translation>
             <numerusform>%n개 오브젝트 뒤집기</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/tiled/changetile.cpp" line="+33"/>
+        <source>Change Terrain Image</source>
+        <translation>지형 이미지 변경</translation>
+    </message>
+    <message>
+        <source>Change Terrain Color</source>
+        <translation>지형 색 변경</translation>
+    </message>
+    <message>
+        <source>Change Terrain Count</source>
+        <translation>지형 수 변경</translation>
+    </message>
+    <message>
+        <source>Lower Layer</source>
+        <translation>레이어 내리기</translation>
+    </message>
+    <message>
+        <source>Change Terrain Name</source>
+        <translation>지형 이름 변경</translation>
+    </message>
+    <message>
+        <source>Change Tileset</source>
+        <translation>타일셋 변경</translation>
+    </message>
+    <message>
+        <source>Show Object</source>
+        <translation>오브젝트 표시</translation>
+    </message>
+    <message>
+        <source>Move Object</source>
+        <translation>오브젝트 이동</translation>
+    </message>
+    <message>
+        <source>Hide Object</source>
+        <translation>오브젝트 표시 안함</translation>
+    </message>
+    <message>
+        <source>Remove Terrain Set</source>
+        <translation>지형 셋 삭제</translation>
+    </message>
+    <message>
+        <source>Add Object</source>
+        <translation>오브젝트 추가</translation>
+    </message>
+    <message>
+        <source>Change Drawing Offset</source>
+        <translation>그리기 오프셋 변경</translation>
+    </message>
+    <message>
+        <source>Add Objects</source>
+        <translation>오브젝트 추가</translation>
+    </message>
+    <message>
+        <source>Change Orientation</source>
+        <translation>구도 변경</translation>
+    </message>
+    <message>
+        <source>Add Layer</source>
+        <translation>레이어 추가</translation>
+    </message>
+    <message>
+        <source>Add Tiles</source>
+        <translation>타일 추가</translation>
+    </message>
+    <message>
+        <source>Change Selection</source>
+        <translation>선택 영역 변경</translation>
+    </message>
+    <message>
+        <source>Shape Fill</source>
+        <translation>도형 채우기</translation>
+    </message>
+    <message>
+        <source>Change Tile Terrain</source>
+        <translation>타일 지형 변경</translation>
+    </message>
+    <message>
+        <source>Remove Terrain</source>
+        <translation>지형 삭제</translation>
+    </message>
+    <message>
+        <source>Change Tile Size</source>
+        <translation>타일 크기 변경</translation>
+    </message>
+    <message>
         <source>Change Tile Type</source>
         <translation>타일 타입 변경</translation>
     </message>
     <message>
-        <location filename="../src/tiled/swaptiles.cpp" line="+36"/>
-        <source>Swap Tiles</source>
-        <translation>타일 바꾸기</translation>
+        <source>Remove Tileset</source>
+        <translation>타일셋 삭제</translation>
     </message>
     <message>
-        <location filename="../src/tiled/tilesetdocument.cpp" line="-408"/>
         <source>Reload Tileset</source>
         <translation>타일셋 다시 불러오기</translation>
     </message>
     <message>
-        <location filename="../src/tiled/editablemap.cpp" line="-124"/>
-        <source>Change Tile Size</source>
-        <translation type="unfinished"></translation>
+        <source>Raise Layer</source>
+        <translation>레이어 올리기</translation>
+    </message>
+    <message>
+        <source>Change Tile Height</source>
+        <translation>타일 높이 변경</translation>
+    </message>
+    <message>
+        <source>Change Layer Tint Color</source>
+        <translation>레이어 색조 색상 변경</translation>
+    </message>
+    <message>
+        <source>Move Object to Layer</source>
+        <translation>오브젝트를 레이어로 이동</translation>
+    </message>
+    <message>
+        <source>Hide Layer</source>
+        <translation>레이어 표시 안함</translation>
+    </message>
+    <message>
+        <source>Change Layer Parallax Factor</source>
+        <translation>레이어 시차 요소 변경</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/tiled/mapdocument.cpp" line="-790"/>
-        <source>Raise %n Layer(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location line="+27"/>
-        <source>Lower %n Layer(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <source>Detach %n Template Instance(s)</source>
+        <translation>
+            <numerusform>%n개 템플릿 분리(s)</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../src/tiled/replacetemplate.cpp" line="+34"/>
-        <source>Replace Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/shapefilltool.cpp" line="-57"/>
-        <source>Shape Fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/addremovewangset.cpp" line="+62"/>
-        <source>Add Terrain Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Remove Terrain Set</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changetilewangid.cpp" line="+37"/>
-        <location line="+12"/>
-        <location line="+14"/>
-        <source>Change Tile Terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changewangcolordata.cpp" line="+38"/>
-        <source>Change Terrain Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+26"/>
-        <source>Change Terrain Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+24"/>
-        <source>Change Terrain Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+24"/>
-        <source>Change Terrain Probability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/tiled/changewangsetdata.cpp" line="+38"/>
-        <source>Change Terrain Set Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+30"/>
-        <source>Change Terrain Set Type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+17"/>
-        <source>Change Terrain Count</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+48"/>
-        <source>Remove Terrain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+28"/>
         <source>Set Terrain Set Image</source>
-        <translation type="unfinished"></translation>
+        <translation>지형 지정 이미지 지정</translation>
     </message>
     <message>
-        <location filename="../src/tiled/relocatetiles.cpp" line="+33"/>
-        <source>Relocate Tile</source>
-        <translation type="unfinished"></translation>
+        <source>Change Render Order</source>
+        <translation>렌더링 순서 변경</translation>
+    </message>
+    <message>
+        <source>Change Tile Animation</source>
+        <translation>타일 애니메이션 변경</translation>
+    </message>
+    <message>
+        <source>Unlock Layer</source>
+        <translation>레이어 잠금 해제</translation>
+    </message>
+    <message>
+        <source>Raise Object To Top</source>
+        <translation>오브젝트 맨 위로 올리기</translation>
+    </message>
+    <message>
+        <source>Change Columns</source>
+        <translation>열 변경</translation>
+    </message>
+    <message>
+        <source>Change Terrain Set Name</source>
+        <translation>지형 셋 이름 변경</translation>
+    </message>
+    <message>
+        <source>Change Terrain Set Type</source>
+        <translation>지형 셋 형식 변경</translation>
+    </message>
+    <message>
+        <source>Show Layer</source>
+        <translation>레이어 표시</translation>
+    </message>
+    <message>
+        <source>Change Object Alignment</source>
+        <translation>오브젝트 정렬 변경</translation>
+    </message>
+    <message>
+        <source>Remove Objects</source>
+        <translation>오브젝트 삭제</translation>
+    </message>
+    <message>
+        <source>Change Polygon</source>
+        <translation>다각형 변경</translation>
+    </message>
+    <message>
+        <source>Change Chunk Size</source>
+        <translation>덩어리 크기 변경</translation>
+    </message>
+    <message>
+        <source>Replace Template</source>
+        <translation>템플릿 교체</translation>
+    </message>
+    <message>
+        <source>Change Tile Width</source>
+        <translation>타일 너비 변경</translation>
+    </message>
+    <message>
+        <source>Change Layer Opacity</source>
+        <translation>레이어 불투명도 변경</translation>
+    </message>
+    <message>
+        <source>Change Tile Image</source>
+        <translation>타일 이미지 변경</translation>
+    </message>
+    <message>
+        <source>Change Background Color</source>
+        <translation>배경색 변경</translation>
+    </message>
+    <message>
+        <source>Add Tileset</source>
+        <translation>타일셋 추가</translation>
+    </message>
+    <message>
+        <source>Change Image Layer Properties</source>
+        <translation>이미지 레이어 속성 변경</translation>
+    </message>
+    <message>
+        <source>Change Tile Layer Size</source>
+        <translation>타일 레이어 크기 변경</translation>
+    </message>
+    <message>
+        <source>Change Tile Collision</source>
+        <translation>타일 충돌 변경</translation>
+    </message>
+    <message>
+        <source>Change Compression Level</source>
+        <translation>압축 수준 변경</translation>
+    </message>
+    <message>
+        <source>Change Layer Offset</source>
+        <translation>레이어 Offset 변경</translation>
+    </message>
+    <message>
+        <source>Change Hex Side Length</source>
+        <translation>육각 타일 모서리 길이 변경</translation>
+    </message>
+    <message>
+        <source>Change Grid Size</source>
+        <translation>격자 크기 변경</translation>
+    </message>
+    <message>
+        <source>Change Properties</source>
+        <translation>속성 변경</translation>
+    </message>
+    <message numerus="yes">
+        <source>Lower %n Layer(s)</source>
+        <translation>
+            <numerusform>%n개 레이어(s) 내리기</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remove Property</source>
+        <translation>속성 삭제</translation>
+    </message>
+    <message>
+        <source>Add Property</source>
+        <translation>속성 추가</translation>
+    </message>
+    <message>
+        <source>Lock Layer</source>
+        <translation>레이어 잠금</translation>
+    </message>
+    <message>
+        <source>Resize Object</source>
+        <translation>오브젝트 크기 조정</translation>
+    </message>
+    <message>
+        <source>Remove Object</source>
+        <translation>오브젝트 삭제</translation>
+    </message>
+    <message>
+        <source>Replace Tileset</source>
+        <translation>타일셋 교체</translation>
+    </message>
+    <message>
+        <source>Rename Property</source>
+        <translation>속성 이름 변경</translation>
+    </message>
+    <message>
+        <source>Change Tile Probability</source>
+        <translation>타일 확률 변경</translation>
+    </message>
+    <message numerus="yes">
+        <source>Reset %n Instances</source>
+        <translation>
+            <numerusform>%n 개 인스턴스 초기화</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Rotate Object</source>
+        <translation>오브젝트 회전</translation>
+    </message>
+    <message>
+        <source>Adjust Tile Indexes</source>
+        <translation>타일 인덱스 조정</translation>
+    </message>
+    <message>
+        <source>Edit Tileset</source>
+        <translation>타일셋 편집</translation>
+    </message>
+    <message numerus="yes">
+        <source>Replace %n Object(s) With Template</source>
+        <translation>
+            <numerusform>%n개 오브젝트(s) 템플릿과 함ㄲㅔ 대체</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Change %n Object/s Tile</source>
+        <translation>
+            <numerusform>%n개 오프젝트 타일 변경</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Change Object</source>
+        <translation>오브젝트 변경</translation>
+    </message>
+    <message>
+        <source>Set Property</source>
+        <translation>속성 설정</translation>
+    </message>
+    <message numerus="yes">
+        <source>Raise %n Layer(s)</source>
+        <translation>
+            <numerusform>%n개 레이어 올리기</numerusform>
+        </translation>
     </message>
 </context>
 <context>
-    <name>Utils</name>
+    <name>Tiled::ShortcutSettingsPage</name>
     <message>
-        <location filename="../src/tiled/utils.cpp" line="+54"/>
-        <source>Image files</source>
-        <translation>이미지 파일</translation>
+        <source>Export Shortcuts</source>
+        <translation>단축키 내보내기</translation>
     </message>
     <message>
-        <location line="+421"/>
-        <source>Copy File Path</source>
-        <translation type="unfinished">파일 경로 복사</translation>
+        <source>Import Shortcuts</source>
+        <translation>단축키 가져오기</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <source>Open Containing Folder...</source>
-        <translation type="unfinished">포함하는 폴더 열기...</translation>
+        <source>Invalid shortcuts file.</source>
+        <translation>유효하지 않은 단축키 파일.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Open with System Editor</source>
-        <translation type="unfinished"></translation>
+        <source>Filter</source>
+        <translation>필터</translation>
+    </message>
+    <message>
+        <source>&amp;Export...</source>
+        <translation>내보내기 (&amp;E)...</translation>
+    </message>
+    <message>
+        <source>&amp;Import...</source>
+        <translation>가져오기(&amp;I)...</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Potential conflicts!&lt;/span&gt; &lt;a href=&quot;#show-conflicts&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Set Filter&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;잠재적 충돌!&lt;/span&gt; &lt;a href=&quot;#show-conflicts&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;필터 셋&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&amp;Reset All</source>
+        <translation>모두 초기화(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Error Loading Shortcuts</source>
+        <translation>단축키 로딩 오류</translation>
+    </message>
+    <message>
+        <source>Keyboard Shortcuts</source>
+        <translation>키보드 단축키</translation>
+    </message>
+    <message>
+        <source>Keyboard Mapping Scheme (*.kms)</source>
+        <translation>키보드 매핑 구성표 (*.kms)</translation>
+    </message>
+    <message>
+        <source>Error Saving Shortcuts</source>
+        <translation>단축키 저장 오류</translation>
+    </message>
+</context>
+<context>
+    <name>NoEditorWidget</name>
+    <message>
+        <source>New Tileset...</source>
+        <translation>새로운 타일셋...</translation>
+    </message>
+    <message>
+        <source>New Map...</source>
+        <translation>새로운 맵...</translation>
+    </message>
+    <message>
+        <source>Open File...</source>
+        <translation>파일 열기...</translation>
+    </message>
+    <message>
+        <source>&lt;font size=&quot;+2&quot;&gt;No Open Files&lt;/font&gt;</source>
+        <translation>&lt;font size=&quot;+2&quot;&gt;열린 파일 없음 &lt;/font&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>NoTilesetWidget</name>
+    <message>
+        <source>New Tileset...</source>
+        <translation>새로운 타일셋...</translation>
+    </message>
+</context>
+<context>
+    <name>Droidcraft::DroidcraftPlugin</name>
+    <message>
+        <source>Droidcraft map files (*.dat)</source>
+        <translation>Droidcraft 맵 파일 (*.dat)</translation>
+    </message>
+    <message>
+        <source>The layer must have a size of 48 x 48 tiles!</source>
+        <translation>레이어 크기는 48 x 48 타일이여야 합니다!</translation>
+    </message>
+    <message>
+        <source>The map needs to have exactly one tile layer!</source>
+        <translation>맵은 하나의 타일 레이어만 갖고 있어야 합니다!</translation>
+    </message>
+    <message>
+        <source>This is not a valid Droidcraft map file!</source>
+        <translation>유효한 Droidcraft map 파일이 아닙니다!</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::BrokenLinksWidget</name>
+    <message>
+        <source>Some files could not be found</source>
+        <translation>일부 파일이 발견되지 않을 수 있습니다</translation>
+    </message>
+    <message>
+        <source>Open Tileset...</source>
+        <translation>타일셋 열기...</translation>
+    </message>
+    <message>
+        <source>Locate Directory for Files</source>
+        <translation>파일의 디렉토리 위치 찾기</translation>
+    </message>
+    <message>
+        <source>Open Template...</source>
+        <translation>템플릿 열기...</translation>
+    </message>
+    <message>
+        <source>Error Reading Tileset</source>
+        <translation>타일셋 읽기 오류</translation>
+    </message>
+    <message>
+        <source>Locate Object Template</source>
+        <translation>오브젝트 템플릿 위치 찾기</translation>
+    </message>
+    <message>
+        <source>Error Loading Image</source>
+        <translation>이미지를 불러오는 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Error Reading Object Template</source>
+        <translation>오브젝트 템플릿 읽기 오류</translation>
+    </message>
+    <message>
+        <source>Locate File...</source>
+        <translation>파일 위치 찾기...</translation>
+    </message>
+    <message>
+        <source>Locate File</source>
+        <translation>파일 위치 찾기</translation>
+    </message>
+    <message>
+        <source>One or more referenced files could not be found. You can help locate them below.</source>
+        <translation>하나 이상의 참조된 파일이 발견되지 않을 수 있습니다. 하단에서 위치를 찾을 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>All Files (*)</source>
+        <translation>모든 파일 (*)</translation>
+    </message>
+    <message>
+        <source>Locate External Tileset</source>
+        <translation>외부 타일셋 위치 찾기</translation>
+    </message>
+</context>
+<context>
+    <name>Script Errors</name>
+    <message>
+        <source>Invalid callback</source>
+        <translation>유효하지 않은 callback</translation>
+    </message>
+    <message>
+        <source>Object already part of an object layer</source>
+        <translation>오브젝트가 이니 오브젝트 레이어의 일부임</translation>
+    </message>
+    <message>
+        <source>Could not read from &apos;%1&apos;: %2</source>
+        <translation>읽어 올 수 없습니다 &apos;%1&apos;: %2</translation>
+    </message>
+    <message>
+        <source>File format doesn&apos;t support `write`</source>
+        <translation>파일 형식이 &apos;write&apos;를 지원하지 않습니다</translation>
+    </message>
+    <message>
+        <source>ObjectGroup is in use</source>
+        <translation>오브젝트그룹 사용 중</translation>
+    </message>
+    <message>
+        <source>Invalid argument</source>
+        <translation>유효하지 않은 인수</translation>
+    </message>
+    <message>
+        <source>Process &apos;%1 %2&apos; finished with exit code %3.</source>
+        <translation>&apos;%1 %2&apos; 프로세스가 종료 코드 %3으로 완료되었습니다.</translation>
+    </message>
+    <message>
+        <source>Error running %1: %2</source>
+        <translation>실행 오류 %1: %2</translation>
+    </message>
+    <message>
+        <source>The standard error output was:</source>
+        <translation>표준 오류 출력:</translation>
+    </message>
+    <message>
+        <source>Object not from this map</source>
+        <translation>이 맵의 오브젝트가 아닙니다</translation>
+    </message>
+    <message>
+        <source>Argument %1 is undefined or the wrong type</source>
+        <translation>%1 인수가 정의되지 않았거나 잘못된 형식입니다</translation>
+    </message>
+    <message>
+        <source>Invalid Wang ID</source>
+        <translation>유효하지 않은 Wang ID</translation>
+    </message>
+    <message>
+        <source>Invalid color value</source>
+        <translation>유효하지 않은 색 값</translation>
+    </message>
+    <message>
+        <source>Unknown action: &apos;%1&apos;</source>
+        <translation>알 수 없는 동작: &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>AutoMapping is currently not supported for detached maps</source>
+        <translation>분리된 맵에는 현재 자동 매핑이 지원되지 않습니다</translation>
+    </message>
+    <message>
+        <source>Invalid coordinate</source>
+        <translation>유효하지 않은 코디네이트</translation>
+    </message>
+    <message>
+        <source>Resize is currently not supported for detached maps</source>
+        <translation>분리된 맵에는 현재 크기 조정이 지원되지 않습니다</translation>
+    </message>
+    <message>
+        <source>Invalid file format object (requires string &apos;extension&apos; property)</source>
+        <translation>유효하지 않은 파일 형식 오브젝트(문자열 &apos;확장자&apos; 속성 필요)</translation>
+    </message>
+    <message>
+        <source>Invalid return value for &apos;outputFiles&apos; (string or array expected)</source>
+        <translation>유효하지 않은 &apos;outputFiles&apos;반환입니다(문자열 ㄸㅗ는 배열이 필요함)</translation>
+    </message>
+    <message>
+        <source>Not a layer</source>
+        <translation>레이어가 아닙니다</translation>
+    </message>
+    <message>
+        <source>Unknown action</source>
+        <translation>알 수 없는 동작</translation>
+    </message>
+    <message>
+        <source>Access to TextFile object that was already closed.</source>
+        <translation>이미 닫힌 TextFile 오브젝트에 대한 접근입니다.</translation>
+    </message>
+    <message>
+        <source>Invalid shortName</source>
+        <translation>유효하지 않은 약칭</translation>
+    </message>
+    <message>
+        <source>Not an object</source>
+        <translation>오브젝트가 아닙니다</translation>
+    </message>
+    <message>
+        <source>Error reading tileset</source>
+        <translation>타일셋 읽기 오류</translation>
+    </message>
+    <message>
+        <source>Invalid tool object (requires string &apos;name&apos; property)</source>
+        <translation>유효하지 않은 도구 오브젝트입니다(문자열 &apos;name&apos;속성을 필요로 합니다)</translation>
+    </message>
+    <message>
+        <source>Tileset needs to be an image collection</source>
+        <translation>타일셋이 이미지 모음이어야 합니다</translation>
+    </message>
+    <message>
+        <source>Invalid color name: &apos;%2&apos;</source>
+        <translation>유효하지 않은 색 이름 &apos;%2&apos;</translation>
+    </message>
+    <message>
+        <source>Unable to open file &apos;%1&apos;: %2</source>
+        <translation>파일을 열 수 없습니다 &apos;%1&apos;: %2</translation>
+    </message>
+    <message>
+        <source>Asset is read-only</source>
+        <translation>에셋이 읽기만 가능합니다</translation>
+    </message>
+    <message>
+        <source>Could not write to &apos;%1&apos;: %2</source>
+        <translation>쓸 수 없습니다 &apos;%1&apos;: %2</translation>
+    </message>
+    <message>
+        <source>Can&apos;t reload an embedded tileset</source>
+        <translation>숨겨진 타일셋을 다시 불러올 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Invalid return value for &apos;write&apos; (string or undefined expected)</source>
+        <translation>유효하지 않은 &apos;write&apos; 반환입니다(문자열 ㄸㅗ는 정의되지 않은 예상)</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set the image of an image collection tileset</source>
+        <translation>이미지 모음 타일셋의 이미지를 설정할 수 없습니다</translation>
+    </message>
+    <message>
+        <source>The standard output was:</source>
+        <translation>표준 출력:</translation>
+    </message>
+    <message>
+        <source>Invalid callback function</source>
+        <translation>유효하지 않은 callback 함수</translation>
+    </message>
+    <message>
+        <source>Not a tile</source>
+        <translation>타일이 아닙니다</translation>
+    </message>
+    <message>
+        <source>Can&apos;t set tile size on an image collection tileset</source>
+        <translation>이미지 모음 타일셋에서 타일 크기를 설정할 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Invalid tile ID</source>
+        <translation>유효하지 않은 타일 ID</translation>
+    </message>
+    <message>
+        <source>Can only remove tiles from an image collection tileset</source>
+        <translation>이미지 모음 타일셋에서 타일만 제거할 수 있습니다</translation>
+    </message>
+    <message>
+        <source>Invalid file format object (requires string &apos;name&apos; property)</source>
+        <translation>유효하지 않은 파일 형식(문자열 &apos;name&apos; 속성 필요)</translation>
+    </message>
+    <message>
+        <source>Array expected</source>
+        <translation>배열이 필요합니다</translation>
+    </message>
+    <message>
+        <source>TextFile constructor needs path of file to be opened.</source>
+        <translation>TextFile 생성자를 열려면 파일의 경로가 필요합니다.</translation>
+    </message>
+    <message>
+        <source>Invalid file format object (requires a &apos;write&apos; and/or &apos;read&apos; function property)</source>
+        <translation>유효하지 않은 파일 형식 오브젝트(&apos;ㅆㅡ기&apos;및/ㄸㅗ는 &apos;읽기&apos; 함수 속성 필요)</translation>
+    </message>
+    <message>
+        <source>BinaryFile constructor needs path of file to be opened.</source>
+        <translation>BinaryFile 생성자를 열려면 파일의 경로가 필요합니다.</translation>
+    </message>
+    <message>
+        <source>Editor not available</source>
+        <translation>편집기를 사용할 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Could not seek &apos;%1&apos;: %2</source>
+        <translation>찾을 수 없습니다 &apos;%1&apos;: %2</translation>
+    </message>
+    <message>
+        <source>Merge is currently not supported for detached maps</source>
+        <translation>분리된 맵에 대해서는 병합이 현재 지원되지 않습니다</translation>
+    </message>
+    <message>
+        <source>Invalid ID</source>
+        <translation>유효하지 않은 ID</translation>
+    </message>
+    <message>
+        <source>Not an open asset</source>
+        <translation>오픈 에셋이 아닙니다</translation>
+    </message>
+    <message>
+        <source>Undo system not available for this asset</source>
+        <translation>이 에셋에 사용할 수 없는 시스템 실행 취소</translation>
+    </message>
+    <message>
+        <source>Layer not from this map</source>
+        <translation>이 맵의 레이어가 아닙니다</translation>
+    </message>
+    <message>
+        <source>Layer is in use</source>
+        <translation>사용중인 레이어</translation>
+    </message>
+    <message>
+        <source>Reserved ID</source>
+        <translation>예약된 ID</translation>
+    </message>
+    <message>
+        <source>Layer already part of a map</source>
+        <translation>레이어가 이미 맵의 일부입니다</translation>
+    </message>
+    <message>
+        <source>Layer not found</source>
+        <translation>찾을 수 없는 레이어</translation>
+    </message>
+    <message>
+        <source>Unknown menu</source>
+        <translation>알 수 없는 메뉴</translation>
+    </message>
+    <message>
+        <source>Can only add tiles to an image collection tileset</source>
+        <translation>이미지 모음 타일셋에는 타일만 추가할 수 있습니다</translation>
+    </message>
+    <message>
+        <source>Tile not from the same tileset</source>
+        <translation>같은 타일셋에서 가져온 타일이 아닙니다</translation>
+    </message>
+    <message>
+        <source>Invalid size</source>
+        <translation>유효하지 않은 사이즈</translation>
+    </message>
+    <message>
+        <source>Error running &apos;%1&apos;: %2</source>
+        <translation>실행 오류 &apos;%1&apos;: %2</translation>
+    </message>
+    <message>
+        <source>Tile not from this tileset</source>
+        <translation>이 타일셋에서 가져온 타일이 아닙니다</translation>
+    </message>
+    <message>
+        <source>Index out of range</source>
+        <translation>범위를 벗어난 인덱스</translation>
+    </message>
+    <message>
+        <source>Unknown command</source>
+        <translation>알 수 없는 Command</translation>
+    </message>
+    <message>
+        <source>Error reading map</source>
+        <translation>맵 읽기 오류</translation>
+    </message>
+    <message>
+        <source>Invalid value (negative)</source>
+        <translation>유효하지 않은 값(negative)</translation>
+    </message>
+    <message>
+        <source>Access to BinaryFile object that was already closed.</source>
+        <translation>이미 닫힌 BinaryFile 오브젝트에 대한 접근입니다.</translation>
+    </message>
+    <message>
+        <source>Access to Process object that was already closed.</source>
+        <translation>이미 닫힌 프로세스 오브젝트에 대한 접근입니다.</translation>
+    </message>
+    <message>
+        <source>File format doesn&apos;t support `read`</source>
+        <translation>파일 형식이 &apos;read&apos;를 지원하지 않습니다</translation>
+    </message>
+    <message>
+        <source>Object not found</source>
+        <translation>오브젝트를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Unsupported encoding: %1</source>
+        <translation>지원되지 않는 인코딩: %1</translation>
+    </message>
+    <message>
+        <source>Object not from this asset</source>
+        <translation>이 에셋의 오브젝트가 아닙니다</translation>
+    </message>
+    <message>
+        <source>Separators can&apos;t have actions</source>
+        <translation>구분 기호는 동작을 가질 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Could not resize &apos;%1&apos;: %2</source>
+        <translation>다시 사이즈를 조정할 수 없습니다 &apos;%1&apos;: %2</translation>
+    </message>
+    <message>
+        <source>Wang ID must be an array of length 8</source>
+        <translation>Wang ID는 길이가 8이내여야 합니다</translation>
+    </message>
+    <message>
+        <source>Non-separator item without action</source>
+        <translation>동작이 없는 비구분자 항목</translation>
+    </message>
+</context>
+<context>
+    <name>ObjectTypes</name>
+    <message>
+        <source>File doesn&apos;t contain object types.</source>
+        <translation>파일이 오브젝트 타입을 포함하고 있지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Could not open file.</source>
+        <translation>파일을 열 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>%3
+
+Line %1, column %2</source>
+        <translation>%3
+
+%1 행 , %2 열</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>쓰기용으로 파일을 열 수 없습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TemplatesDock</name>
+    <message>
+        <source>%1: Couldn&apos;t find &quot;%2&quot;</source>
+        <translation>%1: 찾을 수 없습니다 &quot;%2&quot;</translation>
+    </message>
+    <message>
+        <source>Template Editor</source>
+        <translation>템플릿 편집기</translation>
+    </message>
+    <message>
+        <source>Error Reading Tileset</source>
+        <translation>타일셋 읽기 오류</translation>
+    </message>
+    <message>
+        <source>All Files (*)</source>
+        <translation>모든 파일 (*)</translation>
+    </message>
+    <message>
+        <source>Locate External Tileset</source>
+        <translation>외부 타일셋 위치 찾기</translation>
+    </message>
+    <message>
+        <source>Locate Tileset</source>
+        <translation>타일셋 위치 찾기</translation>
+    </message>
+    <message>
+        <source>Open Tileset</source>
+        <translation>타일셋 열기</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::LocatorWidget</name>
+    <message>
+        <source>Filename</source>
+        <translation>파일명</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TilesetDock</name>
+    <message>
+        <source>Tilesets</source>
+        <translation>타일셋</translation>
+    </message>
+    <message>
+        <source>Remove this tileset and all references to the tiles in this tileset?</source>
+        <translation>이 타일셋과 참조된 모든 타일을 삭제하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>The tileset &quot;%1&quot; is still in use by the map!</source>
+        <translation>타일셋 &quot;%1&quot; 은 아직 맵에서 사용되고 있습니다!</translation>
+    </message>
+    <message>
+        <source>&amp;Export Tileset As...</source>
+        <translation>타일셋 내보내기(&amp;E)...</translation>
+    </message>
+    <message>
+        <source>Error saving tileset: %1</source>
+        <translation>타일셋 저장하는 중 오류 발생: %1</translation>
+    </message>
+    <message>
+        <source>Error Reading Tileset</source>
+        <translation>타일셋 읽기 오류</translation>
+    </message>
+    <message>
+        <source>Select Next Tileset</source>
+        <translation>다음 타일셋 선택</translation>
+    </message>
+    <message>
+        <source>Export Tileset</source>
+        <translation>타일셋 내보내기</translation>
+    </message>
+    <message>
+        <source>Edit Tile&amp;set</source>
+        <translation>타일셋 편집(S)(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Remove Tileset</source>
+        <translation>타일셋 삭제</translation>
+    </message>
+    <message>
+        <source>&amp;Remove Tileset</source>
+        <translation>타일셋 삭제(&amp;R)</translation>
+    </message>
+    <message>
+        <source>&amp;Embed Tileset</source>
+        <translation>타일셋 내장(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Dynamically Wrap Tiles</source>
+        <translation>타일을 동적으로 넘기기</translation>
+    </message>
+    <message>
+        <source>New Tileset</source>
+        <translation>새 타일셋</translation>
+    </message>
+    <message>
+        <source>All Files (*)</source>
+        <translation>모든 파일 (*)</translation>
+    </message>
+    <message>
+        <source>Select Previous Tileset</source>
+        <translation>이전 타일셋 선택</translation>
+    </message>
+    <message>
+        <source>Replace Tileset</source>
+        <translation>타일셋 교체</translation>
+    </message>
+</context>
+<context>
+    <name>File Types</name>
+    <message>
+        <source>Automapping Rules files (*.txt)</source>
+        <translation>오토매핑 규칙 파일 (*.txt)</translation>
+    </message>
+    <message>
+        <source>Object Types files (*.xml *.json)</source>
+        <translation>오브젝트 타입 파일 (*.xml *.json)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::NewVersionDialog</name>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Tiled 1.2.5&lt;/span&gt; is available!&lt;br/&gt;&lt;br/&gt;Current version is Tiled 1.2.3.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Tiled 1.2.5&lt;/span&gt; 사용 가능합니다!&lt;br/&gt;&lt;br/&gt;Tiled의 현재 버전은 1.2.3.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;&lt;b&gt;%1 %2&lt;/b&gt; is available!&lt;br/&gt;&lt;br/&gt;Current version is %1 %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;b&gt;%1 %2&lt;/b&gt; 사용 가능합니다!&lt;br/&gt;&lt;br/&gt;현재 버전은 %1 %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Download ↗</source>
+        <translation>다운로드 ↗</translation>
+    </message>
+    <message>
+        <source>Release Notes ↗</source>
+        <translation>릴리스 노트 ↗</translation>
+    </message>
+    <message>
+        <source>Update Available</source>
+        <translation>업데이트 가능</translation>
+    </message>
+</context>
+<context>
+    <name>QtSizePolicyPropertyManager</name>
+    <message>
+        <source>Vertical Stretch</source>
+        <translation>수직 늘이기</translation>
+    </message>
+    <message>
+        <source>Horizontal Policy</source>
+        <translation>수평 정책</translation>
+    </message>
+    <message>
+        <source>&lt;Invalid&gt;</source>
+        <translation>&lt;무효&gt;</translation>
+    </message>
+    <message>
+        <source>[%1, %2, %3, %4]</source>
+        <translation>[%1, %2, %3, %4]</translation>
+    </message>
+    <message>
+        <source>Horizontal Stretch</source>
+        <translation>수평 늘이기</translation>
+    </message>
+    <message>
+        <source>Vertical Policy</source>
+        <translation>수직 정책</translation>
+    </message>
+</context>
+<context>
+    <name>CommandsEdit</name>
+    <message>
+        <source>Clear</source>
+        <translation>지우기</translation>
+    </message>
+    <message>
+        <source>&amp;Save before executing</source>
+        <translation>실행하기전에 저장 (&amp;S)</translation>
+    </message>
+    <message>
+        <source>Shortcut:</source>
+        <translation>단축키:</translation>
+    </message>
+    <message>
+        <source>Browse...</source>
+        <translation>찾아보기...</translation>
+    </message>
+    <message>
+        <source>Show output in Console view</source>
+        <translation>콘솔 창을 보여줍니다</translation>
+    </message>
+    <message>
+        <source>Working Directory:</source>
+        <translation>작업 디렉토리:</translation>
+    </message>
+    <message>
+        <source>Arguments:</source>
+        <translation>인수:</translation>
+    </message>
+    <message>
+        <source>Executable:</source>
+        <translation>실행 파일:</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::IssuesDock</name>
+    <message>
+        <source>Clear</source>
+        <translation>지우기</translation>
+    </message>
+    <message>
+        <source>Show warnings</source>
+        <translation>경고 표시</translation>
+    </message>
+    <message>
+        <source>Filter</source>
+        <translation>필터</translation>
+    </message>
+    <message>
+        <source>Issues</source>
+        <translation>이슈</translation>
+    </message>
+</context>
+<context>
+    <name>CommandDialog</name>
+    <message>
+        <source>Close</source>
+        <translation>닫기</translation>
+    </message>
+    <message>
+        <source>Edit Commands</source>
+        <translation>Command 수정</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::DocumentManager</name>
+    <message>
+        <source>Close</source>
+        <translation>닫기</translation>
+    </message>
+    <message>
+        <source>Tileset Columns Changed</source>
+        <translation>타일셋 열이 변경됨</translation>
+    </message>
+    <message>
+        <source>Close Other Tabs</source>
+        <translation>다른 탭 닫기</translation>
+    </message>
+    <message>
+        <source>Close Tabs to the Right</source>
+        <translation>오른쪽 탭 닫기</translation>
+    </message>
+    <message>
+        <source>%1:
+
+%2</source>
+        <translation>%1:
+
+%2</translation>
+    </message>
+    <message>
+        <source>The number of tile columns in the tileset &apos;%1&apos; appears to have changed from %2 to %3. Do you want to adjust tile references?</source>
+        <translation>&apos;%1&apos; 타일셋 열의 수가 &apos;%2&apos; 에서 &apos;%3&apos; 으로 변경되었습니다. 타일에 대한 참조를 조정하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>Save File As</source>
+        <translation>다름 이름으로 저장</translation>
+    </message>
+    <message>
+        <source>Unrecognized file format.</source>
+        <translation>인식할 수 없는 파일 형식.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::MiniMapDock</name>
+    <message>
+        <source>Mini-map</source>
+        <translation>미니맵</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ProjectPropertiesDialog</name>
+    <message>
+        <source>Files</source>
+        <translation>파일</translation>
+    </message>
+    <message>
+        <source>Object types</source>
+        <translation>오브젝트 타입</translation>
+    </message>
+    <message>
+        <source>Directory</source>
+        <translation>디렉토리</translation>
+    </message>
+    <message>
+        <source>Automapping rules</source>
+        <translation>오토맵 규칙</translation>
+    </message>
+    <message>
+        <source>Extensions</source>
+        <translation>확장</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ExportAsImageDialog</name>
+    <message>
+        <source>Image</source>
+        <translation>이미지</translation>
+    </message>
+    <message>
+        <source>Export as Image</source>
+        <translation>이미지로 내보내기</translation>
+    </message>
+    <message>
+        <source>Out of Memory</source>
+        <translation>메모리 부족</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>내보내기</translation>
+    </message>
+    <message>
+        <source>The resulting image would be %1 x %2 pixels and take %3 GB of memory. Tiled is unable to create such an image. Try reducing the zoom level.</source>
+        <translation>생성된 이미지는 %1 x %2 픽셀이며, %3 GB의 메모리를 사용합니다. Tiled가 이미지를 생성할 수 없습니다. 확대 레벨을 낮춰보세요.</translation>
+    </message>
+    <message>
+        <source>Image too Big</source>
+        <translation>이미지가 너무 큽니다</translation>
+    </message>
+    <message>
+        <source>Could not allocate sufficient memory for the image. Try reducing the zoom level or using a 64-bit version of Tiled.</source>
+        <translation>이미지에 충분한 메모리를 할당할 수 없습니다. 줌 레벨을 낮추거나 64비트 버전의 Tiled를 써보십시오.</translation>
+    </message>
+    <message>
+        <source>%1 already exists.
+Do you want to replace it?</source>
+        <translation>%1 는 이미 존재합니다.
+덮어쓰시겠습니까?</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::EditPolygonTool</name>
+    <message>
+        <source>Join Nodes</source>
+        <translation>노드 병합</translation>
+    </message>
+    <message>
+        <source>Extend Polyline</source>
+        <translation>폴리선 확장</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n Point(s)</source>
+        <translation>
+            <numerusform>%n 포인트 이동</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Split Segment</source>
+        <translation>선 분할</translation>
+    </message>
+    <message>
+        <source>Delete Segment</source>
+        <translation>분할 삭제</translation>
+    </message>
+    <message>
+        <source>Split Segments</source>
+        <translation>선을 분할</translation>
+    </message>
+    <message numerus="yes">
+        <source>Delete %n Node(s)</source>
+        <translation>
+            <numerusform>%n 노드 삭제</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Edit Polygons</source>
+        <translation>다각형 편집</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::LayerModel</name>
+    <message>
+        <source>Layer</source>
+        <translation>레이어</translation>
+    </message>
+    <message>
+        <source>Hide Other Layers</source>
+        <translation>다른 레이어 표시 안함</translation>
+    </message>
+    <message>
+        <source>Lock Other Layers</source>
+        <translation>다른 레이어 잠금</translation>
+    </message>
+    <message>
+        <source>Show Other Layers</source>
+        <translation>다른 레이어 표시</translation>
+    </message>
+    <message>
+        <source>Drag Layer(s)</source>
+        <translation>%n 레이어 드래그</translation>
+    </message>
+    <message>
+        <source>Locked</source>
+        <translation>잠금</translation>
+    </message>
+    <message>
+        <source>Hide Layers</source>
+        <translation>레이어 표시 안함</translation>
+    </message>
+    <message>
+        <source>Show Layers</source>
+        <translation>레이어 표시</translation>
+    </message>
+    <message>
+        <source>Lock Layers</source>
+        <translation>레이어 잠금</translation>
+    </message>
+    <message>
+        <source>Unlock Layers</source>
+        <translation>레이어 잠금 해제</translation>
+    </message>
+    <message>
+        <source>Visible</source>
+        <translation>표시됨</translation>
+    </message>
+    <message>
+        <source>Unlock Other Layers</source>
+        <translation>다른 레이어 잠금 해제</translation>
+    </message>
+</context>
+<context>
+    <name>ExportAsImageDialog</name>
+    <message>
+        <source>Name:</source>
+        <translation>이름:</translation>
+    </message>
+    <message>
+        <source>Export As Image</source>
+        <translation>이미지로 내보내기</translation>
+    </message>
+    <message>
+        <source>Draw object &amp;names</source>
+        <translation>객체 그리기 (&amp;N)</translation>
+    </message>
+    <message>
+        <source>Use current &amp;zoom level</source>
+        <translation>현재 보이는 크기로(&amp;Z)</translation>
+    </message>
+    <message>
+        <source>Location</source>
+        <translation>위치</translation>
+    </message>
+    <message>
+        <source>&amp;Browse...</source>
+        <translation>찾아보기(&amp;B)...</translation>
+    </message>
+    <message>
+        <source>&amp;Include background color</source>
+        <translation>배경색 포함(&amp;I)</translation>
+    </message>
+    <message>
+        <source>Only include &amp;visible layers</source>
+        <translation>표시된 레이어만 포함(&amp;V)</translation>
+    </message>
+    <message>
+        <source>&amp;Draw tile grid</source>
+        <translation>타일 격자 그리기(&amp;D)</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>설정</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ObjectTypesEditor</name>
+    <message>
+        <source>Name:</source>
+        <translation>이름:</translation>
+    </message>
+    <message>
+        <source>Error Writing Object Types</source>
+        <translation>오브젝트 타입 쓰는중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Error Reading Object Types</source>
+        <translation>오브젝트 타입을 읽어오는 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Import Object Types</source>
+        <translation>오브젝트 타입 가져오기</translation>
+    </message>
+    <message>
+        <source>Remove Object Type</source>
+        <translation>오브젝트 타입 삭제</translation>
+    </message>
+    <message>
+        <source>Add Object Type</source>
+        <translation>오브젝트 타입 추가</translation>
+    </message>
+    <message>
+        <source>Remove Property</source>
+        <translation>속성 삭제</translation>
+    </message>
+    <message>
+        <source>Add Property</source>
+        <translation>속성 추가</translation>
+    </message>
+    <message>
+        <source>Rename Property</source>
+        <translation>속성 이름 변경</translation>
+    </message>
+    <message>
+        <source>Error writing to %1:
+%2</source>
+        <translation>%1 에 쓰기 실패:
+%2</translation>
+    </message>
+    <message>
+        <source>Export Object Types</source>
+        <translation>오브젝트 타입 내보내기</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ResetWidget</name>
+    <message>
+        <source>Reset</source>
+        <translation>초기화</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TileStampModel</name>
+    <message>
+        <source>Stamp</source>
+        <translation>스탬프</translation>
+    </message>
+    <message>
+        <source>Probability</source>
+        <translation>확률</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::MapEditor</name>
+    <message>
+        <source>Tools</source>
+        <translation>도구</translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n Tileset(s)</source>
+        <translation>
+            <numerusform>%n개 타일셋 추가</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1: %2</source>
+        <translation>%1: %2</translation>
+    </message>
+    <message>
+        <source>Tool Options</source>
+        <translation>도구 옵션</translation>
+    </message>
+    <message>
+        <source>Error Reading Tileset</source>
+        <translation>타일셋 읽기 오류</translation>
+    </message>
+    <message>
+        <source>Unrecognized tileset format.</source>
+        <translation>인식할 수 없는 파일 형식.</translation>
+    </message>
+    <message>
+        <source>Paste in Place</source>
+        <translation>같은 위치에 붙여넣기</translation>
+    </message>
+</context>
+<context>
+    <name>QtTreePropertyBrowser</name>
+    <message>
+        <source>Value</source>
+        <translation>값</translation>
+    </message>
+    <message>
+        <source>Property</source>
+        <translation>속성</translation>
+    </message>
+</context>
+<context>
+    <name>QtSizeFPropertyManager</name>
+    <message>
+        <source>Width</source>
+        <translation>너비</translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation>높이</translation>
+    </message>
+    <message>
+        <source>%1 x %2</source>
+        <translation>%1 x %2</translation>
+    </message>
+</context>
+<context>
+    <name>QtSizePropertyManager</name>
+    <message>
+        <source>Width</source>
+        <translation>너비</translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation>높이</translation>
+    </message>
+    <message>
+        <source>%1 x %2</source>
+        <translation>%1 x %2</translation>
+    </message>
+</context>
+<context>
+    <name>TextEditorDialog</name>
+    <message>
+        <source>Edit Text</source>
+        <translation>텍스트 수정</translation>
+    </message>
+    <message>
+        <source>Monospace</source>
+        <translation>모노스페이스</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::WorldManager</name>
+    <message>
+        <source>World: Invalid mapHeight: %1</source>
+        <translation>월드 유효하지 않은 맵높이: %1</translation>
+    </message>
+    <message>
+        <source>World: Invalid mapWidth: %1</source>
+        <translation>월드: 유효하지 않은 맵너비: %1</translation>
+    </message>
+    <message>
+        <source>World: Invalid multiplierY: %1</source>
+        <translation>월드 유효하지 않은 multiplierY: %1</translation>
+    </message>
+    <message>
+        <source>World: Invalid multiplierX: %1</source>
+        <translation>월드: 유효하지않은 multiplierX: %1</translation>
+    </message>
+    <message>
+        <source>World doesn&apos;t support saving</source>
+        <translation>월드가 저장을 지원하지 않습니다</translation>
+    </message>
+    <message>
+        <source>JSON parse error at offset %1:
+%2.</source>
+        <translation>오프셋의 JSON 구문 오류 %1:
+%2.</translation>
+    </message>
+    <message>
+        <source>World contained no valid maps or patterns: %1</source>
+        <translation>월드에 올바른 맵 ㄸㅗ는 패턴이 없습니다: %1</translation>
+    </message>
+    <message>
+        <source>World: Invalid number of captures in &apos;%1&apos;, 2 captures expected</source>
+        <translation>월드: %1의 유효하지 않은 사진, 2 사진들이 예상됩니다</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>읽기용으로 파일을 열 수 없습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>ReplicaIsland::ReplicaIslandPlugin</name>
+    <message>
+        <source>Inconsistent layer sizes!</source>
+        <translation>레이어 크기가 동일하지 않습니다!</translation>
+    </message>
+    <message>
+        <source>Unexpected data at end of file!</source>
+        <translation>파일 끝에 예상치 못한 데이터가 있습니다!</translation>
+    </message>
+    <message>
+        <source>You must define a tile_index property on each layer!</source>
+        <translation>모든 레이어에 type_index 속성을 정의해야 합니다!</translation>
+    </message>
+    <message>
+        <source>Can&apos;t parse layer header!</source>
+        <translation>레이어 헤더를 파싱할 수 없습니다!</translation>
+    </message>
+    <message>
+        <source>You must define a background_index property on the map!</source>
+        <translation>모든 맵에 background_index 속성을 정의해야 합니다!</translation>
+    </message>
+    <message>
+        <source>You must define a type property on each layer!</source>
+        <translation>모든 레이어에 type 속성을 정의해야 합니다!</translation>
+    </message>
+    <message>
+        <source>Can&apos;t save non-tile layer!</source>
+        <translation>타일 레이어가 아닌 것은 저장할 수 없습니다!</translation>
+    </message>
+    <message>
+        <source>Replica Island map files (*.bin)</source>
+        <translation>Replica Island 맵 파일 (*.bin)</translation>
+    </message>
+    <message>
+        <source>Cannot open Replica Island map file!</source>
+        <translation>Replica Island 맵 파일을 열 수 없습니다!</translation>
+    </message>
+    <message>
+        <source>Can&apos;t parse file header!</source>
+        <translation>파일 헤더를 파싱할 수 없습니다!</translation>
+    </message>
+    <message>
+        <source>You must define a scroll_speed property on each layer!</source>
+        <translation>모든 레이어에 scroll_speed 속성을 정의해야 합니다!</translation>
+    </message>
+    <message>
+        <source>File ended in middle of layer!</source>
+        <translation>레이어 중간에서 파일이 끝났습니다!</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ScriptManager</name>
+    <message>
+        <source>Stack traceback:</source>
+        <translation>스택 추적:</translation>
+    </message>
+    <message>
+        <source>Extensions paths changed: %1</source>
+        <translation>확장 경로 변경: %1</translation>
+    </message>
+    <message>
+        <source>Error decoding file: %1</source>
+        <translation>파일 디코딩 오류: %1</translation>
+    </message>
+    <message>
+        <source>Resetting script engine</source>
+        <translation>스크립트 엔진 재설정</translation>
+    </message>
+    <message>
+        <source>At line %1: %2</source>
+        <translation>%1 라인에서: %2</translation>
+    </message>
+    <message>
+        <source>Script files changed: %1</source>
+        <translation>스크립트 파일 변형: %1</translation>
+    </message>
+    <message>
+        <source>Evaluating &apos;%1&apos;</source>
+        <translation>평가 중 &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Error opening file: %1</source>
+        <translation>파일 열기 오류: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::AbstractTileTool</name>
+    <message>
+        <source>empty</source>
+        <translation>비어있음</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TileStampsDock</name>
+    <message>
+        <source>Duplicate Stamp</source>
+        <translation>스탬프 복제</translation>
+    </message>
+    <message>
+        <source>Delete Stamp</source>
+        <translation>스탬프 삭제</translation>
+    </message>
+    <message>
+        <source>Filter</source>
+        <translation>필터</translation>
+    </message>
+    <message>
+        <source>Tile Stamps</source>
+        <translation>타일 스탬프</translation>
+    </message>
+    <message>
+        <source>Delete Selected</source>
+        <translation>선택 사항 제거</translation>
+    </message>
+    <message>
+        <source>Choose the Stamps Folder</source>
+        <translation>스탬프 폴더 선택</translation>
+    </message>
+    <message>
+        <source>Remove Variation</source>
+        <translation>변동 사항 삭제</translation>
+    </message>
+    <message>
+        <source>Set Stamps Folder</source>
+        <translation>스탬프 폴더 설정</translation>
+    </message>
+    <message>
+        <source>Add New Stamp</source>
+        <translation>새로운 스탬프 추가</translation>
+    </message>
+    <message>
+        <source>Add Variation</source>
+        <translation>변동 사항 추가</translation>
+    </message>
+</context>
+<context>
+    <name>CommandLineHandler</name>
+    <message>
+        <source>Map export formats:</source>
+        <translation>맵 내보내기 형식:</translation>
+    </message>
+    <message>
+        <source>Export the specified tileset file to target</source>
+        <translation>지정된 타일셋 파일을 대상으로 내보내기</translation>
+    </message>
+    <message>
+        <source>Export the map or tileset with template instances detached</source>
+        <translation>템플릿 인스턴스가 분리된 타일셋 또는 맵 내보내기</translation>
+    </message>
+    <message>
+        <source>Export the map with tilesets embedded</source>
+        <translation>타일셋 파일이 포함된 내보내기</translation>
+    </message>
+    <message>
+        <source>Only check validity of arguments</source>
+        <translation>인수의 유효함만 확인</translation>
+    </message>
+    <message>
+        <source>Export the map or tileset with types and properties resolved</source>
+        <translation>유형 및 속성이 확인된 타일셋 또는 맵 내보내기</translation>
+    </message>
+    <message>
+        <source>Tileset export formats:</source>
+        <translation>타일셋 내보내기 형식:</translation>
+    </message>
+    <message>
+        <source>Disable hardware accelerated rendering</source>
+        <translation>하드웨어 가속 렌더링 사용하지 않음</translation>
+    </message>
+    <message>
+        <source>Start a new instance, even if an instance is already running</source>
+        <translation>인스턴스가 이미 실행중인 경우에도 새 인스턴스 시작</translation>
+    </message>
+    <message>
+        <source>Print a list of supported export formats</source>
+        <translation>지원되는 내보내기 형식 목록 출력</translation>
+    </message>
+    <message>
+        <source>Minimize the exported file by omitting unnecessary whitespace</source>
+        <translation>불필요한 공백을 생략하여 내보낸 파일 최소화</translation>
+    </message>
+    <message>
+        <source>Display the version</source>
+        <translation>버전 표시</translation>
+    </message>
+    <message>
+        <source>Export the specified map file to target</source>
+        <translation>지정된 지도 파일을 대상으로 내보내기</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ProjectView</name>
+    <message>
+        <source>&amp;Remove Folder from Project</source>
+        <translation>프로젝트의 폴더 삭제(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Select Template Instances</source>
+        <translation>템플릿 인스턴스 선택</translation>
+    </message>
+</context>
+<context>
+    <name>Flare::FlarePlugin</name>
+    <message>
+        <source>Error mapping tile id %1.</source>
+        <translation>타일 ID %1을 매핑하는 중 오류가 발생했습니다.</translation>
+    </message>
+    <message>
+        <source>Flare map files (*.txt)</source>
+        <translation>Flare 맵 파일 (*.txt)</translation>
+    </message>
+    <message>
+        <source>This seems to be no valid flare map. A Flare map consists of at least a header section, a tileset section and one tile layer.</source>
+        <translation>유효한 Flare 맵이 아닌 것 같습니다. Flare 맵은 적어도 하나 이상의 헤더 영역, 타일셋 영역 선택, 하나의 타일 레이어로 구성됩니다.</translation>
+    </message>
+    <message>
+        <source>Error loading tileset %1, which expands to %2. Path not found!</source>
+        <translation>%2로 확장되는 타일셋 %1을 불러오는 중 오류가 발생했습니다. 경로를 찾을 수 없습니다!</translation>
+    </message>
+    <message>
+        <source>No tilesets section found before layer section.</source>
+        <translation>레이어 영역 선택 전에 타일셋 영역을 선택하지 않았습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::DonationDialog</name>
+    <message>
+        <source>Remind me next week</source>
+        <translation>다음 주에 다시 알려주세요</translation>
+    </message>
+    <message>
+        <source>Don&apos;t remind me</source>
+        <translation>다시 알려주지 마세요</translation>
+    </message>
+    <message>
+        <source>Remind me next month</source>
+        <translation>다음 달에 다시 알려주세요</translation>
+    </message>
+    <message>
+        <source>Thanks!</source>
+        <translation>감사합니다!</translation>
+    </message>
+    <message>
+        <source>Thanks a lot for your support! With your help Tiled will keep getting better.</source>
+        <translation>지원에 매우 감사드립니다! 당신의 도움으로 Tiled 는 계속 나아질 것입니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CommandManager</name>
+    <message>
+        <source>Open in text editor</source>
+        <translation>텍스트 편집기에서 열기</translation>
+    </message>
+    <message>
+        <source>Edit Commands...</source>
+        <translation>Command 수정...</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::AbstractTileSelectionTool</name>
+    <message>
+        <source>Subtract Selection</source>
+        <translation>선택 영역 ㅃㅐ기</translation>
+    </message>
+    <message>
+        <source>Add Selection</source>
+        <translation>선택 영역 추가</translation>
+    </message>
+    <message>
+        <source>Replace Selection</source>
+        <translation>선택 영역 대체</translation>
+    </message>
+    <message>
+        <source>Intersect Selection</source>
+        <translation>선택 영역 교차</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CommandProcess</name>
+    <message>
+        <source>Unable to add executable permissions to %1</source>
+        <translation>%1 에 실행 권한을 추가할 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Executing: %1</source>
+        <translation>실행 중: %1</translation>
+    </message>
+    <message>
+        <source>An unknown error occurred.</source>
+        <translation>알 수 없는 오류가 발생하였습니다.</translation>
+    </message>
+    <message>
+        <source>The command crashed.</source>
+        <translation>Command가 충돌하였습니다.</translation>
+    </message>
+    <message>
+        <source>The command failed to start.</source>
+        <translation>Command를 시작하지 못했습니다.</translation>
+    </message>
+    <message>
+        <source>The command timed out.</source>
+        <translation>Command가 시간 초과 되었습니다.</translation>
+    </message>
+    <message>
+        <source>Error Executing %1</source>
+        <translation>%1 실행중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Unable to create/open %1</source>
+        <translation>%1 을 생성하거나 열 수 없습니다</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::PreferencesDialog</name>
+    <message>
+        <source>Select From Any Layer</source>
+        <translation>모든 레이어에서 선택</translation>
+    </message>
+    <message>
+        <source>Selected Layers Only</source>
+        <translation>오직 선택한 레이어만</translation>
+    </message>
+    <message>
+        <source>System default</source>
+        <translation>시스템 기본 설정</translation>
+    </message>
+    <message>
+        <source>Prefer Selected Layers</source>
+        <translation>선택한 레이어 선호</translation>
+    </message>
+</context>
+<context>
+    <name>CommandLineParser</name>
+    <message>
+        <source>Unknown short argument %1.%2: %3</source>
+        <translation>알 수 없는 짧은 인수 %1.%2: %3</translation>
+    </message>
+    <message>
+        <source>Display this help</source>
+        <translation>이 도움말 표시</translation>
+    </message>
+    <message>
+        <source>Usage:
+  %1 [options] [files...]</source>
+        <translation>사용법:
+  %1 [옵션] [파일...]</translation>
+    </message>
+    <message>
+        <source>Options:</source>
+        <translation>옵션:</translation>
+    </message>
+    <message>
+        <source>Unknown long argument %1: %2</source>
+        <translation>알 수 없는 긴 인수 %1: %2</translation>
+    </message>
+    <message>
+        <source>Bad argument %1: lonely hyphen</source>
+        <translation>잘못된 인수 %1: 하이픈(&apos;-&apos;)만 존재</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::AbstractObjectTool</name>
+    <message numerus="yes">
+        <source>Duplicate %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 복제</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Replace With Template</source>
+        <translation>템플릿으로 대체</translation>
+    </message>
+    <message>
+        <source>Lower Object</source>
+        <translation>오브젝트 내리기</translation>
+    </message>
+    <message>
+        <source>Raise Object</source>
+        <translation>오브젝트 올리기</translation>
+    </message>
+    <message>
+        <source>Flip Horizontally</source>
+        <translation>가로로 뒤집기</translation>
+    </message>
+    <message>
+        <source>Lower Object to Bottom</source>
+        <translation>오브젝트 맨 아래로 내리기</translation>
+    </message>
+    <message>
+        <source>Replace Existing Objects</source>
+        <translation>존재하는 오브젝트 대체</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n Object(s) to Layer</source>
+        <translation>
+            <numerusform>%n 오브젝트(s)를 레이어로 이동</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Detach</source>
+        <translation>분리</translation>
+    </message>
+    <message>
+        <source>Add Objects</source>
+        <translation>오브젝트 추가</translation>
+    </message>
+    <message>
+        <source>Apply Collision Shapes</source>
+        <translation>충돌 모양 적용</translation>
+    </message>
+    <message>
+        <source>Can&apos;t create template with embedded tileset</source>
+        <translation>포함된 타일셋을 사용하여 템플릿을 작성할 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Replace With Template &quot;%1&quot;</source>
+        <translation>&quot;%1&quot; 템플릿으로 대체</translation>
+    </message>
+    <message>
+        <source>Reset Template Instance(s)</source>
+        <translation>템플릿 인스턴스 리셋</translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 삭제</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Raise Object to Top</source>
+        <translation>오브젝트 맨 위로 올리기</translation>
+    </message>
+    <message>
+        <source>Flip Vertically</source>
+        <translation>세로로 뒤집기</translation>
+    </message>
+    <message>
+        <source>Reset Tile Size</source>
+        <translation>타일 크기 리셋</translation>
+    </message>
+    <message>
+        <source>Convert to Polygon</source>
+        <translation>다각현으로 변환</translation>
+    </message>
+    <message>
+        <source>Apply Collision(s) to Selected Tiles</source>
+        <translation>선택한 타일에 충돌(s) 적용</translation>
+    </message>
+    <message>
+        <source>Replace Tile</source>
+        <translation>타일 대체</translation>
+    </message>
+    <message>
+        <source>Save As Template</source>
+        <translation>템플릿으로 저장</translation>
+    </message>
+    <message>
+        <source>Object &amp;Properties...</source>
+        <translation>오브젝트 속성(&amp;P)...</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CommandsEdit</name>
+    <message>
+        <source>Select Executable</source>
+        <translation>실행 파일 선택</translation>
+    </message>
+    <message>
+        <source>Select Working Directory</source>
+        <translation>작업 중인 디렉토리 선택</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ObjectRefEdit</name>
+    <message>
+        <source>Select Object on Map</source>
+        <translation>맵의 오브젝트 선택</translation>
+    </message>
+    <message>
+        <source>Search Object</source>
+        <translation>오브젝트 검색</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::AutoMapper</name>
+    <message>
+        <source>No input_&lt;name&gt; layer found!</source>
+        <translation>input_&lt;name&gt; 레이어가 발견되지 않았습니다!</translation>
+    </message>
+    <message>
+        <source>Ignoring unknown property &apos;%2&apos; = &apos;%3&apos; on layer &apos;%4&apos; (rule map &apos;%1&apos;)</source>
+        <translation>&apos;%4&apos;레이어에서 알 수 없는 속성 &apos;%2&apos; = &apos;%3&apos; 을 무시합니다 (규칙 맵 &apos;%1&apos;)</translation>
+    </message>
+    <message>
+        <source>&apos;regions_input&apos; layer must not occur more than once.</source>
+        <translation>&apos;regions_input&apos; 레이어는 둘 이상 존재할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>Layer &apos;%1&apos; is not recognized as a valid layer for Automapping.</source>
+        <translation>&apos;%1&apos; 레이어는 유효한 오토맵 레이어로 인식되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Did you forget an underscore in layer &apos;%1&apos;?</source>
+        <translation>레이어 &apos;%1&apos;의 밑줄 표시를 잊으셨습니까?</translation>
+    </message>
+    <message>
+        <source>Ignoring unknown property &apos;%2&apos; = &apos;%3&apos; (rule map &apos;%1&apos;)</source>
+        <translation>알 수 없는 속성 &apos;%2&apos; = &apos;%3&apos; 을 무시합니다 (규칙 맵 &apos;%1&apos;)</translation>
+    </message>
+    <message>
+        <source>&apos;input_*&apos; and &apos;inputnot_*&apos; layers must be tile layers.</source>
+        <translation>&apos;input_*&apos; 와 &apos;inputnot_*&apos; 레이어는 타일 레이어여야 합니다.</translation>
+    </message>
+    <message>
+        <source>No &apos;regions&apos; or &apos;regions_output&apos; layer found.</source>
+        <translation>&apos;regions&apos; 또는 &apos;regions_output&apos; 레이어가 발견되지 않았습니다.</translation>
+    </message>
+    <message>
+        <source>&apos;regions_output&apos; layer must not occur more than once.</source>
+        <translation>&apos;regions_output&apos; 레이어는 둘 이상 존재할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>No output_&lt;name&gt; layer found!</source>
+        <translation>output_ &lt;name&gt; 레이어가 발견되지 않았습니다!</translation>
+    </message>
+    <message>
+        <source>&apos;regions_*&apos; layers must be tile layers.</source>
+        <translation>&apos;regions_*&apos; 레이어는 타일 레이어여야 합니다.</translation>
+    </message>
+    <message>
+        <source>No &apos;regions&apos; or &apos;regions_input&apos; layer found.</source>
+        <translation>&apos;regions&apos; 또는 &apos;regions_input&apos; 레이어가 발견되지 않았습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CreateTextObjectTool</name>
+    <message>
+        <source>Hello World</source>
+        <translation>Hello World</translation>
+    </message>
+    <message>
+        <source>Insert Text</source>
+        <translation>텍스트 삽입</translation>
+    </message>
+</context>
+<context>
+    <name>Python::PythonMapFormat</name>
+    <message>
+        <source>Script returned false. Please check console.</source>
+        <translation>스크립트가 false를 반환하였습니다. 콘솔을 확인하여 주십시오.</translation>
+    </message>
+    <message>
+        <source>Uncaught exception in script. Please check console.</source>
+        <translation>스크립트에 캐치되지 않은 예외가 있습니다. 콘솔을 확인하여 주십시오.</translation>
+    </message>
+    <message>
+        <source>-- Using script %1 to read %2</source>
+        <translation>-- %2를 읽기 위해 스크립트 %1을 사용합니다</translation>
+    </message>
+    <message>
+        <source>-- Using script %1 to write %2</source>
+        <translation>-- %2를 쓰기 위해 스크립트 %1을 사용합니다</translation>
+    </message>
+</context>
+<context>
+    <name>TbinMapFormat</name>
+    <message>
+        <source>Failed to open file</source>
+        <translation>파일 열기에 실패했습니다</translation>
+    </message>
+    <message>
+        <source>File is not a tbin file.</source>
+        <translation>파일이 tbin 파일이 아닙니다.</translation>
+    </message>
+    <message>
+        <source>Failed to open file.</source>
+        <translation>파일 열기에 실패했습니다.</translation>
+    </message>
+    <message>
+        <source>Bad layer tile data</source>
+        <translation>적합하지 레이어 타일 데이터</translation>
+    </message>
+    <message>
+        <source>Unsupported property type</source>
+        <translation>지원되지 않는 속성 유형</translation>
+    </message>
+    <message>
+        <source>Bad property type</source>
+        <translation>적합하지 않은 속성 유형</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TilesetView</name>
+    <message>
+        <source>Use as Terrain Set Image</source>
+        <translation>지형 셋 이미지 사용</translation>
+    </message>
+    <message>
+        <source>&amp;Swap Tiles</source>
+        <translation>타일 바꾸기(S)(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Use as Terrain Image</source>
+        <translation>지형 이미지 사용</translation>
+    </message>
+    <message>
+        <source>Tile &amp;Properties...</source>
+        <translation>타일 속성(P)(&amp;P)...</translation>
+    </message>
+    <message>
+        <source>Show &amp;Grid</source>
+        <translation>격자 표시(&amp;G)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::WangDock</name>
+    <message>
+        <source>Add Terrain Set</source>
+        <translation>지형 셋 추가</translation>
+    </message>
+    <message>
+        <source>Remove Terrain Set</source>
+        <translation>지형 셋 삭제</translation>
+    </message>
+    <message>
+        <source>Erase Terrain</source>
+        <translation>지형 지우기</translation>
+    </message>
+    <message>
+        <source>Remove Terrain</source>
+        <translation>지형 삭제</translation>
+    </message>
+    <message>
+        <source>Duplicate Terrain Set</source>
+        <translation>지형 셋 복제</translation>
+    </message>
+    <message>
+        <source>New Corner Set</source>
+        <translation>새로운 코너 셋</translation>
+    </message>
+    <message>
+        <source>Patterns</source>
+        <translation>패턴</translation>
+    </message>
+    <message>
+        <source>New Mixed Set</source>
+        <translation>새로운 혼합된 셋</translation>
+    </message>
+    <message>
+        <source>Add Terrain</source>
+        <translation>지형 추가</translation>
+    </message>
+    <message>
+        <source>Terrain Sets</source>
+        <translation>지형 셋</translation>
+    </message>
+    <message>
+        <source>Terrains</source>
+        <translation>지형</translation>
+    </message>
+    <message>
+        <source>New Edge Set</source>
+        <translation>새로운 모서리 셋</translation>
+    </message>
+</context>
+<context>
+    <name>MapReader</name>
+    <message>
+        <source>Compression method &apos;%1&apos; not supported</source>
+        <translation>압축 방식 &apos;%1&apos; 은 지원되지 않습니다</translation>
+    </message>
+    <message>
+        <source>Invalid tile ID: %1</source>
+        <translation>유효하지 않은 타일 ID 입니다: %1</translation>
+    </message>
+    <message>
+        <source>Not a map file.</source>
+        <translation>맵 파일이 아닙니다.</translation>
+    </message>
+    <message>
+        <source>Unable to parse tile at (%1,%2) on layer &apos;%3&apos;: &quot;%4&quot;</source>
+        <translation>타일을 분석할 수 없습니다. (at (%1,%2) on layer &apos;%3&apos;: &quot;%4&quot;)</translation>
+    </message>
+    <message>
+        <source>%3
+
+Line %1, column %2</source>
+        <translation>%3
+
+%1 행 , %2 열</translation>
+    </message>
+    <message>
+        <source>Error reading embedded image for tile %1</source>
+        <translation>내장된 타일 &apos;%1&apos; 의 이미지를 읽는 도중 오류가 발생했습니다</translation>
+    </message>
+    <message>
+        <source>Invalid tileset parameters for tileset &apos;%1&apos;</source>
+        <translation>유효하지 않은 타일셋 &apos;%1&apos;의 타일셋 인수입니다</translation>
+    </message>
+    <message>
+        <source>Unsupported map orientation: &quot;%1&quot;</source>
+        <translation>지원되지 않는 맵 구도 입니다: &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Unable to read file: %1</source>
+        <translation>파일을 읽을 수 없습니다: %1</translation>
+    </message>
+    <message>
+        <source>Invalid tile: %1</source>
+        <translation>유효하지 않은 타일입니다: %1</translation>
+    </message>
+    <message>
+        <source>Not a template file.</source>
+        <translation>템플릿 파일이 아닙니다.</translation>
+    </message>
+    <message>
+        <source>Invalid points data for polygon</source>
+        <translation>유효하지 않은 폴리곤의 포인트 데이터 입니다</translation>
+    </message>
+    <message>
+        <source>Not a tileset file.</source>
+        <translation>타일셋 파일이 아닙니다.</translation>
+    </message>
+    <message>
+        <source>Invalid (negative) tile id: %1</source>
+        <translation>유효하지 않은 타일 ID (음수)입니다: %1</translation>
+    </message>
+    <message>
+        <source>Invalid draw order: %1</source>
+        <translation>유효하지 않은 그리기 순서 입니다: %1</translation>
+    </message>
+    <message>
+        <source>Corrupt layer data for layer &apos;%1&apos;</source>
+        <translation>레이어 &apos;%1&apos; 의 레이어 데이터가 손상되어 있습니다</translation>
+    </message>
+    <message>
+        <source>File not found: %1</source>
+        <translation>파일을 찾을 수 없습니다: %1</translation>
+    </message>
+    <message>
+        <source>Terrains</source>
+        <translation>지형</translation>
+    </message>
+    <message>
+        <source>Unknown encoding: %1</source>
+        <translation>알 수 없는 인코딩 입니다: %1</translation>
+    </message>
+    <message>
+        <source>Unable to parse tile at (%1,%2) on layer &apos;%3&apos;</source>
+        <translation>레이어 &apos;%3&apos; 의 (%1,%2) 타일을 분석할 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Tile used but no tilesets specified</source>
+        <translation>타일에 사용될 타일셋이 지정되어 있지 않습니다</translation>
+    </message>
+    <message>
+        <source>Too many &lt;tile&gt; elements</source>
+        <translation>&lt;tile&gt; 요소가 너무 많습니다</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CommandDialog</name>
+    <message>
+        <source>Global Commands</source>
+        <translation>글로벌 Command</translation>
+    </message>
+    <message>
+        <source>Project Commands</source>
+        <translation>프로젝트 Command</translation>
+    </message>
+</context>
+<context>
+    <name>Json::JsonMapFormat</name>
+    <message>
+        <source>Error parsing file: %1</source>
+        <translation>파일 구문 분석중 오류 발생: %1</translation>
+    </message>
+    <message>
+        <source>Error while writing file:
+%1</source>
+        <translation>파일을 작성하는 도중 오류가 발생했습니다:
+%1</translation>
+    </message>
+    <message>
+        <source>JSON map files (*.json)</source>
+        <translation>JSON 맵 파일 (*.json)</translation>
+    </message>
+    <message>
+        <source>JavaScript map files [Tiled 1.1] (*.js)</source>
+        <translation>JavaScript 맵 파일 [Tiled 1.1](*.js)</translation>
+    </message>
+    <message>
+        <source>JSON map files [Tiled 1.1] (*.json)</source>
+        <translation>JSON 맵 파일 [Tiled 1.1] (*.json)</translation>
+    </message>
+    <message>
+        <source>JavaScript map files (*.js)</source>
+        <translation>JavaScript 맵 파일 (*.js)</translation>
+    </message>
+</context>
+<context>
+    <name>Json::JsonObjectTemplateFormat</name>
+    <message>
+        <source>Error parsing file: %1</source>
+        <translation>파일 구문 분석중 오류 발생: %1</translation>
+    </message>
+    <message>
+        <source>Error while writing file:
+%1</source>
+        <translation>파일을 작성하는 도중 오류가 발생했습니다:
+%1</translation>
+    </message>
+    <message>
+        <source>JSON template files (*.json)</source>
+        <translation>JSON 템플릿 파일 (*.json)</translation>
+    </message>
+    <message>
+        <source>JSON template files [Tiled 1.1] (*.json)</source>
+        <translation>JSON 템플릿 파일 (*.json)</translation>
+    </message>
+</context>
+<context>
+    <name>Json::JsonTilesetFormat</name>
+    <message>
+        <source>Error parsing file: %1</source>
+        <translation>파일 구문 분석중 오류 발생: %1</translation>
+    </message>
+    <message>
+        <source>Error while writing file:
+%1</source>
+        <translation>파일을 작성하는 도중 오류 발생:
+%1</translation>
+    </message>
+    <message>
+        <source>JSON tileset files (*.json)</source>
+        <translation>JSON 타일셋 파일 (*.json)</translation>
+    </message>
+    <message>
+        <source>JSON tileset files [Tiled 1.1] (*.json)</source>
+        <translation>JSON 타일셋 파일 [Tiled 1.1] (*.json)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CommandButton</name>
+    <message>
+        <source>Edit Commands...</source>
+        <translation>Command 수정...</translation>
+    </message>
+    <message>
+        <source>Error Executing Command</source>
+        <translation>Command 실행 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Execute Command</source>
+        <translation>Command 실행</translation>
+    </message>
+    <message>
+        <source>You do not have any commands setup.</source>
+        <translation>Command 설정이 없습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::StampBrush</name>
+    <message>
+        <source>Stamp Brush</source>
+        <translation>스탬프 브러쉬</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::NewVersionButton</name>
+    <message>
+        <source>Error checking for updates</source>
+        <translation>업데이트를 위한 오류 확인</translation>
+    </message>
+    <message>
+        <source>%1 %2 is available</source>
+        <translation>%1 %2 사용 가능합니다</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation>데이터 ㄲㅏ지</translation>
+    </message>
+    <message>
+        <source>Update Available</source>
+        <translation>업데이트 가능</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ShapeFillTool</name>
+    <message>
+        <source>Circle Fill</source>
+        <translation>원형 채우기</translation>
+    </message>
+    <message>
+        <source>Circle</source>
+        <translation>원형</translation>
+    </message>
+    <message>
+        <source>Rectangle Fill</source>
+        <translation>직사각형 채우기</translation>
+    </message>
+    <message>
+        <source>Shape Fill Tool</source>
+        <translation>도형 채우기 도구</translation>
+    </message>
+    <message>
+        <source>Rectangle</source>
+        <translation>직사각형</translation>
+    </message>
+    <message>
+        <source>%1, %2 - %3: (%4 x %5)</source>
+        <translation>%1, %2 - %3: (%4 x %5)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ObjectSelectionTool</name>
+    <message numerus="yes">
+        <source>Move %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 옮기기</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1) %2</source>
+        <translation>%1) %2</translation>
+    </message>
+    <message>
+        <source>Instance of %1</source>
+        <translation>%1의 instance</translation>
+    </message>
+    <message>
+        <source>Unnamed object</source>
+        <translation>이름 없는 오브젝트</translation>
+    </message>
+    <message>
+        <source>Select Touched Objects</source>
+        <translation>터치된 오브젝트 선택</translation>
+    </message>
+    <message>
+        <source>&amp;%1) %2</source>
+        <translation>&amp;%1) %2</translation>
+    </message>
+    <message>
+        <source>Select Objects</source>
+        <translation>오브젝트 선택</translation>
+    </message>
+    <message numerus="yes">
+        <source>Resize %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 크기 조정</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Rotate %n Object(s)</source>
+        <translation>
+            <numerusform>%n개 오브젝트 회전</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Select Enclosed Objects</source>
+        <translation>동봉된 오브젝트 선택</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::WorldMoveMapTool</name>
+    <message>
+        <source>World Tool</source>
+        <translation>월드 도구</translation>
+    </message>
+    <message>
+        <source>Move map to %1, %2 (offset: %3, %4)</source>
+        <translation>%1 맵으로 이동, %2 (오프셋: %3, %4)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::XmlObjectTemplateFormat</name>
+    <message>
+        <source>Tiled template files (*.tx)</source>
+        <translation>Tiled 템플릿 파일 (*.tx)</translation>
+    </message>
+</context>
+<context>
+    <name>QtLocalePropertyManager</name>
+    <message>
+        <source>%1, %2</source>
+        <translation>%1, %2</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>언어</translation>
+    </message>
+    <message>
+        <source>Country</source>
+        <translation>국가</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::FileEdit</name>
+    <message>
+        <source>Choose a Folder</source>
+        <translation>폴더 선택</translation>
+    </message>
+    <message>
+        <source>Choose</source>
+        <translation>선택</translation>
+    </message>
+    <message>
+        <source>Choose a File</source>
+        <translation>파일을 선택하십시오</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::UndoDock</name>
+    <message>
+        <source>&lt;empty&gt;</source>
+        <translation>&lt;비어있음&gt;</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation>히스토리</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::AutomappingManager</name>
+    <message>
+        <source>Apply AutoMap rules</source>
+        <translation>오토맵 규칙 적용</translation>
+    </message>
+    <message>
+        <source>No rules file found at &apos;%1&apos;</source>
+        <translation>&apos;%1&apos;에서 규칙 파일을 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Opening rules map &apos;%1&apos; failed: %2</source>
+        <translation>규칙 맵 &apos;%1&apos; 열기 실패: %2</translation>
+    </message>
+    <message>
+        <source>Error opening rules file &apos;%1&apos;</source>
+        <translation>규칙 파일 열기 오류 &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>File not found: &apos;%1&apos; (referenced by &apos;%2&apos;)</source>
+        <translation>파일을 찾을 수 없습니다: &apos;%1&apos; (referenced by &apos;%2&apos;)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::StampActions</name>
+    <message>
+        <source>Rotate Right</source>
+        <translation>오른쪽으로 회전하기</translation>
+    </message>
+    <message>
+        <source>Flip Horizontally</source>
+        <translation>가로로 뒤집기</translation>
+    </message>
+    <message>
+        <source>Terrain Fill Mode</source>
+        <translation>지형 파일 모드</translation>
+    </message>
+    <message>
+        <source>Random Mode</source>
+        <translation>랜덤 모드</translation>
+    </message>
+    <message>
+        <source>Rotate Left</source>
+        <translation>왼쪽으로 회전하기</translation>
+    </message>
+    <message>
+        <source>Flip Vertically</source>
+        <translation>세로로 뒤집기</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TilesetEditor</name>
+    <message>
+        <source>Remove Tiles</source>
+        <translation>타일 삭제</translation>
+    </message>
+    <message>
+        <source>Unnamed Set</source>
+        <translation>이름 없는 셋</translation>
+    </message>
+    <message>
+        <source>Tiles to be removed are in use by open maps!</source>
+        <translation>삭제될 타일들이 아직 열린 맵에서 사용되고 있습니다!</translation>
+    </message>
+    <message>
+        <source>Tile Animation Editor</source>
+        <translation>타일 애니메이션 편집기</translation>
+    </message>
+    <message>
+        <source>Add Tiles</source>
+        <translation>타일 추가</translation>
+    </message>
+    <message>
+        <source>Could not load &quot;%1&quot;!</source>
+        <translation>&quot;%1&quot; 을 불러올 수 없습니다!</translation>
+    </message>
+    <message>
+        <source>Add anyway?</source>
+        <translation>그래도 추가하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>Dynamically Wrap Tiles</source>
+        <translation>타일을 동적으로 넘기기</translation>
+    </message>
+    <message>
+        <source>Tile &quot;%1&quot; already exists in the tileset!</source>
+        <translation>타일 &quot;%1&quot; 이 이미 타일셋에 존재합니다!</translation>
+    </message>
+    <message>
+        <source>Tileset</source>
+        <translation>타일셋</translation>
+    </message>
+    <message>
+        <source>Remove all references to these tiles?</source>
+        <translation>이 타일에 대한 모든 참조를 삭제하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>Apply this action to all tiles</source>
+        <translation>모든 타일에 이 작업 적용</translation>
+    </message>
+    <message>
+        <source>Rearrange Tiles</source>
+        <translation>타일 재정렬</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::LayerOffsetTool</name>
+    <message>
+        <source>Offset Layers</source>
+        <translation>레이어 Offset</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TmxMapFormat</name>
+    <message>
+        <source>Tiled map files (*.tmx *.xml)</source>
+        <translation>Tiled 맵 파일 (*.tmx *.xml)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ClipboardManager</name>
+    <message>
+        <source>Paste Objects</source>
+        <translation>오브젝트 붙여넣기</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::BucketFillTool</name>
+    <message>
+        <source>Bucket Fill Tool</source>
+        <translation>페인트 통 도구</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ObjectsDock</name>
+    <message>
+        <source>Add Object Layer</source>
+        <translation>오브젝트 레이어 추가</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n Object(s) to Layer</source>
+        <translation>
+            <numerusform>레이어로 %n개 오브젝트(s) 이동</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Filter</source>
+        <translation>필터</translation>
+    </message>
+    <message>
+        <source>Objects</source>
+        <translation>오브젝트</translation>
+    </message>
+    <message>
+        <source>Move Objects Up</source>
+        <translation>오브젝트 위로 이동</translation>
+    </message>
+    <message>
+        <source>Object Properties</source>
+        <translation>오브젝트 속성</translation>
+    </message>
+    <message>
+        <source>Move Objects Down</source>
+        <translation>오브젝트 아래로 이동</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CreatePointObjectTool</name>
+    <message>
+        <source>Insert Point</source>
+        <translation>포인트 삽입</translation>
+    </message>
+</context>
+<context>
+    <name>ObjectTypesEditor</name>
+    <message>
+        <source>Import Object Types</source>
+        <translation>오브젝트 타입 가져오기</translation>
+    </message>
+    <message>
+        <source>Object Types Editor</source>
+        <translation>오브젝트 타입 편집기</translation>
+    </message>
+    <message>
+        <source>Export...</source>
+        <translation>내보내기...</translation>
+    </message>
+    <message>
+        <source>Import...</source>
+        <translation>가져오기...</translation>
+    </message>
+    <message>
+        <source>Export Object Types</source>
+        <translation>오브젝트 타입 내보내기</translation>
     </message>
 </context>
 <context>
     <name>Yy::YyPlugin</name>
     <message>
-        <location filename="../src/plugins/yy/yyplugin.cpp" line="+163"/>
         <source>GameMaker Studio 2 files (*.yy)</source>
-        <translation type="unfinished"></translation>
+        <translation>GameMaker Studio 2 files (*.yy)</translation>
     </message>
 </context>
 <context>
-    <name>main</name>
+    <name>Tiled::CreateTemplateTool</name>
     <message>
-        <location filename="../src/tiledquick/qml/+android/main.qml" line="+17"/>
-        <location filename="../src/tiledquick/qml/main.qml" line="+18"/>
-        <source>Tiled Quick</source>
-        <translation type="unfinished"></translation>
+        <source>Insert Template</source>
+        <translation>템플릿 삽입</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::Document</name>
+    <message>
+        <source>Custom property &apos;%1&apos; refers to non-existing file &apos;%2&apos;</source>
+        <translation>사용자 지정 속성 &apos;%1&apos;이(가) 존재하지 않는 파일 &apos;%2&apos;을(를) 참조합니다</translation>
+    </message>
+</context>
+<context>
+    <name>Utils</name>
+    <message>
+        <source>Copy File Path</source>
+        <translation>파일 경로 복사</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../src/tiledquick/qml/main.qml" line="+53"/>
-        <source>Open...</source>
-        <translation type="unfinished"></translation>
+        <source>Image files</source>
+        <translation>이미지 파일</translation>
     </message>
     <message>
-        <location line="+65"/>
-        <location filename="../src/tiledquick/qml/main.qml" line="+142"/>
-        <source>No map file loaded</source>
-        <translation type="unfinished"></translation>
+        <source>Open with System Editor</source>
+        <translation>시스템 편집기와 열기</translation>
     </message>
     <message>
-        <location filename="../src/tiledquick/qml/main.qml" line="-132"/>
-        <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <source>Open Containing Folder...</source>
+        <translation>포함하는 폴더 열기...</translation>
+    </message>
+</context>
+<context>
+    <name>Command line</name>
+    <message>
+        <source>Format not recognized (see --export-formats)</source>
+        <translation>읽을 수 없는 형식(--export-formats를 참조하십시오)</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <source>Fit Map In View</source>
-        <translation type="unfinished"></translation>
+        <source>No exporter found for target file.</source>
+        <translation>대상 파일에 대한 내보내기가 없습니다.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>File</source>
-        <translation type="unfinished">파일</translation>
+        <source>Failed to load source tileset.</source>
+        <translation>타일셋 소스 로드에 실패했습니다.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <source>Project file &apos;%1&apos; not found.</source>
+        <translation>프로젝트 파일 &apos;%1&apos;을 찾을 수 없습니다.</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
+        <source>Failed to export tileset to target file.</source>
+        <translation>대상 파일에 타일셋 내보내기를 실패했습니다.</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>About Tiled Quick</source>
-        <translation type="unfinished"></translation>
+        <source>Export syntax is --export-map [format] &lt;source&gt; &lt;target&gt;</source>
+        <translation>내보내기 구문 형식은 --export-map [format] &lt;source&gt; &lt;target&gt;</translation>
     </message>
     <message>
-        <location filename="../src/tmxrasterizer/main.cpp" line="+55"/>
-        <source>Renders a Tiled map or world to an image.</source>
-        <translation type="unfinished"></translation>
+        <source>Failed to load source map.</source>
+        <translation>소스 맵을 로드를 실패했습니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>The scale of the output image (default: 1).</source>
-        <translation type="unfinished"></translation>
+        <source>Export syntax is --export-tileset [format] &lt;source&gt; &lt;target&gt;</source>
+        <translation>Export 구문의 형식은 --export-tileset [format] &lt;source&gt; &lt;target&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>scale</source>
-        <translation type="unfinished"></translation>
+        <source>Non-unique file extension. Can&apos;t determine correct export format.</source>
+        <translation>확장자가 한 개가 아닙니다. 올바른 내보내기 형식을 결정할 수 없습니다.</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>The requested size in pixels at which a tile is rendered (overrides the --scale option).</source>
-        <translation type="unfinished"></translation>
+        <source>Failed to export map to target file.</source>
+        <translation>맵 내보내기에 실패했습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::NewMapDialog</name>
+    <message>
+        <source>%1 x %2 pixels</source>
+        <translation>%1 x %2 픽셀</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+3"/>
-        <source>size</source>
-        <translation type="unfinished"></translation>
+        <source>Isometric</source>
+        <translation>아이소메트릭</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <source>The output image fits within a SIZE x SIZE square (overrides the --scale and --tilesize options).</source>
-        <translation type="unfinished"></translation>
+        <source>Save As...</source>
+        <translation>다른 이름으로 저장...</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Antialias edges of primitives.</source>
-        <translation type="unfinished"></translation>
+        <source>Tile layers for this map will consume %L1 GB of memory each. Not creating one by default.</source>
+        <translation>이 맵의 타일 레이어는 각각 %L1 GB 의 메모리를 소모합니다. 기본설정으로 만들지 마십시오.</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Use nearest neighbour instead of smooth blending of pixels.</source>
-        <translation type="unfinished"></translation>
+        <source>Memory Usage Warning</source>
+        <translation>메모리 사용량 경고</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Ignore all layer visibility flags in the map file, and render all layers in the output (default is to omit invisible layers).</source>
-        <translation type="unfinished"></translation>
+        <source>Hexagonal (Staggered)</source>
+        <translation>육각형 (비틀거림)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Specifies a layer to omit from the output image. Can be repeated to hide multiple layers.</source>
-        <translation type="unfinished"></translation>
+        <source>Isometric (Staggered)</source>
+        <translation>아이소메트릭 (비틀거림)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+3"/>
-        <source>name</source>
-        <translation type="unfinished"></translation>
+        <source>Orthogonal</source>
+        <translation>직교</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TileSelectionTool</name>
+    <message>
+        <source>%1, %2 - Rectangle: (%3 x %4)</source>
+        <translation>%1, %2 - 직사각형: (%3 x %4)</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <source>If used only specified layers are shown. Can be repeated to show multiple specified layers only.</source>
-        <translation type="unfinished"></translation>
+        <source>Rectangular Select</source>
+        <translation>사각형 선택</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::WangSetView</name>
+    <message>
+        <source>Terrain Set &amp;Properties...</source>
+        <translation>지형 셋 속성(&amp;P)...</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ImageCache</name>
+    <message>
+        <source>Recursive metatile map detected: %1</source>
+        <translation>재귀 메타타일 맵이 검색되었습니다: %1</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>If used tile animations are advanced by the specified duration.</source>
-        <translation type="unfinished"></translation>
+        <source>Failed to read metatile map %1: %2</source>
+        <translation>메타타일 맵 읽기에 실패했습니다 %1: %2</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ConsoleDock</name>
+    <message>
+        <source>Clear Console</source>
+        <translation>콘솔 지우기</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>duration</source>
-        <translation type="unfinished"></translation>
+        <source>Execute script</source>
+        <translation>스크립트 실행</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Map or world file to render.</source>
-        <translation type="unfinished"></translation>
+        <source>Console</source>
+        <translation>콘솔</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TsxTilesetFormat</name>
+    <message>
+        <source>Tiled tileset files (*.tsx *.xml)</source>
+        <translation>Tiled 타일셋 파일 (*.tsx *.xml)</translation>
+    </message>
+</context>
+<context>
+    <name>Tbin::TbinMapFormat</name>
+    <message>
+        <source>Exception: %1</source>
+        <translation>예외: %1</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Image file to output.</source>
-        <translation type="unfinished"></translation>
+        <source>Tilesheet must have equal margins.</source>
+        <translation>타일시트는 여백이 같아야 합니다.</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <source>Invalid size specified: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <source>Tbin map files (*.tbin)</source>
+        <translation>Tbin 맵 파일 (*.tbin)</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <source>Invalid tile size specified: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <source>Tilesheet must have equal spacings.</source>
+        <translation>타일 시트의 간격은 같아야 합니다.</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <source>Invalid scale specified: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <source>Only object and tile layers supported.</source>
+        <translation>오브젝트와 타일 레이어만 지원됩니다.</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <source>Invalid advance-animations specified: &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <source>Could not open file for writing</source>
+        <translation>쓰기용으로 파일을 열 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/tmxviewer/main.cpp" line="+57"/>
-        <source>Displays a Tiled map (TMX format).</source>
-        <translation type="unfinished"></translation>
+        <source>Map contains no layers.</source>
+        <translation>맵에 레이어가 없습니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Map file to display.</source>
-        <translation type="unfinished"></translation>
+        <source>Different tile sizes per layer are not supported.</source>
+        <translation>레이어별로 다른 타일 크기는 지원되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Invalid animation frame.</source>
+        <translation>유효하지 않은 애니메이션 프레임입니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::Eraser</name>
+    <message>
+        <source>Eraser</source>
+        <translation>지우개</translation>
+    </message>
+</context>
+<context>
+    <name>ObjectRefDialog</name>
+    <message>
+        <source>Filter</source>
+        <translation>필터</translation>
+    </message>
+    <message>
+        <source>Edit Object Reference</source>
+        <translation>객체 참조 편집</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CreatePolygonObjectTool</name>
+    <message>
+        <source>Insert Polygon</source>
+        <translation>다각형 삽입</translation>
+    </message>
+    <message>
+        <source>Connect Polylines</source>
+        <translation>폴리선 연결</translation>
+    </message>
+    <message>
+        <source>Create Polygon</source>
+        <translation>다각형 생성</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::WorldDocument</name>
+    <message>
+        <source>untitled.world</source>
+        <translation>untitled.world</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::FileChangedWarning</name>
+    <message>
+        <source>Ignore</source>
+        <translation>무시</translation>
+    </message>
+    <message>
+        <source>Reload</source>
+        <translation>다시 불러오기</translation>
+    </message>
+    <message>
+        <source>File change detected. Discard changes and reload the file?</source>
+        <translation>파일 변경이 감지되었습니다. 변경 사항들을 무시하고 다시 불러오시겠습니까?</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::LayerDock</name>
+    <message>
+        <source>Layers</source>
+        <translation>레이어</translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation>불투명도:</translation>
+    </message>
+    <message>
+        <source>New Layer</source>
+        <translation>새로운 레이어</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::AbstractWorldTool</name>
+    <message>
+        <source>Error Opening File</source>
+        <translation>파일 여는 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Load Map</source>
+        <translation>맵 불러오기</translation>
+    </message>
+    <message>
+        <source>Add another map to the current world</source>
+        <translation>현재 월드에 또다른 맵 추가</translation>
+    </message>
+    <message>
+        <source>Add a Map to World &quot;%2&quot;</source>
+        <translation>&quot;%2&quot;월드에 맵 추가</translation>
+    </message>
+    <message>
+        <source>Remove the current map from the current world</source>
+        <translation>현재 월드에서 현재 맵 삭제</translation>
+    </message>
+    <message>
+        <source>All Files (*)</source>
+        <translation>모든 파일 (*)</translation>
+    </message>
+    <message>
+        <source>Error opening &apos;%1&apos;:
+%2</source>
+        <translation>열기 오류 &apos;%1&apos;: %2</translation>
+    </message>
+    <message>
+        <source>Add &quot;%1&quot; to World &quot;%2&quot;</source>
+        <translation>&quot;%2&quot;월드에 &quot;%1&quot;추가</translation>
+    </message>
+    <message>
+        <source>Remove &quot;%1&quot; from World &quot;%2&quot;</source>
+        <translation>현재 %2 에서 &quot;%1&quot; 삭제</translation>
+    </message>
+    <message>
+        <source>Add the current map to a loaded world</source>
+        <translation>불러온 월드에 현재 맵 추가</translation>
+    </message>
+</context>
+<context>
+    <name>QtPropertyBrowserUtils</name>
+    <message>
+        <source>Not set</source>
+        <translation>설정되어 있지 않음</translation>
+    </message>
+    <message>
+        <source>[%1, %2]</source>
+        <translation>[%1, %2]</translation>
+    </message>
+    <message>
+        <source>[%1, %2, %3] (%4)</source>
+        <translation>[%1, %2, %3] (%4)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TilesetDocument</name>
+    <message>
+        <source>untitled.tsx</source>
+        <translation>untitled.tsx</translation>
+    </message>
+    <message>
+        <source>Failed to load tileset image &apos;%1&apos;</source>
+        <translation>타일셋 이미지 &apos;%1&apos;를 불러오는데 실패했습니다</translation>
+    </message>
+    <message>
+        <source>Tileset format &apos;%s&apos; not found</source>
+        <translation>타일셋 형식 &apos;%s&apos;를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <source>Failed to load tile image &apos;%1&apos;</source>
+        <translation>타일 이미지 &apos;%1&apos; 을 불러오는 데 실패하였습니다</translation>
+    </message>
+</context>
+<context>
+    <name>TmxViewer</name>
+    <message>
+        <source>TMX Viewer</source>
+        <translation>TMX 뷰어</translation>
+    </message>
+</context>
+<context>
+    <name>DonationDialog</name>
+    <message>
+        <source>&amp;Maybe later</source>
+        <translation>다음 기회에 (&amp;M)</translation>
+    </message>
+    <message>
+        <source>I&apos;m a &amp;supporter!</source>
+        <translation>I&apos;m a &amp;서포터!</translation>
+    </message>
+    <message>
+        <source>&amp;Donate ↗</source>
+        <translation>기부하기 ↗ (&amp;D)</translation>
+    </message>
+    <message>
+        <source>Please consider supporting Tiled development with a small monthly donation.</source>
+        <translation>매월 소정의 기부금으로 Tiled개발을 지원하는 것을 고려해주세요.</translation>
+    </message>
+</context>
+<context>
+    <name>Csv::CsvPlugin</name>
+    <message>
+        <source>CSV files (*.csv)</source>
+        <translation>CSV 파일 (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CreateRectangleObjectTool</name>
+    <message>
+        <source>Insert Rectangle</source>
+        <translation>직사각형 삽입</translation>
+    </message>
+</context>
+<context>
+    <name>Gmx::GmxPlugin</name>
+    <message>
+        <source>GameMaker room files (*.room.gmx)</source>
+        <translation>GameMaker room 파일 (*.room.gmx)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TemplateManager</name>
+    <message>
+        <source>Unable to reload template file: %1</source>
+        <translation>템플릿 파일을 불러올 수 없습니다: %1</translation>
+    </message>
+</context>
+<context>
+    <name>Python::PythonPlugin</name>
+    <message>
+        <source>Reloading Python scripts</source>
+        <translation>Python 스크립트 다시 불러오는 중</translation>
+    </message>
+</context>
+<context>
+    <name>Lua::LuaMapFormat</name>
+    <message>
+        <source>Lua files (*.lua)</source>
+        <translation>Lua 파일 (*.lua)</translation>
+    </message>
+</context>
+<context>
+    <name>Lua::LuaTilesetFormat</name>
+    <message>
+        <source>Lua files (*.lua)</source>
+        <translation>Lua 파일 (*.lua)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ProjectDock</name>
+    <message>
+        <source>Project</source>
+        <translation>프로젝트</translation>
+    </message>
+    <message>
+        <source>Choose Folder</source>
+        <translation>폴더 선택</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ShortcutEditor</name>
+    <message>
+        <source>Reset shortcut to default</source>
+        <translation>단축기 기본값으로 초기화</translation>
+    </message>
+    <message>
+        <source>Remove shortcut</source>
+        <translation>단축키 삭제</translation>
+    </message>
+</context>
+<context>
+    <name>QtCharEdit</name>
+    <message>
+        <source>Clear Char</source>
+        <translation>문자 지우기</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::SelectSameTileTool</name>
+    <message>
+        <source>Select Same Tile</source>
+        <translation>동일한 타일 선택</translation>
+    </message>
+</context>
+<context>
+    <name>RpMap::RpMapPlugin</name>
+    <message>
+        <source>RpTool MapTool files (*.rpmap)</source>
+        <translation>RpTool 맵도구 파일 (*.rpmap)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::IssuesCounter</name>
+    <message numerus="yes">
+        <source>%n warning(s)</source>
+        <translation>
+            <numerusform>%n 경고(s)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n error(s)</source>
+        <translation>
+            <numerusform>%n 오류(s)</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CreateTileObjectTool</name>
+    <message>
+        <source>Insert Tile</source>
+        <translation>타일 삽입</translation>
+    </message>
+</context>
+<context>
+    <name>Defold::DefoldPlugin</name>
+    <message>
+        <source>Defold files (*.tilemap)</source>
+        <translation>Defold 파일 (*.tilemap)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::NoWangSetWidget</name>
+    <message>
+        <source>&lt;p&gt;No tileset with Terrain Sets available.&lt;/p&gt;&lt;p&gt;Open a tileset with a Terrain Set or set up a new Terrain Set to be able to use the Terrain Brush or the Terrain Fill Mode.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;지형 셋이 있는 타일셋을 사용할 수 없습니다.&lt;/p&gt;&lt;p&gt;지형 브러시 ㄸㅗ는 지형 채우기 모드를 사용할 수 있도록 타일셋을 열거나 새 지형 셋을 설정합니다.&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>ProjectPropertiesDialog</name>
+    <message>
+        <source>Project Properties</source>
+        <translation>프로젝트 속성</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::WangBrush</name>
+    <message>
+        <source>Terrain Brush</source>
+        <translation>지형 브러쉬</translation>
+    </message>
+    <message>
+        <source>Missing terrain transition</source>
+        <translation>누락된 지형 전환</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TilesetParametersEdit</name>
+    <message>
+        <source>Edit...</source>
+        <translation>편집...</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::WangColorView</name>
+    <message>
+        <source>Pick Custom Color</source>
+        <translation>커스텀 색상 선택</translation>
+    </message>
+</context>
+<context>
+    <name>AddPropertyDialog</name>
+    <message>
+        <source>Property name</source>
+        <translation>속성 이름</translation>
+    </message>
+    <message>
+        <source>Add Property</source>
+        <translation>속성 추가</translation>
+    </message>
+</context>
+<context>
+    <name>Tengine::TenginePlugin</name>
+    <message>
+        <source>T-Engine4 map files (*.lua)</source>
+        <translation>T-Engine4 맵 파일 (*.lua)</translation>
+    </message>
+</context>
+<context>
+    <name>File Errors</name>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>읽기용으로 파일을 열 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>쓰기용으로 파일을 열 수 없습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>DefoldCollection::DefoldCollectionPlugin</name>
+    <message>
+        <source>Defold collection (*.collection)</source>
+        <translation>Defold 콜렉션 (*.collection)</translation>
+    </message>
+</context>
+<context>
+    <name>QtKeySequenceEdit</name>
+    <message>
+        <source>Clear Shortcut</source>
+        <translation>단축키 지우기</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::TileAnimationEditor</name>
+    <message>
+        <source>Delete Frames</source>
+        <translation>프레임 삭제</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::ProjectModel</name>
+    <message>
+        <source>(Refreshing)</source>
+        <translation>(새로고침 중)</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::MagicWandTool</name>
+    <message>
+        <source>Magic Wand</source>
+        <translation>자동 선택 도구</translation>
+    </message>
+</context>
+<context>
+    <name>Tiled::CreateEllipseObjectTool</name>
+    <message>
+        <source>Insert Ellipse</source>
+        <translation>타원형 삽입</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
I supplemented the existing translation file `tiled_ko.ts`.
Also, I maintained the unity with the existing translation as much as possible.
![example1](https://user-images.githubusercontent.com/44396392/139298330-66b1d508-4369-4d64-b7b7-726d790acdf1.JPG)
I checked the typos as much as possible.
I hope it helps you.
