### PR TITLE
Updated release builds to Qt 6.4.2

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -124,7 +124,10 @@ jobs:
         export EXTRA_QT_PLUGINS=svg
         export LD_LIBRARY_PATH=/opt/Qt/${QT_VERSION}/gcc_64/lib:$PWD/AppDir/usr/lib
         export OUTPUT=Tiled-Qt${{ matrix.qt_version_major }}-x86_64.AppImage
-        ./linuxdeploy-x86_64.AppImage --appdir AppDir --custom-apprun=dist/linux/AppRun --exclude-library "*libpython3*" --plugin qt --output appimage
+        ./linuxdeploy-x86_64.AppImage --appdir AppDir --custom-apprun=dist/linux/AppRun --exclude-library "*libpython3*" --plugin qt
+        # We don't need the bearer plugins (needed for Qt 5 only)
+        rm -rfv AppDir/usr/plugins/bearer
+        ./linuxdeploy-x86_64.AppImage --appdir AppDir --custom-apprun=dist/linux/AppRun --exclude-library "*libpython3*" --output appimage
 
     - name: Upload Tiled.AppImage
       uses: actions/upload-artifact@v3

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install libgl1-mesa-dev libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-randr0 libzstd-dev libcurl4-openssl-dev
+        sudo apt install libgl1-mesa-dev libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-randr0 libxcb-shape0 libzstd-dev libcurl4-openssl-dev
 
     - name: Install Qt
       run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -218,6 +218,7 @@ jobs:
     - name: Deploy Qt
       run: |
         macdeployqt install/Tiled.app -verbose=2
+        rm -f install/Tiled.app/Contents/PlugIns/tls/libqopensslbackend.dylib
         pushd install
         ruby ../dist/macos/fixup-install-names.rb
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -15,8 +15,6 @@ on:
     - '.travis.yml'
 
 env:
-  QT_VERSION: 5.15.2
-  QTCREATOR_VERSION: 7.0.3
   QBS_VERSION: 1.23.1
   SENTRY_VERSION: 0.5.2
   SENTRY_ORG: mapeditor
@@ -53,6 +51,11 @@ jobs:
           qt_version_major: 5
           qt_creator_version: 5.0.3
           gcc_version: 9
+        - image: ubuntu-20.04
+          qt_version: 6.4.2
+          qt_version_major: 6
+          qt_creator_version: 9.0.1
+          gcc_version: 10
 
     env:
       TILED_VERSION: ${{ needs.version.outputs.version }}
@@ -176,10 +179,10 @@ jobs:
       matrix:
         include:
         - qt_version: 5.12.12
-          version_suffix: "10.12"
+          version_suffix: "10.12-10.13"
           qt_creator_version: 5.0.3
-        - qt_version: 5.15.2
-          version_suffix: "10.13+"
+        - qt_version: 6.4.2
+          version_suffix: "10.14+"
           qt_creator_version: 7.0.2
 
     env:
@@ -247,16 +250,16 @@ jobs:
 
     - name: Create Archive
       run: |
-        ditto -c -k --sequesterRsrc --keepParent install/Tiled.app Tiled-macOS-${{ matrix.version_suffix }}.zip
+        ditto -c -k --sequesterRsrc --keepParent install/Tiled.app Tiled_macOS-${{ matrix.version_suffix }}.zip
 
     - name: Upload Tiled.app
       uses: actions/upload-artifact@v3
       with:
-        name: Tiled-macOS-${{ matrix.version_suffix }}.app
-        path: Tiled-macOS-${{ matrix.version_suffix }}.zip
+        name: Tiled_macOS-${{ matrix.version_suffix }}.app
+        path: Tiled_macOS-${{ matrix.version_suffix }}.zip
 
   windows:
-    name: Windows (${{ matrix.arch }}-bit)
+    name: Windows (${{ matrix.arch }}-bit, Qt ${{ matrix.qt_version_major }})
     runs-on: windows-2019
     needs: version
 
@@ -264,19 +267,21 @@ jobs:
       matrix:
         include:
         - qt_version: 5.15.2
+          qt_version_major: 5
           qt_toolchain: win32_mingw81
           arch: 32
           openssl_arch: x86
           mingw_version: 8.1.0
           mingw_component: mingw
           mingw_path: /c/Qt/Tools/mingw810_32/bin
-        - qt_version: 5.15.2
-          qt_toolchain: win64_mingw81
+        - qt_version: 6.4.2
+          qt_version_major: 6
+          qt_toolchain: win64_mingw
           arch: 64
           openssl_arch: x64
-          mingw_version: 8.1.0
-          mingw_component: mingw
-          mingw_path: /c/Qt/Tools/mingw810_64/bin
+          mingw_version: 9.0.0
+          mingw_component: mingw90
+          mingw_path: /c/Qt/Tools/mingw1120_64/bin
 
     env:
       TILED_VERSION: ${{ needs.version.outputs.version }}
@@ -361,7 +366,7 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: Tiled-win64.msi/Tiled-${{ needs.version.outputs.version }}-win64.msi
-        asset_name: Tiled-${{ needs.version.outputs.version }}_Windows_x86_64.msi
+        asset_name: Tiled-${{ needs.version.outputs.version }}_Windows-10+_x86_64.msi
         asset_content_type: application/x-msi
 
     - name: Upload Windows 32-bit installer
@@ -369,7 +374,7 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: Tiled-win32.msi/Tiled-${{ needs.version.outputs.version }}-win32.msi
-        asset_name: Tiled-${{ needs.version.outputs.version }}_Windows_x86.msi
+        asset_name: Tiled-${{ needs.version.outputs.version }}_Windows-7-8_x86.msi
         asset_content_type: application/x-msi
 
     - name: Upload Linux AppImage (Qt5)
@@ -377,23 +382,31 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: Tiled-Qt5-x86_64.AppImage/Tiled-Qt5-x86_64.AppImage
-        asset_name: Tiled-${{ needs.version.outputs.version }}_Linux_x86_64.AppImage
+        asset_name: Tiled-${{ needs.version.outputs.version }}_Linux_Qt-5_x86_64.AppImage
         asset_content_type: application/vnd.appimage
 
-    - name: Upload macOS app (10.12)
+    - name: Upload Linux AppImage (Qt6)
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: Tiled-macOS-10.12.app/Tiled-macOS-10.12.zip
-        asset_name: Tiled-${{ needs.version.outputs.version }}_macOS-10.12.zip
+        asset_path: Tiled-Qt6-x86_64.AppImage/Tiled-Qt6-x86_64.AppImage
+        asset_name: Tiled-${{ needs.version.outputs.version }}_Linux_Qt-6_x86_64.AppImage
+        asset_content_type: application/vnd.appimage
+
+    - name: Upload macOS app (10.12-10.13)
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: Tiled_macOS-10.12-10.13.app/Tiled_macOS-10.12-10.13.zip
+        asset_name: Tiled-${{ needs.version.outputs.version }}_macOS-10.12-10.13.zip
         asset_content_type: application/zip
 
-    - name: Upload macOS app (10.13+)
+    - name: Upload macOS app (10.14+)
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: Tiled-macOS-10.13+.app/Tiled-macOS-10.13+.zip
-        asset_name: Tiled-${{ needs.version.outputs.version }}_macOS-10.13+.zip
+        asset_path: Tiled_macOS-10.14+.app/Tiled_macOS-10.14+.zip
+        asset_name: Tiled-${{ needs.version.outputs.version }}_macOS-10.14+.zip
         asset_content_type: application/zip
 
   sentry:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,15 +12,15 @@ environment:
   BUTLER_API_KEY:
     secure: j7JM5L6KeqpnQukzJLsm7J6oV92SpmyEZLSoED1pZ3gQ79VIkdxtbQmTkqUNZPsz
   matrix:
-    - QTDIR: C:\Qt\6.3\msvc2019_64
+    - QTDIR: C:\Qt\6.4\msvc2019_64
       PYTHONHOME: C:\Python38-x64
       DEFAULT_PROFILE: MSVC2019-x64
       PUSH_RELEASE: false
       ENABLE_ZSTD: false
-    - QTDIR: C:\Qt\5.15\mingw81_64
+    - QTDIR: C:\Qt\6.4\mingw_64
       PYTHONHOME: C:\Python38-x64
-      MINGW: C:\Qt\Tools\mingw810_64
-      DEFAULT_PROFILE: x86_64-w64-mingw32-gcc-8_1_0
+      MINGW: C:\Qt\Tools\mingw1120_64
+      DEFAULT_PROFILE: x86_64-w64-mingw32-gcc-11_2_0
       PUSH_RELEASE: true
       ENABLE_ZSTD: true
       TILED_ITCH_CHANNEL: windows-64bit

--- a/dist/distribute.qbs
+++ b/dist/distribute.qbs
@@ -190,6 +190,27 @@ Product {
     }
 
     Group {
+        name: "Qt TLS Plugins"
+        condition: Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 2;
+        prefix: FileInfo.joinPaths(Qt.core.pluginPath, "/tls/")
+        files: {
+            if (qbs.targetOS.contains("windows")) {
+                if (qbs.debugInformation)
+                    return ["qschannelbackendd.dll"];
+                else
+                    return ["qschannelbackend.dll"];
+            } else if (qbs.targetOS.contains("macos")) {
+                return ["libqsecuretransportbackend.dylib"];
+            }
+
+            return pluginFiles;
+        }
+        excludeFiles: pluginExcludeFiles
+        qbs.install: true
+        qbs.installDir: "plugins/tls"
+    }
+
+    Group {
         name: "Qt XCB GL Integration Plugins"
         condition: qbs.targetOS.contains("linux")
         prefix: FileInfo.joinPaths(Qt.core.pluginPath, "/xcbglintegrations/")
@@ -296,7 +317,11 @@ Product {
 
     Group {
         name: "OpenSSL DLLs"
-        condition: qbs.targetOS.contains("windows") && File.exists(prefix)
+        condition: {
+            return qbs.targetOS.contains("windows") &&
+                    !(Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 2) &&
+                    File.exists(prefix)
+        }
 
         prefix: {
             if (project.openSslPath) {

--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -114,18 +114,22 @@
               <?endif?>
             <?endif?>
 
-            <?ifdef OpenSsl102Dir ?>
-              <File Source="$(var.OpenSsl102Dir)\libeay32.dll" />
-              <File Source="$(var.OpenSsl102Dir)\ssleay32.dll" />
-            <?endif?>
+            <!-- OpenSSL is needed for Qt versions older than 6.2,
+                 otherwise rely on the schannel backend -->
+            <?if $(var.QtVersionMajor) < 6 or $(var.QtVersionMinor) < 2 ?>
+              <?ifdef OpenSsl102Dir ?>
+                <File Source="$(var.OpenSsl102Dir)\libeay32.dll" />
+                <File Source="$(var.OpenSsl102Dir)\ssleay32.dll" />
+              <?endif?>
 
-            <?ifdef OpenSsl111Dir ?>
-              <?if $(var.Platform) = x64 ?>
-                <File Source="$(var.OpenSsl111Dir)\libcrypto-1_1-x64.dll" />
-                <File Source="$(var.OpenSsl111Dir)\libssl-1_1-x64.dll" />
-              <?else?>
-                <File Source="$(var.OpenSsl111Dir)\libcrypto-1_1.dll" />
-                <File Source="$(var.OpenSsl111Dir)\libssl-1_1.dll" />
+              <?ifdef OpenSsl111Dir ?>
+                <?if $(var.Platform) = x64 ?>
+                  <File Source="$(var.OpenSsl111Dir)\libcrypto-1_1-x64.dll" />
+                  <File Source="$(var.OpenSsl111Dir)\libssl-1_1-x64.dll" />
+                <?else?>
+                  <File Source="$(var.OpenSsl111Dir)\libcrypto-1_1.dll" />
+                  <File Source="$(var.OpenSsl111Dir)\libssl-1_1.dll" />
+                <?endif?>
               <?endif?>
             <?endif?>
 
@@ -208,8 +212,6 @@
             <?if $(var.QtVersionMajor) >= 6 and $(var.QtVersionMinor) >= 2 ?>
             <Directory Id="tlsPlugins" Name="tls">
               <Component Id="TlsPlugins" Guid="{98C9FB27-68C9-4B85-AE3B-B59B3735A38E}">
-                <File Source="$(var.QtDir)\plugins\tls\qcertonlybackend.dll"/>
-                <File Source="$(var.QtDir)\plugins\tls\qopensslbackend.dll"/>
                 <File Source="$(var.QtDir)\plugins\tls\qschannelbackend.dll"/>
               </Component>
             </Directory>

--- a/src/tiled/newsbutton.h
+++ b/src/tiled/newsbutton.h
@@ -24,7 +24,7 @@
 
 namespace Tiled {
 
-class NewsButton : public QToolButton
+class NewsButton final : public QToolButton
 {
     Q_OBJECT
 

--- a/src/tiled/tiledapplication.cpp
+++ b/src/tiled/tiledapplication.cpp
@@ -78,7 +78,7 @@ NewVersionChecker &TiledApplication::newVersionChecker()
 NewsFeed &TiledApplication::newsFeed()
 {
     if (!mNewsFeed)
-        mNewsFeed = new NewsFeed(this);
+        mNewsFeed = std::make_unique<NewsFeed>();
     return *mNewsFeed;
 }
 

--- a/src/tiled/tiledapplication.h
+++ b/src/tiled/tiledapplication.h
@@ -25,6 +25,8 @@
 
 #include <QtSingleApplication>
 
+#include <memory>
+
 namespace Tiled {
 
 class NewVersionChecker;
@@ -53,7 +55,7 @@ private:
     ProjectManager mProjectManager;
 
     NewVersionChecker *mNewVersionChecker = nullptr;
-    NewsFeed *mNewsFeed = nullptr;
+    std::unique_ptr<NewsFeed> mNewsFeed;
 };
 
 inline TiledApplication *tiledApp()


### PR DESCRIPTION
Builds against Qt 5.15.2 will remain available for now for older systems.

- [x] Fix building of the AppImage (needs `libxcb-shape0`)
- [x] Avoid warning on startup on macOS (related to OpenSSL plugin)
- [x] Avoid warning on shutdown on Linux
- [x] Ship the needed TLS plugin(s) on Windows (were shipped already, but could use some cleanup: #3572)
- [x] Find a way to not ship the bearer plugins for the Qt 5 AppImage