### PR TITLE
Keep object connections when duplicating as well

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ### Unreleased 1.8 patch
 
-* Keep references between objects when copy/pasting (#3361)
+* Keep references between objects when copy/pasting or duplicating (#3361)
 * Improved default translation used in case of multiple options
 * Fixed 'Add Variation' action in Tile Stamps context menu (#3362)
 * Fixed importing of removed shortcuts (#3367)

--- a/src/libtiled/layer.cpp
+++ b/src/libtiled/layer.cpp
@@ -54,23 +54,6 @@ Layer::Layer(TypeFlag type, const QString &name, int x, int y)
 {
 }
 
-void Layer::resetIds()
-{
-    mId = 0;        // reset out own ID
-
-    switch (layerType()) {
-    case ObjectGroupType:
-        static_cast<ObjectGroup*>(this)->resetObjectIds();
-        break;
-    case GroupLayerType:
-        for (Layer *layer : static_cast<GroupLayer*>(this)->layers())
-            layer->resetIds();
-        break;
-    default:
-        break;
-    }
-}
-
 /**
  * Returns the effective opacity, which is the opacity multiplied by the
  * opacity of any parent layers.

--- a/src/libtiled/layer.h
+++ b/src/libtiled/layer.h
@@ -75,7 +75,6 @@ public:
      */
     int id() const { return mId; }
     void setId(int id) { mId = id; }
-    void resetIds();
 
     const QColor &tintColor() const { return mTintColor; }
     void setTintColor(const QColor &tintColor) { mTintColor = tintColor; }

--- a/src/libtiled/objectgroup.cpp
+++ b/src/libtiled/objectgroup.cpp
@@ -216,17 +216,6 @@ ObjectGroup *ObjectGroup::clone() const
 }
 
 /**
- * Resets the ids of all objects to 0. Mostly used when new ids should be
- * assigned after the object group has been cloned.
- */
-void ObjectGroup::resetObjectIds()
-{
-    const QList<MapObject*> &objects = mObjects;
-    for (MapObject *object : objects)
-        object->resetId();
-}
-
-/**
  * Returns the highest object id in use by this object group, or 0 if no object
  * with assigned id exists.
  */

--- a/src/libtiled/objectgroup.h
+++ b/src/libtiled/objectgroup.h
@@ -169,7 +169,6 @@ public:
 
     ObjectGroup *clone() const override;
 
-    void resetObjectIds();
     int highestObjectId() const;
 
     // Enable easy iteration over objects with range-based for

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -34,6 +34,7 @@
 #include "maprenderer.h"
 #include "object.h"
 #include "objectgroup.h"
+#include "objectreferenceshelper.h"
 #include "tile.h"
 #include "tilelayer.h"
 
@@ -951,13 +952,17 @@ void AutoMapper::copyObjectRegion(const ObjectGroup *srcLayer, const QRectF &rec
     QVector<AddMapObjects::Entry> objectsToAdd;
     objectsToAdd.reserve(objects.size());
 
+    ObjectReferencesHelper objectRefs(mTargetMap);
+
     for (MapObject *obj : objects) {
         MapObject *clone = obj->clone();
-        clone->resetId();
+        objectRefs.reassignId(clone);
         clone->setX(clone->x() + pixelOffset.x());
         clone->setY(clone->y() + pixelOffset.y());
         objectsToAdd.append(AddMapObjects::Entry { clone, dstLayer });
     }
+
+    objectRefs.rewire();
 
     mTargetDocument->undoStack()->push(new AddMapObjects(mTargetDocument, objectsToAdd));
 }

--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -28,6 +28,7 @@
 #include "mapscene.h"
 #include "mapview.h"
 #include "objectgroup.h"
+#include "objectreferenceshelper.h"
 #include "snaphelper.h"
 #include "tile.h"
 #include "tilelayer.h"
@@ -191,29 +192,6 @@ bool ClipboardManager::copySelection(const MapDocument &mapDocument)
     return false;
 }
 
-template <typename Callback>
-static void processObjectReferences(Properties &properties, Callback callback)
-{
-    QMutableMapIterator<QString, QVariant> it(properties);
-    while (it.hasNext()) {
-        QVariant &value = it.next().value();
-
-        if (value.userType() == objectRefTypeId()) {
-            value = QVariant::fromValue(callback(value.value<ObjectRef>()));
-        } else if (value.userType() == propertyValueId()) {
-            auto propertyValue = value.value<PropertyValue>();
-            if (auto type = propertyValue.type()) {
-                if (type->type == PropertyType::PT_Class) {
-                    Properties properties = propertyValue.value.toMap();
-                    processObjectReferences(properties, callback);
-                    propertyValue.value = properties;
-                    value = QVariant::fromValue(propertyValue);
-                }
-            }
-        }
-    }
-}
-
 /**
  * Convenience method that deals with some of the logic related to pasting
  * a group of objects.
@@ -258,29 +236,21 @@ void ClipboardManager::pasteObjectGroup(const ObjectGroup *objectGroup,
     objectsToAdd.reserve(objectGroup->objectCount());
 
     Map *map = mapDocument->map();
-    QHash<int, int> oldIdToNewId;
+    ObjectReferencesHelper objectRefs(map);
 
     for (const MapObject *mapObject : objectGroup->objects()) {
         if (flags & PasteNoTileObjects && !mapObject->cell().isEmpty())
             continue;
 
         MapObject *objectClone = mapObject->clone();
-        objectClone->setId(map->takeNextObjectId());
         objectClone->setPosition(objectClone->position() + insertPos);
+
+        objectRefs.reassignId(objectClone);
+
         objectsToAdd.append(AddMapObjects::Entry { objectClone, currentObjectGroup });
-
-        oldIdToNewId.insert(mapObject->id(), objectClone->id());
     }
 
-    // Rewire object connections in pasted objects, in case some of them
-    // referred to other pasted objects.
-    for (AddMapObjects::Entry &entry : objectsToAdd) {
-        processObjectReferences(entry.mapObject->properties(), [&] (ObjectRef objectRef) {
-            if (const int newId = oldIdToNewId.value(objectRef.id))
-                objectRef.id = newId;
-            return objectRef;
-        });
-    }
+    objectRefs.rewire();
 
     auto command = new AddMapObjects(mapDocument, objectsToAdd);
     command->setText(tr("Paste Objects"));

--- a/src/tiled/editablelayer.cpp
+++ b/src/tiled/editablelayer.cpp
@@ -75,7 +75,7 @@ void EditableLayer::detach()
     setAsset(nullptr);
 
     mDetachedLayer.reset(layer()->clone());
-    mDetachedLayer->resetIds();
+//    mDetachedLayer->resetIds();
     setObject(mDetachedLayer.get());
     EditableManager::instance().mEditables.insert(layer(), this);
 }

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -46,6 +46,7 @@
 #include "movemapobject.h"
 #include "movemapobjecttogroup.h"
 #include "objectgroup.h"
+#include "objectreferenceshelper.h"
 #include "objecttemplate.h"
 #include "offsetlayer.h"
 #include "painttilelayer.h"
@@ -604,37 +605,55 @@ void MapDocument::duplicateLayers(const QList<Layer *> &layers)
         if (layers.contains(layer))
             layersToDuplicate.append(layer);
 
+    struct Duplication {
+        Layer *original;
+        Layer *clone;
+    };
+    QVector<Duplication> duplications;
+    ObjectReferencesHelper objectRefs(map());
+
+    // Duplicate the layers, reassigning any layer and object IDs
+    while (!layersToDuplicate.isEmpty()) {
+        Duplication dup;
+        dup.original = layersToDuplicate.takeFirst();
+        dup.clone = dup.original->clone();
+
+        // If a group layer gets duplicated, make sure any children are removed
+        // from the remaining list of layers to duplicate
+        if (dup.original->isGroupLayer()) {
+            layersToDuplicate.erase(std::remove_if(layersToDuplicate.begin(),
+                                                   layersToDuplicate.end(),
+                                                   [&] (Layer *layer) {
+                                        return layer->isParentOrSelf(dup.original);
+                                    }), layersToDuplicate.end());
+        }
+
+        objectRefs.reassignIds(dup.clone);
+        dup.clone->setName(tr("Copy of %1").arg(dup.clone->name()));
+
+        duplications.append(dup);
+    }
+
+    objectRefs.rewire();
+
+    // Actually add each duplicated layer
     QList<Layer *> newLayers;
     GroupLayer *previousParentLayer = nullptr;
     int previousIndex = 0;
 
-    while (!layersToDuplicate.isEmpty()) {
-        Layer *layer = layersToDuplicate.takeFirst();
-
-        // If a group layer gets duplicated, make sure any children are removed
-        // from the remaining list of layers to duplicate
-        if (layer->isGroupLayer()) {
-            for (int i = layersToDuplicate.size() - 1; i >= 0; --i)
-                if (layersToDuplicate.at(i)->isParentOrSelf(layer))
-                    layersToDuplicate.removeAt(i);
-        }
-
-        Layer *duplicate = layer->clone();
-        duplicate->resetIds();
-        duplicate->setName(tr("Copy of %1").arg(duplicate->name()));
-
-        auto parentLayer = layer->parentLayer();
+    for (const auto &dup : qAsConst(duplications)) {
+        auto parentLayer = dup.original->parentLayer();
 
         int index = previousIndex;
         if (newLayers.isEmpty() || previousParentLayer != parentLayer)
-            index = layer->siblingIndex() + 1;
+            index = dup.original->siblingIndex() + 1;
 
-        undoStack()->push(new AddLayer(this, index, duplicate, parentLayer));
+        undoStack()->push(new AddLayer(this, index, dup.clone, parentLayer));
 
         previousParentLayer = parentLayer;
         previousIndex = index;
 
-        newLayers.append(duplicate);
+        newLayers.append(dup.clone);
     }
 
     undoStack()->endMacro();
@@ -1530,12 +1549,16 @@ void MapDocument::duplicateObjects(const QList<MapObject *> &objects)
     QVector<AddMapObjects::Entry> objectsToAdd;
     objectsToAdd.reserve(objects.size());
 
+    ObjectReferencesHelper objectRefs(map());
+
     for (MapObject *mapObject : objects) {
         MapObject *clone = mapObject->clone();
-        clone->resetId();
+        objectRefs.reassignId(clone);
         objectsToAdd.append(AddMapObjects::Entry { clone, mapObject->objectGroup() });
         objectsToAdd.last().index = mapObject->objectGroup()->objects().indexOf(mapObject) + 1;
     }
+
+    objectRefs.rewire();
 
     auto command = new AddMapObjects(this, objectsToAdd);
     command->setText(tr("Duplicate %n Object(s)", "", objects.size()));

--- a/src/tiled/objectreferenceshelper.cpp
+++ b/src/tiled/objectreferenceshelper.cpp
@@ -1,0 +1,99 @@
+/*
+ * objectreferenceshelper.cpp
+ * Copyright 2022, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "objectreferenceshelper.h"
+
+#include "grouplayer.h"
+#include "layer.h"
+#include "map.h"
+#include "mapobject.h"
+#include "objectgroup.h"
+#include "properties.h"
+
+namespace Tiled {
+
+template <typename Callback>
+static void processObjectReferences(Properties &properties, Callback callback)
+{
+    QMutableMapIterator<QString, QVariant> it(properties);
+    while (it.hasNext()) {
+        QVariant &value = it.next().value();
+
+        if (value.userType() == objectRefTypeId()) {
+            value = QVariant::fromValue(callback(value.value<ObjectRef>()));
+        } else if (value.userType() == propertyValueId()) {
+            auto propertyValue = value.value<PropertyValue>();
+            if (auto type = propertyValue.type()) {
+                if (type->type == PropertyType::PT_Class) {
+                    Properties properties = propertyValue.value.toMap();
+                    processObjectReferences(properties, callback);
+                    propertyValue.value = properties;
+                    value = QVariant::fromValue(propertyValue);
+                }
+            }
+        }
+    }
+}
+
+ObjectReferencesHelper::ObjectReferencesHelper(Map *map)
+    : mMap(map)
+{
+}
+
+void ObjectReferencesHelper::reassignId(MapObject *mapObject)
+{
+    mOldIdToObject.insert(mapObject->id(), mapObject);
+    mapObject->setId(mMap->takeNextObjectId());
+}
+
+void ObjectReferencesHelper::reassignIds(Layer *layer)
+{
+    layer->setId(mMap->takeNextLayerId());
+
+    switch (layer->layerType()) {
+    case Layer::ObjectGroupType:
+        for (MapObject *object : static_cast<ObjectGroup*>(layer)->objects())
+            reassignId(object);
+        break;
+    case Layer::GroupLayerType:
+        for (Layer *layer : static_cast<GroupLayer*>(layer)->layers())
+            reassignIds(layer);
+        break;
+    default:
+        break;
+    }
+}
+
+/**
+ * Rewires object connections among the objects that have been assigned new
+ * IDs.
+ */
+void ObjectReferencesHelper::rewire()
+{
+    for (MapObject *mapObject : qAsConst(mOldIdToObject)) {
+        processObjectReferences(mapObject->properties(), [&] (ObjectRef objectRef) {
+            if (const MapObject *referencedObject = mOldIdToObject.value(objectRef.id))
+                objectRef.id = referencedObject->id();
+            return objectRef;
+        });
+    }
+}
+
+} // namespace Tiled

--- a/src/tiled/objectreferenceshelper.h
+++ b/src/tiled/objectreferenceshelper.h
@@ -1,0 +1,50 @@
+/*
+ * objectreferenceshelper.h
+ * Copyright 2022, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QHash>
+
+namespace Tiled {
+
+class Layer;
+class Map;
+class MapObject;
+
+/**
+ * Helps to keep connections between objects in-place when copying groups of
+ * objects.
+ */
+class ObjectReferencesHelper
+{
+public:
+    explicit ObjectReferencesHelper(Map *map);
+
+    void reassignId(MapObject *mapObject);
+    void reassignIds(Layer *layer);
+
+    void rewire();
+
+private:
+    Map *mMap;
+    QHash<int, MapObject*> mOldIdToObject;
+};
+
+} // namespace Tiled

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -188,6 +188,7 @@ SOURCES += aboutdialog.cpp \
     objectrefdialog.cpp \
     objectrefedit.cpp \
     objectreferenceitem.cpp \
+    objectreferenceshelper.cpp \
     objectreferencetool.cpp \
     objectsdock.cpp \
     objectselectionitem.cpp \
@@ -427,6 +428,7 @@ HEADERS += aboutdialog.h \
     objectrefdialog.h \
     objectrefedit.h \
     objectreferenceitem.h \
+    objectreferenceshelper.h \
     objectreferencetool.h \
     objectsdock.h \
     objectselectionitem.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -362,6 +362,8 @@ QtGuiApplication {
         "objectrefedit.h",
         "objectreferenceitem.cpp",
         "objectreferenceitem.h",
+        "objectreferenceshelper.cpp",
+        "objectreferenceshelper.h",
         "objectreferencetool.cpp",
         "objectreferencetool.h",
         "objectsdock.cpp",


### PR DESCRIPTION
Expands on f6bf60ff759a3c5a7ffd02cc1c0e02b7e97bf810. Now this behavior also applies to the following actions:

* Duplicate Layer
* Duplicate Objects
* Layer via Copy
* When the AutoMapper places objects

See issue #3361