### PR TITLE
Make Terrain Brush fill full tiles mode toggle-able

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Added support for SVG 1.2 / CSS blending modes to layers (#3932)
+* Added button to toggle Terrain Brush to full tile mode (by Finlay Pearson, #3407)
 * Added export plugin for Remixed Dungeon (by Mikhael Danilov, #4158)
 * Added "World > World Properties" menu action (with dogboydog, #4190)
 * Scripting: Added API for custom property types (with dogboydog, #3971)

--- a/src/tiled/abstracttileselectiontool.cpp
+++ b/src/tiled/abstracttileselectiontool.cpp
@@ -69,13 +69,13 @@ AbstractTileSelectionTool::AbstractTileSelectionTool(Id id,
     mActionGroup->addAction(mIntersect);
 
     connect(mReplace, &QAction::triggered,
-            [this] { mSelectionMode = mDefaultMode = Replace; });
+            this, [this] { mSelectionMode = mDefaultMode = Replace; });
     connect(mAdd, &QAction::triggered,
-            [this] { mSelectionMode = mDefaultMode = Add; });
+            this, [this] { mSelectionMode = mDefaultMode = Add; });
     connect(mSubtract, &QAction::triggered,
-            [this] { mSelectionMode = mDefaultMode = Subtract; });
+            this, [this] { mSelectionMode = mDefaultMode = Subtract; });
     connect(mIntersect, &QAction::triggered,
-            [this] { mSelectionMode = mDefaultMode = Intersect; });
+            this, [this] { mSelectionMode = mDefaultMode = Intersect; });
 
     AbstractTileSelectionTool::languageChanged();
 }

--- a/src/tiled/resources/images/scalable/fill-full-tiles.svg
+++ b/src/tiled/resources/images/scalable/fill-full-tiles.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg enable-background="new 0 0 24 24" version="1.1" viewBox="0 0 24 24" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
+<g opacity=".55">
+	<rect x="4" y="4" width="16" height="16" fill="#214A88"/>
+	<rect x="5" y="5" width="4" height="4" fill="#719FCF"/>
+	<rect x="10" y="5" width="4" height="4" fill="#719FCF"/>
+	<rect x="15" y="5" width="4" height="4" fill="#719FCF"/>
+	<rect x="15" y="10" width="4" height="4" fill="#719FCF"/>
+	<rect x="15" y="15" width="4" height="4" fill="#719FCF"/>
+	<rect x="10" y="15" width="4" height="4" fill="#719FCF"/>
+	<rect x="5" y="15" width="4" height="4" fill="#719FCF"/>
+	<rect x="5" y="10" width="4" height="4" fill="#719FCF"/>
+	<rect x="6" y="6" width="2" height="2" fill="#507FB7"/>
+	<rect x="11" y="6" width="2" height="2" fill="#507FB7"/>
+	<rect x="16" y="6" width="2" height="2" fill="#507FB7"/>
+	<rect x="16" y="11" width="2" height="2" fill="#507FB7"/>
+	<rect x="16" y="16" width="2" height="2" fill="#507FB7"/>
+	<rect x="11" y="16" width="2" height="2" fill="#507FB7"/>
+	<rect x="6" y="16" width="2" height="2" fill="#507FB7"/>
+	<rect x="6" y="11" width="2" height="2" fill="#507FB7"/>
+</g>
+	<rect x="9" y="9" width="6" height="6" fill="#214A88"/>
+	<rect x="10" y="10" width="4" height="4" fill="#719FCF"/>
+	<rect x="11" y="11" width="2" height="2" fill="#3465A5"/>
+</svg>

--- a/src/tiled/wangbrush.cpp
+++ b/src/tiled/wangbrush.cpp
@@ -100,8 +100,8 @@ WangBrush::WangBrush(QObject *parent)
     mToggleFillFullTiles->setText(tr("Fill Full Tiles"));
 
     ActionManager::registerAction(mToggleFillFullTiles, "ToggleFillFullTiles");
-    connect(mToggleFillFullTiles, &QAction::toggled, this, [this](bool checked) {
-        mIsTileMode = checked;
+    connect(mToggleFillFullTiles, &QAction::triggered, this, [this](bool checked) {
+        mIsTileMode = mIsTileModeDefault = checked;
         stateChanged();
     });
 }
@@ -168,7 +168,7 @@ void WangBrush::mouseReleased(QGraphicsSceneMouseEvent *event)
 void WangBrush::modifiersChanged(Qt::KeyboardModifiers modifiers)
 {
     const bool isControlPressed = modifiers & Qt::ControlModifier;
-    const bool isTileMode = isControlPressed != mToggleFillFullTiles->isChecked();
+    const bool isTileMode = isControlPressed != mIsTileModeDefault;
     const bool rotationalSymmetry = modifiers & Qt::AltModifier;
     const bool lineMode = modifiers & Qt::ShiftModifier;
 
@@ -181,6 +181,7 @@ void WangBrush::modifiersChanged(Qt::KeyboardModifiers modifiers)
 
     if (mIsTileMode != isTileMode) {
         mIsTileMode = isTileMode;
+        mToggleFillFullTiles->setChecked(mIsTileMode);
         changed = true;
     }
 

--- a/src/tiled/wangbrush.cpp
+++ b/src/tiled/wangbrush.cpp
@@ -100,7 +100,6 @@ WangBrush::WangBrush(QObject *parent)
     mToggleFillFullTiles->setCheckable(true);
     mToggleFillFullTiles->setIcon(rotateRightIcon);
     mToggleFillFullTiles->setText(tr("Fill Full Tiles"));
-    mToggleFillFullTiles->setShortcut(Qt::Key_L);
 
     ActionManager::registerAction(mToggleFillFullTiles, "ToggleFillFullTiles");
     connect(mToggleFillFullTiles, &QAction::toggled, [this](bool isChecked) {

--- a/src/tiled/wangbrush.cpp
+++ b/src/tiled/wangbrush.cpp
@@ -97,18 +97,17 @@ WangBrush::WangBrush(QObject *parent)
     mToggleFillFullTiles = new QAction(this);
     mToggleFillFullTiles->setCheckable(true);
     mToggleFillFullTiles->setIcon(fillFullTilesIcon);
-    mToggleFillFullTiles->setText(tr("Fill Full Tiles"));
 
     ActionManager::registerAction(mToggleFillFullTiles, "ToggleFillFullTiles");
     connect(mToggleFillFullTiles, &QAction::triggered, this, [this](bool checked) {
         mIsTileMode = mIsTileModeDefault = checked;
         stateChanged();
     });
+
+    languageChanged();
 }
 
-WangBrush::~WangBrush()
-{
-}
+WangBrush::~WangBrush() = default;
 
 void WangBrush::activate(MapScene *scene)
 {
@@ -136,7 +135,9 @@ void WangBrush::mousePressed(QGraphicsSceneMouseEvent *event)
                 break;
             }
             return;
-        } else if (event->button() == Qt::RightButton && event->modifiers() == Qt::NoModifier) {
+        }
+
+        if (event->button() == Qt::RightButton && event->modifiers() == Qt::NoModifier) {
             switch (mBrushBehavior) {
             case Free:
                 captureHoverColor();

--- a/src/tiled/wangbrush.cpp
+++ b/src/tiled/wangbrush.cpp
@@ -92,17 +92,16 @@ WangBrush::WangBrush(QObject *parent)
     // Set up toolbar action for toggling fill full tiles mode,
     // which basically makes the brush bigger.
 
-    QIcon rotateRightIcon(QLatin1String(":images/scalable/fill-full-tiles.svg"));
+    QIcon fillFullTilesIcon(QLatin1String(":images/scalable/fill-full-tiles.svg"));
 
     mToggleFillFullTiles = new QAction(this);
     mToggleFillFullTiles->setCheckable(true);
-    mToggleFillFullTiles->setIcon(rotateRightIcon);
+    mToggleFillFullTiles->setIcon(fillFullTilesIcon);
     mToggleFillFullTiles->setText(tr("Fill Full Tiles"));
 
     ActionManager::registerAction(mToggleFillFullTiles, "ToggleFillFullTiles");
-    connect(mToggleFillFullTiles, &QAction::toggled, [this](bool isChecked) {
-        mIsFillFullTilesByDefault = isChecked;
-        mIsTileMode = mIsFillFullTilesByDefault;
+    connect(mToggleFillFullTiles, &QAction::toggled, this, [this](bool checked) {
+        mIsTileMode = checked;
         stateChanged();
     });
 }
@@ -169,7 +168,7 @@ void WangBrush::mouseReleased(QGraphicsSceneMouseEvent *event)
 void WangBrush::modifiersChanged(Qt::KeyboardModifiers modifiers)
 {
     const bool isControlPressed = modifiers & Qt::ControlModifier;
-    const bool isTileMode = isControlPressed != mIsFillFullTilesByDefault;
+    const bool isTileMode = isControlPressed != mToggleFillFullTiles->isChecked();
     const bool rotationalSymmetry = modifiers & Qt::AltModifier;
     const bool lineMode = modifiers & Qt::ShiftModifier;
 

--- a/src/tiled/wangbrush.cpp
+++ b/src/tiled/wangbrush.cpp
@@ -151,7 +151,11 @@ void WangBrush::mouseReleased(QGraphicsSceneMouseEvent *event)
 
 void WangBrush::modifiersChanged(Qt::KeyboardModifiers modifiers)
 {
-    const bool isTileMode = modifiers & Qt::ControlModifier;
+    // TODO: set this from a toolbar toggle or something.
+    const bool isTileModeByDefault = true;
+
+    const bool isControlPressed = modifiers & Qt::ControlModifier;
+    const bool isTileMode = isControlPressed != isTileModeByDefault;
     const bool rotationalSymmetry = modifiers & Qt::AltModifier;
     const bool lineMode = modifiers & Qt::ShiftModifier;
 

--- a/src/tiled/wangbrush.cpp
+++ b/src/tiled/wangbrush.cpp
@@ -92,9 +92,7 @@ WangBrush::WangBrush(QObject *parent)
     // Set up toolbar action for toggling fill full tiles mode,
     // which basically makes the brush bigger.
 
-    // TODO: set a proper icon for this action.
-    QIcon rotateRightIcon(QLatin1String(":images/24/rotate-right.png"));
-    rotateRightIcon.addFile(QLatin1String(":images/32/rotate-right.png"));
+    QIcon rotateRightIcon(QLatin1String(":images/scalable/fill-full-tiles.svg"));
 
     mToggleFillFullTiles = new QAction(this);
     mToggleFillFullTiles->setCheckable(true);

--- a/src/tiled/wangbrush.h
+++ b/src/tiled/wangbrush.h
@@ -26,6 +26,8 @@
 #include "wangfiller.h"
 #include "wangset.h"
 
+#include <QToolBar>
+
 namespace Tiled {
 
 class WangBrushItem : public BrushItem
@@ -74,6 +76,8 @@ public:
 
     void setColor(int color);
 
+    void populateToolBar(QToolBar *toolbar) override;
+
 signals:
     void colorCaptured(int color);
 
@@ -120,6 +124,8 @@ private:
     bool mRotationalSymmetry = false;
     bool mLineStartSet = false;
     BrushBehavior mBrushBehavior = Free;
+    QAction *mToggleFillFullTiles;
+    bool mIsFillFullTilesByDefault = false;
 };
 
 } // namespace Tiled

--- a/src/tiled/wangbrush.h
+++ b/src/tiled/wangbrush.h
@@ -125,7 +125,6 @@ private:
     bool mLineStartSet = false;
     BrushBehavior mBrushBehavior = Free;
     QAction *mToggleFillFullTiles;
-    bool mIsFillFullTilesByDefault = false;
 };
 
 } // namespace Tiled

--- a/src/tiled/wangbrush.h
+++ b/src/tiled/wangbrush.h
@@ -121,6 +121,7 @@ private:
     int mCurrentColor = 0;
     BrushMode mBrushMode = Idle;
     bool mIsTileMode = false;
+    bool mIsTileModeDefault = false;
     bool mRotationalSymmetry = false;
     bool mLineStartSet = false;
     BrushBehavior mBrushBehavior = Free;

--- a/src/tiled/wangbrush.h
+++ b/src/tiled/wangbrush.h
@@ -49,7 +49,7 @@ private:
     QRegion mInvalidTiles;
 };
 
-class WangBrush : public AbstractTileTool
+class WangBrush final : public AbstractTileTool
 {
     Q_OBJECT
 


### PR DESCRIPTION
Hi, I have tried to address https://github.com/mapeditor/tiled/issues/3082. I hope it is useful.

A few things I wasn't sure about:
- I don't really understand the translations so I didn't add any for the new text I added.
- I didn't make an icon for the new toolbar tool I added; I just re-used an icon fromsomething else. But it's not really appropriate, so I need some guidance about which icon to pick.