### PR TITLE
Documentation: GID code example tweaks

### DIFF
--- a/docs/reference/global-tile-ids.rst
+++ b/docs/reference/global-tile-ids.rst
@@ -133,7 +133,7 @@ clear, it deals with flags and deduces the appropriate tileset:
          Tileset *tileset = tilesets[i];
 
          if (tileset->first_gid() <= global_tile_id) {
-           tiles[y][x] = tileset->tileAt(global_tile_id - tileset->first_gid());
+           tiles[y][x] = tileset->get_tile(global_tile_id - tileset->first_gid());
            break;
          }
        }


### PR DESCRIPTION
Updated the example C++ code to use "get_tile" as the hypothetical method to get a tile based on its ID instead of "tileAt", for two reasons:

1. The rest of the code uses snake_case, but this one used camelCase for some reason.
2. "tileAt" sounds like it implies that the ID is a location/index. This is misleading, since in Tiled tilesets, the ids are not necessarily positions or indices - tiles may be stored out of order, and the IDs may not even be sequential. I think "get tile" avoids such implications.

As far as I can tell, this shouldn't affect any localisations, as no translations touch the sample code.