### PR TITLE
Allow a tile's object group (collision objects) be cleared via script

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Scripting: Fixed painting issues after changing TileLayer size (#3481)
+* Scripting: Allow assigning null to Tile.objectGroup (by Logan Higinbotham, #3495)
 * Defold plugin: Allow overriding z value also when exporting to .collection (#3214)
 * Qt 6: Fixed invisible tileset tabs when only a single tileset is open
 * Fixed compile against Qt 6.4


### PR DESCRIPTION
- fixes #3495 by handling the case where a user calls `tile.objectGroup = null`, allowing the user to clear out assigned collision shape objects