### PR TITLE
AppImage: Fixed ability to launch without parameters

### DIFF
--- a/dist/linux/AppRun
+++ b/dist/linux/AppRun
@@ -27,32 +27,28 @@ my_help() {
     echo "Tiled help:"
 }
 
-if [ -n "${1}" ]
-then
-    case ${1} in
-        terraingenerator)
-            shift
-            exec "$this_dir"/${bin_dir}/terraingenerator "$@"
-            ;;
-        tiled)
-            shift
-            exec "$this_dir"/${bin_dir}/tiled "$@"
-            ;;
-        tmxrasterizer)
-            shift
-            exec "$this_dir"/${bin_dir}/tmxrasterizer "$@"
-            ;;
-        tmxviewer)
-            shift
-            exec "$this_dir"/${bin_dir}/tmxviewer "$@"
-            ;;
-        "--help")
-            my_help
-            exec "$this_dir"/${bin_dir}/tiled "--help"
-            ;;
-        *)
-            exec "$this_dir"/${bin_dir}/tiled "$@"
-            ;;
-    esac
-
-fi
+case ${1} in
+    terraingenerator)
+        shift
+        exec "$this_dir"/${bin_dir}/terraingenerator "$@"
+        ;;
+    tiled)
+        shift
+        exec "$this_dir"/${bin_dir}/tiled "$@"
+        ;;
+    tmxrasterizer)
+        shift
+        exec "$this_dir"/${bin_dir}/tmxrasterizer "$@"
+        ;;
+    tmxviewer)
+        shift
+        exec "$this_dir"/${bin_dir}/tmxviewer "$@"
+        ;;
+    "--help")
+        my_help
+        exec "$this_dir"/${bin_dir}/tiled "--help"
+        ;;
+    *)
+        exec "$this_dir"/${bin_dir}/tiled "$@"
+        ;;
+esac


### PR DESCRIPTION
After fixing the "is string non-empty" check in de5373af22885e2e75692c0, the script no longer did anything when no parameter was given...

As far as I could see, this check should just be removed.

See #3914