### PR TITLE
Fix compilation on Windows (via Qt Creator)

### DIFF
--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -59,6 +59,7 @@
 #include <QFile>
 #include <QQmlEngine>
 #include <QStandardPaths>
+#include <QStringDecoder>
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
 #include <QTextCodec>
 #endif

--- a/src/tiled/stylehelper.h
+++ b/src/tiled/stylehelper.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <QObject>
 #include <QPalette>
 #include <QString>
 


### PR DESCRIPTION
As an aspiring contributor to this project, I downloaded Qt 6 and cloned the repo and right off the bat whenever trying to build the project I hit these two missing includes, resulting in compilation failure.