### PR TITLE
AppImage: Updated to Sentry 0.6.7

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   QBS_VERSION: 2.0.2
-  SENTRY_VERSION: 0.6.5
+  SENTRY_VERSION: 0.6.7
   SENTRY_ORG: mapeditor
   SENTRY_PROJECT: tiled
   TILED_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Windows: Fixed the support for WebP images (updated to Qt 6.5.3, #3661)
 * Fixed mouse handling issue when zooming while painting (#3863)
 * Fixed possible crash after a scripted tool disappears while active
+* AppImage: Updated to Sentry 0.6.7
 
 ### Tiled 1.10.2 (4 August 2023)
 


### PR DESCRIPTION
Not updating to Sentry 0.7 for now because it changes the default backend to `crashpad`. Tiled should probably use that as well, but for that we need to figure out how to ship its crash handler.