### PR TITLE
Fixed "repeatx" and "repeaty" of ImageLayer for json

### DIFF
--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -814,6 +814,18 @@ std::unique_ptr<ImageLayer> VariantToMapConverter::toImageLayer(const QVariantMa
         imageLayer->loadFromImage(imageSource);
     }
 
+
+	QVariant repeatVariantX = variantMap[QStringLiteral("repeatx")];
+    QVariant repeatVariantY = variantMap[QStringLiteral("repeaty")];
+	
+    if (!repeatVariantX.isNull()) {
+		imageLayer->setRepeatX(repeatVariantX.toBool());
+	}
+
+	if (!repeatVariantY.isNull()) {
+		imageLayer->setRepeatY(repeatVariantY.toBool());
+	}
+
     return imageLayer;
 }
 

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -814,17 +814,8 @@ std::unique_ptr<ImageLayer> VariantToMapConverter::toImageLayer(const QVariantMa
         imageLayer->loadFromImage(imageSource);
     }
 
-
-	QVariant repeatVariantX = variantMap[QStringLiteral("repeatx")];
-    QVariant repeatVariantY = variantMap[QStringLiteral("repeaty")];
-	
-    if (!repeatVariantX.isNull()) {
-		imageLayer->setRepeatX(repeatVariantX.toBool());
-	}
-
-	if (!repeatVariantY.isNull()) {
-		imageLayer->setRepeatY(repeatVariantY.toBool());
-	}
+    imageLayer->setRepeatX(variantMap[QStringLiteral("repeatx")].toBool());
+    imageLayer->setRepeatY(variantMap[QStringLiteral("repeaty")].toBool());
 
     return imageLayer;
 }


### PR DESCRIPTION
I was able to reproduce the bug #3424 and made an attempt to fix the issue.
I added the necessary code to load the "repeatx" and the "repeaty" property of ImageLayer correctly from tmj/json.