### PR TITLE
Tweaked handling of Hexagonal (Staggered) maps by Terrain Brush

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Fixed object labels to adjust to application font changes
+* Improved Terrain Brush for Hexagonal (Staggered) maps with side length 0 (#3617)
 * Qt 6: Increased the image allocation limit from 128 MB to 1 GB (#3616)
 
 ### Tiled 1.10.0 (10 March 2023)

--- a/src/tiled/bucketfilltool.cpp
+++ b/src/tiled/bucketfilltool.cpp
@@ -23,17 +23,14 @@
 
 #include "bucketfilltool.h"
 
-#include "addremovetileset.h"
 #include "brushitem.h"
 #include "tilepainter.h"
-#include "tile.h"
 #include "tilelayer.h"
 #include "mapdocument.h"
-#include "painttilelayer.h"
-#include "staggeredrenderer.h"
 #include "stampactions.h"
 
-#include <QApplication>
+#include <QCoreApplication>
+#include <QUndoStack>
 
 #include <memory>
 

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -21,15 +21,11 @@
 
 #include "stampbrush.h"
 
-#include "addremovelayer.h"
-#include "addremovetileset.h"
 #include "brushitem.h"
 #include "geometry.h"
 #include "map.h"
 #include "mapdocument.h"
 #include "mapscene.h"
-#include "painttilelayer.h"
-#include "staggeredrenderer.h"
 #include "stampactions.h"
 #include "tile.h"
 #include "tilestamp.h"
@@ -59,13 +55,13 @@ StampBrush::StampBrush(QObject *parent)
     connect(mStampActions->random(), &QAction::toggled, this, &StampBrush::randomChanged);
     connect(mStampActions->wangFill(), &QAction::toggled, this, &StampBrush::wangFillChanged);
 
-    connect(mStampActions->flipHorizontal(), &QAction::triggered,
+    connect(mStampActions->flipHorizontal(), &QAction::triggered, this,
             [this] { emit stampChanged(mStamp.flipped(FlipHorizontally)); });
-    connect(mStampActions->flipVertical(), &QAction::triggered,
+    connect(mStampActions->flipVertical(), &QAction::triggered, this,
             [this] { emit stampChanged(mStamp.flipped(FlipVertically)); });
-    connect(mStampActions->rotateLeft(), &QAction::triggered,
+    connect(mStampActions->rotateLeft(), &QAction::triggered, this,
             [this] { emit stampChanged(mStamp.rotated(RotateLeft)); });
-    connect(mStampActions->rotateRight(), &QAction::triggered,
+    connect(mStampActions->rotateRight(), &QAction::triggered, this,
             [this] { emit stampChanged(mStamp.rotated(RotateRight)); });
 }
 

--- a/src/tiled/wangfiller.h
+++ b/src/tiled/wangfiller.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "grid.h"
-#include "map.h"
 #include "wangset.h"
 
 #include <QList>
@@ -33,7 +32,7 @@
 namespace Tiled {
 
 class MapRenderer;
-class StaggeredRenderer;
+class HexagonalRenderer;
 
 /**
  * WangFiller provides functions for choosing cells based on a surrounding map
@@ -87,7 +86,7 @@ private:
 
     const WangSet &mWangSet;
     const MapRenderer * const mMapRenderer;
-    const StaggeredRenderer * const mStaggeredRenderer;
+    const HexagonalRenderer * const mHexagonalRenderer;
     bool mCorrectionsEnabled = false;
 
     QPainter *mDebugPainter = nullptr;


### PR DESCRIPTION
Now Hexagonal (Staggered) maps are treated the same way as Isometric (Staggered) maps, which might be better than treating them as orthogonal maps. It at least fixes the behavior when "hex side length" is 0, but it does not mean hexagonal maps are actually supported by the Terrain Brush.

Closes #3617