### PR TITLE
Display the image base name for unnamed tile objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added support for setting custom properties on the project (#2903)
 * Removed Space and Ctrl+Space shortcuts from Layers view to avoid conflict with panning (#3672)
+* Display the image base name for unnamed tile objects referring to single images
 * Scripting: Added API for editing tile layers using terrain sets (with a-morphous, #3758)
 * Scripting: Support erasing tiles in Tool.preview and TileMap.merge
 * Scripting: Added WangSet.effectiveTypeForColor


### PR DESCRIPTION
When an unnamed tile object refers to single images (from an image collection tileset), the image base name will now be displayed in the Objects view.

This can help identify objects and also allows the filter to work with the image names for these objects:

![image](https://github.com/mapeditor/tiled/assets/531764/0694dc69-26c8-4510-9160-7caed5200365)
