### PR TITLE
Display read-only state of open files using a lock icon

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added --project command-line parameter for use when exporting (#3797)
 * Added group layer names in "Move Object to Layer" menu (#3454)
+* Added lock icon to open tabs for which the file is read-only
 * Made adding "Copy" when duplicating optional and disabled by default (#3917)
 * Layer names are now trimmed when edited in the UI, to avoid accidental whitespace
 * Scripting: Added API for working with worlds (#3539)

--- a/src/tiled/document.cpp
+++ b/src/tiled/document.cpp
@@ -41,9 +41,13 @@ Document::Document(DocumentType type, const QString &fileName,
     : QObject(parent)
     , mType(type)
     , mFileName(fileName)
-    , mCanonicalFilePath(QFileInfo(mFileName).canonicalFilePath())
     , mUndoStack(new QUndoStack(this))
 {
+    const QFileInfo fileInfo { fileName };
+    mLastSaved = fileInfo.lastModified();
+    mCanonicalFilePath = fileInfo.canonicalFilePath();
+    mReadOnly = !fileInfo.isWritable();
+
     if (!mCanonicalFilePath.isEmpty())
         sDocumentInstances.insert(mCanonicalFilePath, this);
 
@@ -308,6 +312,15 @@ void Document::setIgnoreBrokenLinks(bool ignoreBrokenLinks)
 void Document::setChangedOnDisk(bool changedOnDisk)
 {
     mChangedOnDisk = changedOnDisk;
+}
+
+void Document::setReadOnly(bool readOnly)
+{
+    if (mReadOnly == readOnly)
+        return;
+
+    mReadOnly = readOnly;
+    emit isReadOnlyChanged(readOnly);
 }
 
 } // namespace Tiled

--- a/src/tiled/document.h
+++ b/src/tiled/document.h
@@ -115,6 +115,9 @@ public:
     bool changedOnDisk() const;
     void setChangedOnDisk(bool changedOnDisk);
 
+    bool isReadOnly() const;
+    void setReadOnly(bool readOnly);
+
     virtual QString lastExportFileName() const = 0;
     virtual void setLastExportFileName(const QString &fileName) = 0;
 
@@ -132,6 +135,7 @@ signals:
     void fileNameChanged(const QString &fileName,
                          const QString &oldFileName);
     void modifiedChanged();
+    void isReadOnlyChanged(bool readOnly);
 
     void currentObjectSet(Object *object);
     void currentObjectChanged(Object *object);
@@ -176,6 +180,7 @@ private:
 
     QUndoStack * const mUndoStack;
 
+    bool mReadOnly = false;
     bool mModified = false;
     bool mChangedOnDisk = false;
     bool mIgnoreBrokenLinks = false;
@@ -231,6 +236,11 @@ inline bool Document::ignoreBrokenLinks() const
 inline bool Document::changedOnDisk() const
 {
     return mChangedOnDisk;
+}
+
+inline bool Document::isReadOnly() const
+{
+    return mReadOnly;
 }
 
 inline const QHash<QString, Document *> &Document::documentInstances()

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -25,6 +25,7 @@
 #include "tilesetdocument.h"
 
 #include <QHash>
+#include <QIcon>
 #include <QList>
 #include <QObject>
 #include <QPointF>
@@ -221,6 +222,8 @@ private:
 
     MapDocument *openMapFile(const QString &path);
     TilesetDocument *openTilesetFile(const QString &path);
+
+    QIcon mLockedIcon;
 
     QVector<DocumentPtr> mDocuments;
     QMap<QString, WorldDocument*> mWorldDocuments;


### PR DESCRIPTION
This should be mostly helpful for people using a VCS like Perforce or Subversion, which may require a file to be checked out or locked before it can be edited.

For now the read-only icon is a lock, which is common, but it may be confusing for Subversion users since they actually need to lock the file to make it writable.