### PR TITLE
Fixed object assignment buttons in tile collision editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@
 * Fixed possible crash after a scripted tool disappears while active
 * Fixed updating of used tilesets after resizing map (#3884)
 * Fixed alignment of shortcuts in action search
+* Fixed object assignment buttons in tile collision editor (#3399)
 * AppImage: Fixed ability to open paths with spaces from the CLI (#3914)
 * AppImage: Updated to Sentry 0.6.7
 

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -206,7 +206,7 @@ MapEditor::MapEditor(QObject *parent)
     mToolsToolBar->addAction(mToolManager->registerTool(new LayerOffsetTool(this)));
     mToolsToolBar->addSeparator();  // todo: hide when there are no tool extensions
 
-    const auto tools = PluginManager::instance()->objects<AbstractTool>();
+    const auto tools = PluginManager::objects<AbstractTool>();
     for (auto tool : tools)
         mToolsToolBar->addAction(mToolManager->registerTool(tool));
 

--- a/src/tiled/tilecollisiondock.cpp
+++ b/src/tiled/tilecollisiondock.cpp
@@ -38,6 +38,7 @@
 #include "mapscene.h"
 #include "mapview.h"
 #include "objectgroup.h"
+#include "objectreferencetool.h"
 #include "objectselectiontool.h"
 #include "objectsview.h"
 #include "preferences.h"
@@ -110,6 +111,7 @@ TileCollisionDock::TileCollisionDock(QWidget *parent)
 
     mToolManager = new ToolManager(this);
     toolsToolBar->addAction(mToolManager->registerTool(new ObjectSelectionTool(this)));
+    toolsToolBar->addAction(mToolManager->registerTool(new ObjectReferenceTool(this)));
     toolsToolBar->addAction(mToolManager->registerTool(new EditPolygonTool(this)));
     toolsToolBar->addAction(mToolManager->registerTool(rectangleObjectsTool));
     toolsToolBar->addAction(mToolManager->registerTool(pointObjectsTool));


### PR DESCRIPTION
Unless I'm missing something, this was only due to the missing ObjectReferenceTool instance in the tile collision editor.

Closes #3399