### PR TITLE
AutoMapping: Fixed automatic output regions for object output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * AutoMapping: When input regions are defined, match in order by default (#3559)
 * AutoMapping: Skip locked layers when applying rules (#3544)
 * AutoMapping: Fixed NoOverlappingOutput in case of multiple output indices (#3551)
+* AutoMapping: Fixed automatic output regions for object output (#3473)
 * Scripting: Added Object.setColorProperty and Object.setFloatProperty (#3423)
 * Scripting: Added tiled.projectFilePath
 * Scripting: Added tiled.versionLessThan

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -44,6 +44,7 @@ namespace Tiled {
 class Layer;
 class Map;
 class MapObject;
+class MapRenderer;
 class ObjectGroup;
 class TileLayer;
 
@@ -419,6 +420,7 @@ private:
      * Map containing the rules.
      */
     const std::unique_ptr<Map> mRulesMap;
+    const std::unique_ptr<MapRenderer> mRulesMapRenderer;
     const QRegularExpression mMapNameFilter;
 
     RuleMapSetup mRuleMapSetup;

--- a/src/tiled/automappingutils.h
+++ b/src/tiled/automappingutils.h
@@ -26,17 +26,22 @@
 namespace Tiled {
 
 class MapObject;
+class MapRenderer;
 class ObjectGroup;
 
 class MapDocument;
+
+QRect objectTileRect(const MapRenderer &renderer,
+                     const MapObject &object);
 
 QList<MapObject*> objectsToErase(const MapDocument *mapDocument,
                                  const ObjectGroup *layer,
                                  const QRegion &where);
 
-QRegion tileRegionOfObjectGroup(const ObjectGroup *layer);
+QRegion tileRegionOfObjectGroup(const MapRenderer &renderer,
+                                const ObjectGroup *objectGroup);
 
-QList<MapObject*> objectsInRegion(const ObjectGroup *layer,
-                                  const QRegion &where);
+QList<MapObject*> objectsInRegion(const ObjectGroup *objectGroup,
+                                  const QRectF &where);
 
 } // namespace Tiled

--- a/tests/automapping/test_automapping.cpp
+++ b/tests/automapping/test_automapping.cpp
@@ -100,7 +100,7 @@ void test_AutoMapping::autoMap()
             const QPoint pos = it.key();
             const Cell &expected = it.value();
             const Cell &seen = mapTileLayer->cellAt(pos);
-            QCOMPARE(expected, seen);
+            QCOMPARE(seen, expected);
         }
     }
 }


### PR DESCRIPTION
With this change, output object layers are taken into account when determining the rule output regions.

The support for outputting objects by AutoMapping is still lacking support for many cases, like polygon/polyline objects or the object alignment setting, but it is at least meant to work for basic rectangle or tile objects.

This change also adjusts tileRegionOfObjectGroup to the change that made object position and size be stored in pixels rather than tiles (55e77677523ba93f797f6723fb22a86a28d38932), as was already done for objectsToErase before (521a40a5dac6552c943f8639f761a8b1e7535b82).

Closes #3473