### PR TITLE
Fixed the entry limit for enums used as flags to be 31

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Scripting: Added WangSet.effectiveTypeForColor
 * Fixed crash when changing file property of custom class (#3783)
 * Fixed loading of invalid color properties (#3793)
+* Fixed handling of enum values with 31 flags and fixed the applied limit (#3658)
 * Fixed object preview position with parallax factor on group layer (#3669)
 * Fixed hover highlight rendering with active parallax factor (#3669)
 * Fixed updating of object selection outlines when changing parallax factor (#3669)

--- a/docs/manual/custom-properties.rst
+++ b/docs/manual/custom-properties.rst
@@ -89,7 +89,7 @@ readable whereas the latter could easier and more efficient to load.
 Finally, an enum can also allow multiple values to be chosen. In this case
 each option is displayed with a checkbox. When saving as string, a
 comma-separated list is used and when saving as number the selected indexes are
-encoded as bitflags. In both cases, the maximum number of flags supported is 30,
+encoded as bitflags. In both cases, the maximum number of flags supported is 31,
 since internally a 32-bit signed integer is used to store the value.
 
 .. _custom-classes:

--- a/src/qtpropertybrowser/src/qtpropertymanager.cpp
+++ b/src/qtpropertybrowser/src/qtpropertymanager.cpp
@@ -5365,10 +5365,10 @@ void QtFlagPropertyManager::setValue(QtProperty *property, int val)
     if (data.val == val)
         return;
 
-    if (val > (1 << data.flagNames.count()) - 1)
+    if (val < 0)
         return;
 
-    if (val < 0)
+    if (static_cast<unsigned>(val) >= (1u << data.flagNames.count()))
         return;
 
     data.val = val;

--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -515,10 +515,10 @@ void PropertyTypesEditor::removeValues()
 
 bool PropertyTypesEditor::checkValueCount(int count)
 {
-    if (count > 32) {
+    if (count > 31) {
         QMessageBox::critical(this,
                               tr("Too Many Values"),
-                              tr("Too many values for enum with values stored as flags. Maximum number of bit flags is 32."));
+                              tr("Too many values for enum with values stored as flags. Maximum number of bit flags is %1.").arg(31));
         return false;
     }
     return true;

--- a/translations/tiled_ar_DZ.ts
+++ b/translations/tiled_ar_DZ.ts
@@ -6165,7 +6165,7 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_bg.ts
+++ b/translations/tiled_bg.ts
@@ -6061,8 +6061,8 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Твърде много стойности за изброен тип, чийто стойности се съхраняват като флагове. Максималния брой на флаговете в този вид е 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Твърде много стойности за изброен тип, чийто стойности се съхраняват като флагове. Максималния брой на флаговете в този вид е %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_cs.ts
+++ b/translations/tiled_cs.ts
@@ -6091,8 +6091,8 @@ Prosím vyberte formát ručně.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Příliš mnoho hodnot pro výčet uložený po bitech. Maximální počet takových hodnot je 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Příliš mnoho hodnot pro výčet uložený po bitech. Maximální počet takových hodnot je %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_de.ts
+++ b/translations/tiled_de.ts
@@ -6061,8 +6061,8 @@ Bitte Format angeben.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Zu viele Werte für einen Enum, in dem die Werte als Flag gespeichert werden. Maximale Anzahl: 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Zu viele Werte für einen Enum, in dem die Werte als Flag gespeichert werden. Maximale Anzahl: %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_en.ts
+++ b/translations/tiled_en.ts
@@ -6050,8 +6050,8 @@ Please select specific format.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_es.ts
+++ b/translations/tiled_es.ts
@@ -6058,7 +6058,7 @@ Por favor seleccione un formato específico.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_fi.ts
+++ b/translations/tiled_fi.ts
@@ -6061,8 +6061,8 @@ Ole hyvä ja valitse tietty tiedostomuoto.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Liian monta arvoa enumille, jonka arvot on tallennettu lippuina. Lippujen enimmäismäärä on 32 bittiä.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Liian monta arvoa enumille, jonka arvot on tallennettu lippuina. Lippujen enimmäismäärä on %1 bittiä.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_fr.ts
+++ b/translations/tiled_fr.ts
@@ -6088,8 +6088,8 @@ Veuillez sélectionner un format spécifique.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Trop de valeurs de cette énumération sont stockées en tant que drapeaux. Le nombre maximal de bits de drapeaux est 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Trop de valeurs de cette énumération sont stockées en tant que drapeaux. Le nombre maximal de bits de drapeaux est %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_he.ts
+++ b/translations/tiled_he.ts
@@ -6050,7 +6050,7 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_hu.ts
+++ b/translations/tiled_hu.ts
@@ -6061,8 +6061,8 @@ Válasszon egy adott formátumot.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Túl sok érték egy jelzőkként tárolt értékekkel rendelkező felsorolásnál. A bitjelzők legnagyobb száma 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Túl sok érték egy jelzőkként tárolt értékekkel rendelkező felsorolásnál. A bitjelzők legnagyobb száma %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_it.ts
+++ b/translations/tiled_it.ts
@@ -6061,7 +6061,7 @@ Seleziona un formato specifico.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_ja.ts
+++ b/translations/tiled_ja.ts
@@ -6035,7 +6035,7 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_ko.ts
+++ b/translations/tiled_ko.ts
@@ -6033,7 +6033,7 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_nb.ts
+++ b/translations/tiled_nb.ts
@@ -6061,7 +6061,7 @@ Vennligst velgt et spesifikt format.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_nl.ts
+++ b/translations/tiled_nl.ts
@@ -6061,7 +6061,7 @@ Kies een specifiek bestandsformaat.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_pl.ts
+++ b/translations/tiled_pl.ts
@@ -6087,7 +6087,7 @@ Proszę wybrać konkretny format.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_pt.ts
+++ b/translations/tiled_pt.ts
@@ -6061,8 +6061,8 @@ Por favor, selecione um formato específico.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Muitos valores para enumeração com valores armazenados como sinalizadores. O número máximo de sinalizadores de bits é 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Muitos valores para enumeração com valores armazenados como sinalizadores. O número máximo de sinalizadores de bits é %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_pt_PT.ts
+++ b/translations/tiled_pt_PT.ts
@@ -6061,8 +6061,8 @@ Por favor, selecione um formato específico.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Muitos valores para enumeração com valores armazenados como sinalizadores. O número máximo de sinalizadores de bits é 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Muitos valores para enumeração com valores armazenados como sinalizadores. O número máximo de sinalizadores de bits é %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_ru.ts
+++ b/translations/tiled_ru.ts
@@ -6088,8 +6088,8 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation type="unfinished">Слишком много значений для перечисления со значениями сохраненными как флаги. Максимальное количество бит-флагов - 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation type="unfinished">Слишком много значений для перечисления со значениями сохраненными как флаги. Максимальное количество бит-флагов - %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_sv.ts
+++ b/translations/tiled_sv.ts
@@ -6061,8 +6061,8 @@ Var god ange det specifika formatet.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>För många värden för enum med värden lagrade som flaggor. Maximalt antal bitflaggor är 32.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>För många värden för enum med värden lagrade som flaggor. Maximalt antal bitflaggor är %1.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_th.ts
+++ b/translations/tiled_th.ts
@@ -6033,7 +6033,7 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_tr.ts
+++ b/translations/tiled_tr.ts
@@ -6037,8 +6037,8 @@ Lütfen belirli bir biçim seçin.</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>Bayrak olarak depolanan değerleri olan enum için çok fazla değer. En fazla bit bayrağı sayısı 32&apos;dir.</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>Bayrak olarak depolanan değerleri olan enum için çok fazla değer. En fazla bit bayrağı sayısı %1&apos;dir.</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_uk.ts
+++ b/translations/tiled_uk.ts
@@ -6086,7 +6086,7 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tiled_zh_CN.ts
+++ b/translations/tiled_zh_CN.ts
@@ -6036,8 +6036,8 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
-        <translation>枚举值太多，其值存储为标志。位标志的最大数量为 32。</translation>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
+        <translation>枚举值太多，其值存储为标志。位标志的最大数量为 %1。</translation>
     </message>
     <message>
         <location line="+69"/>

--- a/translations/tiled_zh_TW.ts
+++ b/translations/tiled_zh_TW.ts
@@ -6034,7 +6034,7 @@ Please select specific format.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is 32.</source>
+        <source>Too many values for enum with values stored as flags. Maximum number of bit flags is %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Due to the use of a 32-bit int to store the flags, the maximum number of flags is actually 30 rather than 32. When more entries are added, the editing of enum values breaks entirely.

The translations have been updated to use a parameter for the maximum number of flags in an enum, to make it easier to adjust this value when it might be increased in the future.

Closes #3658