### PR TITLE
AppImage: Fixed ability to open paths with spaces from the CLI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * Fixed possible crash after a scripted tool disappears while active
 * Fixed updating of used tilesets after resizing map (#3884)
 * Fixed alignment of shortcuts in action search
+* AppImage: Fixed ability to open paths with spaces from the CLI (#3914)
 * AppImage: Updated to Sentry 0.6.7
 
 ### Tiled 1.10.2 (4 August 2023)

--- a/dist/linux/AppRun
+++ b/dist/linux/AppRun
@@ -27,7 +27,7 @@ my_help() {
     echo "Tiled help:"
 }
 
-if [ -n ${1} ]
+if [ -n "${1}" ]
 then
     case ${1} in
         terraingenerator)


### PR DESCRIPTION
The check whether the file existed was missing quotes.

Closes #3914