### PR TITLE
Ignore selection changes when marking a file as modified

### DIFF
--- a/src/tiled/changeselectedarea.h
+++ b/src/tiled/changeselectedarea.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "undocommands.h"
+
 #include <QRegion>
 #include <QUndoCommand>
 
@@ -40,6 +42,8 @@ public:
 
     void undo() override;
     void redo() override;
+
+    int id() const override { return Cmd_ChangeSelectedArea; }
 
 private:
     void swapSelection();

--- a/src/tiled/document.cpp
+++ b/src/tiled/document.cpp
@@ -187,32 +187,28 @@ void Document::currentObjectDocumentDestroyed()
 
 void Document::updateModifiedChanged()
 {
-    bool modified = true;
-
     const QUndoStack &undo = *undoStack();
-    if (undo.isClean()) {
+    const int cleanIndex = undo.cleanIndex();
+    bool modified = !undo.isClean();
+
+    if (modified && cleanIndex != -1) {
         modified = false;
-    } else {
-        const int cleanIndex = undo.cleanIndex();
-        if (cleanIndex != -1) {
-            modified = false;
 
-            // if cleanIndex is 2 and index is 5, we check commands 4 to 2
-            int from = undo.index() - 1;
-            int to = cleanIndex;
+        // if cleanIndex is 2 and index is 5, we check commands 4 to 2
+        int from = undo.index() - 1;
+        int to = cleanIndex;
 
-            // if cleanIndex is 2 but index is 0, we check commands 1 to 0
-            if (from < to) {
-                to = undo.index();
-                from = cleanIndex - 1;
-            }
+        // if cleanIndex is 2 but index is 0, we check commands 1 to 0
+        if (from < to) {
+            to = undo.index();
+            from = cleanIndex - 1;
+        }
 
-            for (int index = from; index >= to; --index) {
-                const QUndoCommand *command = undo.command(index);
-                if (command->id() != Cmd_ChangeSelectedArea) {
-                    modified = true;
-                    break;
-                }
+        for (int index = from; index >= to; --index) {
+            const QUndoCommand *command = undo.command(index);
+            if (command->id() != Cmd_ChangeSelectedArea) {
+                modified = true;
+                break;
             }
         }
     }

--- a/src/tiled/document.h
+++ b/src/tiled/document.h
@@ -161,6 +161,8 @@ private:
     void currentObjectDocumentChanged(const ChangeEvent &change);
     void currentObjectDocumentDestroyed();
 
+    void updateModifiedChanged();
+
     const DocumentType mType;
 
     QString mFileName;
@@ -168,6 +170,7 @@ private:
 
     QUndoStack * const mUndoStack;
 
+    bool mModified = false;
     bool mChangedOnDisk = false;
     bool mIgnoreBrokenLinks = false;
 
@@ -192,6 +195,14 @@ inline QString Document::canonicalFilePath() const
 inline QUndoStack *Document::undoStack() const
 {
     return mUndoStack;
+}
+
+/**
+ * Returns whether the document has unsaved changes.
+ */
+inline bool Document::isModified() const
+{
+    return mModified;
 }
 
 /**

--- a/src/tiled/undocommands.h
+++ b/src/tiled/undocommands.h
@@ -31,12 +31,13 @@ namespace Tiled {
 enum UndoCommands {
     Cmd_ChangeLayerOffset,
     Cmd_ChangeLayerOpacity,
+    Cmd_ChangeLayerTintColor,
+    Cmd_ChangeSelectedArea,
     Cmd_ChangeTileTerrain,
     Cmd_ChangeTileWangId,
     Cmd_ChangeTilesetTileOffset,
     Cmd_EraseTiles,
     Cmd_PaintTileLayer,
-    Cmd_ChangeLayerTintColor
 };
 
 /**


### PR DESCRIPTION
Changing the selected area is an undo command so that it can be undone, but since it does not actually modify the file it should not cause the file to get marked as modified.

Closes #3194