### PR TITLE
Godot exporter collision fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Added --project command-line parameter for use when exporting (#3797)
 * Scripting: Added API for working with worlds (#3539)
 * JSON format: Fixed tile order when loading a tileset using the old format
+* Godot export: Fixed positioning of tile collision shapes (by Ryan Petrie, #3862)
 * tmxrasterizer: Added --hide-object and --show-object arguments (by Lars Luz, #3819)
 * tmxrasterizer: Added --frames and --frame-duration arguments to export animated maps as multiple images (#3868)
 * tmxviewer: Added support for viewing JSON maps (#3866)

--- a/src/plugins/tscn/tscnplugin.cpp
+++ b/src/plugins/tscn/tscnplugin.cpp
@@ -424,6 +424,9 @@ static bool exportTileCollisions(QFileDevice *device, const Tile *tile,
     if (const auto objectGroup = tile->objectGroup()) {
         int polygonId = 0;
 
+        const auto centerX = tile->width() / 2;
+        const auto centerY = tile->height() / 2;
+
         for (const auto object : objectGroup->objects()) {
             const auto shape = object->shape();
 
@@ -434,9 +437,6 @@ static bool exportTileCollisions(QFileDevice *device, const Tile *tile,
             }
 
             foundCollisions = true;
-
-            const auto centerX = tile->width() / 2;
-            const auto centerY = tile->height() / 2;
 
             device->write(formatByteString(
                 "%1/physics_layer_0/polygon_%2/points = PackedVector2Array(",
@@ -458,13 +458,12 @@ static bool exportTileCollisions(QFileDevice *device, const Tile *tile,
                 break;
             }
             case MapObject::Polygon: {
-                auto polygon = object->polygon().toPolygon();
                 bool first = true;
-                for (auto point : polygon) {
+                for (auto point : object->polygon()) {
                     if (!first)
                         device->write(", ");
-                    double x = object->x() + point.x() - centerX;
-                    double y = object->y() + point.y() - centerY;
+                    auto x = object->x() + point.x() - centerX;
+                    auto y = object->y() + point.y() - centerY;
                     flipState(x, y, flippedState);
                     device->write(formatByteString("%1, %2", x, y));
                     first = false;

--- a/src/plugins/tscn/tscnplugin.cpp
+++ b/src/plugins/tscn/tscnplugin.cpp
@@ -435,8 +435,8 @@ static bool exportTileCollisions(QFileDevice *device, const Tile *tile,
 
             foundCollisions = true;
 
-            const auto centerX = tile->width() / 2 - object->x();
-            const auto centerY = tile->height() / 2 - object->y();
+            const auto centerX = tile->width() / 2;
+            const auto centerY = tile->height() / 2;
 
             device->write(formatByteString(
                 "%1/physics_layer_0/polygon_%2/points = PackedVector2Array(",
@@ -446,8 +446,8 @@ static bool exportTileCollisions(QFileDevice *device, const Tile *tile,
             case MapObject::Rectangle: {
                 auto x1 = object->x() - centerX;
                 auto y1 = object->y() - centerY;
-                auto x2 = object->width() - centerX;
-                auto y2 = object->height() - centerY;
+                auto x2 = object->x() + object->width() - centerX;
+                auto y2 = object->y() + object->height() - centerY;
 
                 flipState(x1, y1, flippedState);
                 flipState(x2, y2, flippedState);
@@ -463,8 +463,8 @@ static bool exportTileCollisions(QFileDevice *device, const Tile *tile,
                 for (auto point : polygon) {
                     if (!first)
                         device->write(", ");
-                    auto x = point.x() - centerX;
-                    auto y = point.y() - centerY;
+                    double x = point.x() - centerX;
+                    double y = point.y() - centerY;
                     flipState(x, y, flippedState);
                     device->write(formatByteString("%1, %2", x, y));
                     first = false;

--- a/src/plugins/tscn/tscnplugin.cpp
+++ b/src/plugins/tscn/tscnplugin.cpp
@@ -463,8 +463,8 @@ static bool exportTileCollisions(QFileDevice *device, const Tile *tile,
                 for (auto point : polygon) {
                     if (!first)
                         device->write(", ");
-                    double x = point.x() - centerX;
-                    double y = point.y() - centerY;
+                    double x = object->x() + point.x() - centerX;
+                    double y = object->y() + point.y() - centerY;
                     flipState(x, y, flippedState);
                     device->write(formatByteString("%1, %2", x, y));
                     first = false;


### PR DESCRIPTION
The exporter was incorrectly using the collision object's X and Y position as a part of the tile's center. Fixed the calculation for both rectangles and polygons. Tested on a local Windows build.