### PR TITLE
Scripting: Fixed UI issues after setting class values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Changed default shortcut for "Save As" to Ctrl+Shift+S and removed shortcut from "Save All" (#3933)
 * Layer names are now trimmed when edited in the UI, to avoid accidental whitespace
 * Scripting: Added API for working with worlds (#3539)
+* Scripting: Added Object.setProperty overload for setting nested values
 * Scripting: Added Tile.image for accessing a tile's image data
 * Scripting: Added Image.copy overload that takes a rectangle
 * Scripting: Added Tileset.imageFileName and ImageLayer.imageFileName

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Scripting: Added Image.copy overload that takes a rectangle
 * Scripting: Added Tileset.imageFileName and ImageLayer.imageFileName
 * Scripting: Added FilePath.localFile and FileEdit.fileName (string alternatives to Qt.QUrl properties)
+* Scripting: Added tiled.color to create color values
 * Scripting: Made Tileset.margin and Tileset.tileSpacing writable
 * Scripting: Restored compatibility for MapObject.polygon (#3845)
 * Scripting: Fixed issues with editing properties after setting class values from script

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Scripting: Added FilePath.localFile and FileEdit.fileName (string alternatives to Qt.QUrl properties)
 * Scripting: Made Tileset.margin and Tileset.tileSpacing writable
 * Scripting: Restored compatibility for MapObject.polygon (#3845)
+* Scripting: Fixed issues with editing properties after setting class values from script
 * TMX format: Embedded images are now also supported on tilesets and image layers
 * JSON format: Fixed tile order when loading a tileset using the old format
 * Godot 4 plugin: Added support for exporting objects (by Rick Yorgason, #3615)

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1052,6 +1052,28 @@ declare class TiledObject {
   setProperty(name: string, value: TiledObjectPropertyValue): void;
 
   /**
+   * Sets the value of an object's property identified the given \a path
+   * to \a value.
+   *
+   * The \a path is a list of property names, where each name identifies
+   * a member of the previous member's value. The last name in the list
+   * identifies the property to set.
+   *
+   * Supported types are `bool`, `number`, `string`, {@link FilePath},
+   * {@link ObjectRef}, {@link MapObject} and {@link PropertyValue}.
+   *
+   * @note When setting a `number`, the property type will be set to either
+   * `int` or `float`, depending on whether it is a whole number. To force
+   * the property to be `float`, use {@link setFloatProperty}.
+   *
+   * @note This function does not support setting `color` properties. Use
+   * {@link setColorProperty} instead.
+   *
+   * @since 1.11
+   */
+  setProperty(path: string[], value: TiledObjectPropertyValue): void;
+
+  /**
    * Sets the value of the custom property with the given name to the given
    * color value.
    *

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1040,7 +1040,7 @@ declare class TiledObject {
   /**
    * Sets the value of the custom property with the given name. Supported
    * types are `bool`, `number`, `string`, {@link FilePath},
-   * {@link ObjectRef} and {@link MapObject}.
+   * {@link ObjectRef}, {@link MapObject} and {@link PropertyValue}.
    *
    * @note When setting a `number`, the property type will be set to either
    * `int` or `float`, depending on whether it is a whole number. To force

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -391,12 +391,12 @@ declare namespace Qt {
      * Controls whether this widget is visible.
      * When toggling this property, the dialog layout will automatically adjust itself
      * based on the visible widgets.
-     * Qt documentation: [QWidget.visible](https://doc.qt.io/qt-6/qwidget.html#visible-prop);
+     * Qt documentation: [QWidget::visible](https://doc.qt.io/qt-6/qwidget.html#visible-prop);
      */
     visible: boolean;
     /**
      * If false, the widget cannot be interacted with.
-     * Qt documentation: [QWidget.enabled](https://doc.qt.io/qt-6/qwidget.html#enabled-prop)
+     * Qt documentation: [QWidget::enabled](https://doc.qt.io/qt-6/qwidget.html#enabled-prop)
      */
     enabled: boolean;
     /**
@@ -992,7 +992,7 @@ declare class ObjectGroup extends Layer {
 /**
  * A type alias used to describe the possible values in object properties.
  */
-type TiledObjectPropertyValue = number | string | boolean | ObjectRef | FilePath | MapObject | PropertyValue | undefined
+type TiledObjectPropertyValue = number | string | boolean | color | ObjectRef | FilePath | MapObject | PropertyValue | undefined
 
 /**
  * An interface used to describe object properties.
@@ -1038,16 +1038,15 @@ declare class TiledObject {
   property(name: string): TiledObjectPropertyValue;
 
   /**
-   * Sets the value of the custom property with the given name. Supported
-   * types are `bool`, `number`, `string`, {@link FilePath},
-   * {@link ObjectRef}, {@link MapObject} and {@link PropertyValue}.
+   * Sets the value of the custom property with the given name.
+   *
+   * Supported types are `bool`, `number`, `string`, {@link color},
+   * {@link FilePath}, {@link ObjectRef}, {@link MapObject} and
+   * {@link PropertyValue}.
    *
    * @note When setting a `number`, the property type will be set to either
    * `int` or `float`, depending on whether it is a whole number. To force
    * the property to be `float`, use {@link setFloatProperty}.
-   *
-   * @note This function does not support setting `color` properties. Use
-   * {@link setColorProperty} instead.
    */
   setProperty(name: string, value: TiledObjectPropertyValue): void;
 
@@ -1059,15 +1058,13 @@ declare class TiledObject {
    * a member of the previous member's value. The last name in the list
    * identifies the property to set.
    *
-   * Supported types are `bool`, `number`, `string`, {@link FilePath},
-   * {@link ObjectRef}, {@link MapObject} and {@link PropertyValue}.
+   * Supported types are `bool`, `number`, `string`, {@link color},
+   * {@link FilePath}, {@link ObjectRef}, {@link MapObject} and
+   * {@link PropertyValue}.
    *
    * @note When setting a `number`, the property type will be set to either
    * `int` or `float`, depending on whether it is a whole number. To force
    * the property to be `float`, use {@link setFloatProperty}.
-   *
-   * @note This function does not support setting `color` properties. Use
-   * {@link setColorProperty} instead.
    *
    * @since 1.11
    */
@@ -1080,6 +1077,7 @@ declare class TiledObject {
    * The color is specified as a string "#RGB", "#RRGGBB" or "#AARRGGBB".
    *
    * @since 1.10
+   * @deprecated Use {@link setProperty} with a value created by {@link tiled.color} instead.
    */
   setColorProperty(name: string, value: color): void;
 
@@ -1092,6 +1090,7 @@ declare class TiledObject {
    * defaults to 255.
    *
    * @since 1.10
+   * @deprecated Use {@link setProperty} with a value created by {@link tiled.color} instead.
    */
   setColorProperty(name: string, red: number, green: number, blue: number, alpha?: number): void;
 
@@ -2155,10 +2154,10 @@ declare class Image {
   setPixel(x: number, y: number, index_or_rgb: number): void;
 
   /**
-   * Sets the color at the specified location to the given color by
-   * string (supports values like "#rrggbb").
+   * Sets the color at the specified location to the given color (supports
+   * values like "#rrggbb" or those created by {@link tiled.color}).
    */
-  setPixelColor(x: number, y: number, color: string): void;
+  setPixelColor(x: number, y: number, color: color): void;
 
   /**
    * Fills the image with the given 32-bit unsigned color value (ARGB) or color
@@ -2167,10 +2166,10 @@ declare class Image {
   fill(index_or_rgb: number): void;
 
   /**
-   * Fills the image with the given color by string (supports values like
-   * "#rrggbb").
+   * Fills the image with the given color (supports values like
+   * "#rrggbb" or those created by {@link tiled.color}).
    */
-  fill(color: string): void;
+  fill(color: color): void;
 
   /**
    * Loads the image from the given file name. When no format is given it
@@ -2214,10 +2213,10 @@ declare class Image {
   setColor(index: number, rgb: number): void;
 
   /**
-   * Sets the color at the given index in the color table to a color by
-   * string (supports values like "#rrggbb").
+   * Sets the color at the given index in the color table to a color (supports
+   * values like "#rrggbb" or those created by {@link tiled.color}).
    */
-  setColor(index: number, color: string) : void;
+  setColor(index: number, color: color) : void;
 
   /**
    * Sets the color table given by an array of either 32-bit color values
@@ -3505,6 +3504,8 @@ declare class WangSet extends TiledObject {
  * and "#AARRGGBB" respectively. For example, the color red corresponds to a
  * triplet of "#FF0000" and a slightly transparent blue to a quad of
  * "#800000FF".
+ *
+ * Use {@link tiled.color} to create a color value.
  */
 interface color {}
 
@@ -4517,6 +4518,24 @@ declare namespace tiled {
    * `undefined` if no object was found.
    */
   export function mapFormatForFile(fileName: string): MapFormat | undefined;
+
+  /**
+   * Creates a {@link color} based on the given color name (i.e. red or #ff0000).
+   *
+   * See [QColor::fromString](https://doc.qt.io/qt-6/qcolor.html#fromString)
+   * for the accepted color names.
+   *
+   * @since 1.11
+   */
+  export function color(name: string): color;
+
+  /**
+   * Creates a {@link color} with the RGB value r, g, b, and the alpha-channel
+   * (transparency) value of a (which defaults to 1.0).
+   *
+   * @since 1.11
+   */
+  export function color(r: number, g: number, b: number, a?: number): color;
 
   /**
    * Creates a {@link FilePath} object with the given URL.

--- a/src/libtiled/object.cpp
+++ b/src/libtiled/object.cpp
@@ -106,6 +106,11 @@ QVariantMap Object::resolvedProperties() const
     return allProperties;
 }
 
+bool Object::setProperty(const QStringList &path, const QVariant &value)
+{
+    return setPropertyMemberValue(mProperties, path, value);
+}
+
 void Object::setPropertyTypes(const SharedPropertyTypes &propertyTypes)
 {
     mPropertyTypes = propertyTypes;

--- a/src/libtiled/object.h
+++ b/src/libtiled/object.h
@@ -140,6 +140,18 @@ public:
     { mProperties.insert(name, value); }
 
     /**
+     * Sets the value of an object's property identified the given \a path
+     * to \a value.
+     *
+     * The \a path is a list of property names, where each name identifies
+     * a member of the previous member's value. The last name in the list
+     * identifies the property to set.
+     *
+     * Returns whether the property was set.
+     */
+    bool setProperty(const QStringList &path, const QVariant &value);
+
+    /**
      * Removes the property with the given \a name.
      */
     void removeProperty(const QString &name)

--- a/src/tiled/editableobject.cpp
+++ b/src/tiled/editableobject.cpp
@@ -57,6 +57,19 @@ void EditableObject::setPropertyImpl(const QString &name, const QVariant &value)
         mObject->setProperty(name, fromScript(value));
 }
 
+void EditableObject::setPropertyImpl(const QStringList &path, const QVariant &value)
+{
+    if (path.isEmpty()) {
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid argument"));
+        return;
+    }
+
+    if (Document *doc = document())
+        asset()->push(new SetProperty(doc, { mObject }, path, fromScript(value)));
+    else
+        mObject->setProperty(path, fromScript(value));
+}
+
 void EditableObject::setProperties(const QVariantMap &properties)
 {
     if (Document *doc = document())

--- a/src/tiled/editableobject.cpp
+++ b/src/tiled/editableobject.cpp
@@ -49,7 +49,7 @@ bool EditableObject::isReadOnly() const
     return asset() && asset()->isReadOnly();
 }
 
-void EditableObject::setProperty(const QString &name, const QVariant &value)
+void EditableObject::setPropertyImpl(const QString &name, const QVariant &value)
 {
     if (Document *doc = document())
         asset()->push(new SetProperty(doc, { mObject }, name, fromScript(value)));

--- a/src/tiled/editableobject.h
+++ b/src/tiled/editableobject.h
@@ -60,6 +60,7 @@ public:
 
     Q_INVOKABLE QVariant property(const QString &name) const;
     Q_INVOKABLE void setProperty(const QString &name, const QJSValue &value);
+    Q_INVOKABLE void setProperty(const QStringList &path, const QJSValue &value);
     Q_INVOKABLE void setColorProperty(const QString &name, const QColor &value);
     Q_INVOKABLE void setColorProperty(const QString &name, int r, int g, int b, int a = 255);
     Q_INVOKABLE void setFloatProperty(const QString &name, qreal value);
@@ -89,6 +90,7 @@ protected:
 
 private:
     void setPropertyImpl(const QString &name, const QVariant &value);
+    void setPropertyImpl(const QStringList &path, const QVariant &value);
 
     QVariant toScript(const QVariant &value) const;
     QVariant fromScript(const QVariant &value) const;
@@ -118,6 +120,11 @@ inline QVariant EditableObject::property(const QString &name) const
 inline void EditableObject::setProperty(const QString &name, const QJSValue &value)
 {
     setPropertyImpl(name, value.toVariant());
+}
+
+inline void EditableObject::setProperty(const QStringList &path, const QJSValue &value)
+{
+    setPropertyImpl(path, value.toVariant());
 }
 
 inline void EditableObject::setColorProperty(const QString &name, const QColor &value)

--- a/src/tiled/editableobject.h
+++ b/src/tiled/editableobject.h
@@ -22,6 +22,7 @@
 
 #include "object.h"
 
+#include <QJSValue>
 #include <QObject>
 
 namespace Tiled {
@@ -58,7 +59,7 @@ public:
     const QString &className() const;
 
     Q_INVOKABLE QVariant property(const QString &name) const;
-    Q_INVOKABLE void setProperty(const QString &name, const QVariant &value);
+    Q_INVOKABLE void setProperty(const QString &name, const QJSValue &value);
     Q_INVOKABLE void setColorProperty(const QString &name, const QColor &value);
     Q_INVOKABLE void setColorProperty(const QString &name, int r, int g, int b, int a = 255);
     Q_INVOKABLE void setFloatProperty(const QString &name, qreal value);
@@ -87,6 +88,8 @@ protected:
     void moveOwnershipToCpp();
 
 private:
+    void setPropertyImpl(const QString &name, const QVariant &value);
+
     QVariant toScript(const QVariant &value) const;
     QVariant fromScript(const QVariant &value) const;
     QVariantMap toScript(const QVariantMap &value) const;
@@ -112,19 +115,24 @@ inline QVariant EditableObject::property(const QString &name) const
     return toScript(mObject->property(name));
 }
 
+inline void EditableObject::setProperty(const QString &name, const QJSValue &value)
+{
+    setPropertyImpl(name, value.toVariant());
+}
+
 inline void EditableObject::setColorProperty(const QString &name, const QColor &value)
 {
-    setProperty(name, value);
+    setPropertyImpl(name, value);
 }
 
 inline void EditableObject::setColorProperty(const QString &name, int r, int g, int b, int a)
 {
-    setProperty(name, QColor(r, g, b, a));
+    setPropertyImpl(name, QColor(r, g, b, a));
 }
 
 inline void EditableObject::setFloatProperty(const QString &name, qreal value)
 {
-    setProperty(name, value);
+    setPropertyImpl(name, value);
 }
 
 inline QVariantMap EditableObject::properties() const

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -240,6 +240,20 @@ MapEditor *ScriptModule::mapEditor() const
     return nullptr;
 }
 
+QColor ScriptModule::color(const QString &name) const
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+    return QColor::isValidColor(name) ? QColor(name) : QColor();
+#else
+    return QColor::fromString(name);
+#endif
+}
+
+QColor ScriptModule::color(float r, float g, float b, float a) const
+{
+    return QColor::fromRgbF(r, g, b, a);
+}
+
 FilePath ScriptModule::filePath(const QUrl &path) const
 {
     return { path };

--- a/src/tiled/scriptmodule.h
+++ b/src/tiled/scriptmodule.h
@@ -105,6 +105,8 @@ public:
     TilesetEditor *tilesetEditor() const;
     MapEditor *mapEditor() const;
 
+    Q_INVOKABLE QColor color(const QString &name) const;
+    Q_INVOKABLE QColor color(float r, float g, float b, float a = 1.0f) const;
     Q_INVOKABLE Tiled::FilePath filePath(const QUrl &path) const;
     Q_INVOKABLE Tiled::ObjectRef objectRef(int id) const;
     Q_INVOKABLE QVariant propertyValue(const QString &typeName, const QJSValue &value) const;

--- a/src/tiled/scriptmodule.h
+++ b/src/tiled/scriptmodule.h
@@ -107,7 +107,7 @@ public:
 
     Q_INVOKABLE Tiled::FilePath filePath(const QUrl &path) const;
     Q_INVOKABLE Tiled::ObjectRef objectRef(int id) const;
-    Q_INVOKABLE QVariant propertyValue(const QString &typeName, const QVariant &value) const;
+    Q_INVOKABLE QVariant propertyValue(const QString &typeName, const QJSValue &value) const;
     Q_INVOKABLE bool versionLessThan(const QString &a);
     Q_INVOKABLE bool versionLessThan(const QString &a, const QString &b);
 


### PR DESCRIPTION
When setting a class value from a script, the value was not getting converted from a JS object to a QVariantMap. This tripped up code elsewhere, for example making the UI unable to edit the values (though it could still display them, and they also got saved correctly).

This change adds the missing conversion from JS object to QVariantMap to `tiled.propertyValue` and `Object.setProperty`.