### PR TITLE
GitHub Actions: Avoid shipping debug information in AppImage

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -124,6 +124,8 @@ jobs:
         export EXTRA_QT_PLUGINS=svg
         export LD_LIBRARY_PATH=/opt/Qt/${QT_VERSION}/gcc_64/lib:$PWD/AppDir/usr/lib
         export OUTPUT=Tiled-Qt${{ matrix.qt_version_major }}-x86_64.AppImage
+        # Avoid shipping the debug information
+        find AppDir -name \*.debug -delete
         ./linuxdeploy-x86_64.AppImage --appdir AppDir --custom-apprun=dist/linux/AppRun --exclude-library "*libpython3*" --plugin qt
         # We don't need the bearer plugins (needed for Qt 5 only)
         rm -rfv AppDir/usr/plugins/bearer


### PR DESCRIPTION
Debug information was getting installed after using the convenience install properties in 46c447422209929b14e6622dec51942d5bbe09b1. However, we do not want to include these files in the AppImage since they make it very big.