### PR TITLE
Terrain tools now ignore irrelevant labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * tmxviewer: Added support for viewing JSON maps (#3866)
 * AutoMapping: Ignore empty outputs per-rule (#3523)
 * Windows: Fixed the support for WebP images (updated to Qt 6.6.1, #3661)
+* Fixed terrain tool behavior and terrain overlays after changing terrain set type (#3204, #3260)
 * Fixed mouse handling issue when zooming while painting (#3863)
 * Fixed possible crash after a scripted tool disappears while active
 * Fixed updating of used tilesets after resizing map (#3884)

--- a/src/libtiled/wangset.h
+++ b/src/libtiled/wangset.h
@@ -88,6 +88,8 @@ public:
     constexpr operator quint64() const { return mId; }
     inline void setId(quint64 id) { mId = id; }
 
+    bool isEmpty() const { return mId == 0; }
+
     int edgeColor(int index) const;
     int cornerColor(int index) const;
 
@@ -100,13 +102,13 @@ public:
     void setIndexColor(int index, unsigned value);
 
     void updateToAdjacent(WangId adjacent, int position);
-    void mergeWith(WangId wangId, quint64 mask);
+    void mergeWith(WangId wangId, WangId mask);
 
     bool hasWildCards() const;
     bool hasCornerWildCards() const;
     bool hasEdgeWildCards() const;
-    quint64 mask() const;
-    quint64 mask(int value) const;
+    WangId mask() const;
+    WangId mask(int value) const;
 
     bool hasCornerWithColor(int value) const;
     bool hasEdgeWithColor(int value) const;
@@ -117,6 +119,11 @@ public:
     void flipVertically();
     WangId flippedHorizontally() const;
     WangId flippedVertically() const;
+
+    bool operator==(WangId other) const { return mId == other.mId; }
+    bool operator!=(WangId other) const { return mId != other.mId; }
+    WangId operator& (quint64 mask) const { return mId & mask; }
+    WangId operator&=(quint64 mask) { return mId &= mask; }
 
     static Index indexByGrid(int x, int y);
     static Index oppositeIndex(int index);
@@ -134,9 +141,9 @@ private:
     quint64 mId;
 };
 
-inline void WangId::mergeWith(WangId wangId, quint64 mask)
+inline void WangId::mergeWith(WangId wangId, WangId mask)
 {
-    mId = (mId & ~mask) | (wangId & mask);
+    *this = (*this & ~mask) | (wangId & mask);
 }
 
 inline WangId::Index WangId::oppositeIndex(int index)
@@ -261,6 +268,8 @@ public:
     Type type() const;
     void setType(Type type);
 
+    WangId typeMask() const;
+
     int imageTileId() const;
     void setImageTileId(int imageTileId);
     Tile *imageTile() const;
@@ -323,6 +332,7 @@ private:
     Tileset *mTileset;
     QString mName;
     Type mType;
+    WangId mTypeMask;
     int mImageTileId;
 
     // How many unique, full WangIds are active in this set.
@@ -366,13 +376,9 @@ inline WangSet::Type WangSet::type() const
     return mType;
 }
 
-/**
- * Changes the type of this Wang set. Does not modify any WangIds to make sure
- * they adhere to the type!
- */
-inline void WangSet::setType(WangSet::Type type)
+inline WangId WangSet::typeMask() const
 {
-    mType = type;
+    return mTypeMask;
 }
 
 inline int WangSet::imageTileId() const

--- a/src/tiled/changetilewangid.cpp
+++ b/src/tiled/changetilewangid.cpp
@@ -103,7 +103,7 @@ bool ChangeTileWangId::mergeWith(const QUndoCommand *other)
     if (!mMergeable)
         return false;
 
-    const ChangeTileWangId *o = static_cast<const ChangeTileWangId*>(other);
+    auto o = static_cast<const ChangeTileWangId*>(other);
     if (o->mTilesetDocument && !(mTilesetDocument == o->mTilesetDocument &&
                                  mWangSet == o->mWangSet))
         return false;

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -259,7 +259,8 @@ void TileDelegate::drawWangOverlay(QPainter *painter,
     setupTilesetGridTransform(*tile->tileset(), transform, targetRect);
     painter->setTransform(transform, true);
 
-    paintWangOverlay(painter, wangSet->wangIdOfTile(tile),
+    paintWangOverlay(painter,
+                     wangSet->wangIdOfTile(tile) & wangSet->typeMask(),
                      *wangSet,
                      targetRect);
 

--- a/src/tiled/wangdock.cpp
+++ b/src/tiled/wangdock.cpp
@@ -235,7 +235,7 @@ WangDock::WangDock(QWidget *parent)
     mEraseWangIdsButton->setIcon(QIcon(QLatin1String(":images/22/stock-tool-eraser.png")));
     mEraseWangIdsButton->setCheckable(true);
     mEraseWangIdsButton->setAutoExclusive(true);
-    mEraseWangIdsButton->setChecked(mCurrentWangId == 0);
+    mEraseWangIdsButton->setChecked(mCurrentWangId.isEmpty());
 
     connect(mEraseWangIdsButton, &QPushButton::clicked,
             this, &WangDock::activateErase);


### PR DESCRIPTION
Changing the type of a Terrain Set does not clear no longer relevant bits from each tile, in order to allow changing the type back and forth without destroying this information.

However, this caused the terrain overlays to be confusing and terrain tools to behave erratically. Now, the irrelevant bits of each tile's terrain info is masked out where appropriate.

Closes #3204
Closes #3260