### PR TITLE
Python plugin: Raised minimum Python version to 3.8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Godot 4 plugin: Use Godot 4.2 tile transformation flags (by Rick Yorgason, #3895)
 * Godot 4 plugin: Fixed positioning of tile collision shapes (by Ryan Petrie, #3862)
 * GameMaker 2 plugin: Fixed positioning of objects on isometric maps
+* Python plugin: Raised minimum Python version to 3.8
 * tmxrasterizer: Added --hide-object and --show-object arguments (by Lars Luz, #3819)
 * tmxrasterizer: Added --frames and --frame-duration arguments to export animated maps as multiple images (#3868)
 * tmxrasterizer: Fixed --hide/show-layer to work on group layers (#3899)

--- a/qbs/imports/PythonProbe.qbs
+++ b/qbs/imports/PythonProbe.qbs
@@ -7,10 +7,9 @@ import qbs.Utilities
 Probe {
     id: pythonDllProbe
 
-    condition: qbs.targetOS.contains("windows")
-
     property string pythonDir: pythonInstallDir // Input
     property string buildVariant: qbs.buildVariant // Input
+    property string minVersion: "3.5" // Input
     property string fileNamePrefix // Output
 
     configure: {
@@ -45,9 +44,9 @@ Probe {
                         + output + "'");
                 return;
             }
-            if (Utilities.versionCompare(versionNumberString, "3.5") < 0) {
+            if (Utilities.versionCompare(versionNumberString, minVersion) < 0) {
                 printWarning("The Python installation at '" + pythonDir
-                             + "' has version " + versionNumberString + ", but 3.5 or higher "
+                             + "' has version " + versionNumberString + ", but " + minVersion + " or higher "
                              + "is required.");
                 return;
             }

--- a/src/plugins/python/python.qbs
+++ b/src/plugins/python/python.qbs
@@ -10,7 +10,7 @@ TiledPlugin {
         if (qbs.targetOS.contains("windows"))
             return pythonDllProbe.found;
 
-        return pkgConfigPython3Embed.found || pkgConfigPython3.found;
+        return pkgConfigPython3.found;
     }
 
     cpp.cxxFlags: {
@@ -22,25 +22,14 @@ TiledPlugin {
 
     Probes.PkgConfigProbe {
         id: pkgConfigPython3
-        name: "python3"
-    }
-
-    Probes.PkgConfigProbe {
-        id: pkgConfigPython3Embed
         name: "python3-embed"
+        minVersion: "3.8"
     }
 
     PythonProbe {
         id: pythonDllProbe
         pythonDir: Environment.getEnv("PYTHONHOME")
-    }
-
-    Properties {
-        condition: pkgConfigPython3Embed.found
-        cpp.cxxFlags: outer.concat(pkgConfigPython3Embed.cflags)
-        cpp.dynamicLibraries: pkgConfigPython3Embed.libraries
-        cpp.libraryPaths: pkgConfigPython3Embed.libraryPaths
-        cpp.linkerFlags: pkgConfigPython3Embed.linkerFlags
+        minVersion: "3.8"
     }
 
     Properties {

--- a/src/plugins/python/pythonplugin.cpp
+++ b/src/plugins/python/pythonplugin.cpp
@@ -76,14 +76,24 @@ PythonPlugin::~PythonPlugin()
 void PythonPlugin::initialize()
 {
     if (!Py_IsInitialized()) {
-        // PEP370
-        Py_NoSiteFlag = 1;
-        Py_NoUserSiteDirectory = 1;
+        // PEP 587
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
+
+        // PEP 370
+        config.site_import = 0;
+        config.user_site_directory = 0;
 
         PyImport_AppendInittab("tiled", PyInit_tiled);
         PyImport_AppendInittab("tiled.qt", PyInit_tiled);
         PyImport_AppendInittab("tiled.Tiled", PyInit_tiled);
-        Py_Initialize();
+
+        PyStatus status = Py_InitializeFromConfig(&config);
+        if (PyStatus_Exception(status)) {
+            Tiled::ERROR("Python initialization failed");
+            handleError();
+            return;
+        }
 
         PyObject *pmod = PyImport_ImportModule("tiled");
 


### PR DESCRIPTION
Fixed deprecation warnings by replacing `Py_NoSiteFlag` and `Py_NoUserSiteDirectory` variables with their `PyConfig` equivalent, supported since Python 3.8.