### PR TITLE
docs: Update pytiled-parser and Arcade description

### DIFF
--- a/docs/reference/support-for-tmx-maps.rst
+++ b/docs/reference/support-for-tmx-maps.rst
@@ -143,9 +143,9 @@ Python
 ~~~~~~
 
 -  `pytiled-parser <https://github.com/benjamin-kirkbride/pytiled_parser>`__: Python parser
-   for JSON maps(No support for TMX format as of v1.0.0)
+   for TMX and JSON maps.
 -  `Arcade <https://api.arcade.academy>`__: 2D game library that uses pytiled-parser for
-   easy loading of JSON maps into a game.(No support for TMX format as of v2.6.0) `Arcade Tiled Examples <https://api.arcade.academy/en/latest/examples/index.html#using-tiled-map-editor-to-create-maps>`_
+   easy loading of Tiled maps into a game. `Arcade Tiled Examples <https://api.arcade.academy/en/latest/examples/index.html#using-tiled-map-editor-to-create-maps>`_
 -  `pytmxlib <http://pytmxlib.readthedocs.org/en/latest/>`__: library
    for programmatic manipulation of TMX maps
 -  `python-tmx <http://python-tmx.nongnu.org>`__: a simple library for


### PR DESCRIPTION
pytiled-parser and Arcade both previously only supported JSON maps, but have recently been updated to add support for TMX as well. This PR just removes the note of not having TMX support from them.