### PR TITLE
Added Windows layout management option

### DIFF
--- a/qbs/imports/TiledPlugin.qbs
+++ b/qbs/imports/TiledPlugin.qbs
@@ -37,7 +37,7 @@ DynamicLibrary {
     Group {
         qbs.install: true
         qbs.installDir: {
-            if (qbs.targetOS.contains("windows"))
+            if (project.windowsLayout)
                 return "plugins/tiled"
             else if (qbs.targetOS.contains("macos"))
                 return "Tiled.app/Contents/PlugIns"

--- a/qbs/imports/TiledQtGuiApplication.qbs
+++ b/qbs/imports/TiledQtGuiApplication.qbs
@@ -29,7 +29,7 @@ QtGuiApplication {
     Group {
         qbs.install: true
         qbs.installDir: {
-            if (qbs.targetOS.contains("windows")) {
+            if (project.windowsLayout) {
                 return "";
             } else if (qbs.targetOS.contains("darwin")) {
                 // Non-bundle applications are installed into the main Tiled.app bundle

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -37,6 +37,9 @@ DynamicLibrary {
         if (project.staticZstd || pkgConfigZstd.found)
             defs.push("TILED_ZSTD_SUPPORT");
 
+        if (project.windowsLayout)
+            defs.push("TILED_WINDOWS_LAYOUT");
+
         return defs;
     }
     cpp.dynamicLibraries: {
@@ -201,7 +204,10 @@ DynamicLibrary {
         qbs.install: true
         qbs.installDir: {
             if (qbs.targetOS.contains("windows"))
-                return ""
+                if (project.windowsLayout)
+                    return ""
+                else
+                    return "bin"
             else
                 return "lib"
         }

--- a/src/libtiled/pluginmanager.cpp
+++ b/src/libtiled/pluginmanager.cpp
@@ -189,7 +189,7 @@ void PluginManager::loadPlugins()
     QString pluginPath = QCoreApplication::applicationDirPath();
 #endif
 
-#if defined(Q_OS_WIN32)
+#if defined(TILED_WINDOWS_LAYOUT)
     pluginPath += QStringLiteral("/plugins/tiled");
 #elif defined(Q_OS_MAC)
     pluginPath += QStringLiteral("/../PlugIns");

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -69,7 +69,10 @@ DynamicLibrary {
         qbs.install: true
         qbs.installDir: {
             if (qbs.targetOS.contains("windows"))
-                return ""
+                if (project.windowsLayout)
+                    return ""
+                else
+                    return "bin"
             else
                 return "lib"
         }

--- a/src/tiled/languagemanager.cpp
+++ b/src/tiled/languagemanager.cpp
@@ -42,7 +42,7 @@ LanguageManager::LanguageManager()
     , mAppTranslator(nullptr)
 {
     mTranslationsDir = QCoreApplication::applicationDirPath();
-#if defined(Q_OS_WIN32)
+#if defined(TILED_WINDOWS_LAYOUT)
     mTranslationsDir += QStringLiteral("/translations");
 #elif defined(Q_OS_MAC)
     mTranslationsDir += QStringLiteral("/../Translations");

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -52,6 +52,9 @@ DynamicLibrary {
         if (project.snapshot)
             defs.push("TILED_SNAPSHOT");
 
+        if (project.windowsLayout)
+            defs.push("TILED_WINDOWS_LAYOUT");
+
         if (qbs.targetOS.contains("linux") && project.dbus && Qt.dbus.present)
             defs.push("TILED_ENABLE_DBUS");
 
@@ -598,7 +601,10 @@ DynamicLibrary {
         qbs.install: true
         qbs.installDir: {
             if (qbs.targetOS.contains("windows"))
-                return ""
+                if (project.windowsLayout)
+                    return ""
+                else
+                    return "bin"
             else
                 return "lib"
         }

--- a/src/tiledquick/tiledquick.qbs
+++ b/src/tiledquick/tiledquick.qbs
@@ -47,7 +47,7 @@ QtGuiApplication {
         condition: !qbs.targetOS.contains("darwin")
         qbs.install: true
         qbs.installDir: {
-            if (qbs.targetOS.contains("windows"))
+            if (project.windowsLayout)
                 return ""
             else
                 return "bin"

--- a/tiled.qbs
+++ b/tiled.qbs
@@ -13,6 +13,7 @@ Project {
     property bool installHeaders: false
     property bool useRPaths: true
     property bool windowsInstaller: false
+    property bool windowsLayout: qbs.targetOS.contains("windows")
     property bool staticZstd: false
     property bool sentry: false
     property bool dbus: true

--- a/translations/translations.qbs
+++ b/translations/translations.qbs
@@ -18,7 +18,7 @@ Product {
         fileTagsFilter: product.type
         qbs.install: true
         qbs.installDir: {
-            if (qbs.targetOS.contains("windows"))
+            if (project.windowsLayout)
                 return "translations"
             else if (qbs.targetOS.contains("macos"))
                 return "Tiled.app/Contents/Translations"


### PR DESCRIPTION
The new `windowsLayout` project option is enabled by default on Windows.
If this opotion is disabled manually, installed files will follow the Unix-like FHS (Filesystem Hierarchy Standard).

*UPDATE*: I am using these changes as a patch to [add](https://github.com/msys2/MINGW-packages/pull/15464) the `tiled` package in the [MSYS2](https://www.msys2.org/) distribution.
It will be great if similar changes are accepted into the code base of the original project.