### PR TITLE
Restored Tiled 1.8 file format compatibility by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Restored Tiled 1.8 file format compatibility by default (#3560)
 * Added action search popup on Ctrl+Shift+P (with dogboydog, #3449)
 * Added file system actions also for tileset image based tilesets (#3448)
 * Fixed new layer names to be always unique (by Logan Higinbotham, #3452)

--- a/docs/reference/json-map-format.rst
+++ b/docs/reference/json-map-format.rst
@@ -206,7 +206,6 @@ Object
     :header: Field, Type, Description
     :widths: 1, 1, 4
 
-    class,            string,           "The class of the object (renamed from ``type`` since 1.9, optional)"
     ellipse,          bool,             "Used to mark an object as an ellipse"
     gid,              int,              "Global tile ID, only if object represents a tile"
     height,           double,           "Height in pixels."
@@ -219,6 +218,7 @@ Object
     rotation,         double,           "Angle in degrees clockwise"
     template,         string,           "Reference to a template file, in case object is a :doc:`template instance </manual/using-templates>`"
     text,             :ref:`json-object-text`, "Only used for text objects"
+    type,             string,           "The class of the object (was saved as ``class`` in 1.9, optional)"
     visible,          bool,             "Whether object is shown in editor."
     width,            double,           "Width in pixels."
     x,                double,           "X coordinate in pixels"
@@ -230,7 +230,6 @@ Object Example
 .. code:: json
 
     {
-      "class":"npc",
       "gid":5,
       "height":0,
       "id":1,
@@ -242,6 +241,7 @@ Object Example
           "value":12
         }],
       "rotation":0,
+      "type":"npc",
       "visible":true,
       "width":0,
       "x":32,
@@ -254,12 +254,12 @@ Ellipse Example
 .. code:: json
 
     {
-      "class":"",
       "ellipse":true,
       "height":152,
       "id":13,
       "name":"",
       "rotation":0,
+      "type":"",
       "visible":true,
       "width":248,
       "x":560,
@@ -272,11 +272,11 @@ Rectangle Example
 .. code:: json
 
     {
-      "class":"",
       "height":184,
       "id":14,
       "name":"",
       "rotation":0,
+      "type":"",
       "visible":true,
       "width":368,
       "x":576,
@@ -289,12 +289,12 @@ Point Example
 .. code:: json
 
     {
-      "class":"",
       "height":0,
       "id":20,
       "name":"",
       "point":true,
       "rotation":0,
+      "type":"",
       "visible":true,
       "width":0,
       "x":220,
@@ -307,7 +307,6 @@ Polygon Example
 .. code:: json
 
     {
-      "class":"",
       "height":0,
       "id":15,
       "name":"",
@@ -333,6 +332,7 @@ Polygon Example
         "y":-288
       }],
       "rotation":0,
+      "type":"",
       "visible":true,
       "width":0,
       "x":-176,
@@ -345,7 +345,6 @@ Polyline Example
 .. code:: json
 
     {
-      "class":"",
       "height":0,
       "id":16,
       "name":"",
@@ -375,6 +374,7 @@ Polyline Example
         "y":0
       }],
       "rotation":0,
+      "type":"",
       "visible":true,
       "width":0,
       "x":240,
@@ -387,7 +387,6 @@ Text Example
 .. code:: json
 
     {
-      "class":"",
       "height":19,
       "id":15,
       "name":"",
@@ -397,6 +396,7 @@ Text Example
         "wrap":true
       },
       "rotation":0,
+      "type":"",
       "visible":true,
       "width":248,
       "x":48,
@@ -552,7 +552,6 @@ Tile (Definition)
     :widths: 1, 1, 4
 
     animation,        array,              "Array of :ref:`Frames <json-frame>`"
-    class,            string,             "The class of the tile (renamed from ``type`` since 1.9, optional)"
     id,               int,                "Local ID of the tile"
     image,            string,             "Image representing this tile (optional, used for image collection tilesets)"
     imageheight,      int,                "Height of the tile image in pixels"
@@ -564,7 +563,8 @@ Tile (Definition)
     objectgroup,      :ref:`json-layer`,  "Layer with type ``objectgroup``, when collision shapes are specified (optional)"
     probability,      double,             "Percentage chance this tile is chosen when competing with others in the editor (optional)"
     properties,       array,              "Array of :ref:`Properties <json-property>`"
-    terrain,          array,              "Index of terrain for each corner of tile (optional)"
+    terrain,          array,              "Index of terrain for each corner of tile (optional, replaced by :ref:`Wang sets <json-wangset>` since 1.5)"
+    type,             string,             "The class of the tile (was saved as ``class`` in 1.9, optional)"
 
 A tileset that associates information with each tile, like its image
 path, may include a ``tiles`` array property. Each tile
@@ -735,6 +735,14 @@ A point on a polygon or a polyline, relative to the position of the object.
 
 Changelog
 ---------
+
+Tiled 1.10
+~~~~~~~~~~
+
+* Renamed the ``class`` property on :ref:`json-tile` and :ref:`json-object`
+  back to ``type``, to keep compatibility with Tiled 1.8 and earlier. The
+  property remains ``class`` in other places since it could not be renamed
+  to ``type`` everywhere.
 
 Tiled 1.9
 ~~~~~~~~~

--- a/docs/reference/tmx-changelog.rst
+++ b/docs/reference/tmx-changelog.rst
@@ -4,6 +4,14 @@ TMX Changelog
 Below are described the changes/additions that were made to the
 :doc:`tmx-map-format` for recent versions of Tiled.
 
+Tiled 1.10
+----------
+
+-  Renamed the ``class`` attribute on :ref:`tmx-tileset-tile` and
+   :ref:`tmx-object` back to ``type``, to keep compatibility with Tiled 1.8
+   and earlier. The attribute remains ``class`` for other elements since it
+   could not be renamed to ``type`` everywhere.
+
 Tiled 1.9
 ---------
 

--- a/docs/reference/tmx-map-format.rst
+++ b/docs/reference/tmx-map-format.rst
@@ -297,8 +297,8 @@ tiles (e.g. to extend a Wang set by transforming existing tiles).
 ~~~~~~
 
 -  **id:** The local tile ID within its tileset.
--  **class:** The type of the tile. Refers to an object type and is used
-   by tile objects. (optional) (since 1.0, renamed from ``type`` since 1.9)
+-  **type:** The class of the tile. Is inherited by tile objects. (since 1.0,
+   defaults to "", was saved as ``class`` in 1.9)
 -  *terrain:* Defines the terrain type of each corner of the tile,
    given as comma-separated indexes in the terrain types array in the
    order top-left, top-right, bottom-left, bottom-right. Leaving out a
@@ -536,8 +536,8 @@ Can contain any number: :ref:`tmx-object`
    object was deleted, no object gets the same ID. Can not be changed in Tiled.
    (since Tiled 0.11)
 -  **name:** The name of the object. An arbitrary string. (defaults to "")
--  **class:** The class of the object. An arbitrary string. (defaults to "",
-   renamed from ``type`` since 1.9)
+-  **type:** The class of the object. An arbitrary string. (defaults to "",
+   was saved as ``class`` in 1.9)
 -  **x:** The x coordinate of the object in pixels. (defaults to 0)
 -  **y:** The y coordinate of the object in pixels. (defaults to 0)
 -  **width:** The width of the object in pixels. (defaults to 0)

--- a/src/libtiled/fileformat.cpp
+++ b/src/libtiled/fileformat.cpp
@@ -30,7 +30,7 @@
 
 namespace Tiled {
 
-CompatibilityVersion FileFormat::mCompatibilityVersion = Tiled_Latest;
+CompatibilityVersion FileFormat::mCompatibilityVersion = Tiled_Current;
 
 FileFormat::FileFormat(QObject *parent)
     : QObject(parent)
@@ -64,13 +64,23 @@ void FileFormat::setCompatibilityVersion(CompatibilityVersion version)
 QString FileFormat::versionString()
 {
     switch (mCompatibilityVersion) {
-    case Tiled::Tiled_1_8:
+    case Tiled_1_8:
         return QStringLiteral("1.8");
-    case Tiled::UnknownVersion:
-    case Tiled::Tiled_Latest:
+    case Tiled_1_9:
+        return QStringLiteral("1.9");
+    case UnknownVersion:
+    case Tiled_Current:
+    case Tiled_Latest:
         break;
     }
-    return QStringLiteral("1.9");
+    return QStringLiteral("1.10");
+}
+
+QString FileFormat::classPropertyNameForObject()
+{
+    if (mCompatibilityVersion == Tiled_1_9)
+        return QStringLiteral("class");
+    return QStringLiteral("type");
 }
 
 } // namespace Tiled

--- a/src/libtiled/fileformat.h
+++ b/src/libtiled/fileformat.h
@@ -92,6 +92,7 @@ public:
     static void setCompatibilityVersion(CompatibilityVersion version);
 
     static QString versionString();
+    static QString classPropertyNameForObject();
 
 private:
     static CompatibilityVersion mCompatibilityVersion;

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -288,12 +288,8 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
             addProperties(tileVariant, properties);
         }
 
-        if (!tile->className().isEmpty()) {
-            if (FileFormat::compatibilityVersion() <= Tiled_1_8)
-                tileVariant[QStringLiteral("type")] = tile->className();
-            else
-                tileVariant[QStringLiteral("class")] = tile->className();
-        }
+        if (!tile->className().isEmpty())
+            tileVariant[FileFormat::classPropertyNameForObject()] = tile->className();
         if (tile->probability() != 1.0)
             tileVariant[QStringLiteral("probability")] = tile->probability();
         if (!tile->imageSource().isEmpty()) {
@@ -570,12 +566,8 @@ QVariant MapToVariantConverter::toVariant(const MapObject &object) const
     if (notTemplateInstance || object.propertyChanged(MapObject::NameProperty))
         objectVariant[QStringLiteral("name")] = name;
 
-    if (notTemplateInstance || !className.isEmpty()) {
-        if (FileFormat::compatibilityVersion() <= Tiled_1_8)
-            objectVariant[QStringLiteral("type")] = className;
-        else
-            objectVariant[QStringLiteral("class")] = className;
-    }
+    if (notTemplateInstance || !className.isEmpty())
+        objectVariant[FileFormat::classPropertyNameForObject()] = className;
 
     if (notTemplateInstance || object.propertyChanged(MapObject::CellProperty))
         if (!object.cell().isEmpty())

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -445,11 +445,8 @@ void MapWriterPrivate::writeTileset(QXmlStreamWriter &w, const Tileset &tileset,
                                  QString::number(imageRect.height()));
             }
 
-            if (!tile->className().isEmpty()) {
-                const bool classAsType = FileFormat::compatibilityVersion() <= Tiled_1_8;
-                w.writeAttribute(classAsType ? QStringLiteral("type")
-                                             : QStringLiteral("class"), tile->className());
-            }
+            if (!tile->className().isEmpty())
+                w.writeAttribute(FileFormat::classPropertyNameForObject(), tile->className());
             if (tile->probability() != 1.0)
                 w.writeAttribute(QStringLiteral("probability"), QString::number(tile->probability()));
             if (!tile->properties().isEmpty())
@@ -517,7 +514,7 @@ void MapWriterPrivate::writeTileset(QXmlStreamWriter &w, const Tileset &tileset,
             w.writeAttribute(QStringLiteral("tile"), QString::number(ws->imageTileId()));
 
             for (int i = 1; i <= ws->colorCount(); ++i) {
-                if (WangColor *wc = ws->colorAt(i).data()) {
+                if (const WangColor *wc = ws->colorAt(i).data()) {
                     w.writeStartElement(QStringLiteral("wangcolor"));
 
                     w.writeAttribute(QStringLiteral("name"), wc->name());
@@ -777,11 +774,8 @@ void MapWriterPrivate::writeObject(QXmlStreamWriter &w,
     if (shouldWrite(!name.isEmpty(), isTemplateInstance, mapObject.propertyChanged(MapObject::NameProperty)))
         w.writeAttribute(QStringLiteral("name"), name);
 
-    if (!className.isEmpty()) {
-        const bool classAsType = FileFormat::compatibilityVersion() <= Tiled_1_8;
-        w.writeAttribute(classAsType ? QStringLiteral("type")
-                                     : QStringLiteral("class"), className);
-    }
+    if (!className.isEmpty())
+        w.writeAttribute(FileFormat::classPropertyNameForObject(), className);
 
     if (shouldWrite(!mapObject.cell().isEmpty(), isTemplateInstance, mapObject.propertyChanged(MapObject::CellProperty))) {
         const unsigned gid = mGidMapper.cellToGid(mapObject.cell());

--- a/src/libtiled/tiled.cpp
+++ b/src/libtiled/tiled.cpp
@@ -210,6 +210,10 @@ Tiled::CompatibilityVersion Tiled::versionFromString(const QString &string)
 {
     if (string == QLatin1String("1.8"))
         return Tiled_1_8;
+    else if (string == QLatin1String("1.9"))
+        return Tiled_1_9;
+    else if (string == QLatin1String("1.10"))
+        return Tiled_1_10;
     else if (string == QLatin1String("latest"))
         return Tiled_Latest;
     return UnknownVersion;

--- a/src/libtiled/tiled.h
+++ b/src/libtiled/tiled.h
@@ -72,6 +72,9 @@ enum LoadingStatus {
 enum CompatibilityVersion {
     UnknownVersion  = 0,
     Tiled_1_8       = 1080,
+    Tiled_1_9       = 1090,
+    Tiled_1_10      = 1100,
+    Tiled_Current   = Tiled_1_10,
     Tiled_Latest    = 65535,
 };
 

--- a/src/plugins/lua/luaplugin.cpp
+++ b/src/plugins/lua/luaplugin.cpp
@@ -52,6 +52,11 @@ using namespace Tiled;
 
 namespace Lua {
 
+static const char* classPropertyNameForObject()
+{
+    return FileFormat::compatibilityVersion() == Tiled_1_9 ? "class" : "type";
+}
+
 class LuaWriter
 {
 public:
@@ -404,7 +409,7 @@ void LuaWriter::writeTileset(const Tileset &tileset,
         mWriter.writeKeyAndValue("id", tile->id());
 
         if (!tile->className().isEmpty()) {
-            mWriter.writeKeyAndValue(FileFormat::compatibilityVersion() <= Tiled_1_8 ? "type" : "class",
+            mWriter.writeKeyAndValue(classPropertyNameForObject(),
                                      tile->className());
         }
 
@@ -465,6 +470,7 @@ void LuaWriter::writeWangSet(const WangSet &wangSet)
     mWriter.writeKeyAndValue("name", wangSet.name());
     mWriter.writeKeyAndValue("class", wangSet.className());
     mWriter.writeKeyAndValue("tile", wangSet.imageTileId());
+    mWriter.writeKeyAndValue("wangsettype", wangSetTypeToString(wangSet.type()));
 
     writeProperties(wangSet.properties());
 
@@ -715,7 +721,7 @@ void LuaWriter::writeMapObject(const Tiled::MapObject *mapObject)
     mWriter.writeStartTable();
     mWriter.writeKeyAndValue("id", mapObject->id());
     mWriter.writeKeyAndValue("name", mapObject->name());
-    mWriter.writeKeyAndValue(FileFormat::compatibilityVersion() <= Tiled_1_8 ? "type" : "class",
+    mWriter.writeKeyAndValue(classPropertyNameForObject(),
                              mapObject->className());
     mWriter.writeKeyAndValue("shape", toString(mapObject->shape()));
 

--- a/src/tiled/project.h
+++ b/src/tiled/project.h
@@ -52,7 +52,7 @@ public:
     QString mObjectTypesFile;
     QString mAutomappingRulesFile;
     QVector<Command> mCommands;
-    CompatibilityVersion mCompatibilityVersion = Tiled_Latest;
+    CompatibilityVersion mCompatibilityVersion = Tiled_Current;
 
 private:
     QDateTime mLastSaved;

--- a/src/tiled/projectpropertiesdialog.cpp
+++ b/src/tiled/projectpropertiesdialog.cpp
@@ -47,6 +47,8 @@ ProjectPropertiesDialog::ProjectPropertiesDialog(Project &project, QWidget *pare
 
     const QMap<CompatibilityVersion, QString> versionToName {
         { Tiled_1_8,             tr("Tiled 1.8") },
+        { Tiled_1_9,             tr("Tiled 1.9") },
+        { Tiled_1_10,            tr("Tiled 1.10") },
         { Tiled_Latest,          tr("Latest") },
     };
     mVersions = versionToName.keys();


### PR DESCRIPTION
Since Tiled 1.9, the "type" attribute was written out as "class", for consistency with the new "class" attribute added to other elements. This change affected the TMX, JSON and Lua formats. For compatibility, a "Compatibility Version" option was introduced for projects, which could be used to restore compatibility with Tiled 1.8.

This change has unfortunately caused considerable confusion, and many existing libraries and frameworks supporting Tiled files still do not support "class" even half a year after this change. Renaming this attribute just for consistency was clearly a mistake.

This change restores the compatibility with Tiled 1.8 by default, using "class" only in new places but reverting back to the older "type" attribute for map objects and tiles. This is not consistent, but compatibility is more important than consistency.

For projects that came to rely on the Tiled 1.9 approach of using "class" consistently, a new "Tiled 1.9" compatibility mode has been introduced.

Finally, new projects no longer default to the latest version, but rather to the current version. This means that should there ever be a reason to break compatibility in the future, such breakage will not affect existing projects (when they are using a .tiled-project file at least).