### PR TITLE
Fixed object labels to adjust to application font changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Fixed object labels to adjust to application font changes
+
 ### Tiled 1.10.0 (10 March 2023)
 
 * Restored Tiled 1.8 file format compatibility by default (#3560)

--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -26,17 +26,13 @@
 #include "automappingmanager.h"
 #include "changeevents.h"
 #include "changemapproperty.h"
-#include "changeselectedarea.h"
-#include "editablegrouplayer.h"
-#include "editableimagelayer.h"
 #include "editablelayer.h"
 #include "editablemanager.h"
 #include "editablemapobject.h"
-#include "editableobjectgroup.h"
 #include "editableselectedarea.h"
 #include "editabletilelayer.h"
+#include "editabletileset.h"
 #include "grouplayer.h"
-#include "imagelayer.h"
 #include "mapobject.h"
 #include "maprenderer.h"
 #include "minimaprenderer.h"
@@ -46,7 +42,6 @@
 #include "scriptmanager.h"
 #include "tilelayer.h"
 #include "tileset.h"
-#include "tilesetdocument.h"
 
 #include <QCoreApplication>
 #include <QQmlEngine>

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -444,6 +444,9 @@ bool MapScene::event(QEvent *event)
         if (mSelectedTool)
             mSelectedTool->mouseLeft();
         break;
+    case QEvent::FontChange:
+        emit fontChanged();
+        break;
     default:
         break;
     }

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -90,6 +90,7 @@ signals:
 
     void sceneRefreshed();
 
+    void fontChanged();
     void parallaxParametersChanged();
 
 protected:

--- a/src/tiled/objectreferenceitem.h
+++ b/src/tiled/objectreferenceitem.h
@@ -28,7 +28,6 @@ class MapObject;
 class MapRenderer;
 
 class ArrowHead;
-class ObjectSelectionItem;
 
 class ObjectReferenceItem : public QGraphicsItem
 {

--- a/src/tiled/objectselectionitem.h
+++ b/src/tiled/objectselectionitem.h
@@ -85,6 +85,9 @@ public:
     QRectF boundingRect() const override { return QRectF(); }
     void paint(QPainter *, const QStyleOptionGraphicsItem *, QWidget *) override {}
 
+protected:
+    QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
+
 private:
     void changeEvent(const ChangeEvent &event);
     void propertyRemoved(Object *object, const QString &name);
@@ -107,6 +110,8 @@ private:
     void objectLabelVisibilityChanged();
     void showObjectReferencesChanged();
     void objectLineWidthChanged();
+
+    void sceneFontChanged();
 
     void addRemoveObjectLabels();
     void addRemoveObjectOutlines();


### PR DESCRIPTION
When changing the custom application font, the object labels were not immediately updating their size.