### PR TITLE
Introduced caching of tinted pixmaps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * AutoMapping: Accumulate touched layers in AutoMap While Drawing (#3313)
 * AutoMapping: Support map name filters in rules.txt (#3014)
 * Split up object types file type selection
+* Optimized rendering of tinted layers by caching tinted images
 * tmxrasterizer: Added options to hide certain layer types (#3343)
 * Raised minimum supported Qt version from 5.6 to 5.12 (drops Windows XP support)
 * Raised minimum C++ version to C++17


### PR DESCRIPTION
Since the tinting is so expensive, we're now keeping up to 100 MB of tinted versions allocated.