### PR TITLE
MapToVariantConverter: Write out the correct version for Tilesets

### DIFF
--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -176,7 +176,7 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
 
         // Include version in external tilesets
         if (mVersion == 2)
-            tilesetVariant[QStringLiteral("version")] = QStringLiteral("1.8");
+            tilesetVariant[QStringLiteral("version")] = FileFormat::versionString();
         else
             tilesetVariant[QStringLiteral("version")] = 1.1;
         tilesetVariant[QStringLiteral("tiledversion")] = QCoreApplication::applicationVersion();


### PR DESCRIPTION
After the 1.8 compatibility mode was added in 1.9, `toVariant(Map)` was updated to use `FileFormat::versionString()`, but `toVariant(Tileset)` was not and was still always writing out "1.8".