### PR TITLE
Use Tile::imageRect instead of cutting out tiles

### DIFF
--- a/src/libtiled/imagecache.h
+++ b/src/libtiled/imagecache.h
@@ -39,24 +39,6 @@
 
 namespace Tiled {
 
-struct TILEDSHARED_EXPORT TilesheetParameters
-{
-    QString fileName;
-    int tileWidth;
-    int tileHeight;
-    int spacing;
-    int margin;
-    QColor transparentColor;
-
-    bool operator==(const TilesheetParameters &other) const;
-};
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-uint TILEDSHARED_EXPORT qHash(const TilesheetParameters &key, uint seed = 0) Q_DECL_NOTHROW;
-#else
-size_t TILEDSHARED_EXPORT qHash(const TilesheetParameters &key, size_t seed = 0) Q_DECL_NOTHROW;
-#endif
-
 struct LoadedImage
 {
     LoadedImage();
@@ -68,7 +50,6 @@ struct LoadedImage
     QDateTime lastModified;
 };
 
-struct CutTiles;
 struct LoadedPixmap;
 class Map;
 
@@ -77,7 +58,6 @@ class TILEDSHARED_EXPORT ImageCache
 public:
     static LoadedImage loadImage(const QString &fileName);
     static QPixmap loadPixmap(const QString &fileName);
-    static QVector<QPixmap> cutTiles(const TilesheetParameters &parameters);
 
     static void remove(const QString &fileName);
 
@@ -86,7 +66,6 @@ private:
 
     static QHash<QString, LoadedImage> sLoadedImages;
     static QHash<QString, LoadedPixmap> sLoadedPixmaps;
-    static QHash<TilesheetParameters, CutTiles> sCutTiles;
 };
 
 } // namespace Tiled

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -499,6 +499,12 @@ void MapReaderPrivate::readTilesetTile(Tileset &tileset)
 
     Tile *tile = tileset.findOrCreateTile(id);
 
+    const QRect imageRect(atts.value(QLatin1String("x")).toInt(),
+                          atts.value(QLatin1String("y")).toInt(),
+                          atts.value(QLatin1String("width")).toInt(),
+                          atts.value(QLatin1String("height")).toInt());
+    tile->setImageRect(imageRect);
+
     tile->setType(atts.value(QLatin1String("type")).toString());
 
     // Read tile quadrant terrain ids as Wang IDs. This is possible because the
@@ -539,11 +545,7 @@ void MapReaderPrivate::readTilesetTile(Tileset &tileset)
                     if (imageReference.source.isEmpty())
                         xml.raiseError(tr("Error reading embedded image for tile %1").arg(id));
                 }
-                const QRect imageRect(atts.value(QLatin1String("x")).toInt(),
-                                      atts.value(QLatin1String("y")).toInt(),
-                                      atts.value(QLatin1String("width")).toInt(),
-                                      atts.value(QLatin1String("height")).toInt());
-                tileset.setTileImage(tile, image, imageReference.source, imageRect);
+                tileset.setTileImage(tile, image, imageReference.source);
             }
         } else if (xml.name() == QLatin1String("objectgroup")) {
             std::unique_ptr<ObjectGroup> objectGroup = readObjectGroup();

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -290,7 +290,7 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
             }
 
             const QRect &imageRect = tile->imageRect();
-            if (!imageRect.isNull() && imageRect != tile->image().rect()) {
+            if (!imageRect.isNull() && imageRect != tile->image().rect() && tileset.isCollection()) {
                 tileVariant[QStringLiteral("x")] = imageRect.x();
                 tileVariant[QStringLiteral("y")] = imageRect.y();
                 tileVariant[QStringLiteral("width")] = imageRect.width();

--- a/src/libtiled/tile.cpp
+++ b/src/libtiled/tile.cpp
@@ -68,6 +68,15 @@ QSharedPointer<Tileset> Tile::sharedTileset() const
     return mTileset->sharedFromThis();
 }
 
+/**
+ * Returns the image of this tile, or the image of its tileset if it doesn't
+ * have an individual one.
+ */
+const QPixmap &Tile::image() const
+{
+    return mImage.isNull() ? mTileset->image() : mImage;
+}
+
 // Using some internal Qt API here, but this is the function that is also used
 // by QGraphicsPixmapItem, so my assumption is that it is better suited for
 // this task than using QPainterPath::addRegion.

--- a/src/libtiled/tile.h
+++ b/src/libtiled/tile.h
@@ -149,14 +149,6 @@ inline Tileset *Tile::tileset() const
 }
 
 /**
- * Returns the image of this tile.
- */
-inline const QPixmap &Tile::image() const
-{
-    return mImage;
-}
-
-/**
  * Returns the URL of the external image that represents this tile.
  * When this tile doesn't refer to an external image, an empty URL is
  * returned.
@@ -184,7 +176,7 @@ inline const QRect &Tile::imageRect() const
  */
 inline int Tile::width() const
 {
-    return mImageRect.isNull() ? mImage.width() : mImageRect.width();
+    return mImageRect.width();
 }
 
 /**
@@ -192,7 +184,7 @@ inline int Tile::width() const
  */
 inline int Tile::height() const
 {
-    return mImageRect.isNull() ? mImage.height() : mImageRect.height();
+    return mImageRect.height();
 }
 
 /**
@@ -200,7 +192,7 @@ inline int Tile::height() const
  */
 inline QSize Tile::size() const
 {
-    return mImageRect.isNull() ? mImage.size() : mImageRect.size();
+    return mImageRect.size();
 }
 
 /**

--- a/src/libtiled/tileset.h
+++ b/src/libtiled/tileset.h
@@ -177,6 +177,8 @@ public:
     void setImageSource(const QString &url);
     QString imageSourceString() const;
 
+    const QPixmap &image() const;
+
     bool isCollection() const;
 
     int columnCountForWidth(int width) const;
@@ -204,8 +206,9 @@ public:
 
     void setTileImage(Tile *tile,
                       const QPixmap &image,
-                      const QUrl &source = QUrl(),
-                      const QRect &rect = QRect());
+                      const QUrl &source = QUrl());
+    void setTileImageRect(Tile *tile, const QRect &imageRect);
+
     /**
      * @deprecated Only kept around for the Python API!
      */
@@ -254,11 +257,15 @@ public:
     static Orientation orientationFromString(const QString &);
 
 private:
+    void initializeTilesetTiles();
+
+    void maybeUpdateTileSize(QSize oldSize, QSize newSize);
     void updateTileSize();
 
     QString mName;
     QString mFileName;
     ImageReference mImageReference;
+    QPixmap mImage;
     int mTileWidth;
     int mTileHeight;
     int mTileSpacing;
@@ -568,6 +575,11 @@ inline QString Tileset::imageSourceString() const
 {
     const QUrl &url = imageSource();
     return url.isLocalFile() ? url.toLocalFile() : url.toString();
+}
+
+inline const QPixmap &Tileset::image() const
+{
+    return mImage;
 }
 
 /**

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -319,6 +319,12 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
     auto readTile = [&](Tile *tile, const QVariantMap &tileVar) {
         bool ok = true;
 
+        const QRect imageRect(tileVar[QStringLiteral("x")].toInt(),
+                              tileVar[QStringLiteral("y")].toInt(),
+                              tileVar[QStringLiteral("width")].toInt(),
+                              tileVar[QStringLiteral("height")].toInt());
+        tile->setImageRect(imageRect);
+
         tile->setType(tileVar[QStringLiteral("type")].toString());
 
         // Read tile terrain ids as Wang IDs.
@@ -348,11 +354,7 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
         QVariant imageVariant = tileVar[QStringLiteral("image")];
         if (!imageVariant.isNull()) {
             const QUrl imagePath = toUrl(imageVariant.toString(), mDir);
-            const QRect imageRect(tileVar[QStringLiteral("x")].toInt(),
-                                  tileVar[QStringLiteral("y")].toInt(),
-                                  tileVar[QStringLiteral("width")].toInt(),
-                                  tileVar[QStringLiteral("height")].toInt());
-            tileset->setTileImage(tile, QPixmap(imagePath.toLocalFile()), imagePath, imageRect);
+            tileset->setTileImage(tile, QPixmap(imagePath.toLocalFile()), imagePath);
         }
 
         QVariantMap objectGroupVariant = tileVar[QStringLiteral("objectgroup")].toMap();

--- a/src/tiled/brokenlinks.cpp
+++ b/src/tiled/brokenlinks.cpp
@@ -584,8 +584,7 @@ void LinkFixer::tryFixLink(const BrokenLink &link)
         } else {
             auto command = new ChangeTileImageSource(tilesetDocument,
                                                      link._tile,
-                                                     newFileUrl,
-                                                     link._tile->imageRect());
+                                                     newFileUrl);
 
             tilesetDocument->undoStack()->push(command);
         }
@@ -630,8 +629,7 @@ bool LinkFixer::tryFixLink(const BrokenLink &link, const QString &newFilePath)
         } else {
             auto command = new ChangeTileImageSource(tilesetDocument,
                                                      link._tile,
-                                                     newSource,
-                                                     link._tile->imageRect());
+                                                     newSource);
 
             tilesetDocument->undoStack()->push(command);
         }

--- a/src/tiled/changetile.cpp
+++ b/src/tiled/changetile.cpp
@@ -20,6 +20,7 @@
 
 #include "changetile.h"
 
+#include "mapdocument.h"
 #include "tile.h"
 #include "tilesetdocument.h"
 
@@ -75,6 +76,32 @@ qreal ChangeTileProbability::getValue(const Tile *tile) const
 void ChangeTileProbability::setValue(Tile *tile, const qreal &probability) const
 {
     static_cast<TilesetDocument*>(document())->setTileProbability(tile, probability);
+}
+
+
+ChangeTileImageRect::ChangeTileImageRect(TilesetDocument *tilesetDocument,
+                                         const QList<Tile *> &tiles,
+                                         const QVector<QRect> &rects,
+                                         QUndoCommand *parent)
+    : ChangeValue(tilesetDocument, tiles, rects, parent)
+{
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Image Rect"));
+}
+
+QRect ChangeTileImageRect::getValue(const Tile *tile) const
+{
+    return tile->imageRect();
+}
+
+void ChangeTileImageRect::setValue(Tile *tile, const QRect &rect) const
+{
+    tile->tileset()->setTileImageRect(tile, rect);
+
+    emit static_cast<TilesetDocument*>(document())->tileImageSourceChanged(tile);
+
+    for (MapDocument *mapDocument : static_cast<TilesetDocument*>(document())->mapDocuments())
+        emit mapDocument->tileImageSourceChanged(tile);
 }
 
 } // namespace Tiled

--- a/src/tiled/changetile.h
+++ b/src/tiled/changetile.h
@@ -69,4 +69,19 @@ protected:
     void setValue(Tile *tile, const qreal &probability) const override;
 };
 
+class ChangeTileImageRect : public ChangeValue<Tile, QRect>
+{
+public:
+    ChangeTileImageRect(TilesetDocument *tilesetDocument,
+                        const QList<Tile*> &tiles,
+                        const QVector<QRect> &rects,
+                        QUndoCommand *parent = nullptr);
+
+    int id() const override { return Cmd_ChangeTileImageRect; }
+
+protected:
+    QRect getValue(const Tile *tile) const override;
+    void setValue(Tile *tile, const QRect &rect) const override;
+};
+
 } // namespace Tiled

--- a/src/tiled/changetileimagesource.cpp
+++ b/src/tiled/changetileimagesource.cpp
@@ -30,26 +30,22 @@ namespace Tiled {
 
 ChangeTileImageSource::ChangeTileImageSource(TilesetDocument *tilesetDocument,
                                              Tile *tile,
-                                             const QUrl &imageSource,
-                                             const QRect &imageRect)
+                                             const QUrl &imageSource)
     : mTilesetDocument(tilesetDocument)
     , mTile(tile)
     , mOldImageSource(tile->imageSource())
     , mNewImageSource(imageSource)
-    , mOldImageRect(tile->imageRect())
-    , mNewImageRect(imageRect)
 {
     setText(QCoreApplication::translate("Undo Commands",
                                         "Change Tile Image"));
 }
 
-void ChangeTileImageSource::apply(const QUrl &imageSource, const QRect &imageRect)
+void ChangeTileImageSource::apply(const QUrl &imageSource)
 {
     // todo: make sure remote source loading is triggered
     mTilesetDocument->setTileImage(mTile,
                                    ImageCache::loadPixmap(imageSource.toLocalFile()),
-                                   imageSource,
-                                   imageRect);
+                                   imageSource);
 }
 
 } // namespace Tiled

--- a/src/tiled/changetileimagesource.h
+++ b/src/tiled/changetileimagesource.h
@@ -22,7 +22,6 @@
 
 #include <QUndoCommand>
 #include <QUrl>
-#include <QRect>
 
 namespace Tiled {
 
@@ -35,21 +34,18 @@ class ChangeTileImageSource : public QUndoCommand
 public:
     ChangeTileImageSource(TilesetDocument *tilesetDocument,
                           Tile *tile,
-                          const QUrl &imageSource,
-                          const QRect &imageRect);
+                          const QUrl &imageSource);
 
-    void undo() override { apply(mOldImageSource, mOldImageRect); }
-    void redo() override { apply(mNewImageSource, mNewImageRect); }
+    void undo() override { apply(mOldImageSource); }
+    void redo() override { apply(mNewImageSource); }
 
 private:
-    void apply(const QUrl &imageSource, const QRect &imageRect);
+    void apply(const QUrl &imageSource);
 
     TilesetDocument *mTilesetDocument;
     Tile *mTile;
     const QUrl mOldImageSource;
     const QUrl mNewImageSource;
-    const QRect mOldImageRect;
-    const QRect mNewImageRect;
 };
 
 } // namespace Tiled

--- a/src/tiled/editabletile.cpp
+++ b/src/tiled/editabletile.cpp
@@ -148,8 +148,7 @@ void EditableTile::setImageFileName(const QString &fileName)
         }
 
         asset()->push(new ChangeTileImageSource(doc, tile(),
-                                                QUrl::fromLocalFile(fileName),
-                                                imageRect()));
+                                                QUrl::fromLocalFile(fileName)));
     } else if (!checkReadOnly()) {
         tile()->setImage(ImageCache::loadPixmap(fileName));
         tile()->setImageSource(QUrl::fromLocalFile(fileName));
@@ -164,9 +163,7 @@ void EditableTile::setImageRect(const QRect &rect)
             return;
         }
 
-        asset()->push(new ChangeTileImageSource(doc, tile(),
-                                                QUrl::fromLocalFile(imageFileName()),
-                                                rect));
+        asset()->push(new ChangeTileImageRect(doc, { tile() }, { rect }));
     } else if (!checkReadOnly()) {
         tile()->setImageRect(rect);
     }

--- a/src/tiled/tilesetdocument.cpp
+++ b/src/tiled/tilesetdocument.cpp
@@ -411,12 +411,11 @@ void TilesetDocument::setTileType(Tile *tile, const QString &type)
 
 void TilesetDocument::setTileImage(Tile *tile,
                                    const QPixmap &image,
-                                   const QUrl &source,
-                                   const QRect &rect)
+                                   const QUrl &source)
 {
     Q_ASSERT(tile->tileset() == mTileset.data());
 
-    mTileset->setTileImage(tile, image, source, rect);
+    mTileset->setTileImage(tile, image, source);
     emit tileImageSourceChanged(tile);
 
     for (MapDocument *mapDocument : mapDocuments())

--- a/src/tiled/tilesetdocument.h
+++ b/src/tiled/tilesetdocument.h
@@ -112,7 +112,7 @@ public:
     WangColorModel *wangColorModel(WangSet *wangSet);
 
     void setTileType(Tile *tile, const QString &type);
-    void setTileImage(Tile *tile, const QPixmap &image, const QUrl &source, const QRect &rect);
+    void setTileImage(Tile *tile, const QPixmap &image, const QUrl &source);
     void setTileProbability(Tile *tile, qreal probability);
     void swapTileObjectGroup(Tile *tile, std::unique_ptr<ObjectGroup> &objectGroup);
 

--- a/src/tiled/undocommands.h
+++ b/src/tiled/undocommands.h
@@ -41,6 +41,7 @@ enum UndoCommands {
     Cmd_ChangeMapObject,
     Cmd_ChangeMapObjectTransform,
     Cmd_ChangeSelectedArea,
+    Cmd_ChangeTileImageRect,
     Cmd_ChangeTileProbability,
     Cmd_ChangeTileType,
     Cmd_ChangeTileWangId,


### PR DESCRIPTION
Now that we're storing a sub-rectangle for each tile, we can use it to avoid actually cutting out the tiles from the tileset image.

Changing of a tile's image rect now also has its own undo command, and the tile image rect property is visible also for tiles from tileset-image based tilesets, though not editable for now.