### PR TITLE
JSON format: Fixed tile order when loading a tileset using the old format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* JSON format: Fixed tile order when loading a tileset using the old format
+
 ### Tiled 1.10.2 (4 August 2023)
 
 * Added support for setting custom properties on the project (#2903)

--- a/src/libtiled/tileset.cpp
+++ b/src/libtiled/tileset.cpp
@@ -516,6 +516,13 @@ bool Tileset::anyTileOutOfOrder() const
     return false;
 }
 
+void Tileset::resetTileOrder()
+{
+    mTiles.clear();
+    for (Tile *tile : std::as_const(mTilesById))
+        mTiles.append(tile);
+}
+
 /**
  * Sets the \a image to be used for the given \a tile.
  *

--- a/src/libtiled/tileset.h
+++ b/src/libtiled/tileset.h
@@ -228,6 +228,7 @@ public:
     QList<int> relocateTiles(const QList<Tile *> &tiles, int location);
 
     bool anyTileOutOfOrder() const;
+    void resetTileOrder();
 
     void setNextTileId(int nextId);
     int nextTileId() const;

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -434,6 +434,13 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
         tileset->findOrCreateTile(tileId)->setProperties(properties);
     }
 
+    if (!tilesVariantMap.isEmpty() || !propertiesVariantMap.isEmpty()) {
+        // The presence of either of these maps indicates that the tileset
+        // is in the old 1.0 format. This means the tiles may not have been
+        // added in the right order.
+        tileset->resetTileOrder();
+    }
+
     // Read the tiles saved as a list (1.2 format)
     const QVariantList tilesVariantList = tilesVariant.toList();
     for (int i = 0; i < tilesVariantList.count(); ++i) {


### PR DESCRIPTION
Since Tiled 1.7, the order of tiles in the tileset file determines the display order. But this should not be the case for tilesets stored in the old JSON format (which was replaced in Tiled 1.2), since it used an object with the tile IDs as string keys for storing tile meta-data and these keys get sorted alphabetically. This was resulting in tiles with associated data getting displayed in an order like "1, 10, 11, 12, 13, ..., 2, 21, ...".