### PR TITLE
Smartly choose a new layer name to prevent duplicate names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Fixed new layer names to be always unique (#3452)
 * Scripting: Fixed painting issues after changing TileLayer size (#3481)
 * Defold plugin: Allow overriding z value also when exporting to .collection (#3214)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ### Unreleased
 
-* Fixed new layer names to be always unique (#3452)
+* Fixed new layer names to be always unique (by Logan Higinbotham, #3452)
 * Scripting: Fixed painting issues after changing TileLayer size (#3481)
 * Defold plugin: Allow overriding z value also when exporting to .collection (#3214)
 

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -488,7 +488,7 @@ void MapDocument::rotateSelectedObjects(RotateDirection direction)
 Layer *MapDocument::addLayer(Layer::TypeFlag layerType)
 {
     Layer *layer = nullptr;
-    QString name = newLayerName(layerType);
+    const QString name = newLayerName(layerType);
     Q_ASSERT(!name.isEmpty());
 
     switch (layerType) {
@@ -1473,14 +1473,16 @@ QString MapDocument::newLayerName(Layer::TypeFlag layerType) const
     }
 
     QSet<QString> layerNames;
-    for (const auto& layer : mMap->allLayers(layerType))
-            layerNames.insert(layer->name());
-
-    int number = 1;
-    auto candidateName = tr(parametricName).arg(number);
-    while (layerNames.contains(candidateName)) {
-        candidateName = tr(parametricName).arg(++number);
+    int number = 0;
+    for (const auto layer : mMap->allLayers(layerType)) {
+        ++number;
+        layerNames.insert(layer->name());
     }
+
+    QString candidateName;
+    do {
+        candidateName = tr(parametricName).arg(++number);
+    } while (layerNames.contains(candidateName));
 
     return candidateName;
 }

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -388,6 +388,8 @@ private:
 
     void moveObjectIndex(const MapObject *object, int count);
 
+    QString newLayerName(Layer::TypeFlag layerType) const;
+
     /*
      * QString is used since the formats referenced here may be dynamically
      * added by a plugin, and can also be removed again.


### PR DESCRIPTION
Fixes #3452 by attempting to use the default "{Type} Layer {Number}" name, incrementing {Number} if any collisions occur.