### PR TITLE
Scripting: Added Tile.image for accessing a tile's image data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Added --project command-line parameter for use when exporting (#3797)
 * Scripting: Added API for working with worlds (#3539)
 * Scripting: Added Tile.image for accessing a tile's image data
+* Scripting: Added Tileset.imageFileName and ImageLayer.imageFileName
 * Scripting: Made Tileset.margin and Tileset.tileSpacing writable
 * JSON format: Fixed tile order when loading a tileset using the old format
 * Godot export: Fixed positioning of tile collision shapes (by Ryan Petrie, #3862)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,13 +2,14 @@
 
 * Added --project command-line parameter for use when exporting (#3797)
 * Scripting: Added API for working with worlds (#3539)
+* Scripting: Added Tile.image for accessing a tile's image data
+* Scripting: Made Tileset.margin and Tileset.tileSpacing writable
 * JSON format: Fixed tile order when loading a tileset using the old format
 * Godot export: Fixed positioning of tile collision shapes (by Ryan Petrie, #3862)
 * tmxrasterizer: Added --hide-object and --show-object arguments (by Lars Luz, #3819)
-* Scripting: Made Tileset.margin and Tileset.tileSpacing writable
 * tmxrasterizer: Added --frames and --frame-duration arguments to export animated maps as multiple images (#3868)
 * tmxviewer: Added support for viewing JSON maps (#3866)
-* Windows: Fixed the support for WebP images (updated to Qt 6.5.3, #3661)
+* Windows: Fixed the support for WebP images (updated to Qt 6.6.1, #3661)
 * Fixed mouse handling issue when zooming while painting (#3863)
 * Fixed possible crash after a scripted tool disappears while active
 * TMX format: Embedded images are now also supported on tilesets and image layers

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -2432,6 +2432,17 @@ declare class Tile extends TiledObject {
   imageFileName : string
 
   /**
+   * Returns the image of this tile, or the image of its tileset if it doesn't
+   * have an individual one.
+   *
+   * You can assign an {@link Image} to this property to change the tile's
+   * image. See {@link setImage} for more information.
+   *
+   * @since 1.10.3
+   */
+  image: Image;
+
+  /**
    * The source rectangle (in pixels) for this tile.
    *
    * This can be either a sub-rectangle of the tile image when the tile is part
@@ -2474,7 +2485,15 @@ declare class Tile extends TiledObject {
   /**
    * Sets the image of this tile.
    *
-   * @warning This function has no undo and does not affect the saved tileset!
+   * You should prefer to set the {@link imageFileName} when possible. This
+   * function is mostly useful when the image data is loaded from a custom
+   * format.
+   *
+   * If an image is set directly on a tile, instead of setting the {@link
+   * imageFileName}, when saving the tileset the image data will be embedded
+   * for formats that support this (currently only TMX/TSX).
+   *
+   * @warning This function has no undo!
    */
   setImage(image : Image) : void
 }
@@ -3454,6 +3473,13 @@ declare class Tileset extends Asset {
    * repeatedly setting up the tiles in response to changing parameters.
    *
    * @note Map files are supported tileset image source as well.
+   *
+   * @since 1.10.3
+   */
+  imageFileName : string
+
+  /**
+   * @deprecated Use {@link imageFileName} instead.
    */
   image : string
 
@@ -4716,6 +4742,7 @@ declare class ColorButton extends Qt.QWidget {
    */
   colorChanged: Signal<color>;
 }
+
 /**
  * Widget with a button which opens a file picker dialog
  * and displays the path in the dialog.
@@ -4740,11 +4767,11 @@ declare class FileEdit extends Qt.QWidget {
    */
   filter: FileFilter;
 }
+
 /**
  * A widget that displays an {@link Image} on your dialog.
  */
 declare class ImageWidget extends Qt.QWidget {
-
   /**
    * The image to be displayed in the widget
    */

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -2214,14 +2214,25 @@ declare class ImageLayer extends Layer {
 
   /**
    * Reference to the image rendered by this layer.
+   *
+   * If you need a plain string, you'll want to use {@link imageFileName}
+   * instead.
    */
   imageSource: Qt.QUrl;
 
   /**
+   * Reference to the image rendered by this layer.
+   *
+   * @since 1.10.3
+   */
+  imageFileName: string;
+
+  /**
    * Returns a copy of this layer's image.
    *
-   * When assigning an image to this property, the imageSource property is
-   * cleared. Use {@link setImage} when you want to also set the imageSource.
+   * When assigning an image to this property, the {@link imageFileName}
+   * property is cleared. Use {@link setImage} when you want to also set the
+   * imageSource.
    *
    * @warning This property is writable but has no undo!
    *

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -2260,8 +2260,8 @@ declare class ImageLayer extends Layer {
   constructor(name? : string);
 
   /**
-   * Sets the image for this layer to the given image, optionally also
-   * setting the source of the image.
+   * Sets the image for this layer to the given image, optionally also setting
+   * its file name. The existing image file name is cleared.
    *
    * @warning This function has no undo!
    */
@@ -2494,19 +2494,24 @@ declare class Tile extends TiledObject {
   readonly tileset : Tileset
 
   /**
-   * Sets the image of this tile.
+   * Sets the image of this tile, optionally also setting its file name. The
+   * existing image file name is cleared.
    *
-   * You should prefer to set the {@link imageFileName} when possible. This
-   * function is mostly useful when the image data is loaded from a custom
+   * You should prefer to just set the {@link imageFileName} when possible.
+   * This function is mostly useful when the image data is loaded from a custom
    * format.
    *
-   * If an image is set directly on a tile, instead of setting the {@link
-   * imageFileName}, when saving the tileset the image data will be embedded
-   * for formats that support this (currently only TMX/TSX).
+   * If an image is set directly on a tile, without specifying its file name,
+   * when saving the tileset the image data will be embedded for formats that
+   * support this (currently only TMX/TSX).
+   *
+   * @note Before Tiled 1.10.3, this function did not change the image file
+   * name. For compatibility, set {@link imageFileName} before calling this
+   * function, if necessary.
    *
    * @warning This function has no undo!
    */
-  setImage(image : Image) : void
+  setImage(image : Image, source?: string) : void
 }
 
 /**

--- a/src/tiled/editableimagelayer.cpp
+++ b/src/tiled/editableimagelayer.cpp
@@ -20,6 +20,7 @@
 
 #include "editableimagelayer.h"
 
+#include "changeevents.h"
 #include "changeimagelayerproperty.h"
 #include "editablemap.h"
 #include "scriptimage.h"
@@ -75,6 +76,9 @@ void EditableImageLayer::setImage(ScriptImage *image, const QUrl &source)
 
     // WARNING: This function has no undo!
     imageLayer()->loadFromImage(QPixmap::fromImage(image->image()), source);
+
+    if (auto doc = document())
+        emit doc->changed(ImageLayerChangeEvent(imageLayer(), ImageLayerChangeEvent::ImageSourceProperty));
 }
 
 void EditableImageLayer::setRepeatX(bool repeatX)

--- a/src/tiled/editableimagelayer.cpp
+++ b/src/tiled/editableimagelayer.cpp
@@ -69,6 +69,11 @@ void EditableImageLayer::setImageSource(const QUrl &imageSource)
     }
 }
 
+void EditableImageLayer::setImageFileName(const QString &fileName)
+{
+    setImageSource(QUrl::fromLocalFile(fileName));
+}
+
 void EditableImageLayer::setImage(ScriptImage *image, const QUrl &source)
 {
     if (checkReadOnly())

--- a/src/tiled/editableimagelayer.h
+++ b/src/tiled/editableimagelayer.h
@@ -33,6 +33,7 @@ class EditableImageLayer : public EditableLayer
 
     Q_PROPERTY(QColor transparentColor READ transparentColor WRITE setTransparentColor)
     Q_PROPERTY(QUrl imageSource READ imageSource WRITE setImageSource)
+    Q_PROPERTY(QString imageFileName READ imageFileName WRITE setImageFileName)
     Q_PROPERTY(Tiled::ScriptImage *image READ image WRITE setImage)
     Q_PROPERTY(bool repeatX READ repeatX WRITE setRepeatX)
     Q_PROPERTY(bool repeatY READ repeatY WRITE setRepeatY)
@@ -47,12 +48,14 @@ public:
 
     const QColor &transparentColor() const;
     const QUrl &imageSource() const;
+    QString imageFileName() const;
     ScriptImage *image() const;
     bool repeatX() const;
     bool repeatY() const;
 
     void setTransparentColor(const QColor &transparentColor);
     void setImageSource(const QUrl &imageSource);
+    void setImageFileName(const QString &fileName);
     void setRepeatX(bool repeatX);
     void setRepeatY(bool repeatY);
 
@@ -70,6 +73,11 @@ inline const QColor &EditableImageLayer::transparentColor() const
 inline const QUrl &EditableImageLayer::imageSource() const
 {
     return imageLayer()->imageSource();
+}
+
+inline QString EditableImageLayer::imageFileName() const
+{
+    return imageLayer()->imageSource().toString(QUrl::PreferLocalFile);
 }
 
 inline bool EditableImageLayer::repeatX() const

--- a/src/tiled/editabletile.cpp
+++ b/src/tiled/editabletile.cpp
@@ -30,6 +30,7 @@
 #include "objectgroup.h"
 #include "scriptimage.h"
 #include "scriptmanager.h"
+#include "tilesetdocument.h"
 
 #include <QCoreApplication>
 #include <QJSEngine>
@@ -88,15 +89,20 @@ EditableTileset *EditableTile::tileset() const
     return static_cast<EditableTileset*>(asset());
 }
 
-void EditableTile::setImage(ScriptImage *image)
+void EditableTile::setImage(ScriptImage *image, const QString &fileName)
 {
     if (!image) {
         ScriptManager::instance().throwNullArgError(0);
         return;
     }
 
+    const auto pixmap = QPixmap::fromImage(image->image());
+
     // WARNING: This function has no undo!
-    tile()->setImage(QPixmap::fromImage(image->image()));
+    if (auto doc = tilesetDocument())
+        doc->setTileImage(tile(), pixmap, QUrl::fromLocalFile(fileName));
+    else
+        tile()->setImage(pixmap);
 }
 
 void EditableTile::detach()

--- a/src/tiled/editabletile.cpp
+++ b/src/tiled/editabletile.cpp
@@ -48,6 +48,11 @@ EditableTile::~EditableTile()
         setObject(nullptr);
 }
 
+ScriptImage *EditableTile::image() const
+{
+    return new ScriptImage(tile()->image().toImage());
+}
+
 EditableObjectGroup *EditableTile::objectGroup() const
 {
     if (!mAttachedObjectGroup) {

--- a/src/tiled/editabletile.h
+++ b/src/tiled/editabletile.h
@@ -42,6 +42,7 @@ class EditableTile : public EditableObject
     Q_PROPERTY(QSize size READ size)
     Q_PROPERTY(QString type READ className WRITE setClassName)  // compatibility with Tiled < 1.9
     Q_PROPERTY(QString imageFileName READ imageFileName WRITE setImageFileName)
+    Q_PROPERTY(Tiled::ScriptImage *image READ image WRITE setImage)
     Q_PROPERTY(QRect imageRect READ imageRect WRITE setImageRect)
     Q_PROPERTY(qreal probability READ probability WRITE setProbability)
     Q_PROPERTY(Tiled::EditableObjectGroup *objectGroup READ objectGroup WRITE setObjectGroup)
@@ -76,6 +77,7 @@ public:
     int height() const;
     QSize size() const;
     QString imageFileName() const;
+    ScriptImage *image() const;
     QRect imageRect() const;
     qreal probability() const;
     EditableObjectGroup *objectGroup() const;

--- a/src/tiled/editabletile.h
+++ b/src/tiled/editabletile.h
@@ -85,7 +85,8 @@ public:
     bool isAnimated() const;
     EditableTileset *tileset() const;
 
-    Q_INVOKABLE void setImage(Tiled::ScriptImage *image);
+    Q_INVOKABLE void setImage(Tiled::ScriptImage *image,
+                              const QString &fileName = QString());
 
     Tile *tile() const;
 

--- a/src/tiled/editabletileset.cpp
+++ b/src/tiled/editabletileset.cpp
@@ -245,7 +245,7 @@ void EditableTileset::setName(const QString &name)
         tileset()->setName(name);
 }
 
-void EditableTileset::setImage(const QString &imageFilePath)
+void EditableTileset::setImageFileName(const QString &imageFilePath)
 {
     if (isCollection() && tileCount() > 0) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Can't set the image of an image collection tileset"));

--- a/src/tiled/editabletileset.cpp
+++ b/src/tiled/editabletileset.cpp
@@ -28,6 +28,7 @@
 #include "scriptmanager.h"
 #include "tilesetchanges.h"
 #include "tilesetdocument.h"
+#include "tilesetmanager.h"
 #include "tilesetwangsetmodel.h"
 
 #include <QCoreApplication>
@@ -78,7 +79,11 @@ void EditableTileset::loadFromImage(ScriptImage *image, const QString &source)
     }
 
     // WARNING: This function has no undo!
-    tileset()->loadFromImage(image->image(), source);
+    if (tileset()->loadFromImage(image->image(), source))
+        emit TilesetManager::instance()->tilesetImagesChanged(tileset());
+
+    if (auto doc = tilesetDocument())
+        emit doc->tilesetChanged(tileset());
 }
 
 EditableTile *EditableTileset::tile(int id)

--- a/src/tiled/editabletileset.h
+++ b/src/tiled/editabletileset.h
@@ -35,7 +35,8 @@ class EditableTileset : public EditableAsset
     Q_OBJECT
 
     Q_PROPERTY(QString name READ name WRITE setName)
-    Q_PROPERTY(QString image READ image WRITE setImage)
+    Q_PROPERTY(QString image READ imageFileName WRITE setImageFileName) // deprecated
+    Q_PROPERTY(QString imageFileName READ imageFileName WRITE setImageFileName)
     Q_PROPERTY(QList<QObject*> tiles READ tiles)
     Q_PROPERTY(QList<QObject*> wangSets READ wangSets)
     Q_PROPERTY(int tileCount READ tileCount)
@@ -108,7 +109,7 @@ public:
     AssetType::Value assetType() const override { return AssetType::Tileset; }
 
     const QString &name() const;
-    QString image() const;
+    QString imageFileName() const;
     int tileCount() const;
     int columnCount() const;
     int nextTileId() const;
@@ -156,7 +157,7 @@ public:
 
 public slots:
     void setName(const QString &name);
-    void setImage(const QString &imageFilePath);
+    void setImageFileName(const QString &imageFilePath);
     void setTileWidth(int width);
     void setTileHeight(int height);
     void setTileSize(QSize size);
@@ -199,7 +200,7 @@ inline const QString &EditableTileset::name() const
     return tileset()->name();
 }
 
-inline QString EditableTileset::image() const
+inline QString EditableTileset::imageFileName() const
 {
     return tileset()->imageSource().toString(QUrl::PreferLocalFile);
 }


### PR DESCRIPTION
Usually one could load the image based on `Tile.imageFileName`, but when a tile's image has been set directly using `Tile.setImage`, this is not possible. This can happen for example when an importer has used this function since there was no external image file to refer to, or it used an unsupported image format.

`Tile.image` now provides convenient access to the tile's image, falling back to the tileset's image when the tile has no individual image.

As such, this function also provides access to the tileset's image, which would ideally be available through `Tileset.image`, but this property was already taken and used for the image file name. To free up this property in the future it is now deprecated. Extensions should switch to the new `Tileset.imageFileName` property.

Part of issue #3630