### PR TITLE
YY Plugin: Determine sprite names by looking for meta files

### DIFF
--- a/docs/manual/export-yy.rst
+++ b/docs/manual/export-yy.rst
@@ -37,10 +37,16 @@ Since Tiled currently only exports a map as a GameMaker room, any sprites,
 tilesets and objects used by the map are expected to be already available in
 the GameMaker project.
 
-For sprites, the sprite name is be derived from the image file name by
-removing the file extension. If necessary, the sprite name can be explicitly
-specified using a custom ``sprite`` property (supported on tilesets, tiles
-from image collection tilesets and image layers).
+For sprites, the sprite name is derived by looking for a ``*.yy`` file in the
+directory of the image file and up to two parent directories. If such a file
+is found, it is assumed to be the associated meta file and its name without
+the file extension is used.
+If no ``*.yy`` file can be found, the name of the image file without its file
+extension is used.
+
+If necessary, the sprite name can be explicitly specified using a custom
+``sprite`` property (supported on tilesets, tiles from image collection
+tilesets and image layers).
 
 For tilesets, the tileset name entered in Tiled must match the name of the
 tileset asset in GameMaker.


### PR DESCRIPTION
Before assuming the name of an image file without its extension to be the name of the associated sprite, search the current and up to two parent directories for a *.yy meta file. If found, use its name without the file extension instead.
A custom "sprite" property may still override this feature and will also prevent file system crawling.

This enables a user to use the sprite image files directly from their game project for image layers without having to specify the custom "sprite" property or using a copy with a proper name, as GameMaker Studio2 uses some UUID naming scheme for asset files.
The search is extended to parent directories as sprites resources also may contain subdirectories for individual layers. By the same token, a user may store different versions of an asset in the same folder. This is purely for added convenience so "it just works", even if a user merely wishes to have a Sprite be represented only by one of its layers.