### PR TITLE
Windows: Remove unnecessary TLS plugins and OpenSSL DLLs

### DIFF
--- a/dist/distribute.qbs
+++ b/dist/distribute.qbs
@@ -190,6 +190,27 @@ Product {
     }
 
     Group {
+        name: "Qt TLS Plugins"
+        condition: Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 2;
+        prefix: FileInfo.joinPaths(Qt.core.pluginPath, "/tls/")
+        files: {
+            if (qbs.targetOS.contains("windows")) {
+                if (qbs.debugInformation)
+                    return ["qschannelbackendd.dll"];
+                else
+                    return ["qschannelbackend.dll"];
+            } else if (qbs.targetOS.contains("macos")) {
+                return ["libqsecuretransportbackend.dylib"];
+            }
+
+            return pluginFiles;
+        }
+        excludeFiles: pluginExcludeFiles
+        qbs.install: true
+        qbs.installDir: "plugins/tls"
+    }
+
+    Group {
         name: "Qt XCB GL Integration Plugins"
         condition: qbs.targetOS.contains("linux")
         prefix: FileInfo.joinPaths(Qt.core.pluginPath, "/xcbglintegrations/")
@@ -296,7 +317,11 @@ Product {
 
     Group {
         name: "OpenSSL DLLs"
-        condition: qbs.targetOS.contains("windows") && File.exists(prefix)
+        condition: {
+            return qbs.targetOS.contains("windows") &&
+                    !(Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 2) &&
+                    File.exists(prefix)
+        }
 
         prefix: {
             if (project.openSslPath) {

--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -114,18 +114,22 @@
               <?endif?>
             <?endif?>
 
-            <?ifdef OpenSsl102Dir ?>
-              <File Source="$(var.OpenSsl102Dir)\libeay32.dll" />
-              <File Source="$(var.OpenSsl102Dir)\ssleay32.dll" />
-            <?endif?>
+            <!-- OpenSSL is needed for Qt versions older than 6.2,
+                 otherwise rely on the schannel backend -->
+            <?if $(var.QtVersionMajor) < 6 or $(var.QtVersionMinor) < 2 ?>
+              <?ifdef OpenSsl102Dir ?>
+                <File Source="$(var.OpenSsl102Dir)\libeay32.dll" />
+                <File Source="$(var.OpenSsl102Dir)\ssleay32.dll" />
+              <?endif?>
 
-            <?ifdef OpenSsl111Dir ?>
-              <?if $(var.Platform) = x64 ?>
-                <File Source="$(var.OpenSsl111Dir)\libcrypto-1_1-x64.dll" />
-                <File Source="$(var.OpenSsl111Dir)\libssl-1_1-x64.dll" />
-              <?else?>
-                <File Source="$(var.OpenSsl111Dir)\libcrypto-1_1.dll" />
-                <File Source="$(var.OpenSsl111Dir)\libssl-1_1.dll" />
+              <?ifdef OpenSsl111Dir ?>
+                <?if $(var.Platform) = x64 ?>
+                  <File Source="$(var.OpenSsl111Dir)\libcrypto-1_1-x64.dll" />
+                  <File Source="$(var.OpenSsl111Dir)\libssl-1_1-x64.dll" />
+                <?else?>
+                  <File Source="$(var.OpenSsl111Dir)\libcrypto-1_1.dll" />
+                  <File Source="$(var.OpenSsl111Dir)\libssl-1_1.dll" />
+                <?endif?>
               <?endif?>
             <?endif?>
 
@@ -208,8 +212,6 @@
             <?if $(var.QtVersionMajor) >= 6 and $(var.QtVersionMinor) >= 2 ?>
             <Directory Id="tlsPlugins" Name="tls">
               <Component Id="TlsPlugins" Guid="{98C9FB27-68C9-4B85-AE3B-B59B3735A38E}">
-                <File Source="$(var.QtDir)\plugins\tls\qcertonlybackend.dll"/>
-                <File Source="$(var.QtDir)\plugins\tls\qopensslbackend.dll"/>
                 <File Source="$(var.QtDir)\plugins\tls\qschannelbackend.dll"/>
               </Component>
             </Directory>


### PR DESCRIPTION
Since Qt 6.2, there is a schannel backend TLS plugin which uses Windows API rather than OpenSSL, which should suffice for our purposes.

Also adjusted distribute.qbs to ship these plugins for Windows and macOS.