### PR TITLE
Fix point label placement to stick near the point object

### DIFF
--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -196,31 +196,25 @@ void MapObjectLabel::syncWithMapObject(const MapRenderer &renderer)
 
     boundingRect.adjust(-margin*2, -margin, margin*2, margin);
 
-    QPointF screenPos = renderer.pixelToScreenCoords(mObject->position());
+    QPointF pos = renderer.pixelToScreenCoords(mObject->position());
     QRectF bounds = mObject->screenBounds(renderer);
 
+    // Adjust the bounding box for object rotation
+    bounds = rotateAt(pos, mObject->rotation()).mapRect(bounds);
+
+    // Center the object name on the object bounding box
     if (mObject->shape() == MapObject::Point) {
-        // Use screenspace offset, since the Point annotation rescales with the zoom-level
-        mScreenspaceOffset = { 0, -bounds.height() };
-
-        if (auto mapScene = static_cast<MapScene*>(scene()))
-            screenPos += mapScene->absolutePositionForLayer(*mObject->objectGroup());
-
-        setPos(screenPos);
+        // Use a local offset, since point objects don't scale with the view
+        boundingRect.translate(0, -bounds.height());
+        mTextPos.ry() -= bounds.height();
     } else {
-        mScreenspaceOffset = { 0, 0 };
-
-        // Adjust the bounding box for object rotation
-        bounds = rotateAt(screenPos, mObject->rotation()).mapRect(bounds);
-
-        // Center the object name on the object bounding box
-        QPointF pos((bounds.left() + bounds.right()) / 2, bounds.top());
-
-        if (auto mapScene = static_cast<MapScene*>(scene()))
-            pos += mapScene->absolutePositionForLayer(*mObject->objectGroup());
-
-        setPos(pos);
+        pos = { (bounds.left() + bounds.right()) / 2, bounds.top() };
     }
+
+    if (auto mapScene = static_cast<MapScene*>(scene()))
+        pos += mapScene->absolutePositionForLayer(*mObject->objectGroup());
+
+    setPos(pos);
 
     if (mBoundingRect != boundingRect) {
         prepareGeometryChange();
@@ -241,18 +235,13 @@ void MapObjectLabel::updateColor()
 
 QRectF MapObjectLabel::boundingRect() const
 {
-    return mBoundingRect.translated(mScreenspaceOffset).adjusted(0, 0, 1, 1);
+    return mBoundingRect.adjusted(0, 0, 1, 1);
 }
 
 void MapObjectLabel::paint(QPainter *painter,
                            const QStyleOptionGraphicsItem *,
                            QWidget *)
 {
-    if (!mScreenspaceOffset.isNull()) {
-        painter->save();
-        painter->translate(mScreenspaceOffset);
-    }
-
     painter->setRenderHint(QPainter::Antialiasing);
     painter->setBrush(Qt::black);
     painter->setPen(Qt::NoPen);
@@ -265,9 +254,6 @@ void MapObjectLabel::paint(QPainter *painter,
     painter->drawText(mTextPos + QPointF(1,1), mObject->name());
     painter->setPen(Qt::white);
     painter->drawText(mTextPos, mObject->name());
-
-    if (!mScreenspaceOffset.isNull())
-        painter->restore();
 }
 
 

--- a/src/tiled/objectselectionitem.h
+++ b/src/tiled/objectselectionitem.h
@@ -56,6 +56,16 @@ public:
                QWidget *) override;
 
 private:
+    // For most cases, an object label is anchored to some world position
+    // but for object annotations that have a fixed screen size rather than
+    // a fixed world size (like for the Point object), we must anchor the label
+    // to some screen pixel.  We cannot offset the object via setPos() as the offset
+    // will scale with the zoom level (aka, translating the position by 10 in 
+    // `syncWithMapObject` will result in 10 being scaled as the zoom level changes).
+    // Thus, hold off on this offsetting until we are in `paint` such that the offset can
+    // be done in screen space rather than world space.
+    QPointF mScreenspaceOffset;
+
     QRectF mBoundingRect;
     QPointF mTextPos;
     const MapObject *mObject;

--- a/src/tiled/objectselectionitem.h
+++ b/src/tiled/objectselectionitem.h
@@ -56,16 +56,6 @@ public:
                QWidget *) override;
 
 private:
-    // For most cases, an object label is anchored to some world position
-    // but for object annotations that have a fixed screen size rather than
-    // a fixed world size (like for the Point object), we must anchor the label
-    // to some screen pixel.  We cannot offset the object via setPos() as the offset
-    // will scale with the zoom level (aka, translating the position by 10 in 
-    // `syncWithMapObject` will result in 10 being scaled as the zoom level changes).
-    // Thus, hold off on this offsetting until we are in `paint` such that the offset can
-    // be done in screen space rather than world space.
-    QPointF mScreenspaceOffset;
-
     QRectF mBoundingRect;
     QPointF mTextPos;
     const MapObject *mObject;


### PR DESCRIPTION
- fixes #3400 which notes that the labels for points are attached to a world coordinate, rather than a screenspace coordinate
	- the issue came about when points were changed from having a world-fixed size to now having a screen-fixed size, such that the annotation remains the same size when changing the zoom level of the map editor
 - one minor issue with this fix is that the painterScale used seems to be one "frame" behind whenever we are re-rendering due to a zoom level change; this corrects itself on the next non-cached repaint (for example, by panning the map editor)
- I have a prototype of a different fix where this one-frame lag doesn't occur but a different issue occurs; the bounding box of the label does not match where it is actually rendered and thus Qt graphics does not allow it to repaint after something was drawn over top of it