### PR TITLE
Point rotation

### DIFF
--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -422,7 +422,7 @@ inline bool MapObject::hasDimensions() const
  * Returns true if this object can be rotated.
  */
 inline bool MapObject::canRotate() const
-{ return mShape != Point; }
+{ return true; }
 
 inline bool MapObject::isTileObject() const
 { return !mCell.isEmpty(); }

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -97,8 +97,7 @@ void MapObjectItem::syncWithMapObject()
     }
 
     setVisible(mObject->isVisible());
-    setFlag(QGraphicsItem::ItemIgnoresTransformations,
-            mObject->shape() == MapObject::Point);
+    setFlag(QGraphicsItem::ItemIgnoresTransformations, false);
 }
 
 void MapObjectItem::setIsHoverIndicator(bool isHoverIndicator)

--- a/src/tiled/objectreferenceitem.cpp
+++ b/src/tiled/objectreferenceitem.cpp
@@ -199,13 +199,11 @@ QPointF ObjectReferenceItem::objectCenter(MapObject *object, const MapRenderer &
 {
     QPointF screenPos = renderer.pixelToScreenCoords(object->position());
 
-    if (object->shape() != MapObject::Point) {
-        QRectF bounds = object->screenBounds(renderer);
+    QRectF bounds = object->screenBounds(renderer);
 
-        // Adjust the bounding box for object rotation
-        bounds = rotateAt(screenPos, object->rotation()).mapRect(bounds);
-        screenPos = bounds.center();
-    }
+    // Adjust the bounding box for object rotation
+    bounds = rotateAt(screenPos, object->rotation()).mapRect(bounds);
+    screenPos = bounds.center();
 
     if (auto mapScene = qobject_cast<MapScene*>(scene()))
         screenPos += mapScene->absolutePositionForLayer(*object->objectGroup());

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -110,8 +110,7 @@ void MapObjectOutline::syncWithMapObject(const MapRenderer &renderer)
 
     setPos(pixelPos);
     setRotation(mObject->rotation());
-    setFlag(QGraphicsItem::ItemIgnoresTransformations,
-            mObject->shape() == MapObject::Point);
+    setFlag(QGraphicsItem::ItemIgnoresTransformations, false);
 
     if (mBoundingRect != bounds) {
         prepareGeometryChange();

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -202,13 +202,7 @@ void MapObjectLabel::syncWithMapObject(const MapRenderer &renderer)
     bounds = rotateAt(pos, mObject->rotation()).mapRect(bounds);
 
     // Center the object name on the object bounding box
-    if (mObject->shape() == MapObject::Point) {
-        // Use a local offset, since point objects don't scale with the view
-        boundingRect.translate(0, -bounds.height());
-        mTextPos.ry() -= bounds.height();
-    } else {
-        pos = { (bounds.left() + bounds.right()) / 2, bounds.top() };
-    }
+    pos = { (bounds.left() + bounds.right()) / 2, bounds.top() };
 
     if (auto mapScene = static_cast<MapScene*>(scene()))
         pos += mapScene->absolutePositionForLayer(*mObject->objectGroup());

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -371,7 +371,7 @@ void ObjectSelectionTool::activate(MapScene *scene)
     connect(mapDocument(), &MapDocument::mapChanged,
             this, &ObjectSelectionTool::updateHandlesAndOrigin);
     connect(mapDocument(), &MapDocument::selectedObjectsChanged,
-            this, &ObjectSelectionTool::updateHandlesAndOrigin);
+            this, &ObjectSelectionTool::updateHandlesAndOriginAndMode);
     connect(mapDocument(), &MapDocument::tilesetTilePositioningChanged,
             this, &ObjectSelectionTool::updateHandlesAndOrigin);
     connect(scene, &MapScene::parallaxParametersChanged,
@@ -395,7 +395,7 @@ void ObjectSelectionTool::deactivate(MapScene *scene)
     disconnect(mapDocument(), &MapDocument::mapChanged,
                this, &ObjectSelectionTool::updateHandlesAndOrigin);
     disconnect(mapDocument(), &MapDocument::selectedObjectsChanged,
-               this, &ObjectSelectionTool::updateHandlesAndOrigin);
+               this, &ObjectSelectionTool::updateHandlesAndOriginAndMode);
     disconnect(mapDocument(), &MapDocument::tilesetTilePositioningChanged,
                this, &ObjectSelectionTool::updateHandlesAndOrigin);
     disconnect(scene, &MapScene::parallaxParametersChanged,
@@ -802,12 +802,17 @@ void ObjectSelectionTool::changeEvent(const ChangeEvent &event)
 
 void ObjectSelectionTool::updateHandles()
 {
-    updateHandlesImpl(false);
+    updateHandlesImpl(false, false);
 }
 
 void ObjectSelectionTool::updateHandlesAndOrigin()
 {
-    updateHandlesImpl(true);
+    updateHandlesImpl(true, false);
+}
+
+void ObjectSelectionTool::updateHandlesAndOriginAndMode()
+{
+    updateHandlesImpl(true, true);
 }
 
 // TODO: Check whether this function should be moved into MapObject::bounds
@@ -983,7 +988,7 @@ static QRectF uniteBounds(const QRectF &a, const QRectF &b)
     return QRectF(left, top, right - left, bottom - top);
 }
 
-void ObjectSelectionTool::updateHandlesImpl(bool resetOriginIndicator)
+void ObjectSelectionTool::updateHandlesImpl(bool resetOriginIndicator, bool shouldResetMode)
 {
     if (mAction == Moving || mAction == Rotating || mAction == Resizing)
         return;
@@ -992,6 +997,9 @@ void ObjectSelectionTool::updateHandlesImpl(bool resetOriginIndicator)
     const bool showHandles = objects.size() > 0 && (objects.size() > 1 || canResizeOrRotate(objects.first()));
 
     if (showHandles) {
+        if (shouldResetMode)
+            resetModeForSelection(objects);
+
         MapRenderer *renderer = mapDocument()->renderer();
         QRectF boundingRect = objectBounds(objects.first(), renderer,
                                            objectTransform(objects.first(), renderer, mapScene()));

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -687,18 +687,12 @@ void ObjectSelectionTool::mouseReleased(QGraphicsSceneMouseEvent *event)
                     if (selection.size() > 1 || selection.first()->canRotate())
                         setMode(Rotate);
                 } else {
-                    if (selection.size() == 1 && selection.first()->canRotate() && !canResize(selection.first()))
-                        setMode(Rotate);
-                    else
-                        setMode(Resize);
+                    resetModeForSelection(selection);
                 }
             } else {
                 selection.clear();
                 selection.append(mClickedObject);
-                if (selection.first()->canRotate() && !canResize(selection.first()))
-                    setMode(Rotate);
-                else
-                    setMode(Resize);
+                resetModeForSelection(selection);
                 mapDocument()->setSelectedObjects(selection);
             }
         } else if (!(modifiers & Qt::ShiftModifier)) {
@@ -1660,6 +1654,17 @@ void ObjectSelectionTool::finishResizing()
     mMovingObjects.clear();
 
     updateHandlesAndOrigin();
+}
+
+void ObjectSelectionTool::resetModeForSelection(const QList<MapObject *> &selection)
+{
+    if (selection.size() == 1)
+        if (selection.first()->canRotate())
+            if (!canResize(selection.first())) {
+                setMode(Rotate);
+                return;
+            }
+    setMode(Resize);
 }
 
 void ObjectSelectionTool::setMode(Mode mode)

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -58,8 +58,6 @@
 
 using namespace Tiled;
 
-static bool canResize(const MapObject *object);
-
 namespace Tiled {
 
 enum AnchorPosition {

--- a/src/tiled/objectselectiontool.h
+++ b/src/tiled/objectselectiontool.h
@@ -124,6 +124,7 @@ private:
     void finishResizing();
 
     void setMode(Mode mode);
+    void resetModeForSelection(const QList<MapObject *> &selection);
     void saveSelectionState();
 
     enum AbortReason {

--- a/src/tiled/objectselectiontool.h
+++ b/src/tiled/objectselectiontool.h
@@ -72,6 +72,7 @@ private:
 
     void updateHandles();
     void updateHandlesAndOrigin();
+    void updateHandlesAndOriginAndMode();
     void updateHandleVisibility();
 
     void objectsAboutToBeRemoved(const QList<MapObject *> &);
@@ -92,7 +93,7 @@ private:
         Rotate,
     };
 
-    void updateHandlesImpl(bool resetOriginIndicator);
+    void updateHandlesImpl(bool resetOriginIndicator, bool shouldResetMode);
 
     void updateHover(const QPointF &pos);
     QList<MapObject*> objectsAboutToBeSelected(const QPointF &pos,

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -835,8 +835,7 @@ void PropertyBrowser::addMapObjectProperties()
         addProperty(HeightProperty, QMetaType::Double, tr("Height"), groupProperty);
     }
 
-    bool isPoint = mapObject->shape() == MapObject::Point;
-    addProperty(RotationProperty, QMetaType::Double, tr("Rotation"), groupProperty)->setEnabled(!isPoint);
+    addProperty(RotationProperty, QMetaType::Double, tr("Rotation"), groupProperty);
 
     if (mMapObjectFlags & ObjectHasTile) {
         QtVariantProperty *flippingProperty =


### PR DESCRIPTION
Some use cases:

- give points visible directions/angles
- place multiple points at the same position without overlapping

![image](https://github.com/mapeditor/tiled/assets/7191895/c85b9297-6b78-4d60-accd-85c260d19f59)
