### PR TITLE
Scripting: Replaced TileMap.selectedArea with TileMap.selectedRegion

### DIFF
--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -2174,6 +2174,8 @@ declare class Layer extends TiledObject {
  * get the {@link region} of this area, modify that region, and then assign it
  * back. The necessary methods have been added to the {@link region} type with
  * Tiled 1.8.
+ *
+ * @deprecated Use {@link region} instead.
  */
 interface SelectedArea {
   /**
@@ -2354,8 +2356,17 @@ declare class TileMap extends Asset {
 
   /**
    * The selected area of tiles.
+   *
+   * @deprecated Use {@link selectedRegion} instead, which returns {@link region}.
    */
   readonly selectedArea : SelectedArea
+
+  /**
+   * The selected area of tiles.
+   *
+   * @since 1.10
+   */
+  selectedRegion : region
 
   /**
    * The current layer.

--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -69,6 +69,7 @@ EditableMap::EditableMap(MapDocument *mapDocument, QObject *parent)
     connect(mapDocument, &MapDocument::layerAdded, this, &EditableMap::attachLayer);
     connect(mapDocument, &MapDocument::layerRemoved, this, &EditableMap::detachLayer);
 
+    connect(mapDocument, &MapDocument::selectedAreaChanged, this, &EditableMap::selectedRegionChanged);
     connect(mapDocument, &MapDocument::currentLayerChanged, this, &EditableMap::currentLayerChanged);
     connect(mapDocument, &MapDocument::selectedLayersChanged, this, &EditableMap::selectedLayersChanged);
     connect(mapDocument, &MapDocument::selectedObjectsChanged, this, &EditableMap::selectedObjectsChanged);
@@ -120,6 +121,13 @@ QList<QObject *> EditableMap::layers()
         editables.append(editableManager.editableLayer(this, layer));
 
     return editables;
+}
+
+RegionValueType EditableMap::selectedRegion() const
+{
+    if (auto document = mapDocument())
+        return RegionValueType(document->selectedArea());
+    return {};
 }
 
 EditableLayer *EditableMap::currentLayer()
@@ -608,6 +616,11 @@ void EditableMap::setLayerDataFormat(LayerDataFormat value)
         push(new ChangeMapProperty(doc, static_cast<Map::LayerDataFormat>(value)));
     else if (!checkReadOnly())
         map()->setLayerDataFormat(static_cast<Map::LayerDataFormat>(value));
+}
+
+void EditableMap::setSelectedRegion(const RegionValueType &region)
+{
+    push(new ChangeSelectedArea(mapDocument(), region.region()));
 }
 
 void EditableMap::setCurrentLayer(EditableLayer *layer)

--- a/src/tiled/editablemap.h
+++ b/src/tiled/editablemap.h
@@ -58,6 +58,7 @@ class EditableMap : public EditableAsset
     Q_PROPERTY(QList<QObject*> tilesets READ tilesets)
     Q_PROPERTY(QList<QObject*> layers READ layers)
     Q_PROPERTY(Tiled::EditableSelectedArea *selectedArea READ selectedArea CONSTANT)
+    Q_PROPERTY(Tiled::RegionValueType selectedRegion READ selectedRegion WRITE setSelectedRegion NOTIFY selectedRegionChanged)
     Q_PROPERTY(Tiled::EditableLayer* currentLayer READ currentLayer WRITE setCurrentLayer NOTIFY currentLayerChanged)
     Q_PROPERTY(QList<QObject*> selectedLayers READ selectedLayers WRITE setSelectedLayers NOTIFY selectedLayersChanged)
     Q_PROPERTY(QList<QObject*> selectedObjects READ selectedObjects WRITE setSelectedObjects NOTIFY selectedObjectsChanged)
@@ -133,6 +134,7 @@ public:
     QList<QObject*> tilesets() const;
     QList<QObject*> layers();
     EditableSelectedArea *selectedArea();
+    RegionValueType selectedRegion() const;
     EditableLayer *currentLayer();
     QList<QObject*> selectedLayers();
     QList<QObject*> selectedObjects();
@@ -192,6 +194,7 @@ public:
     void setRenderOrder(RenderOrder value);
     void setBackgroundColor(const QColor &value);
     void setLayerDataFormat(LayerDataFormat value);
+    void setSelectedRegion(const RegionValueType &region);
     void setCurrentLayer(EditableLayer *layer);
     void setSelectedLayers(const QList<QObject*> &layers);
     void setSelectedObjects(const QList<QObject*> &objects);
@@ -202,6 +205,7 @@ public:
     QSharedPointer<Document> createDocument() override;
 
 signals:
+    void selectedRegionChanged();
     void currentLayerChanged();
     void selectedLayersChanged();
     void selectedObjectsChanged();


### PR DESCRIPTION
This new property has type `region` instead of `SelectedArea`, with the goal of unifying region values in the JS API.

Remaining issues with this change:

* It is not possible to assign a rectangle, for example created by `Qt.rect` to `selectedRegion`. I'm not sure if this can be fixed by adding overloads for the setter.
* It is not possible to create a new region value from script. Probably requires adding something like `tiled.region(...)` that can create either a empty or rectangular region.