### PR TITLE
Add missing doc for html property on QTextEdit and fix missing parameter in Dialog.addImage

### DIFF
--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -428,6 +428,12 @@ declare namespace Qt {
        * Check the text with {@link plainText} or {@link html} when this is emitted.
        */
       textChanged: Signal<void>;
+      /**
+       * This property holds the text editor's contents as HTML 
+       * See the supported HTML subset here:
+       * https://doc.qt.io/qt-6/richtext-html-subset.html
+       */
+      html: string;
     }
 
     type CheckState = number;

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -4188,9 +4188,9 @@ declare class Dialog {
   addSeparator(labelText?:string): Qt.QFrame;
 
   /**
-   * Adds an image widget that can display an image in a dialog
+   * Adds an image widget that can display an image in a dialog.
    */
-   addImage(image: Image): ImageWidget;
+   addImage(labelText: string, image: Image): ImageWidget;
 
   /**
    * Add a {@link Qt.QSlider} widget to the dialog to allow a user to


### PR DESCRIPTION
I realized this was missing today despite being linked to elsewhere in the scripting doc.