### PR TITLE
Made adding "Copy" when duplicating optional

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ### Unreleased
 
 * Added --project command-line parameter for use when exporting (#3797)
+* Made adding "Copy" when duplicating optional and disabled by default (#3917)
+* Layer names are now trimmed when edited in the UI, to avoid accidental whitespace
 * Scripting: Added API for working with worlds (#3539)
 * Scripting: Added Tile.image for accessing a tile's image data
 * Scripting: Added Tileset.imageFileName and ImageLayer.imageFileName

--- a/src/tiled/editor.cpp
+++ b/src/tiled/editor.cpp
@@ -20,11 +20,40 @@
 
 #include "editor.h"
 
+#include <QCoreApplication>
+#include <QRegularExpression>
+
 namespace Tiled {
+
+Preference<bool> Editor::duplicateAddsCopy { "Editor/DuplicateAddsCopy" };
 
 Editor::Editor(QObject *parent)
     : QObject(parent)
 {
+}
+
+QString Editor::nameOfDuplicate(const QString &name)
+{
+    if (name.isEmpty() || !duplicateAddsCopy)
+        return name;
+
+    const QString copyText = tr("Copy");
+
+    // Look for an existing postfix, optionally capturing a number
+    const QRegularExpression regexp = QRegularExpression(QStringLiteral(
+        R"((.*)\s*%1\s*(\d+)?$)").arg(copyText));
+
+    const QRegularExpressionMatch match = regexp.match(name);
+    if (match.hasMatch()) {
+        const QString copyName = match.captured(1).trimmed();
+        const QString capturedNumber = match.captured(2);
+        const int copyNumber = capturedNumber.isNull() ? 2 : capturedNumber.toInt() + 1;
+
+        return QStringLiteral("%1 %2 %3").arg(copyName, copyText,
+                                              QString::number(copyNumber));
+    }
+
+    return QStringLiteral("%1 %2").arg(name, copyText);
 }
 
 } // namespace Tiled

--- a/src/tiled/editor.h
+++ b/src/tiled/editor.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "preferences.h"
+
 #include <QObject>
 
 class QToolBar;
@@ -68,6 +70,10 @@ public:
     virtual void performStandardAction(StandardAction action) = 0;
 
     virtual void resetLayout() = 0;
+
+    static Preference<bool> duplicateAddsCopy;
+
+    static QString nameOfDuplicate(const QString &name);
 
 signals:
     void enabledStandardActionsChanged();

--- a/src/tiled/layermodel.cpp
+++ b/src/tiled/layermodel.cpp
@@ -189,7 +189,7 @@ bool LayerModel::setData(const QModelIndex &index, const QVariant &value,
             return true;
         }
     } else if (role == Qt::EditRole) {
-        const QString newName = value.toString();
+        const QString newName = value.toString().trimmed();
         if (layer->name() != newName) {
             SetLayerName *rename = new SetLayerName(mMapDocument, { layer },
                                                     newName);

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -33,6 +33,7 @@
 #include "changeselectedarea.h"
 #include "containerhelpers.h"
 #include "editablemap.h"
+#include "editor.h"
 #include "flipmapobjects.h"
 #include "geometry.h"
 #include "grouplayer.h"
@@ -634,7 +635,7 @@ void MapDocument::duplicateLayers(const QList<Layer *> &layers)
         }
 
         objectRefs.reassignIds(dup.clone);
-        dup.clone->setName(tr("Copy of %1").arg(dup.clone->name()));
+        dup.clone->setName(Editor::nameOfDuplicate(dup.clone->name()));
 
         duplications.append(dup);
     }
@@ -1595,6 +1596,7 @@ void MapDocument::duplicateObjects(const QList<MapObject *> &objects)
 
     for (MapObject *mapObject : objects) {
         MapObject *clone = mapObject->clone();
+        clone->setName(Editor::nameOfDuplicate(clone->name()));
         objectRefs.reassignId(clone);
         objectsToAdd.append(AddMapObjects::Entry { clone, mapObject->objectGroup() });
         objectsToAdd.last().index = mapObject->objectGroup()->objects().indexOf(mapObject) + 1;

--- a/src/tiled/mapobjectmodel.cpp
+++ b/src/tiled/mapobjectmodel.cpp
@@ -288,7 +288,7 @@ bool MapObjectModel::setData(const QModelIndex &index, const QVariant &value,
             return true;
         }
         case Qt::EditRole: {
-            const QString newName = value.toString();
+            const QString newName = value.toString().trimmed();
             if (layer->name() != newName) {
                 SetLayerName *rename = new SetLayerName(mMapDocument,
                                                         { layer },

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -22,6 +22,7 @@
 #include "ui_preferencesdialog.h"
 
 #include "abstractobjecttool.h"
+#include "editor.h"
 #include "languagemanager.h"
 #include "mapobjectitem.h"
 #include "mapview.h"
@@ -71,8 +72,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
                                                   tr("Prefer Selected Layers"),
                                                   tr("Selected Layers Only") });
 
-    PluginListModel *pluginListModel = new PluginListModel(this);
-    QSortFilterProxyModel *pluginProxyModel = new QSortFilterProxyModel(this);
+    auto *pluginListModel = new PluginListModel(this);
+    auto *pluginProxyModel = new QSortFilterProxyModel(this);
     pluginProxyModel->setSortLocaleAware(true);
     pluginProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
     pluginProxyModel->setSourceModel(pluginListModel);
@@ -111,8 +112,10 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
         Sentry::instance()->setUserConsent(value ? Sentry::ConsentGiven : Sentry::ConsentRevoked);
     });
     mUi->crashReportingLabel->setOpenExternalLinks(true);
+    mUi->crashReportingAndUpdates->setTitle(tr("Updates and Crash Reporting"));
 #else
-    mUi->crashReporting->setVisible(false);
+    mUi->sendCrashReports->setVisible(false);
+    mUi->crashReportingLabel->setVisible(false);
 #endif
 
     connect(mUi->languageCombo, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
@@ -139,6 +142,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             this, [] (bool checked) { MapView::ourAutoScrollingEnabled = checked; });
     connect(mUi->smoothScrolling, &QCheckBox::toggled,
             this, [] (bool checked) { MapView::ourSmoothScrollingEnabled = checked; });
+    connect(mUi->duplicateAddsCopy, &QCheckBox::toggled,
+            this, [] (bool checked) { Editor::duplicateAddsCopy = checked; });
 
     connect(mUi->styleCombo, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, &PreferencesDialog::styleComboChanged);
@@ -230,6 +235,7 @@ void PreferencesDialog::fromPreferences()
     mUi->wheelZoomsByDefault->setChecked(prefs->wheelZoomsByDefault());
     mUi->autoScrolling->setChecked(MapView::ourAutoScrollingEnabled);
     mUi->smoothScrolling->setChecked(MapView::ourSmoothScrollingEnabled);
+    mUi->duplicateAddsCopy->setChecked(Editor::duplicateAddsCopy);
 
     const QFont customFont = prefs->customFont();
     mUi->fontGroupBox->setChecked(prefs->useCustomFont());

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>544</width>
-    <height>595</height>
+    <width>567</width>
+    <height>706</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -108,31 +108,22 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="crashReporting">
+        <widget class="QGroupBox" name="crashReportingAndUpdates">
          <property name="title">
-          <string>Crash Reporting</string>
+          <string>Updates</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <property name="spacing">
-           <number>0</number>
-          </property>
+         <layout class="QVBoxLayout" name="verticalLayout_8">
           <item>
-           <widget class="QCheckBox" name="sendCrashReports">
+           <widget class="QCheckBox" name="displayNewsCheckBox">
             <property name="text">
-             <string>Enable sending anonymous crash reports</string>
+             <string>Display news in status bar</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="crashReportingLabel">
+           <widget class="QCheckBox" name="displayNewVersionCheckBox">
             <property name="text">
-             <string>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;)</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::RichText</enum>
-            </property>
-            <property name="buddy">
-             <cstring>sendCrashReports</cstring>
+             <string>Highlight new version in status bar</string>
             </property>
            </widget>
           </item>
@@ -148,6 +139,30 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QCheckBox" name="sendCrashReports">
+              <property name="text">
+               <string>Enable sending anonymous crash reports</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="crashReportingLabel">
+              <property name="text">
+               <string>(&lt;a href=&quot;https://www.mapeditor.org/crash-reporting&quot;&gt;more information&lt;/a&gt;)</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::RichText</enum>
+              </property>
+              <property name="buddy">
+               <cstring>sendCrashReports</cstring>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -171,29 +186,13 @@
       <attribute name="title">
        <string>Interface</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_7">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <widget class="QGroupBox" name="interfaceGroupBox">
          <property name="title">
           <string>Interface</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="objectLineWidth">
-            <property name="suffix">
-             <string> pixels</string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>2.000000000000000</double>
-            </property>
-           </widget>
-          </item>
           <item row="4" column="3">
            <spacer name="horizontalSpacer_5">
             <property name="orientation">
@@ -207,8 +206,35 @@
             </property>
            </spacer>
           </item>
-          <item row="6" column="1">
-           <widget class="QComboBox" name="objectSelectionBehaviorCombo"/>
+          <item row="0" column="2" colspan="2">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Major grid:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>&amp;Language:</string>
+            </property>
+            <property name="buddy">
+             <cstring>languageCombo</cstring>
+            </property>
+           </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_3">
@@ -224,6 +250,16 @@
            <widget class="QLabel" name="label_8">
             <property name="text">
              <string>Background fade color:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="Tiled::ColorButton" name="gridColor"/>
+          </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="QCheckBox" name="openGL">
+            <property name="text">
+             <string>Hardware &amp;accelerated drawing (OpenGL)</string>
             </property>
            </widget>
           </item>
@@ -258,83 +294,16 @@
             </item>
            </layout>
           </item>
-          <item row="3" column="1">
-           <widget class="QSpinBox" name="gridFine">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>128</number>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="0">
-           <widget class="QCheckBox" name="smoothScrolling">
-            <property name="text">
-             <string>Use s&amp;mooth scrolling</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Major grid:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="Tiled::ColorButton" name="gridColor"/>
-          </item>
-          <item row="10" column="0" colspan="2">
-           <widget class="QCheckBox" name="autoScrolling">
-            <property name="text">
-             <string>Middle mouse button uses auto-&amp;scrolling</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>&amp;Language:</string>
-            </property>
-            <property name="buddy">
-             <cstring>languageCombo</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2" colspan="2">
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="languageCombo"/>
-          </item>
-          <item row="9" column="0" colspan="2">
-           <widget class="QCheckBox" name="wheelZoomsByDefault">
-            <property name="text">
-             <string>Mouse wheel &amp;zooms by default</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="1">
            <widget class="Tiled::ColorButton" name="backgroundFadeColor"/>
           </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_6">
+          <item row="5" column="0">
+           <widget class="QLabel" name="label">
             <property name="text">
-             <string>Object selection behavior:</string>
+             <string>Object line width:</string>
             </property>
             <property name="buddy">
-             <cstring>objectSelectionBehaviorCombo</cstring>
+             <cstring>objectLineWidth</cstring>
             </property>
            </widget>
           </item>
@@ -348,27 +317,32 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0" colspan="2">
-           <widget class="QCheckBox" name="openGL">
-            <property name="text">
-             <string>Hardware &amp;accelerated drawing (OpenGL)</string>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="languageCombo"/>
+          </item>
+          <item row="5" column="1" colspan="2">
+           <widget class="QDoubleSpinBox" name="objectLineWidth">
+            <property name="suffix">
+             <string> pixels</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>2.000000000000000</double>
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Object line width:</string>
+          <item row="3" column="1" colspan="2">
+           <widget class="QSpinBox" name="gridFine">
+            <property name="minimum">
+             <number>1</number>
             </property>
-            <property name="buddy">
-             <cstring>objectLineWidth</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0" colspan="2">
-           <widget class="QCheckBox" name="preciseTileObjectSelection">
-            <property name="text">
-             <string>Pixel-perfect tile object selection</string>
+            <property name="maximum">
+             <number>128</number>
             </property>
            </widget>
           </item>
@@ -378,20 +352,74 @@
        <item>
         <widget class="QGroupBox" name="updatesGroupBox">
          <property name="title">
-          <string>Updates</string>
+          <string>Behavior</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <item>
-           <widget class="QCheckBox" name="displayNewsCheckBox">
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Display news in status bar</string>
+             <string>Object selection behavior:</string>
+            </property>
+            <property name="buddy">
+             <cstring>objectSelectionBehaviorCombo</cstring>
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QCheckBox" name="displayNewVersionCheckBox">
+          <item row="0" column="1">
+           <widget class="QComboBox" name="objectSelectionBehaviorCombo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <spacer name="horizontalSpacer_6">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>190</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="0" colspan="3">
+           <widget class="QCheckBox" name="preciseTileObjectSelection">
             <property name="text">
-             <string>Highlight new version in status bar</string>
+             <string>Pixel-perfect tile object selection</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <widget class="QCheckBox" name="wheelZoomsByDefault">
+            <property name="text">
+             <string>Mouse wheel &amp;zooms by default</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="3">
+           <widget class="QCheckBox" name="autoScrolling">
+            <property name="text">
+             <string>Middle mouse button uses auto-&amp;scrolling</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="QCheckBox" name="smoothScrolling">
+            <property name="text">
+             <string>Use s&amp;mooth scrolling</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0" colspan="3">
+           <widget class="QCheckBox" name="duplicateAddsCopy">
+            <property name="text">
+             <string>Add &quot;Copy&quot; when duplicating</string>
             </property>
            </widget>
           </item>
@@ -643,6 +671,8 @@
   <tabstop>detachTemplateInstances</tabstop>
   <tabstop>resolveObjectTypesAndProperties</tabstop>
   <tabstop>minimizeOutput</tabstop>
+  <tabstop>displayNewsCheckBox</tabstop>
+  <tabstop>displayNewVersionCheckBox</tabstop>
   <tabstop>sendCrashReports</tabstop>
   <tabstop>languageCombo</tabstop>
   <tabstop>gridColor</tabstop>
@@ -651,17 +681,19 @@
   <tabstop>gridMajorX</tabstop>
   <tabstop>gridMajorY</tabstop>
   <tabstop>objectLineWidth</tabstop>
+  <tabstop>openGL</tabstop>
   <tabstop>objectSelectionBehaviorCombo</tabstop>
   <tabstop>preciseTileObjectSelection</tabstop>
-  <tabstop>openGL</tabstop>
   <tabstop>wheelZoomsByDefault</tabstop>
   <tabstop>autoScrolling</tabstop>
   <tabstop>smoothScrolling</tabstop>
-  <tabstop>displayNewsCheckBox</tabstop>
-  <tabstop>displayNewVersionCheckBox</tabstop>
+  <tabstop>duplicateAddsCopy</tabstop>
   <tabstop>styleCombo</tabstop>
   <tabstop>baseColor</tabstop>
   <tabstop>selectionColor</tabstop>
+  <tabstop>fontGroupBox</tabstop>
+  <tabstop>fontComboBox</tabstop>
+  <tabstop>fontSize</tabstop>
   <tabstop>pluginList</tabstop>
   <tabstop>extensionsPathEdit</tabstop>
   <tabstop>openExtensionsPathButton</tabstop>

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -984,7 +984,7 @@ void TilesetEditor::duplicateWangSet()
         return;
 
     WangSet *duplicate = wangSet->clone(tileset);
-    duplicate->setName(QCoreApplication::translate("Tiled::MapDocument", "Copy of %1").arg(duplicate->name()));
+    duplicate->setName(nameOfDuplicate(wangSet->name()));
 
     mCurrentTilesetDocument->undoStack()->push(new AddWangSet(mCurrentTilesetDocument,
                                                               duplicate));


### PR DESCRIPTION
The option is disabled by default. When enabled, the behavior is a little bit nicer when creating many duplicates, since they now get numbered rather than adding "Copy Copy Copy..."