### PR TITLE
Fixed remaining lag after switching off hardware acceleration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * Qt 6: Fixed behavior of "Class of" selection popup
 * Fixed positioning of point object name labels (by Logan Higinbotham, #3400)
 * Fixed slight drift when zooming the map view in/out
+* Fixed remaining lag after switching off hardware acceleration (#3584)
 * Fixed compile against Qt 6.4
 * snap: Added Wayland platform plugin and additional image format plugins
 * AppImage: Updated to Sentry 0.5.4

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -159,6 +159,7 @@ private:
     void updateLayerComboIndex();
 
     void setupQuickStamps();
+    void setUseOpenGL(bool useOpenGL);
     void retranslateUi();
     void showTileCollisionShapesChanged(bool enabled);
     void parallaxEnabledChanged(bool enabled);

--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -72,9 +72,7 @@ MapView::MapView(QWidget *parent, Mode mode)
 #endif
 
 #ifndef QT_NO_OPENGL
-    Preferences *prefs = Preferences::instance();
-    setUseOpenGL(prefs->useOpenGL());
-    connect(prefs, &Preferences::useOpenGLChanged, this, &MapView::setUseOpenGL);
+    setUseOpenGL(Preferences::instance()->useOpenGL());
 #endif
 
     QWidget *v = viewport();

--- a/src/tiled/mapview.h
+++ b/src/tiled/mapview.h
@@ -96,6 +96,8 @@ public:
     void forceCenterOn(QPointF pos);
     void forceCenterOn(QPointF pos, const Layer &layer);
 
+    void setUseOpenGL(bool useOpenGL);
+
 protected:
     bool event(QEvent *event) override;
 
@@ -124,7 +126,6 @@ signals:
 
 private:
     void adjustScale(qreal scale);
-    void setUseOpenGL(bool useOpenGL);
     void updateSceneRect(const QRectF &sceneRect);
     void updateSceneRect(const QRectF &sceneRect, const QTransform &transform);
     void updateViewRect();


### PR DESCRIPTION
The `QOpenGLWidget` causes the surface type for the window to switch to `OpenGLSurface`, but it doesn't automatically switch back to `RasterSurface` when the last `QOpenGLWidget` is deleted again.

Closes #3584