### PR TITLE
Qt 6: Fixed behavior of "Class of" selection popup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Scripting: Renamed Tileset.collection to Tileset.isCollection (#3543)
 * Defold plugin: Allow overriding z value also when exporting to .collection (#3214)
 * Qt 6: Fixed invisible tileset tabs when only a single tileset is open
+* Qt 6: Fixed behavior of "Class of" selection popup
 * Fixed positioning of point object name labels (by Logan Higinbotham, #3400)
 * Fixed slight drift when zooming the map view in/out
 * Fixed compile against Qt 6.4

--- a/src/tiled/imagecolorpickerwidget.cpp
+++ b/src/tiled/imagecolorpickerwidget.cpp
@@ -24,11 +24,6 @@
 
 #include "utils.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-#include <QDesktopWidget>
-#else
-#include <QScreen>
-#endif
 #include <QMouseEvent>
 
 using namespace Tiled;
@@ -62,11 +57,7 @@ bool ImageColorPickerWidget::selectColor(const QString &image)
     mScaleX = 1;
     mScaleY = 1;
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    const QRect screenRect = QApplication::desktop()->availableGeometry(parentWidget());
-#else
-    const QRect screenRect = parentWidget()->screen()->availableGeometry();
-#endif
+    const QRect screenRect = Utils::screenRect(parentWidget());
     const int maxW = screenRect.width() * 2 / 3;
     const int maxH = screenRect.height() * 2 / 3;
 

--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -24,7 +24,6 @@
 #include "addpropertydialog.h"
 #include "colorbutton.h"
 #include "custompropertieshelper.h"
-#include "object.h"
 #include "objecttypes.h"
 #include "preferences.h"
 #include "project.h"
@@ -33,8 +32,6 @@
 #include "savefile.h"
 #include "session.h"
 #include "utils.h"
-#include "varianteditorfactory.h"
-#include "variantpropertymanager.h"
 
 #include <QCheckBox>
 #include <QCloseEvent>
@@ -51,6 +48,7 @@
 #include <QToolBar>
 
 #include <QtTreePropertyBrowser>
+#include <QtVariantProperty>
 
 namespace Tiled {
 
@@ -68,23 +66,6 @@ static bool confirm(const QString &title, const QString& text, QWidget *parent)
                                 QMessageBox::Yes | QMessageBox::No,
                                 QMessageBox::No) == QMessageBox::Yes;
 }
-
-class PersistentMenu : public QMenu
-{
-public:
-    using QMenu::QMenu;
-
-    void setVisible(bool visible) override
-    {
-        // Don't hide the menu when over a checkbox
-        if (!visible)
-            if (auto action = activeAction())
-                if (action->isCheckable())
-                    return;
-
-        QMenu::setVisible(visible);
-    }
-};
 
 
 PropertyTypesFilter::PropertyTypesFilter(const QString &lastPath)
@@ -104,7 +85,6 @@ PropertyTypesEditor::PropertyTypesEditor(QWidget *parent)
     , mPropertyTypesModel(new PropertyTypesModel(this))
     , mDetailsLayout(new QFormLayout)
     , mValuesModel(new QStringListModel(this))
-    , mClassOfMenu(new PersistentMenu(this))
 {
     mUi->setupUi(this);
 
@@ -115,10 +95,7 @@ PropertyTypesEditor::PropertyTypesEditor(QWidget *parent)
     mUi->propertyTypesView->setModel(mPropertyTypesModel);
     mUi->horizontalLayout->addLayout(mDetailsLayout);
 
-    const struct {
-        ClassPropertyType::ClassUsageFlag flag;
-        QString name;
-    } flagsWithNames[] = {
+    mFlagsWithNames = {
         { ClassPropertyType::MapClass,          tr("Map") },
         { ClassPropertyType::LayerClass,        tr("Layer") },
         { ClassPropertyType::MapObjectClass,    tr("Object") },
@@ -127,16 +104,6 @@ PropertyTypesEditor::PropertyTypesEditor(QWidget *parent)
         { ClassPropertyType::WangColorClass,    tr("Terrain") },
         { ClassPropertyType::WangSetClass,      tr("Terrain Set") },
     };
-
-    for (auto &entry : flagsWithNames) {
-        auto action = mClassOfMenu->addAction(entry.name);
-        action->setCheckable(true);
-        action->setData(entry.flag);
-        connect(action, &QAction::toggled,
-                this, [this, flag = entry.flag] (bool checked) {
-            setUsageFlags(flag, checked);
-        });
-    }
 
     mAddEnumPropertyTypeAction = new QAction(this);
     mAddClassPropertyTypeAction = new QAction(this);
@@ -518,6 +485,44 @@ bool PropertyTypesEditor::checkValueCount(int count)
     return true;
 }
 
+void PropertyTypesEditor::openClassOfPopup()
+{
+    ClassPropertyType *classType = selectedClassPropertyType();
+    if (!classType)
+        return;
+
+    QFrame *popup = new QFrame(this, Qt::Popup);
+    popup->setAttribute(Qt::WA_DeleteOnClose);
+    popup->setFrameStyle(QFrame::StyledPanel | QFrame::Plain);
+
+    QVBoxLayout *layout = new QVBoxLayout(popup);
+    const int space = Utils::dpiScaled(4);
+    layout->setSpacing(space);
+    layout->setContentsMargins(space, space, space, space);
+
+    for (auto &entry : mFlagsWithNames) {
+        auto checkBox = new QCheckBox(entry.name);
+        checkBox->setChecked(classType->usageFlags & entry.flag);
+        layout->addWidget(checkBox);
+
+        connect(checkBox, &QCheckBox::toggled,
+                this, [this, flag = entry.flag] (bool checked) {
+            setUsageFlags(flag, checked);
+        });
+    }
+
+    // Focus the first checkbox for convenient keyboard navigation
+    layout->itemAt(0)->widget()->setFocus();
+
+    const QSize size = popup->sizeHint();
+    popup->setGeometry(Utils::popupGeometry(mClassOfButton, size));
+    popup->show();
+
+    connect(popup, &QWidget::destroyed, this, [this] {
+        mClassOfButton->setDown(false);
+    });
+}
+
 void PropertyTypesEditor::openAddMemberDialog()
 {
     const PropertyType *propertyType = selectedPropertyType();
@@ -829,12 +834,9 @@ void PropertyTypesEditor::updateClassUsageDetails(const ClassPropertyType &class
     mClassOfCheckBox->setChecked(classType.usageFlags & ClassPropertyType::AnyObjectClass);
 
     QStringList selectedTypes;
-    const auto actions = mClassOfMenu->actions();
-    for (QAction *typeAction : actions) {
-        const auto flag = typeAction->data().toInt();
-        typeAction->setChecked(classType.usageFlags & flag);
-        if (classType.usageFlags & flag)
-            selectedTypes.append(typeAction->text());
+    for (const NamedFlag &namedFlag : qAsConst(mFlagsWithNames)) {
+        if (classType.usageFlags & namedFlag.flag)
+            selectedTypes.append(namedFlag.name);
     }
 
     if (selectedTypes.isEmpty()) {
@@ -926,9 +928,9 @@ void PropertyTypesEditor::addClassProperties()
 
     mClassOfButton = new QPushButton(tr("Select Types"));
     mClassOfButton->setAutoDefault(false);
-    mClassOfButton->setMenu(mClassOfMenu);
     mClassOfCheckBox = new QCheckBox(tr("Class of"));
 
+    connect(mClassOfButton, &QToolButton::pressed, this, &PropertyTypesEditor::openClassOfPopup);
     connect(mClassOfCheckBox, &QCheckBox::toggled,
             this, [this] (bool checked) { setUsageFlags(ClassPropertyType::AnyObjectClass, checked); });
 
@@ -1072,18 +1074,17 @@ void PropertyTypesEditor::memberValueChanged(const QStringList &path, const QVar
     if (mUpdatingDetails)
         return;
 
-    PropertyType *propertyType = selectedPropertyType();
-    if (!propertyType || !propertyType->isClass())
+    ClassPropertyType *classType = selectedClassPropertyType();
+    if (!classType)
         return;
 
-    auto &classType = static_cast<ClassPropertyType&>(*propertyType);
     auto &topLevelName = path.first();
 
-    if (!setPropertyMemberValue(classType.members, path, value))
+    if (!setPropertyMemberValue(classType->members, path, value))
         return;
 
     if (auto property = mPropertiesHelper->property(topLevelName))
-        property->setValue(mPropertiesHelper->toDisplayValue(classType.members.value(topLevelName)));
+        property->setValue(mPropertiesHelper->toDisplayValue(classType->members.value(topLevelName)));
 
     applyPropertyTypes();
 }

--- a/src/tiled/propertytypeseditor.h
+++ b/src/tiled/propertytypeseditor.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "properties.h"
+#include "propertytype.h"
 
 #include <QDialog>
 
@@ -29,7 +29,6 @@ class QComboBox;
 class QFormLayout;
 class QItemSelection;
 class QLineEdit;
-class QMenu;
 class QStringListModel;
 class QTreeView;
 
@@ -102,6 +101,7 @@ private:
     void removeValues();
     bool checkValueCount(int count);
 
+    void openClassOfPopup();
     void openAddMemberDialog();
     void addMember(const QString &name, const QVariant &value = QVariant());
     void editMember(const QString &name);
@@ -122,6 +122,12 @@ private:
 
     void retranslateUi();
 
+    struct NamedFlag {
+        ClassPropertyType::ClassUsageFlag flag;
+        QString name;
+    };
+    QVector<NamedFlag> mFlagsWithNames;
+
     Ui::PropertyTypesEditor *mUi;
     PropertyTypesModel *mPropertyTypesModel;
     QFormLayout *mDetailsLayout = nullptr;
@@ -136,7 +142,6 @@ private:
     QCheckBox *mUseAsPropertyCheckBox = nullptr;
     QCheckBox *mClassOfCheckBox = nullptr;
     QPushButton *mClassOfButton = nullptr;
-    QMenu *mClassOfMenu;
     QtTreePropertyBrowser *mMembersView = nullptr;
     CustomPropertiesHelper *mPropertiesHelper = nullptr;
 

--- a/src/tiled/utils.h
+++ b/src/tiled/utils.h
@@ -79,6 +79,9 @@ void setThemeIcon(T *t, const char *name)
 
 QIcon colorIcon(const QColor &color, QSize size);
 
+QRect screenRect(const QWidget *widget);
+QRect popupGeometry(const QWidget *parent, QSize popupSize);
+
 void restoreGeometry(QWidget *widget);
 void saveGeometry(QWidget *widget);
 


### PR DESCRIPTION
The hack that was used to keep the `QMenu` visible with Qt 5 no longer worked, since it seems Qt 6 calls `destroy()` instead of `hide()` on the menu.

The `QMenu` is now replaced by a popup with checkboxes.