### PR TITLE
Update Castle Game Engine to link to manual

### DIFF
--- a/docs/reference/support-for-tmx-maps.rst
+++ b/docs/reference/support-for-tmx-maps.rst
@@ -212,7 +212,7 @@ Bevy
 Castle Game Engine (Object Pascal)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  `Castle Game Engine <https://castle-engine.io/>`__ has native support for Tiled maps (see the `CastleTiledMap unit <https://castle-engine.io/apidoc-unstable/html/CastleTiledMap.html>`__)
+-  `Castle Game Engine <https://castle-engine.io/>`__ has native support for Tiled maps (see the `engine manual about Tiled Maps <https://castle-engine.io/tiled_maps>`__)
 
 Cell2D
 ~~~~~~


### PR DESCRIPTION
This PR updates the mention of [Castle Game Engine](https://castle-engine.io/) in Tiled to link to our most recommended page to read about how to use CGE + Tiled: https://castle-engine.io/tiled_maps 

Lately we've done a lot of enhancements and optimizations for Tiled handling recently, see news:

- https://castle-engine.io/wp/2023/05/21/tiled-maps-examples-updated-see-the-new-strategy-game-demo-api-and-docs-improvements-how-to-determine-tile-picked-by-mouse-and-more/
- https://castle-engine.io/wp/2023/03/25/new-component-to-place-tiled-map-in-a-viewport/
- https://castle-engine.io/wp/2023/01/22/big-improvements-and-optimizations-for-tiled-maps-handling-in-tcastlescene/

Thank you for making Tiled -- we're happy to recommend this to CGE users as the best way to design 2D maps!