### PR TITLE
Scripting: Added region.contiguousRegions()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Scripting: Added tiled.projectFilePath
 * Scripting: Added tiled.versionLessThan
 * Scripting: Added TileMap.toImage (#3519)
+* Scripting: Added region.contiguousRegions() (#3576)
 * Scripting: Allow assigning null to Tile.objectGroup (by Logan Higinbotham, #3495)
 * Scripting: Allow changing the items in a combo box added to a dialog
 * Scripting: Fixed painting issues after changing TileLayer size (#3481)

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -128,6 +128,17 @@ interface region {
    * @since 1.8
    */
   intersect(region : region) : void;
+
+  /**
+   * Returns this region as an array of contiguous regions, based on 8-way
+   * connectivity (regions touching each other diagonally are considered
+   * contiguous).
+   *
+   * The returned regions are guaranteed not to touch each other.
+   *
+   * @since 1.10
+   */
+  contiguousRegions() : region[];
 }
 
 /**

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -132,7 +132,7 @@ interface region {
   /**
    * Returns this region as an array of contiguous regions, based on 8-way
    * connectivity (regions touching each other diagonally are considered
-   * contiguous).
+   * one contiguous region).
    *
    * The returned regions are guaranteed not to touch each other.
    *

--- a/src/tiled/regionvaluetype.cpp
+++ b/src/tiled/regionvaluetype.cpp
@@ -20,6 +20,8 @@
 
 #include "regionvaluetype.h"
 
+#include "geometry.h"
+
 namespace Tiled {
 
 RegionValueType::RegionValueType(int x, int y, int w, int h)
@@ -43,13 +45,22 @@ QString RegionValueType::toString() const
     case 0:
         return QStringLiteral("Region(empty)");
     case 1: {
-        QRect r = boundingRect();
+        const QRect r = boundingRect();
         return QString::asprintf("Region(x = %d, y = %d, w = %d, h = %d)",
                                  r.x(), r.y(), r.width(), r.height());
     }
     default:
         return QStringLiteral("Region(...)");
     }
+}
+
+QVector<RegionValueType> RegionValueType::contiguousRegions() const
+{
+    const auto regions = Tiled::coherentRegions(mRegion);
+    QVector<RegionValueType> regionValues;
+    for (const auto &region : regions)
+        regionValues.append(RegionValueType(region));
+    return regionValues;
 }
 
 QVector<QRect> RegionValueType::rects() const

--- a/src/tiled/regionvaluetype.h
+++ b/src/tiled/regionvaluetype.h
@@ -54,6 +54,8 @@ public:
     Q_INVOKABLE void intersect(const QRectF &rect);
     Q_INVOKABLE void intersect(const Tiled::RegionValueType &region);
 
+    Q_INVOKABLE QVector<Tiled::RegionValueType> contiguousRegions() const;
+
     QRect boundingRect() const;
     QVector<QRect> rects() const;
 

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -117,6 +117,7 @@ ScriptManager::ScriptManager(QObject *parent)
     qRegisterMetaType<MapEditor*>();
     qRegisterMetaType<MapView*>();
     qRegisterMetaType<RegionValueType>();
+    qRegisterMetaType<QVector<Tiled::RegionValueType>>();
     qRegisterMetaType<ScriptedAction*>();
     qRegisterMetaType<ScriptedTool*>();
     qRegisterMetaType<TileCollisionDock*>();


### PR DESCRIPTION
Returns this region as an array of contiguous regions, based on 8-way connectivity (regions touching each other diagonally are considered contiguous).

This was an easy to provide convenience function since the functionality already existed for AutoMapping to find the rules in a rule map.