### PR TITLE
Qt 6: Fixed tile rendering when OpenGL is enabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * Defold plugin: Allow overriding z value also when exporting to .collection (#3214)
 * Qt 6: Fixed invisible tileset tabs when only a single tileset is open
 * Qt 6: Fixed behavior of "Class of" selection popup
+* Qt 6: Fixed tile rendering when OpenGL is enabled (#3578)
 * Fixed positioning of point object name labels (by Logan Higinbotham, #3400)
 * Fixed slight drift when zooming the map view in/out
 * Fixed compile against Qt 6.4

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -32,7 +32,6 @@
 #include "mapobject.h"
 #include "tile.h"
 #include "tilelayer.h"
-#include "tileset.h"
 #include "objectgroup.h"
 
 #include <QtMath>

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -491,7 +491,13 @@ void CellRenderer::render(const Cell &cell, const QPointF &screenPos, const QSiz
     fragment.scaleX *= flippedHorizontally ? -1 : 1;
     fragment.scaleY *= flippedVertically ? -1 : 1;
 
+    // Avoid using drawPixmapFragments with OpenGL in Qt 6.4.1 and above
+    // (https://bugreports.qt.io/browse/QTBUG-111416)
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 1)
     if (mIsOpenGL || (fragment.scaleX > 0 && fragment.scaleY > 0)) {
+#else
+    if (!mIsOpenGL && fragment.scaleX > 0 && fragment.scaleY > 0) {
+#endif
         mTile = tile;
         mFragments.append(fragment);
         return;
@@ -525,7 +531,7 @@ void CellRenderer::render(const Cell &cell, const QPointF &screenPos, const QSiz
         mFragments.append(fragment);
         paintTileCollisionShapes();
         mTile = nullptr;
-        mFragments.resize(0);
+        mFragments.clear();
     }
 }
 
@@ -548,7 +554,7 @@ void CellRenderer::flush()
     }
 
     mTile = nullptr;
-    mFragments.resize(0);
+    mFragments.clear();
 }
 
 /**

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -32,7 +32,6 @@
 #include "mapobject.h"
 #include "tile.h"
 #include "tilelayer.h"
-#include "tileset.h"
 #include "objectgroup.h"
 
 #include <QtCore/qmath.h>

--- a/src/libtiledquick/tilelayeritem.cpp
+++ b/src/libtiledquick/tilelayeritem.cpp
@@ -164,7 +164,7 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
         if (tileset != helper.tileset() || tileData.size() == TilesNode::MaxTileCount) {
             if (!tileData.isEmpty()) {
                 node->appendChildNode(new TilesNode(helper.texture(), tileData));
-                tileData.resize(0);
+                tileData.clear();
             }
 
             helper.setTileset(tileset);


### PR DESCRIPTION
Work around an issue introduced in Qt 6.4.1 ([QTBUG-111416](https://bugreports.qt.io/browse/QTBUG-111416)) by not using `QPainter::drawPixmapFragments` in OpenGL mode. This makes rendering tiles a bit less efficient, but at least it works.

Closes #3578