### PR TITLE
snap: Fixed determining of the version

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -154,11 +154,12 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set Tiled version
       id: version
       run: |
-        sed -i 's/^version: .*/version: '"${TILED_VERSION}"'/g' snap/snapcraft.yaml
         if [[ "$TILED_RELEASE" == 'true' ]]; then echo "snap_channel=candidate" >> $GITHUB_OUTPUT ; fi
         if [[ "$TILED_RELEASE" != 'true' ]]; then echo "snap_channel=beta" >> $GITHUB_OUTPUT ; fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: tiled
 adopt-info: tiled
-version: git
 license: GPL-2.0
 base: core22
 
@@ -44,10 +43,13 @@ apps:
 parts:
   tiled:
     plugin: make
+    override-pull: |
+      craftctl default
+      craftctl set version="$(git describe | sed 's/v//')"
     override-build: |
-        qbs setup-toolchains --detect
-        qbs build --jobs "${CRAFT_PARALLEL_BUILD_COUNT}" --command-echo-mode command-line config:release qbs.installPrefix:"/usr" projects.Tiled.version:$(craftctl get version) projects.Tiled.useRPaths:false
-        qbs install --install-root "${CRAFT_PART_INSTALL}" config:release
+      qbs setup-toolchains --detect
+      qbs build --jobs "${CRAFT_PARALLEL_BUILD_COUNT}" --command-echo-mode command-line config:release qbs.installPrefix:"/usr" projects.Tiled.version:$(craftctl get version) projects.Tiled.useRPaths:false
+      qbs install --install-root "${CRAFT_PART_INSTALL}" config:release
     parse-info:
       - usr/share/metainfo/org.mapeditor.Tiled.appdata.xml
     source: .


### PR DESCRIPTION
When using the 'version: git' approach, only the final snap knows the version, but it isn't known yet at compile time so Tiled always shows its version as "git".