### PR TITLE
AutoMapping: Added support for output set probability

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * AutoMapping: Skip locked layers when applying rules (#3544)
 * AutoMapping: Fixed NoOverlappingOutput in case of multiple output indices (#3551)
 * AutoMapping: Fixed automatic output regions for object output (#3473)
+* AutoMapping: Fixed crash on undo when output layers have properties
 * Scripting: Added Object.setColorProperty and Object.setFloatProperty (#3423)
 * Scripting: Added tiled.projectFilePath
 * Scripting: Added tiled.versionLessThan

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Implemented rendering of major grid lines for staggered / hexagonal maps (#3583)
 * Fixed new layer names to be always unique (by Logan Higinbotham, #3452)
 * Fixed broken tile images after importing/exporting a tileset
+* AutoMapping: Added support for output set probability (#3179)
 * AutoMapping: When input regions are defined, match in order by default (#3559)
 * AutoMapping: Skip locked layers when applying rules (#3544)
 * AutoMapping: Fixed NoOverlappingOutput in case of multiple output indices (#3551)

--- a/docs/manual/automapping.rst
+++ b/docs/manual/automapping.rst
@@ -179,9 +179,10 @@ NonEmpty
    This tile matches any non-empty cell.
 
 Other
-   This tile matches any non-empty cell, which contains a tile that is
-   *different* from all the tiles used on the current input layer in the
-   current rule.
+   This tile matches any cell, which contains a tile that is *different* from
+   all the tiles used by the current rule targeting the same input layer. This
+   includes empty cells, unless the Empty tile is explicitly matched on by the
+   rule (since Tiled 1.10).
 
 Negate
    This tile negates the condition at a specific location. It is effectively

--- a/docs/manual/automapping.rst
+++ b/docs/manual/automapping.rst
@@ -323,7 +323,7 @@ The following properties are supported on a per-layer basis:
 .. _automapping-StrictEmpty:
 
 AutoEmpty (alias: StrictEmpty)
-   This layer property is a boolean property. It can be added to
+   This input layer property is a boolean property. It can be added to
    **input** and **inputnot** layers to customize the behavior for
    empty tiles within a rule.
 
@@ -332,6 +332,19 @@ AutoEmpty (alias: StrictEmpty)
    layers and some of the tiles that are part of the same coherent rule are
    empty. Normally these tiles would be ignored, unless the special "Empty"
    tile was placed. With this option they behave as tiles matching "Empty".
+
+.. raw:: html
+
+   <div class="new">New in Tiled 1.10</div>
+
+Probability
+   This float layer property can be added to **output** layers to control the
+   probability that a given output index will be chosen. The probabilities for
+   each output index are relative to one another, and default to 1.0. For
+   example, if you have **outputA** with probability 2 and **outputB** with
+   probability 0.5, A will be chosen four times as often as B. If multiple
+   output layers with the same index have their "Probability" set, the last
+   (top-most) layer's probability will be used.
 
 .. raw:: html
 

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -732,8 +732,16 @@ static void collectCellsInRegion(const QVector<InputLayer> &list,
     for (const InputLayer &inputLayer : list) {
         forEachPointInRegion(r, [&] (int x, int y) {
             const Cell &cell = inputLayer.tileLayer->cellAt(x, y);
-            if (matchType(cell.tile()) == MatchType::Tile)
+            switch (matchType(cell.tile())) {
+            case MatchType::Tile:
                 appendUnique(cells, cell);
+                break;
+            case MatchType::Empty:
+                appendUnique(cells, Cell());
+                break;
+            default:
+                break;
+            }
         });
     }
 }

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -81,6 +81,7 @@ struct OutputSet
     QString name;
     // Maps output layers in mRulesMap to their names in mTargetMap
     QHash<const Layer*, QString> layers;
+    qreal probability = 1.0;
 };
 
 struct RuleOptions
@@ -336,6 +337,7 @@ private:
 
     void setupRuleMapProperties();
     void setupInputLayerProperties(InputLayer &inputLayer);
+    void setupOutputSetProperties(OutputSet &outputSet);
     void setupRuleOptionsArea(RuleOptionsArea &optionsArea, const MapObject *mapObject);
 
     /**

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -206,7 +206,7 @@ struct TILED_EDITOR_EXPORT AutoMappingContext
     std::vector<std::unique_ptr<Layer>> newLayers;  // Layers created in AutoMapper::prepareAutoMap
     QVector<QVector<AddMapObjects::Entry>> newMapObjects;   // Objects placed by AutoMapper
     QSet<MapObject*> mapObjectsToRemove;
-    QHash<Layer*, Properties> changedProperties;
+    QHash<const Layer*, Properties> changedProperties;
 
     // Clones of existing tile layers that might have been changed in AutoMapper::autoMap
     std::unordered_map<TileLayer*, std::unique_ptr<TileLayer>> originalToOutputLayerMapping;

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -81,6 +81,7 @@ struct OutputSet
     QString name;
     // Maps output layers in mRulesMap to their names in mTargetMap
     QHash<const Layer*, QString> layers;
+    QHash<const Layer*, Properties> outputLayerProperties;
     qreal probability = 1.0;
 };
 

--- a/src/tiled/automapperwrapper.cpp
+++ b/src/tiled/automapperwrapper.cpp
@@ -85,24 +85,21 @@ AutoMapperWrapper::AutoMapperWrapper(MapDocument *mapDocument,
     // Apply the changes to existing tile layers
     for (auto& [original, outputLayer] : context.originalToOutputLayerMapping) {
         const QRegion diffRegion = original->computeDiffRegion(*outputLayer);
-        if (diffRegion.isEmpty())
-            continue;
+        if (!diffRegion.isEmpty()) {
+            paint(original, 0, 0, outputLayer.get(),
+                  diffRegion.translated(original->position()));
+        }
 
-        paint(original, 0, 0, outputLayer.get(),
-              diffRegion.translated(original->position()));
+        // Apply any property changes
+        auto propertiesIt = context.changedProperties.find(outputLayer.get());
+        if (propertiesIt != context.changedProperties.end())
+            new ChangeProperties(mapDocument, QString(), original, *propertiesIt, this);
     }
 
     // Make sure to add any newly used tilesets to the map
     for (const SharedTileset &tileset : std::as_const(context.newTilesets))
         if (context.targetMap->isTilesetUsed(tileset.data()))
             new AddTileset(mapDocument, tileset, this);
-
-    // Apply any property changes to existing layers
-    QHashIterator<Layer*, Properties> changedPropertiesIt(context.changedProperties);
-    while (changedPropertiesIt.hasNext()) {
-        const auto item = changedPropertiesIt.next();
-        new ChangeProperties(mapDocument, QString(), item.key(), item.value(), this);
-    }
 
     auto anyObjectForObjectGroup = [&] (ObjectGroup *objectGroup) {
         for (const QVector<AddMapObjects::Entry> &entries : std::as_const(context.newMapObjects)) {

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -453,9 +453,15 @@ static void addAutomappingProperties(Properties &properties, const Object *objec
 
     switch (object->typeId()) {
     case Object::LayerType: {
-        if (static_cast<const Layer*>(object)->name().startsWith(QLatin1String("input"), Qt::CaseInsensitive)) {
+        auto layer = static_cast<const Layer*>(object);
+
+        if (layer->name().startsWith(QLatin1String("input"), Qt::CaseInsensitive)) {
             mergeProperties(properties, QVariantMap {
                 { QStringLiteral("AutoEmpty"), false },
+            });
+        } else if (layer->name().startsWith(QLatin1String("output"), Qt::CaseInsensitive)) {
+            mergeProperties(properties, QVariantMap {
+                { QStringLiteral("Probability"), 1.0 },
             });
         }
         break;


### PR DESCRIPTION
Rather than each output set always having equal probability, it is now possible to specify a probability for each output set, using a custom "Probability" property on any of its layers (when multiple layers in an output set have a "Probability" property, the last / top-most one wins).

The probability between output sets is relative and defaults to 1.0. So for example, when setting it to 2.0 for some output set, it will be twice as likely to be picked as any other output set.

Closes #3179