### PR TITLE
Fixed tile stamp getting messed up on staggered maps in some cases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Fixed object labels to adjust to application font changes
+* Fixed tile stamp getting messed up on staggered maps in some cases (#3431)
 * Improved Terrain Brush for Hexagonal (Staggered) maps with side length 0 (#3617)
 * Qt 6: Increased the image allocation limit from 128 MB to 1 GB (#3616)
 

--- a/src/libtiled/map.cpp
+++ b/src/libtiled/map.cpp
@@ -35,7 +35,6 @@
 #include "mapobject.h"
 #include "objectgroup.h"
 #include "objecttemplate.h"
-#include "tile.h"
 #include "tilelayer.h"
 
 #include <QtMath>
@@ -437,10 +436,9 @@ void Map::normalizeTileLayerPositionsAndMapSize()
             tileLayer->setPosition(tileLayer->position() - contentRect.topLeft());
 
         // Adjust the stagger index when layers are moved by odd amounts
-        const int staggerOffSet = (staggerAxis() == Map::StaggerX ? contentRect.x()
+        const int staggerOffset = (staggerAxis() == Map::StaggerX ? contentRect.x()
                                                                   : contentRect.y()) % 2;
-
-        setStaggerIndex(static_cast<Map::StaggerIndex>((staggerIndex() + staggerOffSet) % 2));
+        setStaggerIndex(static_cast<Map::StaggerIndex>((staggerIndex() + staggerOffset) % 2));
     }
 
     setWidth(contentRect.width());

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -379,7 +379,7 @@ static void shiftRows(TileLayer *tileLayer, Map::StaggerIndex staggerIndex)
 {
     tileLayer->resize(QSize(tileLayer->width() + 1, tileLayer->height()), QPoint());
 
-    for (int y = (staggerIndex + 1) & 1; y < tileLayer->height(); y += 2) {
+    for (int y = (tileLayer->y() + staggerIndex + 1) & 1; y < tileLayer->height(); y += 2) {
         for (int x = tileLayer->width() - 2; x >= 0; --x)
             tileLayer->setCell(x + 1, y, tileLayer->cellAt(x, y));
         tileLayer->setCell(0, y, Cell());
@@ -390,7 +390,7 @@ static void shiftColumns(TileLayer *tileLayer, Map::StaggerIndex staggerIndex)
 {
     tileLayer->resize(QSize(tileLayer->width(), tileLayer->height() + 1), QPoint());
 
-    for (int x = (staggerIndex + 1) & 1; x < tileLayer->width(); x += 2) {
+    for (int x = (tileLayer->x() + staggerIndex + 1) & 1; x < tileLayer->width(); x += 2) {
         for (int y = tileLayer->height() - 2; y >= 0; --y)
             tileLayer->setCell(x, y + 1, tileLayer->cellAt(x, y));
         tileLayer->setCell(x, 0, Cell());


### PR DESCRIPTION
While shifting rows or columns, the layer positions were not being taken into account.

Closes #3431