### PR TITLE
tmxrasterizer: Fixed --hide/show-layer to work on group layers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * GameMaker 2 plugin: Fixed positioning of objects on isometric maps
 * tmxrasterizer: Added --hide-object and --show-object arguments (by Lars Luz, #3819)
 * tmxrasterizer: Added --frames and --frame-duration arguments to export animated maps as multiple images (#3868)
+* tmxrasterizer: Fixed --hide/show-layer to work on group layers (#3899)
 * tmxviewer: Added support for viewing JSON maps (#3866)
 * AutoMapping: Ignore empty outputs per-rule (#3523)
 * Windows: Fixed the support for WebP images (updated to Qt 6.6.1, #3661)


### PR DESCRIPTION
When using --hide-layer or --show-layer with the name of a group layer, it now hides or shows all children of that group layer respectively.

Hiding a layer overrides showing a layer, which means you can hide some children of a group layer that was explicitly shown.

Fixes #3899