### PR TITLE
docs: Small fix to snippet converting from Qt.Url to string

### DIFF
--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -455,7 +455,7 @@ declare namespace Qt {
      * case you need a local file path, you can use the following code:
      *
      * ```js
-     * var path = url.toString().replace(/^file:\/{2}/, '');
+     * var path = url.toString().replace(/^file:\/{3}/, (tiled.platform == 'windows') ? '' : '/');;
      * ```
      *
      * Or have a look at whether an alternative property is available that


### PR DESCRIPTION
On Windows we need to remove three slashes.