### PR TITLE
Fixed several issues with drawing ellipses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Fixed hover highlight rendering with active parallax factor (#3669)
 * Fixed updating of object selection outlines when changing parallax factor (#3669)
 * Fixed "Offset Map" action to offset all objects when choosing "Whole Map" as bounds
+* Fixed several issues with drawing ellipses (#3776)
 * Godot 4 plugin: Export custom tile properties as Custom Data Layers (with Kevin Harrison, #3653)
 * AppImage: Updated to Sentry 0.6.4
 * Qt 6: Increased the image allocation limit from 1 GB to 4 GB (#3616)

--- a/docs/manual/editing-tile-layers.rst
+++ b/docs/manual/editing-tile-layers.rst
@@ -110,7 +110,16 @@ Shape Fill Tool
 Shortcut: ``P`` |rectangle-fill|
 
 This tool provides a quick way to fill rectangles or ellipses with a certain
-tile or pattern. Hold ``Shift`` to fill an exact square or circle.
+tile or pattern.
+
+- Holding ``Shift`` fills an exact square or circle.
+
+.. raw:: html
+
+   <div class="new">Since Tiled 1.10.2</div>
+
+- Holding ``Alt`` draws the rectangle or ellipse centered around the starting
+  location.
 
 You can also flip and rotate the current stamp as described for the
 :ref:`stamp-tool`.

--- a/src/tiled/geometry.h
+++ b/src/tiled/geometry.h
@@ -1,6 +1,8 @@
 /*
  * geometry.h
  * Copyright 2010-2011, Stefan Beller <stefanbeller@googlemail.com>
+ * Copyright 2017, Benjamin Trotter <bdtrotte@ucsc.edu>
+ * Copyright 2017-2023, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
  *
  * This file is part of Tiled.
  *
@@ -27,12 +29,15 @@
 
 namespace Tiled {
 
-QVector<QPoint> pointsOnEllipse(int x0, int y0, int x1, int y1);
+QVector<QPoint> pointsOnEllipse(int xm, int ym, int a, int b);
 QRegion ellipseRegion(int x0, int y0, int x1, int y1);
 QVector<QPoint> pointsOnLine(int x0, int y0, int x1, int y1, bool manhattan = false);
 
-inline QVector<QPoint> pointsOnEllipse(QPoint a, QPoint b)
-{ return pointsOnEllipse(a.x(), a.y(), b.x(), b.y()); }
+inline QVector<QPoint> pointsOnEllipse(QPoint center, int radiusX, int radiusY)
+{ return pointsOnEllipse(center.x(), center.y(), radiusX, radiusY); }
+
+inline QRegion ellipseRegion(QRect rect)
+{ return ellipseRegion(rect.left(), rect.top(), rect.right(), rect.bottom()); }
 
 inline QVector<QPoint> pointsOnLine(QPoint a, QPoint b, bool manhattan = false)
 { return pointsOnLine(a.x(), a.y(), b.x(), b.y(), manhattan); }

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -617,7 +617,9 @@ void StampBrush::updatePreview(QPoint tilePos)
             drawPreviewLayer(pointsOnLine(mStampReference, tilePos));
             break;
         case CircleMidSet:
-            drawPreviewLayer(pointsOnEllipse(mStampReference, tilePos));
+            drawPreviewLayer(pointsOnEllipse(mStampReference,
+                                             qAbs(mStampReference.x() - tilePos.x()),
+                                             qAbs(mStampReference.y() - tilePos.y())));
             break;
         case Capture:
             // already handled above


### PR DESCRIPTION
I've replaced the ellipse drawing algorithms with implementations by Zingl Alois, originally written in 2012 and published under MIT license.

This addresses several issues with the previously used implementations of pointsOnEllipse and ellipseRegion:

* Ellipses no longer degrade when very large (near 2000 tiles in size).

* No more gaps in the ellipse for some sizes.

* Shape Fill tool can now actually draw circles of equal width and height and can draw both even and odd sized ellipses.

The Shape Fill tool was adjusted such that drawing ellipses work in bounding-box mode by default. The Alt modifier now toggles to center + radius mode, which also applies when drawing rectangles.

Closes #3775