### PR TITLE
Fixed possible crash after assigning to tiled.activeAsset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * AutoMapping: Ignore empty outputs per-rule (#3523)
 * AutoMapping: Always apply output sets with empty index
 * Windows: Fixed the support for WebP images (updated to Qt 6.6.1, #3661)
+* Fixed possible crash after assigning to tiled.activeAsset
 * Fixed the option to resolve properties on export to also resolve class members (#3411, #3315)
 * Fixed terrain tool behavior and terrain overlays after changing terrain set type (#3204, #3260)
 * Fixed mouse handling issue when zooming while painting (#3863)

--- a/src/tiled/changemapobject.cpp
+++ b/src/tiled/changemapobject.cpp
@@ -100,9 +100,7 @@ static QList<MapObject*> objectList(const QVector<MapObjectCell> &changes)
 
 void ChangeMapObjectCells::swap()
 {
-    for (int i = 0; i < mChanges.size(); ++i) {
-        MapObjectCell &change = mChanges[i];
-
+    for (auto &change : mChanges) {
         auto cell = change.object->cell();
         change.object->setCell(change.cell);
         change.cell = cell;

--- a/src/tiled/editableasset.cpp
+++ b/src/tiled/editableasset.cpp
@@ -28,14 +28,9 @@
 
 namespace Tiled {
 
-EditableAsset::EditableAsset(Document *document, Object *object, QObject *parent)
+EditableAsset::EditableAsset(Object *object, QObject *parent)
     : EditableObject(this, object, parent)
-    , mDocument(document)
 {
-    if (document) {
-        connect(document, &Document::modifiedChanged,
-                this, &EditableAsset::modifiedChanged);
-    }
 }
 
 QString EditableAsset::fileName() const
@@ -124,6 +119,22 @@ void EditableAsset::redo()
         stack->redo();
     else
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Undo system not available for this asset"));
+}
+
+void EditableAsset::setDocument(Document *document)
+{
+    if (mDocument == document)
+        return;
+
+    if (mDocument)
+        mDocument->disconnect(this);
+
+    if (document) {
+        connect(document, &Document::modifiedChanged,
+                this, &EditableAsset::modifiedChanged);
+    }
+
+    mDocument = document;
 }
 
 } // namespace Tiled

--- a/src/tiled/editableasset.h
+++ b/src/tiled/editableasset.h
@@ -57,7 +57,7 @@ class EditableAsset : public EditableObject
     Q_PROPERTY(AssetType::Value assetType READ assetType CONSTANT)
 
 public:
-    EditableAsset(Document *document, Object *object, QObject *parent = nullptr);
+    EditableAsset(Object *object, QObject *parent = nullptr);
 
     QString fileName() const;
     bool isReadOnly() const override = 0;
@@ -88,22 +88,19 @@ signals:
     void modifiedChanged();
     void fileNameChanged(const QString &fileName, const QString &oldFileName);
 
+protected:
+    virtual void setDocument(Document *document);
+
 private:
     friend class Document;
-    void setDocument(Document *document);
 
-    Document *mDocument;
+    Document *mDocument = nullptr;
 };
 
 
 inline Document *EditableAsset::document() const
 {
     return mDocument;
-}
-
-inline void EditableAsset::setDocument(Document *document)
-{
-    mDocument = document;
 }
 
 } // namespace Tiled

--- a/src/tiled/editablemap.h
+++ b/src/tiled/editablemap.h
@@ -163,7 +163,7 @@ public:
     Q_INVOKABLE void autoMap(const QRectF &region, const QString &rulesFile = QString());
     Q_INVOKABLE void autoMap(const Tiled::RegionValueType &region, const QString &rulesFile = QString());
 
-    Q_INVOKABLE Tiled::ScriptImage *toImage(QSize size = QSize());
+    Q_INVOKABLE Tiled::ScriptImage *toImage(QSize size = QSize()) const;
 
     Q_INVOKABLE QPointF screenToTile(qreal x, qreal y) const;
     Q_INVOKABLE QPointF screenToTile(const QPointF &position) const;
@@ -208,6 +208,9 @@ signals:
     void selectedObjectsChanged();
 
     void regionEdited(const Tiled::RegionValueType &region, Tiled::EditableTileLayer *layer);
+
+protected:
+    void setDocument(Document *document) override;
 
 private:
     void documentChanged(const ChangeEvent &change);

--- a/src/tiled/editableproject.cpp
+++ b/src/tiled/editableproject.cpp
@@ -26,8 +26,9 @@
 namespace Tiled {
 
 EditableProject::EditableProject(ProjectDocument *projectDocument, QObject *parent)
-    : EditableAsset(projectDocument, &projectDocument->project(), parent)
+    : EditableAsset(&projectDocument->project(), parent)
 {
+    setDocument(projectDocument);
 }
 
 QString EditableProject::extensionsPath() const

--- a/src/tiled/editabletileset.h
+++ b/src/tiled/editabletileset.h
@@ -30,7 +30,7 @@ class EditableWangSet;
 class ScriptImage;
 class TilesetDocument;
 
-class EditableTileset : public EditableAsset
+class EditableTileset final : public EditableAsset
 {
     Q_OBJECT
 
@@ -172,6 +172,9 @@ public slots:
     void setOrientation(Orientation orientation);
     void setTransparentColor(const QColor &color);
     void setBackgroundColor(const QColor &color);
+
+protected:
+    void setDocument(Document *document) override;
 
 private:
     bool tilesFromEditables(const QList<QObject*> &editableTiles, QList<Tile *> &tiles);

--- a/src/tiled/editableworld.cpp
+++ b/src/tiled/editableworld.cpp
@@ -31,9 +31,10 @@
 namespace Tiled {
 
 EditableWorld::EditableWorld(WorldDocument *worldDocument, QObject *parent)
-    : EditableAsset(worldDocument, nullptr, parent)
+    : EditableAsset(nullptr, parent)
 {
     setObject(WorldManager::instance().worlds().value(worldDocument->fileName()));
+    setDocument(worldDocument);
 }
 
 bool EditableWorld::containsMap(const QString &fileName) const


### PR DESCRIPTION
When assigning a new map or tileset created from a script to `tiled.activeAsset`, the necessary signals were not connected. This broke the signals from `EditableMap` and it also caused certain ownership transfers from JS to C++ to never take place. The latter could in turn lead to dangling pointers to objects after they were deleted by the garbage collector.

Thanks to @eishiya for discovering this issue!