### PR TITLE
Fix mistake in Search Actions where the shortcut Ctrl+Shift+P was marked as translatable 

### DIFF
--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -801,7 +801,7 @@
     <string>Search actions available in Tiled</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+P</string>
+    <string notr="true">Ctrl+Shift+P</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Found by @eishiya 