### PR TITLE
Revert "Re-enabled Space for toggling layer visibility"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### [Unreleased]
+
+* Removed Space and Ctrl+Space shortcuts from Layers view to avoid conflict with panning (#3672)
+
 ### Tiled 1.10.1 (4 April 2023)
 
 * Make panning with Space require pressing a mouse button as well (#3626)

--- a/src/tiled/layerdock.cpp
+++ b/src/tiled/layerdock.cpp
@@ -24,7 +24,6 @@
 #include "layerdock.h"
 
 #include "actionmanager.h"
-#include "changelayer.h"
 #include "layer.h"
 #include "layermodel.h"
 #include "map.h"
@@ -478,24 +477,11 @@ void LayerView::contextMenuEvent(QContextMenuEvent *event)
 
 void LayerView::keyPressEvent(QKeyEvent *event)
 {
-    Layer *layer = mMapDocument ? mMapDocument->currentLayer() : nullptr;
-
     switch (event->key()) {
     case Qt::Key_Delete:
     case Qt::Key_Backspace:
         if (mMapDocument && !mMapDocument->selectedLayers().isEmpty()) {
             mMapDocument->removeLayers(mMapDocument->selectedLayers());
-            return;
-        }
-        break;
-    case Qt::Key_Space:
-        if (layer) {
-            QUndoCommand *command = nullptr;
-            if (event->modifiers() & Qt::ControlModifier)
-                command = new SetLayerLocked(mMapDocument, { layer }, !layer->isLocked());
-            else
-                command = new SetLayerVisible(mMapDocument, { layer }, !layer->isVisible());
-            mMapDocument->undoStack()->push(command);
             return;
         }
         break;


### PR DESCRIPTION
This reverts commit 0de0f20e304bbed4d8c52e4cc09586bb12d34c5a.

This shortcut was only provided for backwards compatibility, but it often conflicts with using Space for panning the map view and since 359dcb93f3a4248e0380f9965ab9dd6b44308eb9 there are global shortcuts available for toggling layer visility and locked status, making this shortcut no longer necessary.

See issue #3672.