### PR TITLE
tmxviewer: Added support for viewing JSON maps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * JSON format: Fixed tile order when loading a tileset using the old format
 * tmxrasterizer: Added --hide-object and --show-object arguments (by Lars Luz, #3819)
+* tmxviewer: Added support for viewing JSON maps (#3866)
 * Windows: Fixed the support for WebP images (updated to Qt 6.5.3)
 
 ### Tiled 1.10.2 (4 August 2023)

--- a/src/tmxviewer/main.cpp
+++ b/src/tmxviewer/main.cpp
@@ -28,6 +28,7 @@
 
 #include "tmxviewer.h"
 
+#include "pluginmanager.h"
 #include "tiled.h"
 
 #include <QApplication>
@@ -57,8 +58,10 @@ int main(int argc, char *argv[])
     a.setApplicationName(QStringLiteral("TmxViewer"));
     a.setApplicationVersion(QStringLiteral("1.0"));
 
+    Tiled::PluginManager::instance()->loadPlugins();
+
     QCommandLineParser parser;
-    parser.setApplicationDescription(QCoreApplication::translate("main", "Displays a Tiled map (TMX format)."));
+    parser.setApplicationDescription(QCoreApplication::translate("main", "Displays a Tiled map."));
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addPositionalArgument(QStringLiteral("file"), QCoreApplication::translate("main", "Map file to display."));

--- a/src/tmxviewer/tmxviewer.cpp
+++ b/src/tmxviewer/tmxviewer.cpp
@@ -29,6 +29,7 @@
 #include "tmxviewer.h"
 
 #include "map.h"
+#include "mapformat.h"
 #include "mapobject.h"
 #include "mapreader.h"
 #include "maprenderer.h"
@@ -193,10 +194,10 @@ bool TmxViewer::viewMap(const QString &fileName)
 
     mRenderer.reset();
 
-    MapReader reader;
-    mMap = reader.readMap(fileName);
+    QString errorString;
+    mMap = Tiled::readMap(fileName, &errorString);
     if (!mMap) {
-        qWarning().noquote() << "Error:" << reader.errorString();
+        qWarning().noquote() << "Error:" << errorString;
         return false;
     }
 


### PR DESCRIPTION
The viewer can now read any default-enabled map format, which currently only covers the JSON map format in addition to TMX.

Closes #3866