### PR TITLE
Scripting: Fixed crash after using tiled.project

### DIFF
--- a/src/tiled/projectdocument.cpp
+++ b/src/tiled/projectdocument.cpp
@@ -37,6 +37,13 @@ ProjectDocument::ProjectDocument(std::unique_ptr<Project> project, QObject *pare
             this, [this] { mProject->save(); });
 }
 
+ProjectDocument::~ProjectDocument()
+{
+    // The Editable needs to be deleted before the Project, otherwise ~Object()
+    // will delete it, whereas the editable is actually owned by the Document.
+    mEditable.reset();
+}
+
 QString ProjectDocument::displayName() const
 {
     return mProject->fileName();

--- a/src/tiled/projectdocument.h
+++ b/src/tiled/projectdocument.h
@@ -32,6 +32,7 @@ class ProjectDocument : public Document
 
 public:
     ProjectDocument(std::unique_ptr<Project> project, QObject *parent = nullptr);
+    ~ProjectDocument() override;
 
     QString displayName() const override;
     FileFormat *writerFormat() const override;


### PR DESCRIPTION
Crash caused by a double-deletion of the `EditableProject`, since both the `Project` as well as the `ProjectDocument` classes were deleting it from their destructors (in the `Object` and `Document` superclasses, respectively).

This issue was introduced in 4244060c3fcb29ed514de5f419eb165a6cdbfb4f.