### PR TITLE
add containsMap(map:TileMap) scripting method

### DIFF
--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1234,6 +1234,12 @@ declare class World extends Asset {
   containsMap(fileName : string) : boolean;
 
   /**
+   * Returns true if this world contains the given map.
+   * @param map The TileMap to check for.
+   */
+  containsMap(map : TileMap) : boolean;
+
+  /**
    * Change the position and size of a map within this world.
    * @param fileName The file name of the map to change the position and size for.
    * @param rect The new rect describing the position and size of the map.

--- a/src/tiled/editableworld.cpp
+++ b/src/tiled/editableworld.cpp
@@ -41,6 +41,21 @@ bool EditableWorld::containsMap(const QString &fileName) const
     return world()->containsMap(fileName);
 }
 
+bool EditableWorld::containsMap(EditableMap *map) const
+{
+    if (!map) {
+        ScriptManager::instance().throwNullArgError(0);
+        return false;
+    }
+
+    if (map->fileName().isEmpty()) {
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Save this TileMap before checking for its presence in worlds"));
+        return false;
+    }
+
+    return containsMap(map->fileName());
+}
+
 QVector<WorldMapEntry> EditableWorld::maps() const
 {
     return world()->maps;

--- a/src/tiled/editableworld.cpp
+++ b/src/tiled/editableworld.cpp
@@ -49,7 +49,6 @@ bool EditableWorld::containsMap(EditableMap *map) const
     }
 
     if (map->fileName().isEmpty()) {
-        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Save this TileMap before checking for its presence in worlds"));
         return false;
     }
 

--- a/src/tiled/editableworld.h
+++ b/src/tiled/editableworld.h
@@ -51,6 +51,7 @@ public:
     Q_INVOKABLE QVector<WorldMapEntry> mapsInRect(const QRect &rect) const;
     Q_INVOKABLE QVector<WorldMapEntry> allMaps() const;
     Q_INVOKABLE bool containsMap(const QString &fileName) const;
+    Q_INVOKABLE bool containsMap(EditableMap *fileName) const;
     Q_INVOKABLE void setMapRect(const QString &mapFileName, const QRect &rect);
     Q_INVOKABLE void setMapPos(EditableMap *map, int x, int y);
     Q_INVOKABLE void addMap(const QString &mapFileName, const QRect &rect);


### PR DESCRIPTION
In the newly added world scripting feature #3859 , there's a chance that users could  call `containsMap()` with a TileMap and receive a false negative response, as it seems like the TileMap will be coerced to a string.  To avoid this, introduce `containsMap(map:TileMap)` which will take the file name of the given tilemap. 