### PR TITLE
Fix selection highlight issue for unordered layer lists set by script

### DIFF
--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -281,11 +281,11 @@ void MapDocument::switchCurrentLayer(Layer *layer)
 
 void MapDocument::switchSelectedLayers(const QList<Layer *> &layers)
 {
-    setSelectedLayers(layers);
-
     // Automatically make sure the current layer is one of the selected ones
     if (!layers.contains(mCurrentLayer))
         setCurrentLayer(layers.isEmpty() ? nullptr : layers.first());
+
+    setSelectedLayers(layers);
 }
 
 /**


### PR DESCRIPTION
- fixes #3451 where layer selection highlighting was bugging out if the newly set selection was not ordered by layer ID
- this seems to be an event interplay issue with the following sequence:
	- script sets the layer selection to some array
	- first step in handling that is to set the currently selected layers to be the full array, triggering LayerView::selectedLayersChanged to select the whole range
	- second step is to make sure that the mCurrentLayer variable is pointing to an object within that array selection, which in this bad case it is not, so we end up calling setSelectedLayers with one item, triggering LayerView::selectedLayersChanged again with a single item and effectively clearing out the selection we had just highlighted
- fix this by doing the second step before the first step