### PR TITLE
Qt 6: Fixed return value for qHash

### DIFF
--- a/src/tiled/id.cpp
+++ b/src/tiled/id.cpp
@@ -41,7 +41,11 @@ public:
     {}
 
     QByteArray string;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     uint hash;
+#else
+    size_t hash;
+#endif
 };
 
 static bool operator==(const StringHash &sh1, const StringHash &sh2)
@@ -49,13 +53,17 @@ static bool operator==(const StringHash &sh1, const StringHash &sh2)
     return sh1.string == sh2.string;
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 static uint qHash(const StringHash &sh)
+#else
+static size_t qHash(const StringHash &sh)
+#endif
 {
     return sh.hash;
 }
 
-static QHash<quintptr, StringHash> stringFromId;
-static QHash<StringHash, quintptr> idFromString;
+static QHash<uint, StringHash> stringFromId;
+static QHash<StringHash, uint> idFromString;
 
 
 Id::Id(const char *name)

--- a/src/tiled/id.h
+++ b/src/tiled/id.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <QDebug>
 #include <QLatin1String>
 #include <QMetaType>
 
@@ -45,13 +46,16 @@ public:
 private:
     uint mId;
 
-    friend uint qHash(Id id) Q_DECL_NOTHROW;
+    friend auto qHash(Id id) Q_DECL_NOTHROW
+    {
+        return qHash(id.mId, 0);
+    }
 };
 
 
-inline uint qHash(Id id) Q_DECL_NOTHROW
+inline QDebug operator<<(QDebug debug, Id id)
 {
-    return id.mId;
+    return debug << id.name();
 }
 
 QStringList idsToNames(const QList<Id> &ids);


### PR DESCRIPTION
Qt 6 changed the return value for qHash from `uint` to `size_t`.

Opening PR to check whether this works fine on various Qt versions and compilers.