### PR TITLE
CI: Updated to Qbs 2.0.2

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -15,7 +15,7 @@ on:
     - '.travis.yml'
 
 env:
-  QBS_VERSION: 1.23.1
+  QBS_VERSION: 2.0.2
   SENTRY_VERSION: 0.6.4
   SENTRY_ORG: mapeditor
   SENTRY_PROJECT: tiled
@@ -54,7 +54,7 @@ jobs:
     env:
       TILED_VERSION: ${{ needs.version.outputs.version }}
       QT_VERSION: ${{ matrix.qt_version }}
-      QTCREATOR_VERSION: 9.0.1
+      QTCREATOR_VERSION: 10.0.2
 
     steps:
     - name: Checkout repository
@@ -191,17 +191,15 @@ jobs:
         include:
         - qt_version: 5.12.12
           version_suffix: "10.12-10.13"
-          qt_creator_version: 5.0.3
           architectures: x86_64
         - qt_version: 6.5.0
           version_suffix: "10.14+"
-          qt_creator_version: 7.0.2
           architectures: x86_64,arm64
 
     env:
       TILED_VERSION: ${{ needs.version.outputs.version }}
       QT_VERSION: ${{ matrix.qt_version }}
-      QTCREATOR_VERSION: ${{ matrix.qt_creator_version }}
+      QTCREATOR_VERSION: 10.0.2
 
     steps:
     - name: Checkout repository

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ environment:
 configuration: Release
 
 install:
-  - choco install -y qbs --version 1.21.0
+  - choco install -y qbs --version 2.0.2
   - nuget install secure-file -ExcludeVersion
   - set PATH=%PATH%;%QTDIR%\bin;%MINGW%\bin
 

--- a/dist/win/installer.qbs
+++ b/dist/win/installer.qbs
@@ -54,7 +54,8 @@ WindowsInstallerPackage {
 
         defs.push("WindowsVistaStyle")
 
-        if (File.exists(Environment.getEnv("PYTHONHOME")))
+        var pythonHome = Environment.getEnv("PYTHONHOME");
+        if (pythonHome && File.exists(pythonHome))
             defs.push("Python");
 
         var rpMapEnabled = !qbs.toolchain.contains("msvc")

--- a/src/plugins/python/python.qbs
+++ b/src/plugins/python/python.qbs
@@ -8,7 +8,7 @@ TiledPlugin {
 
     condition: {
         if (qbs.targetOS.contains("windows"))
-            return File.exists(Environment.getEnv("PYTHONHOME"));
+            return pythonDllProbe.found;
 
         return pkgConfigPython3Embed.found || pkgConfigPython3.found;
     }


### PR DESCRIPTION
This should fix the macOS builds, which were using Qbs from Qt Creator versions 5.0.3 and 7.0.2, which are no longer available to download.

Using Qt Creator 5.0.3 was necessary on old versions of macOS since it was the last release using Qt 5. We should be able to use a newer version even when building for macOS 10.12-10.13.