### PR TITLE
Fixed some issues with the Offset Map action related to objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Fixed object preview position with parallax factor on group layer (#3669)
 * Fixed hover highlight rendering with active parallax factor (#3669)
 * Fixed updating of object selection outlines when changing parallax factor (#3669)
+* Fixed "Offset Map" action to offset all objects when choosing "Whole Map" as bounds
 * AppImage: Updated to Sentry 0.6.3
 * Qt 6: Increased the image allocation limit from 1 GB to 4 GB (#3616)
 

--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -117,35 +117,24 @@ void MapObject::setTextData(const TextData &textData)
     mTextData = textData;
 }
 
+static void align(QRectF &r, Alignment alignment)
+{
+    r.translate(-alignmentOffset(r.size(), alignment));
+}
+
 /**
  * Shortcut to getting a QRectF from position() and size() that uses cell tile
  * if present.
  *
- * \deprecated See problems in comment.
+ * \deprecated See problems in comment. Try to use \a screenBounds instead.
  */
 QRectF MapObject::boundsUseTile() const
 {
-    // FIXME: This is outdated code:
-    // * It does not take into account that a tile object can be scaled.
-    // * It neglects that origin is not the same in orthogonal and isometric
-    //   maps (see MapObject::alignment).
-    // * It does not deal with rotation.
-
-    if (const Tile *tile = mCell.tile()) {
-        // Using the tile for determining boundary
-        // Note the position given is the bottom-left corner so correct for that
-        return QRectF(QPointF(mPos.x(),
-                              mPos.y() - tile->height()),
-                      tile->size());
-    }
-
-    // No tile so just use regular bounds
-    return bounds();
-}
-
-static void align(QRectF &r, Alignment alignment)
-{
-    r.translate(-alignmentOffset(r.size(), alignment));
+    // FIXME: This does not deal with tile offset, rotation, isometric
+    // projection and polygons.
+    QRectF b = bounds();
+    align(b, alignment());
+    return b;
 }
 
 /**

--- a/src/libtiled/objectgroup.cpp
+++ b/src/libtiled/objectgroup.cpp
@@ -158,26 +158,25 @@ void ObjectGroup::replaceReferencesToTileset(Tileset *oldTileset,
 
 void ObjectGroup::offsetObjects(const QPointF &offset,
                                 const QRectF &bounds,
+                                bool wholeMap,
                                 bool wrapX, bool wrapY)
 {
     if (offset.isNull())
         return;
 
-    const bool boundsValid = bounds.isValid();
-
     for (MapObject *object : std::as_const(mObjects)) {
-        const QPointF objectCenter = object->bounds().center();
-        if (boundsValid && !bounds.contains(objectCenter))
+        const QPointF objectCenter = object->boundsUseTile().center();
+        if (!wholeMap && !bounds.contains(objectCenter))
             continue;
 
         QPointF newCenter(objectCenter + offset);
 
-        if (wrapX && boundsValid) {
+        if (wrapX && bounds.width() > 0) {
             qreal nx = std::fmod(newCenter.x() - bounds.left(), bounds.width());
             newCenter.setX(bounds.left() + (nx < 0 ? bounds.width() + nx : nx));
         }
 
-        if (wrapY && boundsValid) {
+        if (wrapY && bounds.height() > 0) {
             qreal ny = std::fmod(newCenter.y() - bounds.top(), bounds.height());
             newCenter.setY(bounds.top() + (ny < 0 ? bounds.height() + ny : ny));
         }

--- a/src/libtiled/objectgroup.h
+++ b/src/libtiled/objectgroup.h
@@ -156,6 +156,7 @@ public:
      * \sa TileLayer::offsetTiles()
      */
     void offsetObjects(const QPointF &offset, const QRectF &bounds,
+                       bool wholeMap,
                        bool wrapX, bool wrapY);
 
     bool canMergeWith(const Layer *other) const override;

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -1908,9 +1908,11 @@ void MainWindow::offsetMap()
         if (layers.empty())
             return;
 
+        const bool wholeMap = offsetDialog.boundsSelection() == OffsetMapDialog::WholeMap;
         mapDocument->offsetMap(layers,
                                offsetDialog.offset(),
                                offsetDialog.affectedBoundingRect(),
+                               wholeMap,
                                offsetDialog.wrapX(),
                                offsetDialog.wrapY());
     }

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -413,6 +413,7 @@ void MapDocument::autocropMap()
 void MapDocument::offsetMap(const QList<Layer*> &layers,
                             const QPoint offset,
                             const QRect &bounds,
+                            bool wholeMap,
                             bool wrapX, bool wrapY)
 {
     if (layers.empty())
@@ -421,7 +422,7 @@ void MapDocument::offsetMap(const QList<Layer*> &layers,
     undoStack()->beginMacro(tr("Offset Map"));
     for (auto layer : layers) {
         undoStack()->push(new OffsetLayer(this, layer, offset,
-                                          bounds, wrapX, wrapY));
+                                          bounds, wholeMap, wrapX, wrapY));
     }
     undoStack()->endMacro();
 }

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -151,6 +151,7 @@ public:
     void offsetMap(const QList<Layer *> &layers,
                    QPoint offset,
                    const QRect &bounds,
+                   bool wholeMap,
                    bool wrapX, bool wrapY);
 
     void flipSelectedObjects(FlipDirection direction);

--- a/src/tiled/offsetlayer.cpp
+++ b/src/tiled/offsetlayer.cpp
@@ -45,14 +45,13 @@ OffsetLayer::OffsetLayer(MapDocument *mapDocument,
                          Layer *layer,
                          QPoint offset,
                          const QRect &bounds,
+                         bool wholeMap,
                          bool wrapX,
                          bool wrapY)
     : QUndoCommand(QCoreApplication::translate("Undo Commands",
                                                "Offset Layer"))
     , mMapDocument(mapDocument)
-    , mDone(false)
     , mOriginalLayer(layer)
-    , mOffsetLayer(nullptr)
 {
     switch (mOriginalLayer->layerType()) {
     case Layer::TileLayerType:
@@ -74,7 +73,7 @@ OffsetLayer::OffsetLayer(MapDocument *mapDocument,
         const QRectF pixelBounds = renderer->tileToPixelCoords(bounds);
 
         if (mOriginalLayer->layerType() == Layer::ObjectGroupType) {
-            static_cast<ObjectGroup*>(mOffsetLayer)->offsetObjects(pixelOffset, pixelBounds, wrapX, wrapY);
+            static_cast<ObjectGroup*>(mOffsetLayer)->offsetObjects(pixelOffset, pixelBounds, wholeMap, wrapX, wrapY);
         } else {
             // (wrapping not supported for image layers and group layers)
             mOldOffset = mOriginalLayer->offset();

--- a/src/tiled/offsetlayer.h
+++ b/src/tiled/offsetlayer.h
@@ -41,6 +41,7 @@ public:
                 Layer *layer,
                 QPoint offset,
                 const QRect &bounds,
+                bool wholeMap,
                 bool xWrap,
                 bool yWrap);
 
@@ -51,9 +52,9 @@ public:
 
 private:
     MapDocument *mMapDocument;
-    bool mDone;
+    bool mDone = false;
     Layer *mOriginalLayer;
-    Layer *mOffsetLayer;
+    Layer *mOffsetLayer = nullptr;
     QPointF mOldOffset;
     QPointF mNewOffset;
 };

--- a/src/tiled/offsetmapdialog.cpp
+++ b/src/tiled/offsetmapdialog.cpp
@@ -92,7 +92,8 @@ QRect OffsetMapDialog::affectedBoundingRect() const
 
     switch (boundsSelection()) {
     case WholeMap:
-        boundingRect = mMapDocument->map()->tileBoundingRect();
+        if (!mMapDocument->map()->infinite())
+            boundingRect = mMapDocument->map()->tileBoundingRect();
         break;
     case CurrentSelectionArea: {
         const QRegion &selection = mMapDocument->selectedArea();

--- a/src/tiled/offsetmapdialog.cpp
+++ b/src/tiled/offsetmapdialog.cpp
@@ -84,7 +84,7 @@ QList<Layer *> OffsetMapDialog::affectedLayers() const
  * Returns the bounding rect that is to be affected by the offset operation.
  *
  * For infinite maps, when not using the currently selected area, the returned
- * rect is empty.
+ * rect is roughly derived from tile layer contents.
  */
 QRect OffsetMapDialog::affectedBoundingRect() const
 {
@@ -92,8 +92,7 @@ QRect OffsetMapDialog::affectedBoundingRect() const
 
     switch (boundsSelection()) {
     case WholeMap:
-        if (!mMapDocument->map()->infinite())
-            boundingRect = QRect(QPoint(0, 0), mMapDocument->map()->size());
+        boundingRect = mMapDocument->map()->tileBoundingRect();
         break;
     case CurrentSelectionArea: {
         const QRegion &selection = mMapDocument->selectedArea();

--- a/src/tiled/offsetmapdialog.cpp
+++ b/src/tiled/offsetmapdialog.cpp
@@ -84,7 +84,7 @@ QList<Layer *> OffsetMapDialog::affectedLayers() const
  * Returns the bounding rect that is to be affected by the offset operation.
  *
  * For infinite maps, when not using the currently selected area, the returned
- * rect is roughly derived from tile layer contents.
+ * rect is empty.
  */
 QRect OffsetMapDialog::affectedBoundingRect() const
 {

--- a/src/tiled/offsetmapdialog.h
+++ b/src/tiled/offsetmapdialog.h
@@ -49,6 +49,13 @@ public:
     bool wrapX() const;
     bool wrapY() const;
 
+    enum BoundsSelection {
+        WholeMap,
+        CurrentSelectionArea
+    };
+
+    BoundsSelection boundsSelection() const;
+
 private:
     void boundsSelectionChanged();
 
@@ -58,14 +65,8 @@ private:
         SelectedLayers
     };
 
-    enum BoundsSelection {
-        WholeMap,
-        CurrentSelectionArea
-    };
-
     LayerSelection layerSelection() const;
 
-    BoundsSelection boundsSelection() const;
     void setBoundsSelection(BoundsSelection boundsSelection);
 
     Ui::OffsetMapDialog *mUi;


### PR DESCRIPTION
* Make sure all objects are offset when choosing "Whole Map" as bounds.

* Take into account tile object size and alignment when determining whether an object is within the area to offset.

* <s>Support wrapping for infinite maps, where it will wrap based roughly on tile layer contents (chunk-based).</s>