### PR TITLE
Qt 6 / Linux: Improved startup time for some icon themes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * JSON plugin: Fixed loading of empty tilesets created by script (#3542)
 * Improved Terrain Brush for Hexagonal (Staggered) maps with side length 0 (#3617)
 * Qt 6: Increased the image allocation limit from 128 MB to 1 GB (#3616)
+* Qt 6 / Linux: Fixed long startup time for some icon themes
 
 ### Tiled 1.10.0 (10 March 2023)
 

--- a/src/tiled/utils.cpp
+++ b/src/tiled/utils.cpp
@@ -51,6 +51,10 @@
 #endif
 #include <QScreen>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+#include <QtCore/qapplicationstatic.h>
+#endif
+
 static QString toImageFileFilter(const QList<QByteArray> &formats)
 {
     QString filter(QCoreApplication::translate("Utils", "Image files"));
@@ -280,6 +284,29 @@ RangeSet<int> matchingRanges(const QStringList &words, QStringRef string)
 
     return result;
 }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+/*
+ * Caching icons here, since Qt no longer caches null icons in
+ * QIcon::fromTheme.
+ */
+using IconCache = QHash<QString, QIcon>;
+Q_APPLICATION_STATIC(IconCache, iconCache);
+
+QIcon themeIcon(const QString &name)
+{
+    IconCache *cache = iconCache();
+    auto it = cache->find(name);
+    if (it == cache->end())
+        it = cache->insert(name, QIcon::fromTheme(name));
+    return *it;
+}
+#else
+QIcon themeIcon(const QString &name)
+{
+    return QIcon::fromTheme(name);
+}
+#endif
 
 QIcon colorIcon(const QColor &color, QSize size)
 {

--- a/src/tiled/utils.h
+++ b/src/tiled/utils.h
@@ -49,6 +49,8 @@ QString firstExtension(const QString &nameFilter);
 int matchingScore(const QStringList &words, QStringRef string);
 RangeSet<int> matchingRanges(const QStringList &words, QStringRef string);
 
+QIcon themeIcon(const QString &name);
+
 /**
  * Looks up the icon with the specified \a name from the system theme and set
  * it on the instance \a t when found.
@@ -62,9 +64,9 @@ template <class T>
 void setThemeIcon(T *t, const QString &name)
 {
 #ifdef Q_OS_LINUX
-    QIcon themeIcon = QIcon::fromTheme(name);
-    if (!themeIcon.isNull())
-        t->setIcon(themeIcon);
+    const QIcon icon = themeIcon(name);
+    if (!icon.isNull())
+        t->setIcon(icon);
 #else
     Q_UNUSED(t)
     Q_UNUSED(name)


### PR DESCRIPTION
Qt 6 no longer caches theme icons when they could not be found, resulting in many expensive icon searches each time the icon is requested again.

Introduced another icon cache to resolve this problem.