### PR TITLE
docs: Added missing MapObject constructor

### DIFF
--- a/docs/scripting-doc/CHANGELOG.md
+++ b/docs/scripting-doc/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### 1.10.1
+
+- Added the new API from Tiled 1.10.1
+- Added missing documentation for MapObject(shape, name?) constructor
+- Fixed link in docs for Image
+- Improved docs for QCheckBox and QPushButton
+
 ### 1.10.0
 
 - Added the new API from Tiled 1.10.0

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1160,6 +1160,13 @@ interface Font {
 }
 
 /**
+ * The various possible shapes for {@link MapObject} instances.
+ *
+ * Accessible like `MapObject.Rectangle`, `MapObject.Polygon`, etc.
+ */
+type MapObjectShape = typeof MapObject.Rectangle | typeof MapObject.Polygon | typeof MapObject.Polyline | typeof MapObject.Ellipse | typeof MapObject.Text | typeof MapObject.Point;
+
+/**
  * An object that can be part of an {@link ObjectGroup}.
  */
 declare class MapObject extends TiledObject {
@@ -1178,7 +1185,7 @@ declare class MapObject extends TiledObject {
   /**
    * Shape of the object.
    */
-  shape: typeof MapObject.Rectangle | typeof MapObject.Polygon | typeof MapObject.Polyline | typeof MapObject.Ellipse | typeof MapObject.Text | typeof MapObject.Point
+  shape: MapObjectShape;
 
   /**
    * Name of the object.
@@ -1298,6 +1305,11 @@ declare class MapObject extends TiledObject {
    * Constructs a new map object, which can be added to an {@link ObjectGroup}.
    */
   constructor(name? : string)
+
+  /**
+   * Constructs a new map object of the given shape, which can be added to an {@link ObjectGroup}.
+   */
+  constructor(shape: MapObjectShape, name? : string)
 }
 
 /**

--- a/docs/scripting-doc/package-lock.json
+++ b/docs/scripting-doc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapeditor/tiled-api",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapeditor/tiled-api",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "funding": [
         {
           "type": "github",
@@ -125,9 +125,9 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"

--- a/docs/scripting-doc/package.json
+++ b/docs/scripting-doc/package.json
@@ -6,7 +6,7 @@
     "url": "git+https://github.com/mapeditor/tiled.git"
   },
   "types": "./index.d.ts",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "scripts": {
     "test": "tsc"
   },


### PR DESCRIPTION
The constructor overload taking a shape was missing. It appears to have been available since Tiled 1.3, when the scripting API was added.