### PR TITLE
Add more "select all" capabilities for the tileset view and layer view

### DIFF
--- a/src/tiled/layerdock.cpp
+++ b/src/tiled/layerdock.cpp
@@ -452,10 +452,10 @@ void LayerView::contextMenuEvent(QContextMenuEvent *event)
         menu.addAction(handler->actionDuplicateLayers());
         menu.addAction(handler->actionMergeLayersDown());
         menu.addAction(handler->actionRemoveLayers());
-        menu.addSeparator();
     }
     
     // independent of whether index is valid but maintaining positioning
+    menu.addSeparator();
     menu.addAction(handler->actionSelectAllLayers());
 
     if (proxyIndex.isValid()) {

--- a/src/tiled/layerdock.cpp
+++ b/src/tiled/layerdock.cpp
@@ -453,6 +453,12 @@ void LayerView::contextMenuEvent(QContextMenuEvent *event)
         menu.addAction(handler->actionMergeLayersDown());
         menu.addAction(handler->actionRemoveLayers());
         menu.addSeparator();
+    }
+    
+    // independent of whether index is valid but maintaining positioning
+    menu.addAction(handler->actionSelectAllLayers());
+
+    if (proxyIndex.isValid()) {
         menu.addAction(handler->actionMoveLayersUp());
         menu.addAction(handler->actionMoveLayersDown());
         menu.addSeparator();

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -814,6 +814,9 @@ void TilesetView::contextMenuEvent(QContextMenuEvent *event)
     connect(toggleGrid, &QAction::toggled,
             prefs, &Preferences::setShowTilesetGrid);
 
+    QAction *selectAllTiles = menu.addAction(tr("Select &All Tiles"));
+    connect(selectAllTiles, &QAction::triggered, this, &QAbstractItemView::selectAll);
+
     ActionManager::applyMenuExtensions(&menu, MenuIds::tilesetViewTiles);
 
     menu.exec(event->globalPos());


### PR DESCRIPTION
This PR fixes #3444 by adding a way to select all the tiles in the tileset view (useful for treating an entire tileset as a conglomerate stamp) and by adding the pre-existing "select all layers" action to the right-click context menu of the layers list.