### PR TITLE
Add a user preference to disable the zoom limiting on Fit Map In View

### DIFF
--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -59,6 +59,7 @@ using namespace Tiled;
 
 Preference<bool> MapView::ourAutoScrollingEnabled { "Interface/AutoScrolling", false };
 Preference<bool> MapView::ourSmoothScrollingEnabled { "Interface/SmoothScrolling", true };
+Preference<bool> MapView::noZoomLimitEnabled { "Interface/NoZoomLimit", true};
 
 MapView::MapView(QWidget *parent, Mode mode)
     : QGraphicsView(parent)
@@ -165,7 +166,14 @@ void MapView::fitMapInView()
                               height() / (256.0 * tileSize.height()));
 
     centerOn(rect.center());
-    setScale(std::max(std::max(desiredScale, scale256), 0.015625));
+    if (noZoomLimitEnabled)
+    {
+        setScale(desiredScale);
+    }
+    else
+    {
+        setScale(std::max(std::max(desiredScale, scale256), 0.015625));
+    }
 }
 
 void MapView::adjustScale(qreal scale)

--- a/src/tiled/mapview.h
+++ b/src/tiled/mapview.h
@@ -65,6 +65,7 @@ public:
 
     static Preference<bool> ourAutoScrollingEnabled;
     static Preference<bool> ourSmoothScrollingEnabled;
+    static Preference<bool> noZoomLimitEnabled;
 
     MapView(QWidget *parent = nullptr, Mode mode = StaticContents);
     ~MapView() override;

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -137,6 +137,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             this, [] (bool checked) { MapView::ourAutoScrollingEnabled = checked; });
     connect(mUi->smoothScrolling, &QCheckBox::toggled,
             this, [] (bool checked) { MapView::ourSmoothScrollingEnabled = checked; });
+    connect(mUi->noZoomLimit, &QCheckBox::toggled,
+            this, [] (bool checked) { MapView::noZoomLimitEnabled = checked; });
 
     connect(mUi->styleCombo, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, &PreferencesDialog::styleComboChanged);
@@ -217,6 +219,7 @@ void PreferencesDialog::fromPreferences()
     mUi->wheelZoomsByDefault->setChecked(prefs->wheelZoomsByDefault());
     mUi->autoScrolling->setChecked(MapView::ourAutoScrollingEnabled);
     mUi->smoothScrolling->setChecked(MapView::ourSmoothScrollingEnabled);
+    mUi->noZoomLimit->setChecked(MapView::noZoomLimitEnabled);
 
     // Not found (-1) ends up at index 0, system default
     int languageIndex = mUi->languageCombo->findData(prefs->language());

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="generalTab">
       <attribute name="title">
@@ -178,45 +178,13 @@
           <string>Interface</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="objectLineWidth">
-            <property name="suffix">
-             <string> pixels</string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>2.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="3">
-           <spacer name="horizontalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>138</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
           <item row="6" column="1">
            <widget class="QComboBox" name="objectSelectionBehaviorCombo"/>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_3">
+          <item row="8" column="0" colspan="2">
+           <widget class="QCheckBox" name="openGL">
             <property name="text">
-             <string>Grid color:</string>
-            </property>
-            <property name="buddy">
-             <cstring>gridColor</cstring>
+             <string>Hardware &amp;accelerated drawing (OpenGL)</string>
             </property>
            </widget>
           </item>
@@ -224,6 +192,16 @@
            <widget class="QLabel" name="label_8">
             <property name="text">
              <string>Background fade color:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Fine grid divisions:</string>
+            </property>
+            <property name="buddy">
+             <cstring>gridFine</cstring>
             </property>
            </widget>
           </item>
@@ -258,32 +236,60 @@
             </item>
            </layout>
           </item>
-          <item row="3" column="1">
-           <widget class="QSpinBox" name="gridFine">
-            <property name="minimum">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>&amp;Language:</string>
+            </property>
+            <property name="buddy">
+             <cstring>languageCombo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QDoubleSpinBox" name="objectLineWidth">
+            <property name="suffix">
+             <string> pixels</string>
+            </property>
+            <property name="decimals">
              <number>1</number>
             </property>
-            <property name="maximum">
-             <number>128</number>
+            <property name="minimum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>2.000000000000000</double>
             </property>
            </widget>
           </item>
-          <item row="11" column="0">
-           <widget class="QCheckBox" name="smoothScrolling">
-            <property name="text">
-             <string>Use s&amp;mooth scrolling</string>
-            </property>
-           </widget>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="languageCombo"/>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Major grid:</string>
-            </property>
-           </widget>
+          <item row="2" column="1">
+           <widget class="Tiled::ColorButton" name="backgroundFadeColor"/>
           </item>
           <item row="1" column="1">
            <widget class="Tiled::ColorButton" name="gridColor"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Grid color:</string>
+            </property>
+            <property name="buddy">
+             <cstring>gridColor</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Object line width:</string>
+            </property>
+            <property name="buddy">
+             <cstring>objectLineWidth</cstring>
+            </property>
+           </widget>
           </item>
           <item row="10" column="0" colspan="2">
            <widget class="QCheckBox" name="autoScrolling">
@@ -292,13 +298,13 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>&amp;Language:</string>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="gridFine">
+            <property name="minimum">
+             <number>1</number>
             </property>
-            <property name="buddy">
-             <cstring>languageCombo</cstring>
+            <property name="maximum">
+             <number>128</number>
             </property>
            </widget>
           </item>
@@ -315,18 +321,18 @@
             </property>
            </spacer>
           </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="languageCombo"/>
-          </item>
-          <item row="9" column="0" colspan="2">
-           <widget class="QCheckBox" name="wheelZoomsByDefault">
-            <property name="text">
-             <string>Mouse wheel &amp;zooms by default</string>
+          <item row="4" column="3">
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
             </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="Tiled::ColorButton" name="backgroundFadeColor"/>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>138</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item row="6" column="0">
            <widget class="QLabel" name="label_6">
@@ -338,30 +344,17 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_4">
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_7">
             <property name="text">
-             <string>Fine grid divisions:</string>
-            </property>
-            <property name="buddy">
-             <cstring>gridFine</cstring>
+             <string>Major grid:</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="0" colspan="2">
-           <widget class="QCheckBox" name="openGL">
+          <item row="9" column="0" colspan="2">
+           <widget class="QCheckBox" name="wheelZoomsByDefault">
             <property name="text">
-             <string>Hardware &amp;accelerated drawing (OpenGL)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Object line width:</string>
-            </property>
-            <property name="buddy">
-             <cstring>objectLineWidth</cstring>
+             <string>Mouse wheel &amp;zooms by default</string>
             </property>
            </widget>
           </item>
@@ -369,6 +362,20 @@
            <widget class="QCheckBox" name="preciseTileObjectSelection">
             <property name="text">
              <string>Pixel-perfect tile object selection</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="0">
+           <widget class="QCheckBox" name="smoothScrolling">
+            <property name="text">
+             <string>Use s&amp;mooth scrolling</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="0">
+           <widget class="QCheckBox" name="noZoomLimit">
+            <property name="text">
+             <string>No limit on zoom fit to view</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
- The discussion here https://github.com/mapeditor/tiled/issues/3524
- In summary: The ability to zoom to fit has been limited in code for large maps because of historic performance reasons. This may be unnecessary now, so having the ability to make this optional for the user might be preferable.
- An additional check box has been added to the preferences.ui view and preferencesdialog.cpp
- The parameter is exposed within mapview.h as noZoomLimitEnabled
- The new parameter is used in mapview.cpp to enable or disable the use of scale limiting