### PR TITLE
Draw map boundary so it doesn't overlap the map

### DIFF
--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -813,6 +813,8 @@ void MapItem::deleteLayerItems(Layer *layer)
 void MapItem::updateBoundingRect()
 {
     QRect boundingRect = mapDocument()->renderer()->mapBoundingRect();
+    //Leave room for the boundary line so it doesn't overlap the map.
+    boundingRect.adjust(-1, -1, 0, 0);
 
     // This rectangle represents the map boundary and as such is unaffected
     // by layer offsets or image layers.


### PR DESCRIPTION
Currently, the top and left border of the map overlap tile pixels, while the right and bottom do not. This change adjusts the border to be outside the map on all four sides. This is especially helpful for pixel art maps at low zooms, where those overlapped pixels can matter quite a bit.

This change offsets the top left corner by -1,-1 with the assumption that the border is always 1px wide because I could not find any code that ever sets the pen width. If the pen width is dynamic, then this offset will need to be adjusted for the width.

I'm not 100% sure I'm using QRect.adjust() correctly (I half-expect the Qt docs to be lying about how it works), but I need an autobuild to check, hence the early PR :] Will edit after I've tested.

Edit: Ah, of course I failed to account for scaling! The (-1,-1,0,0) adjustment needs to happen to the scaled rect, not the original rect. The good news is QRect.adjust() works like I thought :D