### PR TITLE
Automapping: Ignore empty outputs per-rule

### DIFF
--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -251,16 +251,16 @@ public:
         {
             if (lhs.mChunkPointer == lhs.mChunkEndPointer || rhs.mChunkPointer == rhs.mChunkEndPointer)
                 return lhs.mChunkPointer == rhs.mChunkPointer;
-            else
-                return lhs.mCellPointer == rhs.mCellPointer;
+
+            return lhs.mCellPointer == rhs.mCellPointer;
         }
 
         friend bool operator!=(const iterator& lhs, const iterator& rhs)
         {
             if (lhs.mChunkPointer == lhs.mChunkEndPointer || rhs.mChunkPointer == rhs.mChunkEndPointer)
                 return lhs.mChunkPointer != rhs.mChunkPointer;
-            else
-                return lhs.mCellPointer != rhs.mCellPointer;
+
+            return lhs.mCellPointer != rhs.mCellPointer;
         }
 
         Cell &value() const { return *mCellPointer; }
@@ -307,16 +307,16 @@ public:
         {
             if (lhs.mChunkPointer == lhs.mChunkEndPointer || rhs.mChunkPointer == rhs.mChunkEndPointer)
                 return lhs.mChunkPointer == rhs.mChunkPointer;
-            else
-                return lhs.mCellPointer == rhs.mCellPointer;
+
+            return lhs.mCellPointer == rhs.mCellPointer;
         }
 
         friend bool operator!=(const const_iterator& lhs, const const_iterator& rhs)
         {
             if (lhs.mChunkPointer == lhs.mChunkEndPointer || rhs.mChunkPointer == rhs.mChunkEndPointer)
                 return lhs.mChunkPointer != rhs.mChunkPointer;
-            else
-                return lhs.mCellPointer != rhs.mCellPointer;
+
+            return lhs.mCellPointer != rhs.mCellPointer;
         }
 
         const Cell &value() const { return *mCellPointer; }
@@ -646,8 +646,8 @@ inline const Cell &TileLayer::cellAt(int x, int y) const
 {
     if (const Chunk *chunk = findChunk(x, y))
         return chunk->cellAt(x & CHUNK_MASK, y & CHUNK_MASK);
-    else
-        return Cell::empty;
+
+    return Cell::empty;
 }
 
 inline const Cell &TileLayer::cellAt(QPoint point) const

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -98,13 +98,13 @@ static MatchType matchType(const Tile *tile)
     const QString matchType = tile->resolvedProperty(QStringLiteral("MatchType")).toString();
     if (matchType == QLatin1String("Empty"))
         return MatchType::Empty;
-    else if (matchType == QLatin1String("NonEmpty"))
+    if (matchType == QLatin1String("NonEmpty"))
         return MatchType::NonEmpty;
-    else if (matchType == QLatin1String("Other"))
+    if (matchType == QLatin1String("Other"))
         return MatchType::Other;
-    else if (matchType == QLatin1String("Negate"))
+    if (matchType == QLatin1String("Negate"))
         return MatchType::Negate;
-    else if (matchType == QLatin1String("Ignore"))
+    if (matchType == QLatin1String("Ignore"))
         return MatchType::Ignore;
 
     return MatchType::Tile;
@@ -750,27 +750,16 @@ static void collectCellsInRegion(const QVector<InputLayer> &list,
     }
 }
 
-/**
- * Returns whether the \a tileLayer has any output in the given \a region.
- */
-static bool hasOutputInRegion(const TileLayer &tileLayer,
-                              const QRegion &region)
+static bool isEmptyRegion(const TileLayer &tileLayer,
+                          const QRegion &region)
 {
-    for (const QRect &rect : region) {
-        for (int y = rect.top(); y <= rect.bottom(); ++y) {
-            for (int x = rect.left(); x <= rect.right(); ++x) {
-                switch (matchType(tileLayer.cellAt(x, y).tile())) {
-                case MatchType::Tile:
-                case MatchType::Empty:
-                    return true;
-                default:
-                    break;
-                }
-            }
-        }
-    }
+    for (const QRect &rect : region)
+        for (int y = rect.top(); y <= rect.bottom(); ++y)
+            for (int x = rect.left(); x <= rect.right(); ++x)
+                if (!tileLayer.cellAt(x, y).isEmpty())
+                    return false;
 
-    return false;
+    return true;
 }
 
 /**
@@ -1005,7 +994,7 @@ bool AutoMapper::compileOutputSet(RuleOutputSet &index,
         case Layer::TileLayerType: {
             auto fromTileLayer = static_cast<const TileLayer*>(from);
 
-            if (hasOutputInRegion(*fromTileLayer, outputRegion))
+            if (!isEmptyRegion(*fromTileLayer, outputRegion))
                 index.tileOutputs.append(fromTileLayer);
             break;
         }

--- a/src/tiled/automappingutils.cpp
+++ b/src/tiled/automappingutils.cpp
@@ -45,14 +45,14 @@ QRect objectTileRect(const MapRenderer &renderer,
     return QRectF(topLeft, bottomRight).toAlignedRect();
 }
 
-QList<MapObject*> objectsToErase(const MapDocument *mapDocument,
-                                 const ObjectGroup *layer,
-                                 const QRegion &where)
+QList<MapObject*> objectsInRegion(const MapRenderer &renderer,
+                                  const ObjectGroup *layer,
+                                  const QRegion &where)
 {
     QList<MapObject*> objectsToErase;
 
     for (MapObject *object : layer->objects()) {
-        const QRect tileRect = objectTileRect(*mapDocument->renderer(), *object);
+        const QRect tileRect = objectTileRect(renderer, *object);
         if (where.intersects(tileRect))
             objectsToErase.append(object);
     }

--- a/src/tiled/automappingutils.h
+++ b/src/tiled/automappingutils.h
@@ -29,14 +29,12 @@ class MapObject;
 class MapRenderer;
 class ObjectGroup;
 
-class MapDocument;
-
 QRect objectTileRect(const MapRenderer &renderer,
                      const MapObject &object);
 
-QList<MapObject*> objectsToErase(const MapDocument *mapDocument,
-                                 const ObjectGroup *layer,
-                                 const QRegion &where);
+QList<MapObject*> objectsInRegion(const MapRenderer &renderer,
+                                  const ObjectGroup *layer,
+                                  const QRegion &where);
 
 QRegion tileRegionOfObjectGroup(const MapRenderer &renderer,
                                 const ObjectGroup *objectGroup);


### PR DESCRIPTION
This change introduces a "compileOutputSet" step which is executed as part of collecting the rules. In this step, each rule only receives as possible outputs the output indexes that are non-empty for the region of that rule.

This makes it much easier to add output variation to only some of the rules. Previously, due to the possibility of empty outputs being chosen, having rules with various amounts of variation required setting up separate rule maps.

Closes #3523