### PR TITLE
Qt 6: Fixed visibility of status bar News button

### DIFF
--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include "clipboardmanager.h"
 #include "document.h"
 #include "preferences.h"
 #include "preferencesdialog.h"
@@ -37,6 +36,7 @@
 
 class QComboBox;
 class QLabel;
+class QToolButton;
 
 namespace Ui {
 class MainWindow;
@@ -263,6 +263,7 @@ private:
     MapEditor *mMapEditor;
     TilesetEditor *mTilesetEditor;
     QList<QWidget*> mEditorStatusBarWidgets;
+    QToolButton *mNewsButton;
 
     QPointer<PreferencesDialog> mPreferencesDialog;
 


### PR DESCRIPTION
Unfortunately, a regression in Qt 6.3 is causing the hiding of status bar widgets when switching editors to hide the news button.

Fix proposed in https://codereview.qt-project.org/c/qt/qtbase/+/460302