### PR TITLE
Add drawFill property to custom types to allow disabling the color fill

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added action search popup on Ctrl+Shift+P (with dogboydog, #3449)
 * Added file system actions also for tileset image based tilesets (#3448)
+* Added custom class option to disable drawing fill for objects (with dogboydog, #3312)
 * Fixed new layer names to be always unique (by Logan Higinbotham, #3452)
 * Scripting: Added Object.setColorProperty and Object.setFloatProperty (#3423)
 * Scripting: Added tiled.projectFilePath

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -330,7 +330,8 @@ void IsometricRenderer::drawTileSelection(QPainter *painter,
 
 void IsometricRenderer::drawMapObject(QPainter *painter,
                                       const MapObject *object,
-                                      const QColor &color) const
+                                      const QColor &color,
+                                      const QColor &fillColor) const
 {
     painter->save();
 
@@ -387,8 +388,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         const qreal scale = painterScale();
         const QPointF shadowOffset(0, (lineWidth == 0 ? 1 : lineWidth) / scale);
 
-        QColor brushColor = color;
-        brushColor.setAlpha(50);
+        QColor brushColor = fillColor;
         QBrush brush(brushColor);
 
         pen.setJoinStyle(Qt::RoundJoin);

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -330,7 +330,7 @@ void IsometricRenderer::drawTileSelection(QPainter *painter,
 
 void IsometricRenderer::drawMapObject(QPainter *painter,
                                       const MapObject *object,
-                                      MapObjectColors colors) const
+                                      const MapObjectColors &colors) const
 {
     painter->save();
 

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -330,8 +330,7 @@ void IsometricRenderer::drawTileSelection(QPainter *painter,
 
 void IsometricRenderer::drawMapObject(QPainter *painter,
                                       const MapObject *object,
-                                      const QColor &color,
-                                      const QColor &fillColor) const
+                                      MapObjectColors colors) const
 {
     painter->save();
 
@@ -368,7 +367,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
             painter->setPen(pen);
             painter->drawRect(bounds);
             pen.setStyle(Qt::DotLine);
-            pen.setColor(color);
+            pen.setColor(colors.main);
             painter->setPen(pen);
             painter->drawRect(bounds);
         }
@@ -388,15 +387,15 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         const qreal scale = painterScale();
         const QPointF shadowOffset(0, (lineWidth == 0 ? 1 : lineWidth) / scale);
 
-        QColor brushColor = fillColor;
-        QBrush brush(brushColor);
+
+        QBrush brush = colors.fill.isValid() ? QBrush(colors.fill) : QBrush(Qt::NoBrush);
 
         pen.setJoinStyle(Qt::RoundJoin);
         pen.setCapStyle(Qt::RoundCap);
         pen.setWidthF(lineWidth);
 
         QPen colorPen(pen);
-        colorPen.setColor(color);
+        colorPen.setColor(colors.main);
 
         painter->setPen(pen);
         painter->setRenderHint(QPainter::Antialiasing);
@@ -423,7 +422,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         }
         case MapObject::Point:
             painter->translate(pixelToScreenCoords(object->position()));
-            drawPointObject(painter, color);
+            drawPointObject(painter, colors.main);
             break;
         case MapObject::Rectangle: {
             const QPolygonF polygon = pixelRectToScreenPolygon(bounds);

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -387,7 +387,6 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         const qreal scale = painterScale();
         const QPointF shadowOffset(0, (lineWidth == 0 ? 1 : lineWidth) / scale);
 
-
         QBrush brush = colors.fill.isValid() ? QBrush(colors.fill) : QBrush(Qt::NoBrush);
 
         pen.setJoinStyle(Qt::RoundJoin);

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -64,7 +64,8 @@ public:
 
     void drawMapObject(QPainter *painter,
                        const MapObject *object,
-                       const QColor &color) const override;
+                       const QColor &color,
+                       const QColor &fillColor) const override;
 
     using MapRenderer::pixelToTileCoords;
     QPointF pixelToTileCoords(qreal x, qreal y) const override;

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -64,8 +64,7 @@ public:
 
     void drawMapObject(QPainter *painter,
                        const MapObject *object,
-                       const QColor &color,
-                       const QColor &fillColor) const override;
+                       const MapObjectColors colors) const override;
 
     using MapRenderer::pixelToTileCoords;
     QPointF pixelToTileCoords(qreal x, qreal y) const override;

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -64,7 +64,7 @@ public:
 
     void drawMapObject(QPainter *painter,
                        const MapObject *object,
-                       const MapObjectColors colors) const override;
+                       const MapObjectColors &colors) const override;
 
     using MapRenderer::pixelToTileCoords;
     QPointF pixelToTileCoords(qreal x, qreal y) const override;

--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -304,6 +304,38 @@ QColor MapObject::effectiveColor() const
     return Qt::gray;
 }
 
+/**
+ * A helper function to determine the color of a map object. The color is
+ * determined first of all by the object class, and otherwise by the group
+ * that the object is in. If still no color is defined, it defaults to
+ * gray.
+ */
+MapObjectColors MapObject::effectiveColors() const
+{
+    const QString &effectiveClass = this->effectiveClassName();
+    MapObjectColors colors;
+    // See if this object's class has a color associated with it
+    if (auto type = Object::propertyTypes().findClassFor(effectiveClass, *this)) {
+        colors.main = type->color;
+        if (!type || type->drawFill) {
+            colors.fill = colors.main;
+            colors.fill.setAlpha(50);
+        }
+        // otherwise leave colors.fill invalid
+    }
+    // If not, get color from object group
+    if (mObjectGroup && mObjectGroup->color().isValid()) {
+        colors.main = mObjectGroup->color();
+    } else {
+        colors.main = Qt::gray;
+        colors.fill = colors.main;
+        colors.fill.setAlpha(0);
+    }
+
+    // Fallback color
+    return colors;
+}
+
 QVariant MapObject::mapObjectProperty(Property property) const
 {
     switch (property) {

--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -288,51 +288,25 @@ Alignment MapObject::alignment(const Map *map) const
  * that the object is in. If still no color is defined, it defaults to
  * gray.
  */
-QColor MapObject::effectiveColor() const
-{
-    const QString &effectiveClass = this->effectiveClassName();
-
-    // See if this object's class has a color associated with it
-    if (auto type = Object::propertyTypes().findClassFor(effectiveClass, *this))
-        return type->color;
-
-    // If not, get color from object group
-    if (mObjectGroup && mObjectGroup->color().isValid())
-        return mObjectGroup->color();
-
-    // Fallback color
-    return Qt::gray;
-}
-
-/**
- * A helper function to determine the color of a map object. The color is
- * determined first of all by the object class, and otherwise by the group
- * that the object is in. If still no color is defined, it defaults to
- * gray.
- */
 MapObjectColors MapObject::effectiveColors() const
 {
-    const QString &effectiveClass = this->effectiveClassName();
     MapObjectColors colors;
-    // See if this object's class has a color associated with it
-    if (auto type = Object::propertyTypes().findClassFor(effectiveClass, *this)) {
-        colors.main = type->color;
-        if (!type || type->drawFill) {
-            colors.fill = colors.main;
-            colors.fill.setAlpha(50);
-        }
-        // otherwise leave colors.fill invalid
-    }
-    // If not, get color from object group
-    if (mObjectGroup && mObjectGroup->color().isValid()) {
+    bool drawFill = true;
+
+    if (auto classType = Object::propertyTypes().findClassFor(effectiveClassName(), *this)) {
+        colors.main = classType->color;
+        drawFill = classType->drawFill;
+    } else if (mObjectGroup && mObjectGroup->color().isValid()) {
         colors.main = mObjectGroup->color();
     } else {
         colors.main = Qt::gray;
-        colors.fill = colors.main;
-        colors.fill.setAlpha(0);
     }
 
-    // Fallback color
+    if (drawFill) {
+        colors.fill = colors.main;
+        colors.fill.setAlpha(50);
+    }
+
     return colors;
 }
 

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -67,7 +67,13 @@ struct MapObjectColors
 {
     QColor main;
     QColor fill;
+
+    bool operator!=(const MapObjectColors &other) const
+    {
+        return main != other.main || fill != other.fill;
+    }
 };
+
 /**
  * An object on a map. Objects are positioned and scaled using floating point
  * values, ensuring they are not limited to the tile grid. They are suitable
@@ -478,6 +484,9 @@ inline bool MapObject::isVisible() const
 
 inline void MapObject::setVisible(bool visible)
 { mVisible = visible; }
+
+inline QColor MapObject::effectiveColor() const
+{ return effectiveColors().main; }
 
 inline void MapObject::setChangedProperties(ChangedProperties changedProperties)
 { mChangedProperties = changedProperties; }

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -63,6 +63,11 @@ struct TILEDSHARED_EXPORT TextData
     QSizeF textSize() const;
 };
 
+struct MapObjectColors
+{
+    QColor main;
+    QColor fill;
+};
 /**
  * An object on a map. Objects are positioned and scaled using floating point
  * values, ensuring they are not limited to the tile grid. They are suitable
@@ -195,6 +200,7 @@ public:
     void setVisible(bool visible);
 
     QColor effectiveColor() const;
+    MapObjectColors effectiveColors() const;
 
     QVariant mapObjectProperty(Property property) const;
     void setMapObjectProperty(Property property, const QVariant &value);

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -182,7 +182,7 @@ public:
      */
     virtual void drawMapObject(QPainter *painter,
                                const MapObject *object,
-                               const MapObjectColors colors) const = 0;
+                               const MapObjectColors &colors) const = 0;
 
     /**
      * Draws the a pin in the given \a color using the \a painter.

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include "mapobject.h"
 #include "tiled_global.h"
 
 #include <functional>
@@ -181,8 +182,7 @@ public:
      */
     virtual void drawMapObject(QPainter *painter,
                                const MapObject *object,
-                               const QColor &color,
-                               const QColor &fillColor) const = 0;
+                               const MapObjectColors colors) const = 0;
 
     /**
      * Draws the a pin in the given \a color using the \a painter.

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -181,7 +181,8 @@ public:
      */
     virtual void drawMapObject(QPainter *painter,
                                const MapObject *object,
-                               const QColor &color) const = 0;
+                               const QColor &color,
+                               const QColor &fillColor) const = 0;
 
     /**
      * Draws the a pin in the given \a color using the \a painter.

--- a/src/libtiled/minimaprenderer.cpp
+++ b/src/libtiled/minimaprenderer.cpp
@@ -205,6 +205,7 @@ void MiniMapRenderer::renderToImage(QImage &image, RenderFlags renderFlags) cons
 
                         const QColor color = object->effectiveColor();
                         QColor fillColor = color;
+                        fillColor.setAlpha(50);
                         if (auto type = Object::propertyTypes().findClassFor(object->className(), *object))
                             if (!type->drawFill)
                                 fillColor.setAlpha(0);

--- a/src/libtiled/minimaprenderer.cpp
+++ b/src/libtiled/minimaprenderer.cpp
@@ -203,13 +203,7 @@ void MiniMapRenderer::renderToImage(QImage &image, RenderFlags renderFlags) cons
                             painter.translate(-origin);
                         }
 
-                        const QColor color = object->effectiveColor();
-                        QColor fillColor = color;
-                        fillColor.setAlpha(50);
-                        if (auto type = Object::propertyTypes().findClassFor(object->className(), *object))
-                            if (!type->drawFill)
-                                fillColor.setAlpha(0);
-                        mRenderer->drawMapObject(&painter, object, color, fillColor);
+                        mRenderer->drawMapObject(&painter, object, object->effectiveColors());
 
                         if (object->rotation() != qreal(0))
                             painter.restore();

--- a/src/libtiled/minimaprenderer.cpp
+++ b/src/libtiled/minimaprenderer.cpp
@@ -204,7 +204,11 @@ void MiniMapRenderer::renderToImage(QImage &image, RenderFlags renderFlags) cons
                         }
 
                         const QColor color = object->effectiveColor();
-                        mRenderer->drawMapObject(&painter, object, color);
+                        QColor fillColor = color;
+                        if (auto type = Object::propertyTypes().findClassFor(object->className(), *object))
+                            if (!type->drawFill)
+                                fillColor.setAlpha(0);
+                        mRenderer->drawMapObject(&painter, object, color, fillColor);
 
                         if (object->rotation() != qreal(0))
                             painter.restore();

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -333,8 +333,7 @@ void OrthogonalRenderer::drawTileSelection(QPainter *painter,
 
 void OrthogonalRenderer::drawMapObject(QPainter *painter,
                                        const MapObject *object,
-                                       const QColor &color,
-                                       const QColor &fillColor) const
+                                       const MapObjectColors colors) const
 {
     painter->save();
 
@@ -372,7 +371,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
             painter->setPen(pen);
             painter->drawRect(bounds);
             pen.setStyle(Qt::DotLine);
-            pen.setColor(color);
+            pen.setColor(colors.main);
             painter->setPen(pen);
             painter->drawRect(bounds);
         }
@@ -383,13 +382,12 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
         const QPointF shadowOffset = QPointF(shadowDist * 0.5,
                                              shadowDist * 0.5);
 
-        QPen linePen(color, lineWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
+        QPen linePen(colors.main, lineWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
         linePen.setCosmetic(true);
         QPen shadowPen(linePen);
         shadowPen.setColor(Qt::black);
 
-        QColor brushColor = fillColor;
-        const QBrush fillBrush(brushColor);
+        const QBrush fillBrush = colors.fill.isValid() ? QBrush(colors.fill) : QBrush(Qt::NoBrush);
 
         painter->setRenderHint(QPainter::Antialiasing);
 
@@ -469,7 +467,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
             break;
         }
         case MapObject::Point: {
-            drawPointObject(painter, color);
+            drawPointObject(painter, colors.main);
             break;
         }
         }

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -333,7 +333,7 @@ void OrthogonalRenderer::drawTileSelection(QPainter *painter,
 
 void OrthogonalRenderer::drawMapObject(QPainter *painter,
                                        const MapObject *object,
-                                       const MapObjectColors colors) const
+                                       const MapObjectColors &colors) const
 {
     painter->save();
 

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -333,7 +333,8 @@ void OrthogonalRenderer::drawTileSelection(QPainter *painter,
 
 void OrthogonalRenderer::drawMapObject(QPainter *painter,
                                        const MapObject *object,
-                                       const QColor &color) const
+                                       const QColor &color,
+                                       const QColor &fillColor) const
 {
     painter->save();
 
@@ -387,8 +388,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
         QPen shadowPen(linePen);
         shadowPen.setColor(Qt::black);
 
-        QColor brushColor = color;
-        brushColor.setAlpha(50);
+        QColor brushColor = fillColor;
         const QBrush fillBrush(brushColor);
 
         painter->setRenderHint(QPainter::Antialiasing);

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -61,8 +61,7 @@ public:
 
     void drawMapObject(QPainter *painter,
                        const MapObject *object,
-                       const QColor &color,
-                       const QColor &fillColor) const override;
+                       MapObjectColors colors) const override;
 
     using MapRenderer::pixelToTileCoords;
     QPointF pixelToTileCoords(qreal x, qreal y) const override;

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -61,7 +61,7 @@ public:
 
     void drawMapObject(QPainter *painter,
                        const MapObject *object,
-                       MapObjectColors colors) const override;
+                       const MapObjectColors &colors) const override;
 
     using MapRenderer::pixelToTileCoords;
     QPointF pixelToTileCoords(qreal x, qreal y) const override;

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -61,7 +61,8 @@ public:
 
     void drawMapObject(QPainter *painter,
                        const MapObject *object,
-                       const QColor &color) const override;
+                       const QColor &color,
+                       const QColor &fillColor) const override;
 
     using MapRenderer::pixelToTileCoords;
     QPointF pixelToTileCoords(qreal x, qreal y) const override;

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -364,7 +364,8 @@ void ClassPropertyType::initializeFromJson(const QJsonObject &json)
     if (QColor::isValidColor(colorName))
         color.setNamedColor(colorName);
 
-    const bool drawFillValue = json.value(QLatin1String("drawFill")).toBool();
+    drawFill = json.value(QLatin1String("drawFill")).toBool();
+
     const QJsonValue useAsJson = json.value(QLatin1String("useAs"));
     if (useAsJson.isArray()) {
         const QJsonArray useAsArray = useAsJson.toArray();

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -364,7 +364,9 @@ void ClassPropertyType::initializeFromJson(const QJsonObject &json)
     if (QColor::isValidColor(colorName))
         color.setNamedColor(colorName);
 
-    drawFill = json.value(QLatin1String("drawFill")).toBool();
+    const QString drawFillPropertyName = QLatin1String("drawFill");
+    if (json.contains(drawFillPropertyName))
+        drawFill = json.value(drawFillPropertyName).toBool();
 
     const QJsonValue useAsJson = json.value(QLatin1String("useAs"));
     if (useAsJson.isArray()) {

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -335,6 +335,7 @@ QJsonObject ClassPropertyType::toJson(const ExportContext &context) const
     auto json = PropertyType::toJson(context);
     json.insert(QStringLiteral("members"), members);
     json.insert(QStringLiteral("color"), color.name(QColor::HexArgb));
+    json.insert(QStringLiteral("drawFill"), drawFill);
 
     QJsonArray useAs;
 
@@ -363,6 +364,7 @@ void ClassPropertyType::initializeFromJson(const QJsonObject &json)
     if (QColor::isValidColor(colorName))
         color.setNamedColor(colorName);
 
+    const bool drawFillValue = json.value(QLatin1String("drawFill")).toBool();
     const QJsonValue useAsJson = json.value(QLatin1String("useAs"));
     if (useAsJson.isArray()) {
         const QJsonArray useAsArray = useAsJson.toArray();

--- a/src/libtiled/propertytype.h
+++ b/src/libtiled/propertytype.h
@@ -154,7 +154,7 @@ public:
     QColor color = Qt::gray;
     int usageFlags = AnyUsage;
     bool memberValuesResolved = true;
-
+    bool drawFill = true;
     ClassPropertyType(const QString &name) : PropertyType(PT_Class, name) {}
 
     ExportValue toExportValue(const QVariant &value, const ExportContext &) const override;

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -63,6 +63,17 @@ void MapObjectItem::syncWithMapObject()
         update();
     }
 
+    QColor fillColor;
+    auto type = Object::propertyTypes().findClassFor(mObject->className(), *mObject);
+    if (!type || type->drawFill) {
+        fillColor = color;
+        fillColor.setAlpha(50);
+    }
+    if (fillColor != mFillColor) {
+        mFillColor = fillColor;
+        update();
+    }
+
     QString toolTip = mObject->name();
     const QString &className = mObject->effectiveClassName();
     if (!className.isEmpty())
@@ -140,11 +151,7 @@ void MapObjectItem::paint(QPainter *painter,
     const auto renderer = mMapDocument->renderer();
     const qreal painterScale = renderer->painterScale();
     const QColor color = mIsHoveredIndicator ? mColor.lighter() : mColor;
-    QColor fillColor = color;
-    fillColor.setAlpha(50);
-    if (auto type = Object::propertyTypes().findClassFor(mapObject()->className(), *mapObject()))
-        if (!type->drawFill)
-            fillColor.setAlpha(0);
+    const QColor fillColor = mFillColor;
 
     const qreal previousOpacity = painter->opacity();
 
@@ -155,7 +162,7 @@ void MapObjectItem::paint(QPainter *painter,
         painter->setOpacity(0.4);
 
     painter->translate(-pos());
-    renderer->drawMapObject(painter, mObject, color, fillColor);
+    renderer->drawMapObject(painter, mObject, mObject->effectiveColors());
     painter->translate(pos());
 
     if (mIsHoveredIndicator) {

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -140,6 +140,12 @@ void MapObjectItem::paint(QPainter *painter,
     const auto renderer = mMapDocument->renderer();
     const qreal painterScale = renderer->painterScale();
     const QColor color = mIsHoveredIndicator ? mColor.lighter() : mColor;
+    QColor fillColor = color;
+    fillColor.setAlpha(50);
+    if (auto type = Object::propertyTypes().findClassFor(mapObject()->className(), *mapObject()))
+        if (!type->drawFill)
+            fillColor.setAlpha(0);
+
     const qreal previousOpacity = painter->opacity();
 
     if (flags() & QGraphicsItem::ItemIgnoresTransformations)
@@ -149,7 +155,7 @@ void MapObjectItem::paint(QPainter *painter,
         painter->setOpacity(0.4);
 
     painter->translate(-pos());
-    renderer->drawMapObject(painter, mObject, color);
+    renderer->drawMapObject(painter, mObject, color, fillColor);
     painter->translate(pos());
 
     if (mIsHoveredIndicator) {

--- a/src/tiled/mapobjectitem.h
+++ b/src/tiled/mapobjectitem.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "mapobject.h"
 #include "preferences.h"
 
 #include <QCoreApplication>
@@ -87,7 +88,13 @@ private:
     QTransform tileCollisionObjectsTransform(const Tile &tile) const;
 
     MapDocument *mapDocument() const { return mMapDocument; }
-    QColor color() const { return mColor; }
+    MapObjectColors colors() const
+    {
+        MapObjectColors result;
+        result.main = mColor;
+        result.fill = mFillColor;
+        return result;
+     }
 
     MapObject *mObject;
     MapDocument *mMapDocument;
@@ -95,7 +102,8 @@ private:
     /** Bounding rect cached, for adapting to geometry change correctly. */
     QRectF mBoundingRect;
     QPolygonF mPolygon; // Copy of the polygon, so we know when it changes
-    QColor mColor;      // Cached color of the object
+    QColor mColor;      // Cached main color of the object
+    QColor mFillColor;  // Cached fill color
     bool mIsHoveredIndicator = false;
 };
 

--- a/src/tiled/mapobjectitem.h
+++ b/src/tiled/mapobjectitem.h
@@ -88,13 +88,6 @@ private:
     QTransform tileCollisionObjectsTransform(const Tile &tile) const;
 
     MapDocument *mapDocument() const { return mMapDocument; }
-    MapObjectColors colors() const
-    {
-        MapObjectColors result;
-        result.main = mColor;
-        result.fill = mFillColor;
-        return result;
-     }
 
     MapObject *mObject;
     MapDocument *mMapDocument;
@@ -102,8 +95,7 @@ private:
     /** Bounding rect cached, for adapting to geometry change correctly. */
     QRectF mBoundingRect;
     QPolygonF mPolygon; // Copy of the polygon, so we know when it changes
-    QColor mColor;      // Cached main color of the object
-    QColor mFillColor;  // Cached fill color
+    MapObjectColors mColors; // Cached colors of the object
     bool mIsHoveredIndicator = false;
 };
 

--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -791,6 +791,7 @@ void PropertyTypesEditor::updateDetails()
 
         mColorButton->setColor(classType.color);
         mUseAsPropertyCheckBox->setChecked(classType.isPropertyValueType());
+        mDrawFillPropertyCheckBox->setChecked(classType.drawFill);
         updateClassUsageDetails(classType);
 
         mPropertiesHelper->clear();
@@ -932,11 +933,16 @@ void PropertyTypesEditor::addClassProperties()
     connect(mClassOfCheckBox, &QCheckBox::toggled,
             this, [this] (bool checked) { setUsageFlags(ClassPropertyType::AnyObjectClass, checked); });
 
+    mDrawFillPropertyCheckBox = new QCheckBox(tr("Draw fill"));
+    connect(mDrawFillPropertyCheckBox, &QCheckBox::toggled,
+            this, PropertyTypesEditor::setDrawFill);
+
     auto usageOptions = new QHBoxLayout;
     usageOptions->addWidget(mUseAsPropertyCheckBox);
     usageOptions->addSpacing(Utils::dpiScaled(20));
     usageOptions->addWidget(mClassOfCheckBox);
     usageOptions->addWidget(mClassOfButton);
+    usageOptions->addWidget(mDrawFillPropertyCheckBox);
     usageOptions->addStretch();
 
     QToolBar *membersToolBar = createSmallToolBar(mUi->groupBox);
@@ -1054,7 +1060,17 @@ void PropertyTypesEditor::colorChanged(const QColor &color)
         applyPropertyTypes();
     }
 }
+void PropertyTypesEditor::setDrawFill(bool value)
+{
+    if (mUpdatingDetails)
+        return;
 
+    if (ClassPropertyType *classType = selectedClassPropertyType()) {
+        classType->drawFill = value;
+        updateClassUsageDetails(*classType);
+        applyPropertyTypes();
+    }
+}
 void PropertyTypesEditor::setUsageFlags(int flags, bool value)
 {
     if (mUpdatingDetails)

--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -791,7 +791,7 @@ void PropertyTypesEditor::updateDetails()
 
         mColorButton->setColor(classType.color);
         mUseAsPropertyCheckBox->setChecked(classType.isPropertyValueType());
-        mDrawFillPropertyCheckBox->setChecked(classType.drawFill);
+        mDrawFillCheckBox->setChecked(classType.drawFill);
         updateClassUsageDetails(classType);
 
         mPropertiesHelper->clear();
@@ -907,13 +907,14 @@ void PropertyTypesEditor::addClassProperties()
     connect(mColorButton, &ColorButton::colorChanged,
             this, &PropertyTypesEditor::colorChanged);
 
-    mDrawFillPropertyCheckBox = new QCheckBox(tr("Draw fill"));
-    connect(mDrawFillPropertyCheckBox, &QCheckBox::toggled,
+    mDrawFillCheckBox = new QCheckBox(tr("Draw fill"));
+    connect(mDrawFillCheckBox, &QCheckBox::toggled,
             this, &PropertyTypesEditor::setDrawFill);
     auto nameAndColor = new QHBoxLayout;
     nameAndColor->addWidget(mNameEdit);
     nameAndColor->addWidget(mColorButton);
-    nameAndColor->addWidget(mDrawFillPropertyCheckBox);
+    nameAndColor->addWidget(mDrawFillCheckBox);
+
     mMembersView = new QtTreePropertyBrowser(this);
     mPropertiesHelper = new CustomPropertiesHelper(mMembersView, this);
 
@@ -935,7 +936,6 @@ void PropertyTypesEditor::addClassProperties()
 
     connect(mClassOfCheckBox, &QCheckBox::toggled,
             this, [this] (bool checked) { setUsageFlags(ClassPropertyType::AnyObjectClass, checked); });
-
 
     auto usageOptions = new QHBoxLayout;
     usageOptions->addWidget(mUseAsPropertyCheckBox);
@@ -1059,6 +1059,7 @@ void PropertyTypesEditor::colorChanged(const QColor &color)
         applyPropertyTypes();
     }
 }
+
 void PropertyTypesEditor::setDrawFill(bool value)
 {
     if (mUpdatingDetails)
@@ -1066,10 +1067,10 @@ void PropertyTypesEditor::setDrawFill(bool value)
 
     if (ClassPropertyType *classType = selectedClassPropertyType()) {
         classType->drawFill = value;
-        updateClassUsageDetails(*classType);
         applyPropertyTypes();
     }
 }
+
 void PropertyTypesEditor::setUsageFlags(int flags, bool value)
 {
     if (mUpdatingDetails)

--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -907,10 +907,13 @@ void PropertyTypesEditor::addClassProperties()
     connect(mColorButton, &ColorButton::colorChanged,
             this, &PropertyTypesEditor::colorChanged);
 
+    mDrawFillPropertyCheckBox = new QCheckBox(tr("Draw fill"));
+    connect(mDrawFillPropertyCheckBox, &QCheckBox::toggled,
+            this, &PropertyTypesEditor::setDrawFill);
     auto nameAndColor = new QHBoxLayout;
     nameAndColor->addWidget(mNameEdit);
     nameAndColor->addWidget(mColorButton);
-
+    nameAndColor->addWidget(mDrawFillPropertyCheckBox);
     mMembersView = new QtTreePropertyBrowser(this);
     mPropertiesHelper = new CustomPropertiesHelper(mMembersView, this);
 
@@ -933,16 +936,12 @@ void PropertyTypesEditor::addClassProperties()
     connect(mClassOfCheckBox, &QCheckBox::toggled,
             this, [this] (bool checked) { setUsageFlags(ClassPropertyType::AnyObjectClass, checked); });
 
-    mDrawFillPropertyCheckBox = new QCheckBox(tr("Draw fill"));
-    connect(mDrawFillPropertyCheckBox, &QCheckBox::toggled,
-            this, &PropertyTypesEditor::setDrawFill);
 
     auto usageOptions = new QHBoxLayout;
     usageOptions->addWidget(mUseAsPropertyCheckBox);
     usageOptions->addSpacing(Utils::dpiScaled(20));
     usageOptions->addWidget(mClassOfCheckBox);
     usageOptions->addWidget(mClassOfButton);
-    usageOptions->addWidget(mDrawFillPropertyCheckBox);
     usageOptions->addStretch();
 
     QToolBar *membersToolBar = createSmallToolBar(mUi->groupBox);

--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -935,7 +935,7 @@ void PropertyTypesEditor::addClassProperties()
 
     mDrawFillPropertyCheckBox = new QCheckBox(tr("Draw fill"));
     connect(mDrawFillPropertyCheckBox, &QCheckBox::toggled,
-            this, PropertyTypesEditor::setDrawFill);
+            this, &PropertyTypesEditor::setDrawFill);
 
     auto usageOptions = new QHBoxLayout;
     usageOptions->addWidget(mUseAsPropertyCheckBox);

--- a/src/tiled/propertytypeseditor.h
+++ b/src/tiled/propertytypeseditor.h
@@ -117,6 +117,7 @@ private:
     void nameEditingFinished();
 
     void colorChanged(const QColor &color);
+    void setDrawFill(bool value);
     void setUsageFlags(int flags, bool value);
     void memberValueChanged(const QStringList &path, const QVariant &value);
 
@@ -134,6 +135,7 @@ private:
 
     ColorButton *mColorButton = nullptr;
     QCheckBox *mUseAsPropertyCheckBox = nullptr;
+    QCheckBox *mDrawFillPropertyCheckBox = nullptr;
     QCheckBox *mClassOfCheckBox = nullptr;
     QPushButton *mClassOfButton = nullptr;
     QMenu *mClassOfMenu;

--- a/src/tiled/propertytypeseditor.h
+++ b/src/tiled/propertytypeseditor.h
@@ -135,7 +135,7 @@ private:
 
     ColorButton *mColorButton = nullptr;
     QCheckBox *mUseAsPropertyCheckBox = nullptr;
-    QCheckBox *mDrawFillPropertyCheckBox = nullptr;
+    QCheckBox *mDrawFillCheckBox = nullptr;
     QCheckBox *mClassOfCheckBox = nullptr;
     QPushButton *mClassOfButton = nullptr;
     QMenu *mClassOfMenu;

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -89,6 +89,7 @@ void TmxRasterizer::drawMapLayers(const MapRenderer &renderer,
 
                     const QColor color = object->effectiveColor();
                     QColor fillColor = color;
+                    fillColor.setAlpha(50);
                     if (auto type = Object::propertyTypes().findClassFor(object->className(), *object))
                         if (!type->drawFill)
                             fillColor.setAlpha(0);

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -88,7 +88,11 @@ void TmxRasterizer::drawMapLayers(const MapRenderer &renderer,
                     }
 
                     const QColor color = object->effectiveColor();
-                    renderer.drawMapObject(&painter, object, color);
+                    QColor fillColor = color;
+                    if (auto type = Object::propertyTypes().findClassFor(object->className(), *object))
+                        if (!type->drawFill)
+                            fillColor.setAlpha(0);
+                    renderer.drawMapObject(&painter, object, color, fillColor);
 
                     if (object->rotation() != qreal(0))
                         painter.restore();

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -87,13 +87,7 @@ void TmxRasterizer::drawMapLayers(const MapRenderer &renderer,
                         painter.translate(-origin);
                     }
 
-                    const QColor color = object->effectiveColor();
-                    QColor fillColor = color;
-                    fillColor.setAlpha(50);
-                    if (auto type = Object::propertyTypes().findClassFor(object->className(), *object))
-                        if (!type->drawFill)
-                            fillColor.setAlpha(0);
-                    renderer.drawMapObject(&painter, object, color, fillColor);
+                    renderer.drawMapObject(&painter, object, object->effectiveColors());
 
                     if (object->rotation() != qreal(0))
                         painter.restore();

--- a/src/tmxviewer/tmxviewer.cpp
+++ b/src/tmxviewer/tmxviewer.cpp
@@ -74,16 +74,14 @@ public:
 
     void paint(QPainter *p, const QStyleOptionGraphicsItem *, QWidget *) override
     {
-        const QColor &color = mMapObject->objectGroup()->color();
         p->translate(-pos());
-        QColor fillColor = color.isValid() ? color : Qt::darkGray;
-        fillColor.setAlpha(50);
-        if (auto type = Object::propertyTypes().findClassFor(mMapObject->className(), *mMapObject))
-            if (!type->drawFill)
-                fillColor.setAlpha(0);
-        mRenderer->drawMapObject(p, mMapObject,
-                                 color.isValid() ? color : Qt::darkGray,
-                                 fillColor);
+        MapObjectColors colors = mMapObject->effectiveColors();
+        if (!colors.main.isValid()) {
+            colors.main = Qt::darkGray;
+            colors.fill = colors.main;
+            colors.fill.setAlpha(50);
+        }
+        mRenderer->drawMapObject(p, mMapObject, colors);
     }
 
 private:

--- a/src/tmxviewer/tmxviewer.cpp
+++ b/src/tmxviewer/tmxviewer.cpp
@@ -75,13 +75,7 @@ public:
     void paint(QPainter *p, const QStyleOptionGraphicsItem *, QWidget *) override
     {
         p->translate(-pos());
-        MapObjectColors colors = mMapObject->effectiveColors();
-        if (!colors.main.isValid()) {
-            colors.main = Qt::darkGray;
-            colors.fill = colors.main;
-            colors.fill.setAlpha(50);
-        }
-        mRenderer->drawMapObject(p, mMapObject, colors);
+        mRenderer->drawMapObject(p, mMapObject, mMapObject->effectiveColors());
     }
 
 private:

--- a/src/tmxviewer/tmxviewer.cpp
+++ b/src/tmxviewer/tmxviewer.cpp
@@ -76,8 +76,14 @@ public:
     {
         const QColor &color = mMapObject->objectGroup()->color();
         p->translate(-pos());
+        QColor fillColor = color.isValid() ? color : Qt::darkGray;
+        fillColor.setAlpha(50);
+        if (auto type = Object::propertyTypes().findClassFor(mMapObject->className(), *mMapObject))
+            if (!type->drawFill)
+                fillColor.setAlpha(0);
         mRenderer->drawMapObject(p, mMapObject,
-                                 color.isValid() ? color : Qt::darkGray);
+                                 color.isValid() ? color : Qt::darkGray,
+                                 fillColor);
     }
 
 private:


### PR DESCRIPTION
- [x] Make drawFill value for types load properly when a project is opened
- [x] Add a toggle to the types editor that allows you to set the property
    - [x] Decide on placement of the toggle - Next to the color button for a type, hopefully this is OK
- [x] Export the drawFill value to the custom types JSON
- [x] Hook up the value of drawFill to OrthogonalRenderer::drawMapObject and IsometricRenderer::drawMapObject to conditionally disable the fill. 
- [x] Implement PR feedback
~Respect this setting for Point objects as well?~
Fix #3312

Feel free to squash if merged