### PR TITLE
Scripting: Fixed behavior of Dialog.SameWidgetRows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Scripting: Added read-only access to Project properties (by dogboydog, #3622)
+* Scripting: Fixed behavior of Dialog.SameWidgetRows (#3607)
 * Fixed object labels to adjust to application font changes
 * Fixed grid rendering for odd Hex Side Length values (#3623)
 * Fixed tile stamp getting messed up on staggered maps in some cases (#3431)

--- a/src/tiled/scriptdialog.h
+++ b/src/tiled/scriptdialog.h
@@ -36,7 +36,7 @@ class ScriptImage;
 /**
  * A widget which allows the user to display a ScriptImage
  */
-class ScriptImageWidget: public QLabel
+class ScriptImageWidget : public QLabel
 {
     Q_OBJECT
 
@@ -58,7 +58,7 @@ class ScriptDialog : public QDialog
 
 public:
     enum NewRowMode {
-        SameWidgetRows =0,
+        SameWidgetRows = 0,
         ManualRows = 1,
         SingleWidgetRows = 2
     };
@@ -102,8 +102,10 @@ private:
     int m_widgetsInRow = 0;
     QGridLayout *m_gridLayout;
     QHBoxLayout *m_rowLayout;
-    QString m_lastWidgetTypeName;
+    const QMetaObject *m_lastWidgetType;
     NewRowMode m_newRowMode = SameWidgetRows;
+
+    static QSet<ScriptDialog*> sDialogInstances;
 };
 
 


### PR DESCRIPTION
When a new row was created automatically when adding a widget, it was failing to remember the type of that widget, since `addNewRow` was called after setting `m_lastWidgetTypeName`.

Now the last widget type is set in addDialogWidget instead. Also, we no longer compare the type names but just compare the `QMetaObject` pointers directly.

Also fixed a problem in `ScriptDialog::deleteAllDialogs`, which iterated the `sDialogInstances` container while it was also getting modified as each dialog was deleted.

Closes #3607