### PR TITLE
fix typo in scripting doc for Dialog.exec()

### DIFF
--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -4679,7 +4679,7 @@ declare class Dialog extends Qt.QWidget {
    */
   show(): void;
 
-  /*
+  /**
    * Open the dialog, blocking your script until the Dialog has been
    * accepted or rejected.
    */


### PR DESCRIPTION
I added doc for this in a past PR, but it wasn't showing on the site: 
https://www.mapeditor.org/docs/scripting/classes/Dialog.html#exec