### PR TITLE
Don't display non-existing files as read-only

### DIFF
--- a/src/tiled/document.cpp
+++ b/src/tiled/document.cpp
@@ -46,7 +46,7 @@ Document::Document(DocumentType type, const QString &fileName,
     const QFileInfo fileInfo { fileName };
     mLastSaved = fileInfo.lastModified();
     mCanonicalFilePath = fileInfo.canonicalFilePath();
-    mReadOnly = !fileInfo.isWritable();
+    mReadOnly = fileInfo.exists() && !fileInfo.isWritable();
 
     if (!mCanonicalFilePath.isEmpty())
         sDocumentInstances.insert(mCanonicalFilePath, this);
@@ -94,8 +94,10 @@ void Document::setFileName(const QString &fileName)
             sDocumentInstances.erase(i);
     }
 
+    const QFileInfo fileInfo { fileName };
     mFileName = fileName;
-    mCanonicalFilePath = QFileInfo(fileName).canonicalFilePath();
+    mCanonicalFilePath = fileInfo.canonicalFilePath();
+    setReadOnly(fileInfo.exists() && !fileInfo.isWritable());
 
     if (!mCanonicalFilePath.isEmpty())
         sDocumentInstances.insert(mCanonicalFilePath, this);

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -1125,7 +1125,7 @@ void DocumentManager::fileChanged(const QString &fileName)
     const QFileInfo fileInfo { fileName };
 
     // Always update potentially changed read-only state
-    document->setReadOnly(!fileInfo.isWritable());
+    document->setReadOnly(fileInfo.exists() && !fileInfo.isWritable());
 
     // Ignore change event when it seems to be our own save
     if (fileInfo.lastModified() == document->lastSaved())


### PR DESCRIPTION
Also fixed that when saving a file with a different name, the read-only flag was not refreshed.

Fix for c82539e331d7a90a3202e9f9b40f0486de84fdbd (see #3924).