### PR TITLE
Bring back the arrow down on the "Class of" button

### DIFF
--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -45,6 +45,9 @@
 #include <QPushButton>
 #include <QScopedValueRollback>
 #include <QStringListModel>
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#include <QStylePainter>
+#endif
 #include <QToolBar>
 
 #include <QtTreePropertyBrowser>
@@ -74,18 +77,29 @@ public:
 
     QSize sizeHint() const override
     {
+        QStyleOptionButton option;
+        initStyleOption(&option);
+
         QSize hint = QPushButton::sizeHint();
-
-        QStyleOptionButton opt;
-        initStyleOption(&opt);
-
-        hint.rwidth() += style()->pixelMetric(QStyle::PM_MenuButtonIndicator, &opt, this);
-
+        hint.rwidth() += style()->pixelMetric(QStyle::PM_MenuButtonIndicator, &option, this);
         return hint;
     }
 
 protected:
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    void paintEvent(QPaintEvent *) override
+    {
+        QStyleOptionButton option;
+        initStyleOption(&option);
+
+        QStylePainter p(this);
+        p.drawControl(QStyle::CE_PushButton, option);
+    }
+
+    void initStyleOption(QStyleOptionButton *option) const
+#else
     void initStyleOption(QStyleOptionButton *option) const override
+#endif
     {
         QPushButton::initStyleOption(option);
         option->features |= QStyleOptionButton::HasMenu;

--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -67,6 +67,31 @@ static bool confirm(const QString &title, const QString& text, QWidget *parent)
                                 QMessageBox::No) == QMessageBox::Yes;
 }
 
+class DropDownPushButton : public QPushButton
+{
+public:
+    using QPushButton::QPushButton;
+
+    QSize sizeHint() const override
+    {
+        QSize hint = QPushButton::sizeHint();
+
+        QStyleOptionButton opt;
+        initStyleOption(&opt);
+
+        hint.rwidth() += style()->pixelMetric(QStyle::PM_MenuButtonIndicator, &opt, this);
+
+        return hint;
+    }
+
+protected:
+    void initStyleOption(QStyleOptionButton *option) const override
+    {
+        QPushButton::initStyleOption(option);
+        option->features |= QStyleOptionButton::HasMenu;
+    }
+};
+
 
 PropertyTypesFilter::PropertyTypesFilter(const QString &lastPath)
     : propertyTypesFilter(QCoreApplication::translate("File Types", "Custom Types files (*.json)"))
@@ -926,7 +951,7 @@ void PropertyTypesEditor::addClassProperties()
     connect(mUseAsPropertyCheckBox, &QCheckBox::toggled,
             this, [this] (bool checked) { setUsageFlags(ClassPropertyType::PropertyValueType, checked); });
 
-    mClassOfButton = new QPushButton(tr("Select Types"));
+    mClassOfButton = new DropDownPushButton(tr("Select Types"));
     mClassOfButton->setAutoDefault(false);
     mClassOfCheckBox = new QCheckBox(tr("Class of"));
 


### PR DESCRIPTION
It used to be rendered because a menu was attached. Now that there is no menu attached, we need to override some things to fake it.