### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Media**
+If applicable, add screenshots or videos to help explain your problem.
+
+**Specifications:**
+ - OS: [e.g. Windows 10]
+ - Tiled Version: [e.g. 1.0.0. You can get this from Help -> About Tiled]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.


### PR DESCRIPTION
This PR adds GitHub issue templates for both bug reports and feature requests. Bug / feature labels are automatically added as well.
Bug template:
![image](https://user-images.githubusercontent.com/38186597/156891787-c718ba01-f7c3-4ae5-938e-43522f14163e.png)
Feature template:
![image](https://user-images.githubusercontent.com/38186597/156891799-5e7d9b05-1d1a-4b99-b463-98c8b31af25a.png)

