### PR TITLE
Automapping ignore empty outputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * tmxrasterizer: Added --hide-object and --show-object arguments (by Lars Luz, #3819)
 * tmxrasterizer: Added --frames and --frame-duration arguments to export animated maps as multiple images (#3868)
 * tmxviewer: Added support for viewing JSON maps (#3866)
+* AutoMapping: Ignore empty outputs per-rule (#3523)
 * Windows: Fixed the support for WebP images (updated to Qt 6.6.1, #3661)
 * Fixed mouse handling issue when zooming while painting (#3863)
 * Fixed possible crash after a scripted tool disappears while active

--- a/docs/manual/automapping.md
+++ b/docs/manual/automapping.md
@@ -384,7 +384,7 @@ A result from the two rules above.
 (updating-rules)=
 ## Updating Legacy Rules
 
-If you have some Automapping rules from before Tiled 1.9, they should still work much as they always did in most cases. When Tiled sees that a rule map contains `regions` layers, it will automatically bring back the old behavior - rules will be matched in order by default, and cells within input regions that are empty in all the input layers for a given layer and index will be treated as "Other".
+If you have some Automapping rules from before Tiled 1.9, they should still work much as they always did in most cases. When Tiled sees that a rule map contains `regions` layers, it will automatically bring back the old behavior - rules will be matched in order by default, cells within input regions that are empty in all the input layers for a given layer and index will be treated as "Other", and completely empty output indices will still be selected as valid outputs.
 
 :::{warning}
 In Tiled 1.9.x, the presence of `regions` layers did not imply **MatchInOrder**. If you're using 1.9.x rather than 1.10+ and want to use legacy rules, you'll need to set the **MatchInOrder** map property to `true`.
@@ -394,13 +394,14 @@ If you'd like to instead update your rules to not rely on any legacy behavior, t
 
 * If your rules rely on being applied in a set order, set the [**MatchInOrder**](#MatchInOrder) map property to `true`.
 * When deleting your `regions` layers, make sure you weren't relying on them to connect otherwise disconnected areas of tiles. If you were, use the [Ignore]{.tile .ignore} [special tile](#specialtiles) to connect them on one of the `input` layers, so that Tiled knows they're part of the same rule. To make sure the rules behave exactly the same, fill in any part that was previously part of the input region.
-    
+
 * If were using the [**DeleteTiles**](#DeleteTiles) map property to erase tiles from the output layer, you can keep using this property. If you want to make your rule more visually clear, however, you should unset the **DeleteTiles** property, and instead use the [Empty]{.tile .empty} [special tile](#specialtiles) in all the output cells you want to delete from.
-    
+
 * If were using the [**StrictEmpty**](#AutoEmpty) map property to look for empty input tiles, you should now use the Empty special tile instead in the cells you want to check for being empty. You can also continue use the **StrictEmpty** property (or its newer alias, **AutoEmpty**), as long as at least one other input layer is not empty at those locations.
-    
+
 * If were relying on the behavior that any tile which is left empty on all of the input layers for a given index is treated as “any tile not in this rule”, you should instead use the [Other]{.tile .other} [special tile](#specialtiles) at those locations, and also the [Empty]{.tile .empty} [special tile](#specialtiles) on an inputnot layer at those same locations. The Empty tile is needed because old-style Other never matched Empty, but the MatchType Other tile does match Empty.
-    
+
+* If you have rules that rely on some output indices being empty to randomly not make any changes, you will need to place [**Ignore** special tiles](#specialtiles) in at least one layer of each empty output index so that those indices aren't ignored. Alternatively, you can use [`rule_options`](#object-properties) to give those rules a chance to not run at all.
 
 ## Credits
 

--- a/docs/manual/automapping.md
+++ b/docs/manual/automapping.md
@@ -109,7 +109,7 @@ output[index]_name
 
 Everything after the first underscore is the **name**, which determines which layer in the working map the tiles or objects will be placed on. If the working map includes multiple layers by this name, the bottom-most one will be used. If the rule matches and the working map does not already contain the named output layer, Automapping will create the layer.
 
-The **index** is optional, and is not related to the input indices. Instead, output indices are used to randomize the output: every time the rule finds a match, a random output index is chosen and only the output layers with that index will have their contents placed into the working map.
+The **index** is optional, and is not related to the input indices. Instead, output indices are used to randomize the output: every time the rule finds a match, a random output index is chosen and only the output layers with that index will have their contents placed into the working map. If an output index is completely empty for a given rule, it will never be chosen for that rule (since Tiled 1.10.3).
 
 #### Random Output Example
 

--- a/docs/manual/automapping.md
+++ b/docs/manual/automapping.md
@@ -218,6 +218,7 @@ Probability {bdg-primary}`New in Tiled 1.10`
 
 {bdg-secondary-line}`Since Tiled 1.9`
 
+(object-properties)=
 ### Object Properties
 
 A number of options can be set on individual rules, even within the same rule map. To do this, add an Object Layer to your rule map called `rule_options`. On this layer, you can create plain rectangle objects and any options you set on these objects will apply to all rules they contain.

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -251,16 +251,16 @@ public:
         {
             if (lhs.mChunkPointer == lhs.mChunkEndPointer || rhs.mChunkPointer == rhs.mChunkEndPointer)
                 return lhs.mChunkPointer == rhs.mChunkPointer;
-            else
-                return lhs.mCellPointer == rhs.mCellPointer;
+
+            return lhs.mCellPointer == rhs.mCellPointer;
         }
 
         friend bool operator!=(const iterator& lhs, const iterator& rhs)
         {
             if (lhs.mChunkPointer == lhs.mChunkEndPointer || rhs.mChunkPointer == rhs.mChunkEndPointer)
                 return lhs.mChunkPointer != rhs.mChunkPointer;
-            else
-                return lhs.mCellPointer != rhs.mCellPointer;
+
+            return lhs.mCellPointer != rhs.mCellPointer;
         }
 
         Cell &value() const { return *mCellPointer; }
@@ -307,16 +307,16 @@ public:
         {
             if (lhs.mChunkPointer == lhs.mChunkEndPointer || rhs.mChunkPointer == rhs.mChunkEndPointer)
                 return lhs.mChunkPointer == rhs.mChunkPointer;
-            else
-                return lhs.mCellPointer == rhs.mCellPointer;
+
+            return lhs.mCellPointer == rhs.mCellPointer;
         }
 
         friend bool operator!=(const const_iterator& lhs, const const_iterator& rhs)
         {
             if (lhs.mChunkPointer == lhs.mChunkEndPointer || rhs.mChunkPointer == rhs.mChunkEndPointer)
                 return lhs.mChunkPointer != rhs.mChunkPointer;
-            else
-                return lhs.mCellPointer != rhs.mCellPointer;
+
+            return lhs.mCellPointer != rhs.mCellPointer;
         }
 
         const Cell &value() const { return *mCellPointer; }
@@ -646,8 +646,8 @@ inline const Cell &TileLayer::cellAt(int x, int y) const
 {
     if (const Chunk *chunk = findChunk(x, y))
         return chunk->cellAt(x & CHUNK_MASK, y & CHUNK_MASK);
-    else
-        return Cell::empty;
+
+    return Cell::empty;
 }
 
 inline const Cell &TileLayer::cellAt(QPoint point) const

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -1249,13 +1249,12 @@ void AutoMapper::applyRule(const Rule &rule, QPoint pos,
             outputLayerRegion |= objectTileRect(*mRulesMapRenderer, *mapObject);
         }
 
-        // Translate the regions to the position of the rule and check for
-        // overlap.
+        // Translate the regions to the position of the rule and check for overlap.
         for (auto it = ruleRegionInLayer.keyValueBegin(), it_end = ruleRegionInLayer.keyValueEnd();
              it != it_end; ++it) {
 
-            const Layer *layer = it->first;
-            QRegion &region = it->second;
+            const Layer *layer = it.base().key();
+            QRegion &region = it.base().value();
 
             region.translate(pos.x(), pos.y());
 
@@ -1267,8 +1266,8 @@ void AutoMapper::applyRule(const Rule &rule, QPoint pos,
         for (auto it = ruleRegionInLayer.keyValueBegin(), it_end = ruleRegionInLayer.keyValueEnd();
              it != it_end; ++it) {
 
-            const Layer *layer = it->first;
-            const QRegion &region = it->second;
+            const Layer *layer = it.base().key();
+            const QRegion &region = it.base().value();
 
             applyContext.appliedRegions[layer] |= region;
         }

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -577,6 +577,9 @@ void AutoMapper::setupRules()
     if (setup.mLayerOutputRegions)
         regionOutput |= setup.mLayerOutputRegions->region();
 
+    const bool ignoreEmptyOutputs = !(mRuleMapSetup.mLayerRegions ||
+                                      mRuleMapSetup.mLayerInputRegions);
+
     // When no input regions have been defined at all, derive them from the
     // "input" and "inputnot" layers.
     if (!setup.mLayerRegions && !setup.mLayerInputRegions) {
@@ -635,7 +638,7 @@ void AutoMapper::setupRules()
 
         for (const OutputSet &outputSet : std::as_const(mRuleMapSetup.mOutputSets)) {
             RuleOutputSet index;
-            if (compileOutputSet(index, outputSet, rule.outputRegion))
+            if (compileOutputSet(index, outputSet, rule.outputRegion) || !ignoreEmptyOutputs)
                 rule.outputSets.add(index, outputSet.probability);
         }
     }

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -98,13 +98,13 @@ static MatchType matchType(const Tile *tile)
     const QString matchType = tile->resolvedProperty(QStringLiteral("MatchType")).toString();
     if (matchType == QLatin1String("Empty"))
         return MatchType::Empty;
-    else if (matchType == QLatin1String("NonEmpty"))
+    if (matchType == QLatin1String("NonEmpty"))
         return MatchType::NonEmpty;
-    else if (matchType == QLatin1String("Other"))
+    if (matchType == QLatin1String("Other"))
         return MatchType::Other;
-    else if (matchType == QLatin1String("Negate"))
+    if (matchType == QLatin1String("Negate"))
         return MatchType::Negate;
-    else if (matchType == QLatin1String("Ignore"))
+    if (matchType == QLatin1String("Ignore"))
         return MatchType::Ignore;
 
     return MatchType::Tile;
@@ -750,27 +750,16 @@ static void collectCellsInRegion(const QVector<InputLayer> &list,
     }
 }
 
-/**
- * Returns whether the \a tileLayer has any output in the given \a region.
- */
-static bool hasOutputInRegion(const TileLayer &tileLayer,
-                              const QRegion &region)
+static bool isEmptyRegion(const TileLayer &tileLayer,
+                          const QRegion &region)
 {
-    for (const QRect &rect : region) {
-        for (int y = rect.top(); y <= rect.bottom(); ++y) {
-            for (int x = rect.left(); x <= rect.right(); ++x) {
-                switch (matchType(tileLayer.cellAt(x, y).tile())) {
-                case MatchType::Tile:
-                case MatchType::Empty:
-                    return true;
-                default:
-                    break;
-                }
-            }
-        }
-    }
+    for (const QRect &rect : region)
+        for (int y = rect.top(); y <= rect.bottom(); ++y)
+            for (int x = rect.left(); x <= rect.right(); ++x)
+                if (!tileLayer.cellAt(x, y).isEmpty())
+                    return false;
 
-    return false;
+    return true;
 }
 
 /**
@@ -1005,7 +994,7 @@ bool AutoMapper::compileOutputSet(RuleOutputSet &index,
         case Layer::TileLayerType: {
             auto fromTileLayer = static_cast<const TileLayer*>(from);
 
-            if (hasOutputInRegion(*fromTileLayer, outputRegion))
+            if (!isEmptyRegion(*fromTileLayer, outputRegion))
                 index.tileOutputs.append(fromTileLayer);
             break;
         }

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -74,13 +74,19 @@ struct InputSet
     std::vector<InputConditions> layers;
 };
 
+struct OutputLayer
+{
+    const Layer *layer;
+    QString name;
+};
+
 // One set of output layers sharing the same index
 struct OutputSet
 {
     OutputSet(const QString &name) : name(name) {}
 
     QString name;
-    QVector<const Layer*> layers;
+    QVector<OutputLayer> layers;
     qreal probability = 1.0;
 };
 
@@ -150,8 +156,8 @@ struct RuleMapSetup
     QSet<QString> mOutputTileLayerNames;
     QSet<QString> mOutputObjectGroupNames;
 
-    // Maps output layers in mRulesMap to their names in mTargetMap
-    QHash<const Layer*, QString> mOutputLayerNames;
+    // The properties that should be copied to the target map, when any rule
+    // matches for these output layers.
     QHash<const Layer*, Properties> mOutputLayerProperties;
 };
 
@@ -180,10 +186,23 @@ struct RuleInputSet
     QVector<Cell> cells;
 };
 
+struct RuleOutputTileLayer
+{
+    const TileLayer *tileLayer;         // reference to layer in rule map
+    QString name;                       // target layer name
+};
+
+struct RuleOutputMapObjects
+{
+    const ObjectGroup *objectGroup;     // reference to layer in rule map
+    QVector<const MapObject*> objects;  // references to objects in rule map
+    QString name;                       // target layer name
+};
+
 struct RuleOutputSet
 {
-    QVector<const TileLayer*> tileOutputs;
-    QVector<const MapObject*> objectOutputs;
+    QVector<RuleOutputTileLayer> tileOutputs;
+    QVector<RuleOutputMapObjects> objectOutputs;
 };
 
 struct CompileContext;

--- a/src/tiled/automappingutils.cpp
+++ b/src/tiled/automappingutils.cpp
@@ -45,6 +45,9 @@ QRect objectTileRect(const MapRenderer &renderer,
     return QRectF(topLeft, bottomRight).toAlignedRect();
 }
 
+/**
+ * Returns the list of objects occupying the given region (in tiles).
+ */
 QList<MapObject*> objectsInRegion(const MapRenderer &renderer,
                                   const ObjectGroup *layer,
                                   const QRegion &where)
@@ -67,28 +70,6 @@ QRegion tileRegionOfObjectGroup(const MapRenderer &renderer,
     for (const MapObject *object : objectGroup->objects())
         region |= objectTileRect(renderer, *object);
     return region;
-}
-
-/**
- * Returns the list of objects occupying the given rectangle (in pixels).
- */
-QList<MapObject*> objectsInRegion(const ObjectGroup *objectGroup,
-                                  const QRectF &where)
-{
-    QList<MapObject*> ret;
-    for (MapObject *object : objectGroup->objects()) {
-        // TODO: we are checking bounds, which is only correct for rectangles and
-        // tile objects. polygons and polylines are not covered correctly by this
-        // erase method (we are in fact deleting too many objects)
-        const QRectF rect = object->boundsUseTile();
-
-        // QRegion::intersects() returns false for empty regions even if they are
-        // contained within the region, so we also check for containment of the
-        // top left to include the case of zero size objects.
-        if (where.intersects(rect) || where.contains(rect.topLeft()))
-            ret += object;
-    }
-    return ret;
 }
 
 } // namespace Tiled

--- a/src/tiled/automappingutils.cpp
+++ b/src/tiled/automappingutils.cpp
@@ -45,14 +45,14 @@ QRect objectTileRect(const MapRenderer &renderer,
     return QRectF(topLeft, bottomRight).toAlignedRect();
 }
 
-QList<MapObject*> objectsToErase(const MapDocument *mapDocument,
-                                 const ObjectGroup *layer,
-                                 const QRegion &where)
+QList<MapObject*> objectsInRegion(const MapRenderer &renderer,
+                                  const ObjectGroup *layer,
+                                  const QRegion &where)
 {
     QList<MapObject*> objectsToErase;
 
     for (MapObject *object : layer->objects()) {
-        const QRect tileRect = objectTileRect(*mapDocument->renderer(), *object);
+        const QRect tileRect = objectTileRect(renderer, *object);
         if (where.intersects(tileRect))
             objectsToErase.append(object);
     }

--- a/src/tiled/automappingutils.h
+++ b/src/tiled/automappingutils.h
@@ -29,14 +29,12 @@ class MapObject;
 class MapRenderer;
 class ObjectGroup;
 
-class MapDocument;
-
 QRect objectTileRect(const MapRenderer &renderer,
                      const MapObject &object);
 
-QList<MapObject*> objectsToErase(const MapDocument *mapDocument,
-                                 const ObjectGroup *layer,
-                                 const QRegion &where);
+QList<MapObject*> objectsInRegion(const MapRenderer &renderer,
+                                  const ObjectGroup *layer,
+                                  const QRegion &where);
 
 QRegion tileRegionOfObjectGroup(const MapRenderer &renderer,
                                 const ObjectGroup *objectGroup);

--- a/src/tiled/automappingutils.h
+++ b/src/tiled/automappingutils.h
@@ -39,7 +39,4 @@ QList<MapObject*> objectsInRegion(const MapRenderer &renderer,
 QRegion tileRegionOfObjectGroup(const MapRenderer &renderer,
                                 const ObjectGroup *objectGroup);
 
-QList<MapObject*> objectsInRegion(const ObjectGroup *objectGroup,
-                                  const QRectF &where);
-
 } // namespace Tiled

--- a/tests/automapping/option-ignore-lock/map-result.tmx
+++ b/tests/automapping/option-ignore-lock/map-result.tmx
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="1">
+<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="1">
  <tileset firstgid="1" source="../spr_test_tileset.tsx"/>
  <layer id="1" name="set" width="5" height="5" locked="1">
   <data encoding="csv">
 0,0,0,0,0,
-0,2,4,5,0,
+0,2,4,0,0,
 0,0,0,0,0,
-0,5,4,2,0,
+0,0,4,2,0,
 0,0,0,0,0
 </data>
  </layer>

--- a/tests/automapping/option-ignore-lock/map.tmx
+++ b/tests/automapping/option-ignore-lock/map.tmx
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="1">
+<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="6" nextobjectid="1">
  <tileset firstgid="1" source="../spr_test_tileset.tsx"/>
  <layer id="1" name="set" width="5" height="5" locked="1">
   <data encoding="csv">
 0,0,0,0,0,
-0,2,3,4,0,
+0,2,3,0,0,
 0,0,0,0,0,
-0,4,3,2,0,
+0,0,3,2,0,
 0,0,0,0,0
 </data>
  </layer>

--- a/tests/automapping/option-ignore-lock/rules.tmx
+++ b/tests/automapping/option-ignore-lock/rules.tmx
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="7" height="3" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="2">
+<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="5" height="3" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="2">
  <tileset firstgid="1" source="../spr_test_tileset.tsx"/>
- <layer id="1" name="input_set" width="7" height="3">
+ <layer id="1" name="input_set" width="5" height="3">
   <data encoding="csv">
-0,0,0,0,0,0,0,
-0,2,0,3,0,4,0,
-0,0,0,0,0,0,0
+0,0,0,0,0,
+0,2,0,3,0,
+0,0,0,0,0
 </data>
  </layer>
- <layer id="2" name="output_set" width="7" height="3">
+ <layer id="2" name="output_set" width="5" height="3">
   <data encoding="csv">
-0,0,0,0,0,0,0,
-0,3,0,4,0,5,0,
-0,0,0,0,0,0,0
+0,0,0,0,0,
+0,3,0,4,0,
+0,0,0,0,0
 </data>
  </layer>
  <objectgroup id="4" name="rule_options">
-  <object id="1" x="44" y="12" width="59" height="24">
+  <object id="1" x="44" y="12" width="24" height="24">
    <properties>
     <property name="IgnoreLock" type="bool" value="true"/>
    </properties>

--- a/tests/automapping/test_automapping.cpp
+++ b/tests/automapping/test_automapping.cpp
@@ -59,7 +59,7 @@ void test_AutoMapping::autoMap()
 
         QRect bounds;
         while (Layer *layer = iterator.next()) {
-            if (TileLayer *tileLayer = dynamic_cast<TileLayer*>(layer))
+            if (auto *tileLayer = dynamic_cast<TileLayer*>(layer))
                 bounds = bounds.united(tileLayer->bounds());
         }
         region = bounds;
@@ -91,8 +91,8 @@ void test_AutoMapping::autoMap()
         if (resultLayer->layerType() != Layer::TileLayerType)
             continue;
 
-        const TileLayer *resultTileLayer = static_cast<const TileLayer*>(resultLayer);
-        const TileLayer *mapTileLayer = static_cast<const TileLayer*>(mapLayer);
+        const auto *resultTileLayer = static_cast<const TileLayer*>(resultLayer);
+        const auto *mapTileLayer = static_cast<const TileLayer*>(mapLayer);
 
         QCOMPARE(mapTileLayer->region(), resultTileLayer->region());
 


### PR DESCRIPTION
This change introduces a "compileOutputSet" step which is executed as part of collecting the rules. In this step, each rule only receives as possible outputs the output indexes that are non-empty for the region of that rule.

This makes it much easier to add output variation to only some of the rules. Previously, due to the possibility of empty outputs being chosen, having rules with various amounts of variation required setting up separate rule maps.

Closes #3523

This PR supercedes #3894, which was merged accidentally.