### PR TITLE
Fixed Qt version check for groupbox frame rendering

### DIFF
--- a/src/tiled/tiledproxystyle.cpp
+++ b/src/tiled/tiledproxystyle.cpp
@@ -27,7 +27,7 @@
 #include <QAbstractScrollArea>
 #include <QApplication>
 #include <QComboBox>
-#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 3)
 #include <QGroupBox>
 #endif
 #include <QMainWindow>
@@ -357,7 +357,7 @@ void TiledProxyStyle::drawPrimitive(PrimitiveElement element,
     case PE_FrameGroupBox:
     {
         int topMargin = 3;
-#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 3)
         auto control = qobject_cast<const QGroupBox *>(widget);
         if (control && !control->isCheckable() && control->title().isEmpty()) {
             // Shrinking the topMargin if Not checkable AND title is empty


### PR DESCRIPTION
The change to Qt was cherry-picked to Qt 6.6.3.

This further amends 93f6fef14052e6797440e3f4c4a093f7507b2249.