### PR TITLE
Added `--project` command-line parameter for use when exporting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
 ### Unreleased
 
+* Added --project command-line parameter for use when exporting (#3797)
 * JSON format: Fixed tile order when loading a tileset using the old format
 * tmxrasterizer: Added --hide-object and --show-object arguments (by Lars Luz, #3819)
-* tmxviewer: Added support for viewing JSON maps (#3866)
 * tmxrasterizer: Added --frames and --frame-duration arguments to export animated maps as multiple images (#3868)
+* tmxviewer: Added support for viewing JSON maps (#3866)
 * Windows: Fixed the support for WebP images (updated to Qt 6.5.3, #3661)
 * Fixed mouse handling issue when zooming while painting (#3863)
 * Fixed possible crash after a scripted tool disappears while active

--- a/src/tiled/project.h
+++ b/src/tiled/project.h
@@ -23,6 +23,7 @@
 #include "command.h"
 #include "object.h"
 #include "tiled.h"
+#include "tilededitor_global.h"
 
 #include <QDateTime>
 #include <QStringList>
@@ -32,7 +33,7 @@
 
 namespace Tiled {
 
-class Project : public Object
+class TILED_EDITOR_EXPORT Project : public Object
 {
 public:
     Project();

--- a/src/tiled/projectmanager.h
+++ b/src/tiled/projectmanager.h
@@ -34,7 +34,7 @@ class ProjectModel;
  *
  * No dependencies.
  */
-class ProjectManager : public QObject
+class TILED_EDITOR_EXPORT ProjectManager : public QObject
 {
     Q_OBJECT
 


### PR DESCRIPTION
This allows the `--export-map` and `--export-tileset` parameters to use file formats defined by extensions in the project, and also enables handling of custom types.

Closes #3797