### PR TITLE
tmxrasterizer: Don't watch tileset images for changes

### DIFF
--- a/src/libtiled/filesystemwatcher.h
+++ b/src/libtiled/filesystemwatcher.h
@@ -57,6 +57,9 @@ class TILEDSHARED_EXPORT FileSystemWatcher : public QObject
 public:
     explicit FileSystemWatcher(QObject *parent = nullptr);
 
+    void setEnabled(bool enabled);
+    bool isEnabled() const;
+
     void addPath(const QString &path);
     void addPaths(const QStringList &paths);
     void removePath(const QString &path);
@@ -79,13 +82,20 @@ private:
     void onFileChanged(const QString &path);
     void onDirectoryChanged(const QString &path);
     void pathsChangedTimeout();
+    void clearInternal();
 
     QFileSystemWatcher *mWatcher;
     QMap<QString, int> mWatchCount;
 
     QSet<QString> mChangedPaths;
     QTimer mChangedPathsTimer;
+    bool mEnabled = true;
 };
+
+inline bool FileSystemWatcher::isEnabled() const
+{
+    return mEnabled;
+}
 
 inline void FileSystemWatcher::addPath(const QString &path)
 {

--- a/src/libtiled/tilesetmanager.cpp
+++ b/src/libtiled/tilesetmanager.cpp
@@ -46,9 +46,10 @@ TilesetManager *TilesetManager::mInstance;
  */
 TilesetManager::TilesetManager():
     mWatcher(new FileSystemWatcher(this)),
-    mAnimationDriver(new TileAnimationDriver(this)),
-    mReloadTilesetsOnChange(false)
+    mAnimationDriver(new TileAnimationDriver(this))
 {
+    mWatcher->setEnabled(false);
+
     connect(mWatcher, &FileSystemWatcher::pathsChanged,
             this, &TilesetManager::filesChanged);
 
@@ -169,8 +170,12 @@ void TilesetManager::reloadImages(Tileset *tileset)
  */
 void TilesetManager::setReloadTilesetsOnChange(bool enabled)
 {
-    mReloadTilesetsOnChange = enabled;
-    // TODO: Clear the file system watcher when disabled
+    mWatcher->setEnabled(enabled);
+}
+
+bool TilesetManager::reloadTilesetsOnChange() const
+{
+    return mWatcher->isEnabled();
 }
 
 /**
@@ -206,9 +211,6 @@ void TilesetManager::tilesetImageSourceChanged(const Tileset &tileset,
 
 void TilesetManager::filesChanged(const QStringList &fileNames)
 {
-    if (!mReloadTilesetsOnChange)
-        return;
-
     for (const QString &fileName : fileNames)
         ImageCache::remove(fileName);
 

--- a/src/libtiled/tilesetmanager.h
+++ b/src/libtiled/tilesetmanager.h
@@ -99,12 +99,8 @@ private:
     QList<Tileset*> mTilesets;
     FileSystemWatcher *mWatcher;
     TileAnimationDriver *mAnimationDriver;
-    bool mReloadTilesetsOnChange;
 
     static TilesetManager *mInstance;
 };
-
-inline bool TilesetManager::reloadTilesetsOnChange() const
-{ return mReloadTilesetsOnChange; }
 
 } // namespace Tiled


### PR DESCRIPTION
The TilesetManager no longer watches by default, it now relies on the Tiled Preferences to enable this. This makes sure, that other tools, like the tmxrasterizer, for which it makes no sense to watch the file, will not watch the files (and won't trigger SELinux pop-ups on Fedora...).