### PR TITLE
tmxrasterizer: Added --frames and --frame-duration arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 * JSON format: Fixed tile order when loading a tileset using the old format
 * tmxrasterizer: Added --hide-object and --show-object arguments (by Lars Luz, #3819)
 * tmxviewer: Added support for viewing JSON maps (#3866)
-* Windows: Fixed the support for WebP images (updated to Qt 6.5.3)
+* tmxrasterizer: Added --frames and --frame-duration arguments to export animated maps as multiple images (#3868)
+* Windows: Fixed the support for WebP images (updated to Qt 6.5.3, #3661)
 * Fixed mouse handling issue when zooming while painting (#3863)
 * Fixed possible crash after a scripted tool disappears while active
 

--- a/src/tmxrasterizer/main.cpp
+++ b/src/tmxrasterizer/main.cpp
@@ -85,15 +85,21 @@ int main(int argc, char *argv[])
                             QCoreApplication::translate("main", "Don't render object layers.") },
                           { QStringLiteral("hide-image-layers"),
                             QCoreApplication::translate("main", "Don't render image layers.") },
-                          { QStringLiteral("advance-animations"),
-                            QCoreApplication::translate("main", "If used, tile animations are advanced by the specified duration."),
-                            QCoreApplication::translate("main", "duration") },
                           { QStringLiteral("hide-object"),
                             QCoreApplication::translate("main", "Specifies an object to omit from the output image. Can be repeated to hide multiple objects. If multiple objects share the specified name they all will be hidden."),
                             QCoreApplication::translate("main", "name") },
                           { QStringLiteral("show-object"),
                             QCoreApplication::translate("main", "If used only specified objects are shown. Can be repeated to show multiple specified objects only. If multiple objects share the specified name they all will be shown."),
-                            QCoreApplication::translate("main", "name") }
+                            QCoreApplication::translate("main", "name") },
+                          { QStringLiteral("advance-animations"),
+                            QCoreApplication::translate("main", "If used, tile animations are advanced by the specified duration in milliseconds."),
+                            QCoreApplication::translate("main", "duration") },
+                          { QStringLiteral("frames"),
+                            QCoreApplication::translate("main", "Number of frames to export. This will add a frame number suffix to the image names. Animations are advanced by <frame-duration> for each frame."),
+                            QCoreApplication::translate("main", "number") },
+                          { QStringLiteral("frame-duration"),
+                            QCoreApplication::translate("main", "Duration of each frame in milliseconds, defaults to 100."),
+                            QCoreApplication::translate("main", "number") },
                       });
     parser.addPositionalArgument(QStringLiteral("map|world"), QCoreApplication::translate("main", "Map or world file to render."));
     parser.addPositionalArgument(QStringLiteral("image"), QCoreApplication::translate("main", "Image file to output."));
@@ -153,6 +159,24 @@ int main(int argc, char *argv[])
         w.setAdvanceAnimations(parser.value(QLatin1String("advance-animations")).toInt(&ok));
         if (!ok || w.advanceAnimations() < 0) {
             qWarning().noquote() << QCoreApplication::translate("main", "Invalid advance-animations specified: \"%1\"").arg(parser.value(QLatin1String("advance-animations")));
+            exit(1);
+        }
+    }
+
+    if (parser.isSet(QLatin1String("frames"))) {
+        bool ok;
+        w.setFrameCount(parser.value(QLatin1String("frames")).toInt(&ok));
+        if (!ok || w.frameCount() < 0) {
+            qWarning().noquote() << QCoreApplication::translate("main", "Invalid number of frames specified: \"%1\"").arg(parser.value(QLatin1String("frames")));
+            exit(1);
+        }
+    }
+
+    if (parser.isSet(QLatin1String("frame-duration"))) {
+        bool ok;
+        w.setFrameDuration(parser.value(QLatin1String("frame-duration")).toInt(&ok));
+        if (!ok || w.frameDuration() < 0) {
+            qWarning().noquote() << QCoreApplication::translate("main", "Invalid frame-duration specified: \"%1\"").arg(parser.value(QLatin1String("frame-duration")));
             exit(1);
         }
     }

--- a/src/tmxrasterizer/tmxrasterizer.h
+++ b/src/tmxrasterizer/tmxrasterizer.h
@@ -92,7 +92,7 @@ private:
     int mLayerTypesToShow = Layer::AnyLayerType & ~Layer::GroupLayerType;
 
     void drawMapLayers(const MapRenderer &renderer, QPainter &painter, QPoint mapOffset = QPoint(0, 0)) const;
-    int renderMap(const QString &mapFileName, const QString &imageFileName);
+    int renderMap(const MapRenderer &renderer, const QString &imageFileName);
     int renderWorld(const QString &worldFileName, const QString &imageFileName);
     int saveImage(const QString &imageFileName, const QImage &image) const;
     bool shouldDrawLayer(const Layer *layer) const;

--- a/src/tmxrasterizer/tmxrasterizer.h
+++ b/src/tmxrasterizer/tmxrasterizer.h
@@ -49,6 +49,8 @@ public:
     int tileSize() const { return mTileSize; }
     int size() const { return mSize; }
     int advanceAnimations() const { return mAdvanceAnimations; }
+    int frameCount() const { return mFrameCount; }
+    int frameDuration() const { return mFrameDuration; }
     bool useAntiAliasing() const { return mUseAntiAliasing; }
     bool smoothImages() const { return mSmoothImages; }
     bool ignoreVisibility() const { return mIgnoreVisibility; }
@@ -57,6 +59,8 @@ public:
     void setTileSize(int tileSize) { mTileSize = tileSize; }
     void setSize(int size) { mSize = size; }
     void setAdvanceAnimations(int duration) { mAdvanceAnimations = duration; }
+    void setFrameCount(int frameCount) { mFrameCount = frameCount; }
+    void setFrameDuration(int frameDuration) { mFrameDuration = frameDuration; }
     void setAntiAliasing(bool useAntiAliasing) { mUseAntiAliasing = useAntiAliasing; }
     void setSmoothImages(bool smoothImages) { mSmoothImages = smoothImages; }
     void setIgnoreVisibility(bool IgnoreVisibility) { mIgnoreVisibility = IgnoreVisibility; }
@@ -69,13 +73,15 @@ public:
 
     void setLayerTypeVisible(Layer::TypeFlag layerType, bool visible);
 
-    int render(const QString &fileName, const QString &imageFileName);
+    int render(const QString &fileName, QString imageFileName);
 
 private:
     qreal mScale = 1.0;
     int mTileSize = 0;
     int mSize = 0;
     int mAdvanceAnimations = 0;
+    int mFrameCount = 0;
+    int mFrameDuration = 100;
     bool mUseAntiAliasing = false;
     bool mSmoothImages = true;
     bool mIgnoreVisibility = false;


### PR DESCRIPTION
These allow exporting animated maps as multiple numbered images, which can be combined into a GIF or other format using another tool.

The `--advance-animations` parameter stays for compatibility, and determines the time of the first exported frame, whereas `--frame-duration` determines the time between each frame.

Example usage:

```
tmxrasterizer desert.tmx desert.png --frames 5
```

The above will create the following list of images:
```
desert0.png
desert1.png
desert2.png
desert3.png
desert4.png
```
And each rendered frame will have advanced by another 100ms from the previous one (the default frame duration).

This is related to #1433, though it does not actually create a GIF (but other animation formats may be preferred anyway).