### PR TITLE
update libGDX wiki URL

### DIFF
--- a/docs/reference/support-for-tmx-maps.rst
+++ b/docs/reference/support-for-tmx-maps.rst
@@ -323,7 +323,7 @@ LibGDX
 
 -  `libgdx <http://libgdx.badlogicgames.com/>`__, a Java-based
    Android/desktop/HTML5 game library,
-   `provides <https://github.com/libgdx/libgdx/wiki/Tile-maps>`__ a
+   `provides <https://libgdx.com/wiki/graphics/2d/tile-maps>`__ a
    packer, loader and renderer for TMX maps
 
 LITIengine


### PR DESCRIPTION
libGDX wiki URL on "Support for TMX maps" page on the docs is outdated. The new one is on [libGDX's official website](https://libgdx.com/wiki).