### PR TITLE
Refuse to add files to a world that don't load as maps

### DIFF
--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -277,7 +277,7 @@ void AbstractWorldTool::addAnotherMapToWorld(QPoint insertPos)
     QString error;
     DocumentPtr document = DocumentManager::instance()->loadDocument(fileName, nullptr, &error);
 
-    if (!document) {
+    if (!document || document->type() != Document::MapDocumentType) {
         QMessageBox::critical(MainWindow::instance(),
                               tr("Error Opening File"),
                               tr("Error opening '%1':\n%2").arg(fileName, error));


### PR DESCRIPTION
The check on whether we could open the file wasn't checking what kind of file was getting loaded, which could lead to trying to add non-map files to a world.