### PR TITLE
Scripting: add displayImage property to Tile to get pre-cropped image

### DIFF
--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -2474,6 +2474,16 @@ declare class Tile extends TiledObject {
   image: Image;
 
   /**
+   * Returns the image of this tile, cropped to its {@link imageRect}
+   * to include only the visible portion of the image.
+   *
+   * This property is read-only.
+   * 
+   * @since 1.11
+   */
+  displayImage: Image;
+
+  /**
    * The source rectangle (in pixels) for this tile.
    *
    * This can be either a sub-rectangle of the tile image when the tile is part

--- a/src/tiled/editabletile.cpp
+++ b/src/tiled/editabletile.cpp
@@ -54,6 +54,12 @@ ScriptImage *EditableTile::image() const
     return new ScriptImage(tile()->image().toImage());
 }
 
+ScriptImage *EditableTile::displayImage() const
+{
+    QPixmap cropped = tile()->image().copy(tile()->imageRect());
+    return new ScriptImage(cropped.toImage());
+}
+
 EditableObjectGroup *EditableTile::objectGroup() const
 {
     if (!mAttachedObjectGroup) {

--- a/src/tiled/editabletile.h
+++ b/src/tiled/editabletile.h
@@ -43,6 +43,7 @@ class EditableTile : public EditableObject
     Q_PROPERTY(QString type READ className WRITE setClassName)  // compatibility with Tiled < 1.9
     Q_PROPERTY(QString imageFileName READ imageFileName WRITE setImageFileName)
     Q_PROPERTY(Tiled::ScriptImage *image READ image WRITE setImage)
+    Q_PROPERTY(Tiled::ScriptImage *displayImage READ displayImage)
     Q_PROPERTY(QRect imageRect READ imageRect WRITE setImageRect)
     Q_PROPERTY(qreal probability READ probability WRITE setProbability)
     Q_PROPERTY(Tiled::EditableObjectGroup *objectGroup READ objectGroup WRITE setObjectGroup)
@@ -78,6 +79,7 @@ public:
     QSize size() const;
     QString imageFileName() const;
     ScriptImage *image() const;
+    ScriptImage *displayImage() const;
     QRect imageRect() const;
     qreal probability() const;
     EditableObjectGroup *objectGroup() const;


### PR DESCRIPTION
I saw #3918 is marking these as `@since 1.11` , so I did the same here, but I could change it. 

The idea here was to provide a pre-cropped image (since `Tile.image` returns the full image)  so that you could display it on a dialog. It came up when I was asking if a new type of widget  that lets you select & preview a tile (a TileButton like a color picker button) might be useful.

Let me know what you think 

Example script: 
https://gist.github.com/dogboydog/363a4fec2e7b1c408e9ecc4b93234bde

Example images 
![image](https://github.com/mapeditor/tiled/assets/9920963/f9e46196-8df4-4702-919d-ee15d75d2890)
![image](https://github.com/mapeditor/tiled/assets/9920963/a4ea37bb-b9f4-4bf5-a1a2-abacb8601fdc)
