### PR TITLE
Fixed map reload in case map is open as part of a world

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * Automapping: Added per-input-layer properties for ignoring flip flags (#3803)
 * AutoMapping: Always apply output sets with empty index
 * Windows: Fixed the support for WebP images (updated to Qt 6.6.1, #3661)
+* Fixed issues related to map and tileset reloading
 * Fixed possible crash after assigning to tiled.activeAsset
 * Fixed the option to resolve properties on export to also resolve class members (#3411, #3315)
 * Fixed terrain tool behavior and terrain overlays after changing terrain set type (#3204, #3260)

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -4608,6 +4608,13 @@ declare namespace tiled {
   export const assetOpened: Signal<Asset>;
 
   /**
+   * An asset has been reloaded.
+   *
+   * @since 1.11
+   */
+  export const assetReloaded: Signal<Asset>;
+
+  /**
    * An asset is about to be saved. Can be used to make last-minute
    * changes.
    */

--- a/src/libtiled/imagecache.cpp
+++ b/src/libtiled/imagecache.cpp
@@ -29,7 +29,6 @@
 #include "imagecache.h"
 
 #include "logginginterface.h"
-#include "map.h"
 #include "mapformat.h"
 #include "minimaprenderer.h"
 

--- a/src/libtiled/layer.cpp
+++ b/src/libtiled/layer.cpp
@@ -366,7 +366,7 @@ bool LayerIterator::operator==(const LayerIterator &other) const
  * Returns the global layer index for the given \a layer. Obtained by iterating
  * the layer's map while incrementing the index until layer is found.
  */
-int globalIndex(Layer *layer)
+int globalIndex(const Layer *layer)
 {
     if (!layer)
         return -1;

--- a/src/libtiled/layer.h
+++ b/src/libtiled/layer.h
@@ -436,7 +436,7 @@ inline Layer *LayerIterator::operator->() const
 }
 
 
-TILEDSHARED_EXPORT int globalIndex(Layer *layer);
+TILEDSHARED_EXPORT int globalIndex(const Layer *layer);
 TILEDSHARED_EXPORT Layer *layerAtGlobalIndex(const Map *map, int index);
 
 } // namespace Tiled

--- a/src/libtiled/wangset.cpp
+++ b/src/libtiled/wangset.cpp
@@ -418,6 +418,12 @@ WangSet::WangSet(Tileset *tileset,
     setType(type);
 }
 
+WangSet::~WangSet()
+{
+    for (auto &color : std::as_const(mColors))
+        color->mWangSet = nullptr;
+}
+
 /**
  * Changes the type of this Wang set.
  *

--- a/src/libtiled/wangset.h
+++ b/src/libtiled/wangset.h
@@ -258,6 +258,7 @@ public:
             const QString &name,
             Type type,
             int imageTileId = -1);
+    ~WangSet();
 
     Tileset *tileset() const;
     void setTileset(Tileset *tileset);

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -214,7 +214,7 @@ void AbstractWorldTool::showContextMenu(QGraphicsSceneMouseEvent *event)
                        this, [=] { addAnotherMapToWorld(insertPos); });
 
         if (targetDocument != nullptr && targetDocument != currentDocument) {
-            const QString targetFilename = targetDocument->fileName();
+            const QString &targetFilename = targetDocument->fileName();
             menu.addAction(QIcon(QLatin1String(":images/24/world-map-remove-this.png")),
                            tr("Remove \"%1\" from World \"%2\"")
                            .arg(targetDocument->displayName(),

--- a/src/tiled/brokenlinks.h
+++ b/src/tiled/brokenlinks.h
@@ -90,6 +90,8 @@ signals:
     void hasBrokenLinksChanged(bool hasBrokenLinks);
 
 private:
+    void documentChanged(const ChangeEvent &event);
+
     void tileImageSourceChanged(Tile *tile);
     void tilesetChanged(Tileset *tileset);
 

--- a/src/tiled/changeevents.h
+++ b/src/tiled/changeevents.h
@@ -37,6 +37,8 @@ class ChangeEvent
 {
 public:
     enum Type {
+        DocumentAboutToReload,
+        DocumentReloaded,
         ObjectsChanged,
         MapChanged,
         LayerChanged,
@@ -68,6 +70,22 @@ protected:
 
     // not virtual, but protected to avoid calling at this level
     ~ChangeEvent()
+    {}
+};
+
+class AboutToReloadEvent : public ChangeEvent
+{
+public:
+    AboutToReloadEvent()
+        : ChangeEvent(DocumentAboutToReload)
+    {}
+};
+
+class ReloadEvent : public ChangeEvent
+{
+public:
+    ReloadEvent()
+        : ChangeEvent(DocumentReloaded)
     {}
 };
 

--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -73,7 +73,7 @@ static QString replaceVariables(const QString &string, bool quoteValues = true)
 
     // Perform variable replacement
     if (Document *document = DocumentManager::instance()->currentDocument()) {
-        const QString fileName = document->fileName();
+        const QString &fileName = document->fileName();
         QFileInfo fileInfo(fileName);
         const QString mapPath = fileInfo.absolutePath();
         const QString projectPath = QFileInfo(ProjectManager::instance()->project().fileName()).absolutePath();

--- a/src/tiled/document.cpp
+++ b/src/tiled/document.cpp
@@ -168,6 +168,10 @@ void Document::setCurrentObject(Object *object, Document *owningDocument)
 void Document::currentObjectDocumentChanged(const ChangeEvent &change)
 {
     switch (change.type) {
+    case ChangeEvent::DocumentAboutToReload:
+        setCurrentObject(nullptr);
+        break;
+
     case ChangeEvent::TilesAboutToBeRemoved: {
         auto tilesEvent = static_cast<const TilesEvent&>(change);
 

--- a/src/tiled/document.h
+++ b/src/tiled/document.h
@@ -67,8 +67,8 @@ public:
 
     DocumentType type() const { return mType; }
 
-    QString fileName() const;
-    QString canonicalFilePath() const;
+    const QString &fileName() const;
+    const QString &canonicalFilePath() const;
 
     /**
      * Returns the name with which to display this document. It is the file name
@@ -128,8 +128,6 @@ public:
 
     virtual void checkIssues() {}
 
-    static const QHash<QString, Document *> &documentInstances();
-
 signals:
     void changed(const ChangeEvent &change);
     void saved();
@@ -186,17 +184,15 @@ private:
     bool mModified = false;
     bool mChangedOnDisk = false;
     bool mIgnoreBrokenLinks = false;
-
-    static QHash<QString, Document*> sDocumentInstances;
 };
 
 
-inline QString Document::fileName() const
+inline const QString &Document::fileName() const
 {
     return mFileName;
 }
 
-inline QString Document::canonicalFilePath() const
+inline const QString &Document::canonicalFilePath() const
 {
     return mCanonicalFilePath;
 }
@@ -243,11 +239,6 @@ inline bool Document::changedOnDisk() const
 inline bool Document::isReadOnly() const
 {
     return mReadOnly;
-}
-
-inline const QHash<QString, Document *> &Document::documentInstances()
-{
-    return sDocumentInstances;
 }
 
 using DocumentPtr = QSharedPointer<Document>;

--- a/src/tiled/document.h
+++ b/src/tiled/document.h
@@ -88,6 +88,8 @@ public:
      */
     virtual bool save(const QString &fileName, QString *error = nullptr) = 0;
 
+    virtual bool canReload() const { return false; }
+
     virtual FileFormat *writerFormat() const = 0;
 
     QDateTime lastSaved() const { return mLastSaved; }

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -173,7 +173,7 @@ DocumentManager::DocumentManager(QObject *parent)
     JumpToObject::activated = [this] (const JumpToObject &jump) {
         if (auto mapDocument = openMapFile(jump.mapFile)) {
             if (auto object = mapDocument->map()->findObjectById(jump.objectId)) {
-                mapDocument->focusMapObjectRequested(object);
+                emit mapDocument->focusMapObjectRequested(object);
                 mapDocument->setSelectedObjects({ object });
             }
         }
@@ -209,7 +209,7 @@ DocumentManager::DocumentManager(QObject *parent)
                 break;
             case Object::MapObjectType:
                 if (auto object = mapDocument->map()->findObjectById(select.id)) {
-                    mapDocument->focusMapObjectRequested(object);
+                    emit mapDocument->focusMapObjectRequested(object);
                     mapDocument->setSelectedObjects({ object });
                     obj = object;
                 }
@@ -356,7 +356,7 @@ void DocumentManager::restoreState()
 }
 
 /**
- * Returns the current map document, or 0 when there is none.
+ * Returns the current document, or nullptr when there is none.
  */
 Document *DocumentManager::currentDocument() const
 {
@@ -385,7 +385,7 @@ MapView *DocumentManager::viewForDocument(MapDocument *mapDocument) const
 }
 
 /**
- * Searches for a document with the given \a fileName and returns its
+ * Searches for an open document with the given \a fileName and returns its
  * index. Returns -1 when the document isn't open.
  */
 int DocumentManager::findDocument(const QString &fileName) const
@@ -570,9 +570,6 @@ int DocumentManager::insertDocument(int index, const DocumentPtr &document)
         }
     }
 
-    if (!document->fileName().isEmpty())
-        mFileSystemWatcher->addPath(document->fileName());
-
     if (Editor *editor = mEditorForType.value(document->type()))
         editor->addDocument(documentPtr);
 
@@ -639,7 +636,7 @@ DocumentPtr DocumentManager::loadDocument(const QString &fileName,
 {
     // Try to find it in already loaded documents
     QString canonicalFilePath = QFileInfo(fileName).canonicalFilePath();
-    if (Document *doc = Document::documentInstances().value(canonicalFilePath))
+    if (Document *doc = mDocumentByFileName.value(canonicalFilePath))
         return doc->sharedFromThis();
 
     if (!fileFormat) {
@@ -831,7 +828,7 @@ void DocumentManager::closeOtherDocuments(int index)
 
     for (int i = mTabBar->count() - 1; i >= 0; --i) {
         if (i != index)
-            documentCloseRequested(i);
+            emit documentCloseRequested(i);
 
         if (!mMultiDocumentClose)
             return;
@@ -849,7 +846,7 @@ void DocumentManager::closeDocumentsToRight(int index)
     mMultiDocumentClose = true;
 
     for (int i = mTabBar->count() - 1; i > index; --i) {
-        documentCloseRequested(i);
+        emit documentCloseRequested(i);
 
         if (!mMultiDocumentClose)
             return;
@@ -871,13 +868,10 @@ void DocumentManager::closeDocumentAt(int index)
     mDocuments.removeAt(index);
     mTabBar->removeTab(index);
 
+    document->disconnect(this);
+
     if (Editor *editor = mEditorForType.value(document->type()))
         editor->removeDocument(document.data());
-
-    if (!document->fileName().isEmpty()) {
-        mFileSystemWatcher->removePath(document->fileName());
-        document->setChangedOnDisk(false);
-    }
 
     if (auto mapDocument = qobject_cast<MapDocument*>(document.data())) {
         for (const SharedTileset &tileset : mapDocument->map()->tilesets())
@@ -886,8 +880,6 @@ void DocumentManager::closeDocumentAt(int index)
         if (tilesetDocument->mapDocuments().isEmpty()) {
             mTilesetDocumentsModel->remove(tilesetDocument);
             emit tilesetDocumentRemoved(tilesetDocument);
-        } else {
-            tilesetDocument->disconnect(this);
         }
     }
 
@@ -914,32 +906,47 @@ bool DocumentManager::reloadCurrentDocument()
  * Reloads the document at the given \a index. Will not ask the user whether to
  * save any changes!
  *
- * Returns whether the document loaded successfully.
+ * Returns whether the document reloaded successfully.
  */
 bool DocumentManager::reloadDocumentAt(int index)
 {
     const auto document = mDocuments.at(index);
+    return reloadDocument(document.data());
+}
+
+/**
+ * Reloads the given \a document.
+ *
+ * The document may not actually be open in any editor. It might be a map that
+ * is loaded as part of a world, or a tileset that is loaded as part of a map.
+ *
+ * Returns whether the document reloaded successfully.
+ */
+bool DocumentManager::reloadDocument(Document *document)
+{
     QString error;
 
-    if (auto mapDocument = document.objectCast<MapDocument>()) {
+    if (auto mapDocument = qobject_cast<MapDocument*>(document)) {
         if (!mapDocument->reload(&error)) {
             emit reloadError(tr("%1:\n\n%2").arg(document->fileName(), error));
             return false;
         }
 
-        const bool isCurrent = index == mTabBar->currentIndex();
+        const bool isCurrent = document == currentDocument();
         if (isCurrent) {
             if (mBrokenLinksModel->hasBrokenLinks())
                 mBrokenLinksWidget->show();
         }
 
-        checkTilesetColumns(mapDocument.data());
+        // Only check tileset columns for open maps since for other maps we
+        // may not have TilesetDocument instances created for their tilesets.
+        if (findDocument(document) != -1)
+            checkTilesetColumns(mapDocument);
 
     } else if (auto tilesetDocument = qobject_cast<TilesetDocument*>(document)) {
         if (tilesetDocument->isEmbedded()) {
             // For embedded tilesets, we need to reload the map
-            index = findDocument(tilesetDocument->mapDocuments().first());
-            if (!reloadDocumentAt(index))
+            if (!reloadDocument(tilesetDocument->mapDocuments().first()))
                 return false;
         } else if (!tilesetDocument->reload(&error)) {
             emit reloadError(tr("%1:\n\n%2").arg(document->fileName(), error));
@@ -947,12 +954,15 @@ bool DocumentManager::reloadDocumentAt(int index)
         }
 
         tilesetDocument->setChangedOnDisk(false);
+    } else {
+        // We don't support reloading other document types at the moment
+        return false;
     }
 
     if (!isDocumentChangedOnDisk(currentDocument()))
         mFileChangedWarning->setVisible(false);
 
-    emit documentReloaded(document.data());
+    emit documentReloaded(document);
 
     return true;
 }
@@ -987,16 +997,12 @@ void DocumentManager::currentIndexChanged()
     emit currentDocumentChanged(document);
 }
 
-void DocumentManager::fileNameChanged(const QString &fileName,
-                                      const QString &oldFileName)
+void DocumentManager::fileNameChanged(const QString &/* fileName */,
+                                      const QString &/* oldFileName */)
 {
-    if (!fileName.isEmpty())
-        mFileSystemWatcher->addPath(fileName);
-    if (!oldFileName.isEmpty())
-        mFileSystemWatcher->removePath(oldFileName);
+    Document *document = static_cast<Document*>(sender());
 
     // Update the tabs for all opened embedded tilesets
-    Document *document = static_cast<Document*>(sender());
     if (MapDocument *mapDocument = qobject_cast<MapDocument*>(document)) {
         for (const SharedTileset &tileset : mapDocument->map()->tilesets()) {
             if (auto tilesetDocument = findTilesetDocument(tileset))
@@ -1128,13 +1134,12 @@ void DocumentManager::filesChanged(const QStringList &fileNames)
 
 void DocumentManager::fileChanged(const QString &fileName)
 {
-    const int index = findDocument(fileName);
-
-    // Most likely the file was removed
-    if (index == -1)
+    const auto document = mDocumentByFileName.value(fileName);
+    if (!document) {
+        qWarning() << "Document not found for changed file:" << fileName;
         return;
+    }
 
-    const auto &document = mDocuments.at(index);
     const QFileInfo fileInfo { fileName };
 
     // Always update potentially changed read-only state
@@ -1145,8 +1150,8 @@ void DocumentManager::fileChanged(const QString &fileName)
         return;
 
     // Automatically reload when there are no unsaved changes
-    if (!isDocumentModified(document.data())) {
-        reloadDocumentAt(index);
+    if (!isDocumentModified(document)) {
+        reloadDocument(document);
         return;
     }
 
@@ -1268,6 +1273,38 @@ TilesetDocument *DocumentManager::openTilesetFile(const QString &path)
     openFile(path);
     const int i = findDocument(path);
     return i == -1 ? nullptr : qobject_cast<TilesetDocument*>(mDocuments.at(i).data());
+}
+
+void DocumentManager::registerDocument(Document *document)
+{
+    const QString &canonicalPath = document->canonicalFilePath();
+    if (canonicalPath.isEmpty())
+        return;
+
+    // Always add path because FileSystemWatcher handles duplicates
+    mFileSystemWatcher->addPath(canonicalPath);
+
+    const auto i = mDocumentByFileName.constFind(canonicalPath);
+    if (i != mDocumentByFileName.constEnd()) {
+        qWarning() << "Document already registered:" << canonicalPath;
+        return;
+    }
+
+    mDocumentByFileName.insert(canonicalPath, document);
+}
+
+void DocumentManager::unregisterDocument(Document *document)
+{
+    const QString &canonicalPath = document->canonicalFilePath();
+    if (canonicalPath.isEmpty())
+        return;
+
+    // Always remove path because FileSystemWatcher handles duplicates
+    mFileSystemWatcher->removePath(canonicalPath);
+
+    const auto i = mDocumentByFileName.constFind(canonicalPath);
+    if (i != mDocumentByFileName.constEnd() && *i == document)
+        mDocumentByFileName.erase(i);
 }
 
 WorldDocument *DocumentManager::ensureWorldDocument(const QString &fileName)

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -147,6 +147,7 @@ public:
 signals:
     void documentCreated(Document *document);
     void documentOpened(Document *document);
+    void documentReloaded(Document *document);
     void documentAboutToBeSaved(Document *document);
     void documentSaved(Document *document);
 
@@ -198,6 +199,7 @@ private:
     void fileNameChanged(const QString &fileName,
                          const QString &oldFileName);
     void updateDocumentTab(Document *document);
+    void onDocumentChanged(const ChangeEvent &event);
     void onDocumentSaved();
     void documentTabMoved(int from, int to);
     void tabContextMenuRequested(const QPoint &pos);

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -68,6 +68,7 @@ class DocumentManager : public QObject
     ~DocumentManager() override;
 
     friend class MainWindow;
+    friend class Document;      // for file watching
 
 public:
     static DocumentManager *instance();
@@ -123,6 +124,7 @@ public:
 
     bool reloadCurrentDocument();
     bool reloadDocumentAt(int index);
+    bool reloadDocument(Document *document);
 
     void checkTilesetColumns(MapDocument *mapDocument);
     bool checkTilesetColumns(TilesetDocument *tilesetDocument);
@@ -225,6 +227,9 @@ private:
     MapDocument *openMapFile(const QString &path);
     TilesetDocument *openTilesetFile(const QString &path);
 
+    void registerDocument(Document *document);
+    void unregisterDocument(Document *document);
+
     QIcon mLockedIcon;
 
     QVector<DocumentPtr> mDocuments;
@@ -245,6 +250,7 @@ private:
 
     QUndoGroup *mUndoGroup;
     FileSystemWatcher *mFileSystemWatcher;
+    QHash<QString, Document*> mDocumentByFileName;
 
     static DocumentManager *mInstance;
 

--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -698,6 +698,16 @@ void EditableMap::setDocument(Document *document)
 void EditableMap::documentChanged(const ChangeEvent &change)
 {
     switch (change.type) {
+    case ChangeEvent::DocumentAboutToReload:
+        for (Layer *layer : map()->layers())
+            detachLayer(layer);
+
+        mRenderer.reset();
+        setObject(nullptr);
+        break;
+    case ChangeEvent::DocumentReloaded:
+        setObject(mapDocument()->map());
+        break;
     case ChangeEvent::MapChanged:
         if (static_cast<const MapChangeEvent&>(change).property == Map::OrientationProperty)
             mRenderer.reset();

--- a/src/tiled/editabletileset.cpp
+++ b/src/tiled/editabletileset.cpp
@@ -22,6 +22,7 @@
 
 #include "addremovetiles.h"
 #include "addremovewangset.h"
+#include "changeevents.h"
 #include "editabletile.h"
 #include "editablewangset.h"
 #include "scriptimage.h"
@@ -402,6 +403,7 @@ void EditableTileset::setDocument(Document *document)
 
     if (auto doc = tilesetDocument()) {
         connect(doc, &Document::fileNameChanged, this, &EditableAsset::fileNameChanged);
+        connect(doc, &Document::changed, this, &EditableTileset::documentChanged);
         connect(doc, &TilesetDocument::tilesAdded, this, &EditableTileset::attachTiles);
         connect(doc, &TilesetDocument::tilesRemoved, this, &EditableTileset::detachTiles);
         connect(doc, &TilesetDocument::tileObjectGroupChanged, this, &EditableTileset::tileObjectGroupChanged);
@@ -427,6 +429,23 @@ bool EditableTileset::tilesFromEditables(const QList<QObject *> &editableTiles, 
     }
 
     return true;
+}
+
+void EditableTileset::documentChanged(const ChangeEvent &event)
+{
+    switch (event.type) {
+    case ChangeEvent::DocumentAboutToReload:
+        detachTiles(tileset()->tiles());
+        detachWangSets(tileset()->wangSets());
+
+        setObject(nullptr);
+        break;
+    case ChangeEvent::DocumentReloaded:
+        setObject(tilesetDocument()->tileset().data());
+        break;
+    default:
+        break;
+    }
 }
 
 void EditableTileset::attachTiles(const QList<Tile *> &tiles)

--- a/src/tiled/editabletileset.h
+++ b/src/tiled/editabletileset.h
@@ -25,6 +25,7 @@
 
 namespace Tiled {
 
+class ChangeEvent;
 class EditableTile;
 class EditableWangSet;
 class ScriptImage;
@@ -179,6 +180,7 @@ protected:
 private:
     bool tilesFromEditables(const QList<QObject*> &editableTiles, QList<Tile *> &tiles);
 
+    void documentChanged(const ChangeEvent &event);
     void attachTiles(const QList<Tile*> &tiles);
     void detachTiles(const QList<Tile*> &tiles);
     void detachWangSets(const QList<WangSet*> &wangSets);

--- a/src/tiled/layerdock.h
+++ b/src/tiled/layerdock.h
@@ -103,9 +103,12 @@ protected:
 private:
     void onExpanded(const QModelIndex &index);
     void onCollapsed(const QModelIndex &index);
+    void restoreExpandedLayers();
 
     void currentRowChanged(const QModelIndex &proxyIndex);
     void indexPressed(const QModelIndex &proxyIndex);
+
+    void documentChanged(const ChangeEvent &event);
     void currentLayerChanged(Layer *layer);
     void selectedLayersChanged();
     void layerRemoved(Layer *layer);

--- a/src/tiled/layermodel.h
+++ b/src/tiled/layermodel.h
@@ -98,8 +98,9 @@ signals:
 private:
     void documentChanged(const ChangeEvent &change);
 
-    MapDocument *mMapDocument;
-    Map *mMap;
+    Map *map() const;
+
+    MapDocument *mMapDocument = nullptr;
 
     QIcon mTileLayerIcon;
     QIcon mObjectGroupIcon;

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -2323,9 +2323,8 @@ void MainWindow::retranslateUi()
 void MainWindow::exportMapAs(MapDocument *mapDocument)
 {
     SessionOption<QString> lastUsedExportFilter { "map.lastUsedExportFilter" };
-    QString fileName = mapDocument->fileName();
     QString selectedFilter = lastUsedExportFilter;
-    auto exportDetails = chooseExportDetails<MapFormat>(fileName,
+    auto exportDetails = chooseExportDetails<MapFormat>(mapDocument->fileName(),
                                                         mapDocument->lastExportFileName(),
                                                         selectedFilter,
                                                         this);

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -2151,7 +2151,7 @@ void MainWindow::updateActions()
     mUi->actionExportAsImage->setEnabled(mapDocument);
     mUi->actionExport->setEnabled(mapDocument || tilesetDocument);
     mUi->actionExportAs->setEnabled(mapDocument || tilesetDocument);
-    mUi->actionReload->setEnabled(mapDocument || (tilesetDocument && tilesetDocument->canReload()));
+    mUi->actionReload->setEnabled(document && document->canReload());
     mUi->actionClose->setEnabled(document);
     mUi->actionCloseAll->setEnabled(document);
 

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -69,6 +69,25 @@
 
 using namespace Tiled;
 
+class ReloadMap : public QUndoCommand
+{
+public:
+    ReloadMap(MapDocument *mapDocument, std::unique_ptr<Map> map)
+        : mMapDocument(mapDocument)
+        , mMap(std::move(map))
+    {
+        setText(QCoreApplication::translate("Undo Commands", "Reload Map"));
+    }
+
+    void undo() override { mMapDocument->swapMap(mMap); }
+    void redo() override { mMapDocument->swapMap(mMap); }
+
+private:
+    MapDocument *mMapDocument;
+    std::unique_ptr<Map> mMap;
+};
+
+
 MapDocument::MapDocument(std::unique_ptr<Map> map)
     : Document(MapDocumentType, map->fileName)
     , mMap(std::move(map))
@@ -155,6 +174,42 @@ bool MapDocument::save(const QString &fileName, QString *error)
     }
 
     emit saved();
+    return true;
+}
+
+bool MapDocument::canReload() const
+{
+    return !fileName().isEmpty() && !mReaderFormat.isEmpty();
+}
+
+bool MapDocument::reload(QString *error)
+{
+    if (!canReload())
+        return false;
+
+    auto format = findFileFormat<MapFormat>(mReaderFormat, FileFormat::Read);
+    if (!format) {
+        if (error)
+            *error = tr("Map format '%s' not found").arg(mReaderFormat);
+        return false;
+    }
+
+    auto map = format->read(fileName());
+
+    if (!map) {
+        if (error)
+            *error = format->errorString();
+        return false;
+    }
+
+    map->fileName = fileName();
+
+    undoStack()->push(new ReloadMap(this, std::move(map)));
+    undoStack()->setClean();
+
+    mLastSaved = QFileInfo(fileName()).lastModified();
+    setChangedOnDisk(false);
+
     return true;
 }
 
@@ -1530,6 +1585,54 @@ void MapDocument::checkIssues()
                 checkFilePathProperties(mapObject);
         }
     }
+}
+
+void MapDocument::swapMap(std::unique_ptr<Map> &other)
+{
+    // Store previous state
+    const int currentLayerId = currentLayer() ? currentLayer()->id() : -1;
+
+    QVector<int> selectedLayerIds;
+    for (const Layer *layer : selectedLayers())
+        selectedLayerIds.append(layer->id());
+
+    QVector<int> selectedObjectIds;
+    for (const MapObject *object : selectedObjects())
+        selectedObjectIds.append(object->id());
+
+    // Bring pointers to safety
+    setSelectedLayers({});
+    setSelectedObjects({});
+    setAboutToBeSelectedObjects({});
+    setHoveredMapObject(nullptr);
+    setCurrentLayer(nullptr);
+    setCurrentObject(nullptr);
+
+    emit changed(AboutToReloadEvent());
+
+    mMap.swap(other);
+    createRenderer();
+
+    emit changed(ReloadEvent());
+
+    // Restore previous state
+    QList<MapObject*> selectedObjects;
+    for (int id : selectedObjectIds) {
+        if (MapObject *object = mMap->findObjectById(id))
+            selectedObjects.append(object);
+    }
+    setSelectedObjects(selectedObjects);
+
+    if (currentLayerId != -1)
+        if (auto layer = mMap->findLayerById(currentLayerId))
+            switchCurrentLayer(layer);
+
+    QList<Layer*> selectedLayers;
+    for (int id : selectedLayerIds) {
+        if (Layer *layer = mMap->findLayerById(id))
+            selectedLayers.append(layer);
+    }
+    switchSelectedLayers(selectedLayers);
 }
 
 void MapDocument::updateTemplateInstances(const ObjectTemplate *objectTemplate)

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -67,7 +67,7 @@ using MapDocumentPtr = QSharedPointer<MapDocument>;
  * selected layer and provides an API for adding and removing map objects. It
  * also owns the QUndoStack.
  */
-class TILED_EDITOR_EXPORT MapDocument : public Document
+class TILED_EDITOR_EXPORT MapDocument final : public Document
 {
     Q_OBJECT
 
@@ -91,6 +91,9 @@ public:
     MapDocumentPtr sharedFromThis() { return qSharedPointerCast<MapDocument>(Document::sharedFromThis()); }
 
     bool save(const QString &fileName, QString *error = nullptr) override;
+
+    bool canReload() const override;
+    bool reload(QString *error);
 
     /**
      * Loads a map and returns a MapDocument instance on success. Returns null
@@ -259,6 +262,8 @@ public:
     bool templateAllowed(const ObjectTemplate *objectTemplate) const;
 
     void checkIssues() override;
+
+    void swapMap(std::unique_ptr<Map> &other);
 
     QSet<int> expandedGroupLayers;
     QSet<int> expandedObjectLayers;

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -358,6 +358,21 @@ void MapItem::repaintRegion(const QRegion &region, TileLayer *tileLayer)
 void MapItem::documentChanged(const ChangeEvent &change)
 {
     switch (change.type) {
+    case ChangeEvent::DocumentAboutToReload:
+        for (Layer *layer : mMapDocument->map()->layers())
+            deleteLayerItems(layer);
+        break;
+    case ChangeEvent::DocumentReloaded: {
+        // The renderer has been re-created
+        auto lineWidth = Preferences::instance()->objectLineWidth();
+        mapDocument()->renderer()->setObjectLineWidth(lineWidth);
+
+        createLayerItems(mMapDocument->map()->layers());
+
+        updateBoundingRect();
+        updateLayerPositions();
+        break;
+    }
     case ChangeEvent::ObjectsChanged: {
         auto &objectsChange = static_cast<const ObjectsChangeEvent&>(change);
         if (!objectsChange.objects.isEmpty() && (objectsChange.properties & ObjectsChangeEvent::ClassProperty)) {

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -458,7 +458,7 @@ void MapItem::mapChanged()
     updateBoundingRect();
 
     // When this map is part of a world, update that map's rect when necessary
-    const QString mapFileName = mapDocument()->fileName();
+    const QString &mapFileName = mapDocument()->fileName();
     if (const World *world = WorldManager::instance().worldForMap(mapFileName)) {
         if (world->canBeModified()) {
             const QRect currentRectInWorld = world->mapRect(mapFileName);

--- a/src/tiled/mapobjectmodel.h
+++ b/src/tiled/mapobjectmodel.h
@@ -120,8 +120,9 @@ private:
                          const QVarLengthArray<Column, 3> &columns,
                          const QVector<int> &roles = QVector<int>());
 
-    MapDocument *mMapDocument;
-    Map *mMap;
+    Map *map() const;
+
+    MapDocument *mMapDocument = nullptr;
 
     // cache
     mutable QMap<GroupLayer*, QList<Layer*>> mFilteredLayers;

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -131,7 +131,7 @@ private:
     bool toolMouseMoved(const QPointF &pos, Qt::KeyboardModifiers modifiers);
 
     MapDocument *mMapDocument = nullptr;
-    QHash<Map*, MapItem*> mMapItems;
+    QHash<MapDocument*, MapItem*> mMapItems;
     AbstractTool *mSelectedTool = nullptr;
     DebugDrawItem *mDebugDrawItem = nullptr;
     bool mUnderMouse = false;
@@ -162,7 +162,7 @@ inline MapDocument *MapScene::mapDocument() const
  */
 inline MapItem *MapScene::mapItem(MapDocument *mapDocument) const
 {
-    return mapDocument ? mMapItems.value(mapDocument->map()) : nullptr;
+    return mapDocument ? mMapItems.value(mapDocument) : nullptr;
 }
 
 inline DebugDrawItem *MapScene::debugDrawItem() const

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -368,6 +368,27 @@ QVariant ObjectSelectionItem::itemChange(GraphicsItemChange change, const QVaria
 void ObjectSelectionItem::changeEvent(const ChangeEvent &event)
 {
     switch (event.type) {
+    case ChangeEvent::DocumentAboutToReload:
+        qDeleteAll(mObjectLabels);
+        qDeleteAll(mObjectOutlines);
+        qDeleteAll(mObjectHoverItems);
+        for (const auto &referenceItems : std::as_const(mReferencesBySourceObject))
+            qDeleteAll(referenceItems);
+
+        mObjectLabels.clear();
+        mObjectOutlines.clear();
+        mObjectHoverItems.clear();
+        mReferencesBySourceObject.clear();
+        mReferencesByTargetObject.clear();
+        break;
+
+    case ChangeEvent::DocumentReloaded:
+        if (objectLabelVisibility() == Preferences::AllObjectLabels)
+            addRemoveObjectLabels();
+
+        if (Preferences::instance()->showObjectReferences())
+            addRemoveObjectReferences();
+        break;
     case ChangeEvent::ObjectsChanged: {
         auto &objectsChange = static_cast<const ObjectsChangeEvent&>(event);
         if (!objectsChange.objects.isEmpty() && (objectsChange.properties & ObjectsChangeEvent::ClassProperty)) {

--- a/src/tiled/projectdocument.h
+++ b/src/tiled/projectdocument.h
@@ -26,7 +26,7 @@
 
 namespace Tiled {
 
-class ProjectDocument : public Document
+class ProjectDocument final : public Document
 {
     Q_OBJECT
 

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -62,6 +62,7 @@ ScriptModule::ScriptModule(QObject *parent)
     if (auto documentManager = DocumentManager::maybeInstance()) {
         connect(documentManager, &DocumentManager::documentCreated, this, &ScriptModule::documentCreated);
         connect(documentManager, &DocumentManager::documentOpened, this, &ScriptModule::documentOpened);
+        connect(documentManager, &DocumentManager::documentReloaded, this, &ScriptModule::documentReloaded);
         connect(documentManager, &DocumentManager::documentAboutToBeSaved, this, &ScriptModule::documentAboutToBeSaved);
         connect(documentManager, &DocumentManager::documentSaved, this, &ScriptModule::documentSaved);
         connect(documentManager, &DocumentManager::documentAboutToClose, this, &ScriptModule::documentAboutToClose);
@@ -674,6 +675,11 @@ void ScriptModule::documentCreated(Document *document)
 void ScriptModule::documentOpened(Document *document)
 {
     emit assetOpened(document->editable());
+}
+
+void ScriptModule::documentReloaded(Document *document)
+{
+    emit assetReloaded(document->editable());
 }
 
 void ScriptModule::documentAboutToBeSaved(Document *document)

--- a/src/tiled/scriptmodule.h
+++ b/src/tiled/scriptmodule.h
@@ -150,6 +150,7 @@ public:
 signals:
     void assetCreated(Tiled::EditableAsset *asset);
     void assetOpened(Tiled::EditableAsset *asset);
+    void assetReloaded(Tiled::EditableAsset *asset);
     void assetAboutToBeSaved(Tiled::EditableAsset *asset);
     void assetSaved(Tiled::EditableAsset *asset);
     void assetAboutToBeClosed(Tiled::EditableAsset *asset);
@@ -174,6 +175,7 @@ public slots:
 private:
     void documentCreated(Document *document);
     void documentOpened(Document *document);
+    void documentReloaded(Document *document);
     void documentAboutToBeSaved(Document *document);
     void documentSaved(Document *document);
     void documentAboutToClose(Document *document);

--- a/src/tiled/tileselectionitem.cpp
+++ b/src/tiled/tileselectionitem.cpp
@@ -21,8 +21,6 @@
 #include "tileselectionitem.h"
 
 #include "changeevents.h"
-#include "grouplayer.h"
-#include "map.h"
 #include "mapdocument.h"
 #include "maprenderer.h"
 #include "mapscene.h"
@@ -79,6 +77,10 @@ void TileSelectionItem::paint(QPainter *painter,
 void TileSelectionItem::documentChanged(const ChangeEvent &change)
 {
     switch (change.type) {
+    case ChangeEvent::DocumentReloaded:
+        selectionChanged(mMapDocument->selectedArea(),
+                         mMapDocument->selectedArea());
+        break;
     case ChangeEvent::LayerChanged: {
         const auto &layerChange = static_cast<const LayerChangeEvent&>(change);
         if (layerChange.properties & LayerChangeEvent::PositionProperties)

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -937,9 +937,8 @@ void TilesetDock::tabContextMenuRequested(const QPoint &pos)
     QMenu menu;
 
     auto tilesetDocument = mTilesetDocuments.at(index);
-    const QString fileName = tilesetDocument->fileName();
 
-    Utils::addFileManagerActions(menu, fileName);
+    Utils::addFileManagerActions(menu, tilesetDocument->fileName());
 
     menu.addSeparator();
     menu.addAction(mEditTileset->icon(), mEditTileset->text(), this, [tileset = tilesetDocument->tileset()] {

--- a/src/tiled/tilesetdocument.cpp
+++ b/src/tiled/tilesetdocument.cpp
@@ -258,12 +258,15 @@ void TilesetDocument::swapTileset(SharedTileset &tileset)
     // Bring pointers to safety
     setSelectedTiles(QList<Tile*>());
     setCurrentObject(mTileset.data());
-    mEditable.reset();
+    mWangColorModels.clear();
+
+    emit changed(AboutToReloadEvent());
 
     sTilesetToDocument.remove(mTileset);
     mTileset->swap(*tileset);
     sTilesetToDocument.insert(mTileset, this);
 
+    emit changed(ReloadEvent());
     emit tilesetChanged(mTileset.data());
 }
 

--- a/src/tiled/tilesetdocument.h
+++ b/src/tiled/tilesetdocument.h
@@ -46,7 +46,7 @@ using TilesetDocumentPtr = QSharedPointer<TilesetDocument>;
 /**
  * Represents an editable tileset.
  */
-class TilesetDocument : public Document
+class TilesetDocument final : public Document
 {
     Q_OBJECT
 
@@ -58,7 +58,7 @@ public:
 
     bool save(const QString &fileName, QString *error = nullptr) override;
 
-    bool canReload() const;
+    bool canReload() const override;
     bool reload(QString *error);
 
     /**

--- a/src/tiled/tilesetdocumentsmodel.cpp
+++ b/src/tiled/tilesetdocumentsmodel.cpp
@@ -25,8 +25,6 @@
 #include "tilesetdocument.h"
 #include "tileset.h"
 
-#include <algorithm>
-
 namespace Tiled {
 
 TilesetDocumentsModel::TilesetDocumentsModel(QObject *parent)

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -825,6 +825,9 @@ void TilesetView::resizeEvent(QResizeEvent *event)
 void TilesetView::onChange(const ChangeEvent &change)
 {
     switch (change.type) {
+    case ChangeEvent::DocumentReloaded:
+        refreshColumnCount();
+        break;
     case ChangeEvent::WangSetChanged: {
         auto &wangSetChange = static_cast<const WangSetChangeEvent&>(change);
         if (mEditWangSet && wangSetChange.wangSet == mWangSet &&

--- a/src/tiled/tilesetwangsetmodel.cpp
+++ b/src/tiled/tilesetwangsetmodel.cpp
@@ -35,6 +35,8 @@ TilesetWangSetModel::TilesetWangSetModel(TilesetDocument *tilesetDocument,
     QAbstractListModel(parent),
     mTilesetDocument(tilesetDocument)
 {
+    connect(tilesetDocument, &TilesetDocument::changed,
+            this, &TilesetWangSetModel::documentChanged);
 }
 
 TilesetWangSetModel::~TilesetWangSetModel()
@@ -202,6 +204,20 @@ void TilesetWangSetModel::emitWangSetChange(WangSet *wangSet)
     const QModelIndex index = TilesetWangSetModel::index(wangSet);
     emit dataChanged(index, index);
     emit wangSetChanged(wangSet);
+}
+
+void TilesetWangSetModel::documentChanged(const ChangeEvent &event)
+{
+    switch (event.type) {
+    case ChangeEvent::DocumentAboutToReload:
+        beginResetModel();
+        break;
+    case ChangeEvent::DocumentReloaded:
+        endResetModel();
+        break;
+    default:
+        break;
+    }
 }
 
 #include "moc_tilesetwangsetmodel.cpp"

--- a/src/tiled/tilesetwangsetmodel.h
+++ b/src/tiled/tilesetwangsetmodel.h
@@ -30,6 +30,7 @@ namespace Tiled {
 
 class Tileset;
 
+class ChangeEvent;
 class TilesetDocument;
 
 /**
@@ -94,6 +95,8 @@ signals:
     void wangSetChanged(WangSet *wangSet);
 
 private:
+    void documentChanged(const ChangeEvent &event);
+
     void emitWangSetChange(WangSet *wangSet);
 
     TilesetDocument *mTilesetDocument;

--- a/src/tiled/wangsetmodel.cpp
+++ b/src/tiled/wangsetmodel.cpp
@@ -21,7 +21,6 @@
 #include "wangsetmodel.h"
 
 #include "changeevents.h"
-#include "containerhelpers.h"
 #include "map.h"
 #include "mapdocument.h"
 #include "tile.h"
@@ -259,6 +258,15 @@ void WangSetModel::onTilesetDataChanged(const QModelIndex &topLeft, const QModel
 void WangSetModel::onDocumentChanged(const ChangeEvent &change)
 {
     switch (change.type) {
+    // On tileset reload, we need to reset the model since we don't know what
+    // has changed.
+    case ChangeEvent::DocumentAboutToReload:
+        beginResetModel();
+        break;
+    case ChangeEvent::DocumentReloaded:
+        endResetModel();
+        break;
+
     case ChangeEvent::WangSetAboutToBeAdded: {
         auto wangSetEvent = static_cast<const WangSetEvent&>(change);
 

--- a/src/tiled/worlddocument.h
+++ b/src/tiled/worlddocument.h
@@ -31,7 +31,7 @@ namespace Tiled {
 /**
  * Represents an editable world document.
  */
-class WorldDocument : public Document
+class WorldDocument final : public Document
 {
     Q_OBJECT
 


### PR DESCRIPTION
This is a re-implementation of the way maps are reloaded, to make sure the reload affects all instances and not just the opened editor tab. Previously, the reload was implemented by closing and reopening that tab, which was only a viable method before the implementation of worlds.

This is a rather risky change since the code was never prepared for the map and its internal structures to be replaced entirely without any specific change events. There's a high probability of leaving a roaming pointer somewhere.

Marked as draft because there are a few open tasks:

* Needs much more testing.
* Would be nice to restore object and layer selection after the reload when possible.

Fixes part of issue #3927 (though not entirely, since that would require watching map files for changes also when they aren't open in their own tab).