### PR TITLE
AppImage: Updated to Sentry 0.5.4

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -18,7 +18,7 @@ env:
   QT_VERSION: 5.15.2
   QTCREATOR_VERSION: 7.0.3
   QBS_VERSION: 1.23.1
-  SENTRY_VERSION: 0.5.2
+  SENTRY_VERSION: 0.5.4
   SENTRY_ORG: mapeditor
   SENTRY_PROJECT: tiled
   TILED_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 * Fixed slight drift when zooming the map view in/out
 * Fixed compile against Qt 6.4
 * snap: Added Wayland platform plugin and additional image format plugins
-* AppImage: Updated to Sentry 0.5.2
+* AppImage: Updated to Sentry 0.5.4
 
 ### Tiled 1.9.2 (16 September 2022)
 


### PR DESCRIPTION
* https://github.com/getsentry/sentry-native/releases/tag/0.5.3
* https://github.com/getsentry/sentry-native/releases/tag/0.5.4