### PR TITLE
Stamp Brush right-click cut when Shift is held

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Added --project command-line parameter for use when exporting (#3797)
 * Added group layer names in "Move Object to Layer" menu (#3454)
 * Added lock icon to open tabs for which the file is read-only
+* Added Shift modifier to cut when capturing a tile stamp (by kdx2a, #3961)
 * Made adding "Copy" when duplicating optional and disabled by default (#3917)
 * Layer names are now trimmed when edited in the UI, to avoid accidental whitespace
 * Scripting: Added API for working with worlds (#3539)

--- a/src/tiled/abstracttilefilltool.cpp
+++ b/src/tiled/abstracttilefilltool.cpp
@@ -77,7 +77,7 @@ void AbstractTileFillTool::deactivate(MapScene *scene)
 void AbstractTileFillTool::mousePressed(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::RightButton && event->modifiers() == Qt::NoModifier) {
-        mCaptureStampHelper.beginCapture(tilePosition());
+        mCaptureStampHelper.beginCapture(tilePosition(), false);
         return;
     }
 

--- a/src/tiled/abstracttilefilltool.cpp
+++ b/src/tiled/abstracttilefilltool.cpp
@@ -76,8 +76,8 @@ void AbstractTileFillTool::deactivate(MapScene *scene)
 
 void AbstractTileFillTool::mousePressed(QGraphicsSceneMouseEvent *event)
 {
-    if (event->button() == Qt::RightButton && event->modifiers() == Qt::NoModifier) {
-        mCaptureStampHelper.beginCapture(tilePosition(), false);
+    if (event->button() == Qt::RightButton) {
+        mCaptureStampHelper.beginCapture(tilePosition());
         return;
     }
 
@@ -89,7 +89,8 @@ void AbstractTileFillTool::mouseReleased(QGraphicsSceneMouseEvent *event)
     if (event->button() == Qt::RightButton && mCaptureStampHelper.isActive()) {
         clearOverlay();
 
-        TileStamp stamp = mCaptureStampHelper.endCapture(*mapDocument(), tilePosition());
+        const bool cut = event->modifiers() & Qt::ShiftModifier;
+        TileStamp stamp = mCaptureStampHelper.endCapture(*mapDocument(), tilePosition(), cut);
         if (!stamp.isEmpty())
             emit stampChanged(stamp);
 

--- a/src/tiled/abstracttilefilltool.cpp
+++ b/src/tiled/abstracttilefilltool.cpp
@@ -76,7 +76,9 @@ void AbstractTileFillTool::deactivate(MapScene *scene)
 
 void AbstractTileFillTool::mousePressed(QGraphicsSceneMouseEvent *event)
 {
-    if (event->button() == Qt::RightButton) {
+    if (event->button() == Qt::RightButton &&
+        !(event->modifiers() & Qt::ControlModifier))
+    {
         mCaptureStampHelper.beginCapture(tilePosition());
         return;
     }

--- a/src/tiled/capturestamphelper.cpp
+++ b/src/tiled/capturestamphelper.cpp
@@ -34,14 +34,13 @@ CaptureStampHelper::CaptureStampHelper()
 {
 }
 
-void CaptureStampHelper::beginCapture(QPoint tilePosition, bool cut)
+void CaptureStampHelper::beginCapture(QPoint tilePosition)
 {
     mActive = true;
     mCaptureStart = tilePosition;
-    mCut = cut;
 }
 
-TileStamp CaptureStampHelper::endCapture(MapDocument &mapDocument, QPoint tilePosition)
+TileStamp CaptureStampHelper::endCapture(MapDocument &mapDocument, QPoint tilePosition, bool cut)
 {
     mActive = false;
 
@@ -59,7 +58,7 @@ TileStamp CaptureStampHelper::endCapture(MapDocument &mapDocument, QPoint tilePo
                                   *stamp);
 
     // Delete captured elements when cutting
-    if (mCut && !captured.isEmpty()) {
+    if (cut && !captured.isEmpty()) {
         QList<QUndoCommand*> commands;
         QList<QPair<QRegion, TileLayer*>> erasedRegions;
 

--- a/src/tiled/capturestamphelper.cpp
+++ b/src/tiled/capturestamphelper.cpp
@@ -20,10 +20,8 @@
 
 #include "capturestamphelper.h"
 
-#include "erasetiles.h"
 #include "map.h"
 #include "mapdocument.h"
-#include "tilelayer.h"
 
 #include <memory>
 
@@ -57,28 +55,12 @@ TileStamp CaptureStampHelper::endCapture(MapDocument &mapDocument, QPoint tilePo
                                   captured,
                                   *stamp);
 
-    // Delete captured elements when cutting
+    // Erase captured area when cutting
     if (cut && !captured.isEmpty()) {
-        QList<QUndoCommand*> commands;
-        QList<QPair<QRegion, TileLayer*>> erasedRegions;
-
-        for (auto layer : mapDocument.selectedLayers()) {
-            if (!layer->isTileLayer())
-                continue;
-            TileLayer *const tileLayer = layer->asTileLayer();
-            const QRegion area = captured.intersected(tileLayer->bounds());
-            if (area.isEmpty())
-                continue;
-            // Delete the captured part of the layer
-            commands.append(new EraseTiles(&mapDocument, tileLayer, area));
-            erasedRegions.append({ area, tileLayer });
-        }
-
-        QUndoStack *const undoStack = mapDocument.undoStack();
-        undoStack->beginMacro(Document::tr("Cut"));
-        for (QUndoCommand *command : std::as_const(commands))
-            undoStack->push(command);
-        undoStack->endMacro();
+        const bool allLayers = false;
+        const bool mergeable = false;
+        mapDocument.eraseTileLayers(captured, allLayers, mergeable,
+                                    Document::tr("Cut"));
     }
 
     if (stamp->layerCount() > 0) {

--- a/src/tiled/capturestamphelper.cpp
+++ b/src/tiled/capturestamphelper.cpp
@@ -20,14 +20,12 @@
 
 #include "capturestamphelper.h"
 
-#include "changeselectedarea.h"
 #include "erasetiles.h"
 #include "map.h"
 #include "mapdocument.h"
 #include "tilelayer.h"
 
 #include <memory>
-#include <qundostack.h>
 
 namespace Tiled {
 

--- a/src/tiled/capturestamphelper.h
+++ b/src/tiled/capturestamphelper.h
@@ -33,8 +33,8 @@ class CaptureStampHelper
 public:
     CaptureStampHelper();
 
-    void beginCapture(QPoint tilePosition, bool cut);
-    TileStamp endCapture(MapDocument &mapDocument, QPoint tilePosition);
+    void beginCapture(QPoint tilePosition);
+    TileStamp endCapture(MapDocument &mapDocument, QPoint tilePosition, bool cut);
 
     bool isActive() const { return mActive; }
     void reset();
@@ -44,7 +44,6 @@ public:
 private:
     QPoint mCaptureStart;
     bool mActive;
-    bool mCut;
 };
 
 } // namespace Tiled

--- a/src/tiled/capturestamphelper.h
+++ b/src/tiled/capturestamphelper.h
@@ -33,8 +33,8 @@ class CaptureStampHelper
 public:
     CaptureStampHelper();
 
-    void beginCapture(QPoint tilePosition);
-    TileStamp endCapture(const MapDocument &mapDocument, QPoint tilePosition);
+    void beginCapture(QPoint tilePosition, bool cut);
+    TileStamp endCapture(MapDocument &mapDocument, QPoint tilePosition);
 
     bool isActive() const { return mActive; }
     void reset();
@@ -44,6 +44,7 @@ public:
 private:
     QPoint mCaptureStart;
     bool mActive;
+    bool mCut;
 };
 
 } // namespace Tiled

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -178,6 +178,10 @@ public:
     void paintTileLayers(const Map &map, bool mergeable = false,
                          QVector<SharedTileset> *missingTilesets = nullptr,
                          QHash<TileLayer *, QRegion> *paintedRegions = nullptr);
+    void eraseTileLayers(const QRegion &region,
+                         bool allLayers = false,
+                         bool mergeable = false,
+                         const QString &customName = QString());
 
     void replaceObjectTemplate(const ObjectTemplate *oldObjectTemplate,
                                const ObjectTemplate *newObjectTemplate);

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -465,6 +465,8 @@ void MapDocumentActionHandler::delete_()
     }
 
     for (auto &erased : std::as_const(erasedRegions)) {
+        // Sanity check needed because a script might respond to the below
+        // signal by removing the layer from the map.
         if (erased.second->map() != mMapDocument->map())
             continue;
 

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -201,19 +201,22 @@ void StampBrush::modifiersChanged(Qt::KeyboardModifiers modifiers)
 void StampBrush::updateBrushBehavior()
 {
     BrushBehavior brushBehavior = mBrushBehavior;
+    BrushState brushState = mBrushState;
 
     if (mModifiers & Qt::ShiftModifier) {
-        if (mModifiers & Qt::ControlModifier) {
+        if (mModifiers & Qt::ControlModifier)
             brushBehavior = BrushBehavior::Circle;
-        } else {
+        else
             brushBehavior = BrushBehavior::Line;
-        }
     } else {
         brushBehavior = BrushBehavior::Neutral;
+        if (brushState == BrushState::StartSet)
+            brushState = BrushState::Free;
     }
 
-    if (mBrushBehavior != brushBehavior) {
+    if (brushBehavior != mBrushBehavior || brushState != mBrushState) {
         mBrushBehavior = brushBehavior;
+        mBrushState = brushState;
         updatePreview();
     }
 }

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -128,18 +128,13 @@ void StampBrush::mousePressed(QGraphicsSceneMouseEvent *event)
                 break;
             case BrushState::Free:
                 switch (mBrushBehavior) {
-                case BrushBehavior::Line:
-                    mStampReference = tilePosition();
-                    mBrushState = BrushState::StartSet;
-                    break;
-                case BrushBehavior::Circle:
-                    mStampReference = tilePosition();
-                    mBrushState = BrushState::StartSet;
-                    break;
                 case BrushBehavior::Neutral:
                     beginPaint();
                     break;
-                default:
+                case BrushBehavior::Line:
+                case BrushBehavior::Circle:
+                    mStampReference = tilePosition();
+                    mBrushState = BrushState::StartSet;
                     break;
                 }
                 break;
@@ -193,9 +188,7 @@ void StampBrush::mouseReleased(QGraphicsSceneMouseEvent *event)
 void StampBrush::modifiersChanged(Qt::KeyboardModifiers modifiers)
 {
     mModifiers = modifiers;
-
-    if (!mStamp.isEmpty() || mIsWangFill)
-        updateBrushBehavior();
+    updateBrushBehavior();
 }
 
 void StampBrush::updateBrushBehavior()

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -143,10 +143,7 @@ void StampBrush::mousePressed(QGraphicsSceneMouseEvent *event)
             }
             return;
         } else if (event->button() == Qt::RightButton) {
-            if (event->modifiers() == Qt::NoModifier)
-                beginCapture(false);
-            else if (event->modifiers() & Qt::ShiftModifier)
-                beginCapture(true);
+            beginCapture();
             return;
         }
     }
@@ -310,13 +307,13 @@ void StampBrush::beginPaint()
     doPaint();
 }
 
-void StampBrush::beginCapture(bool cut)
+void StampBrush::beginCapture()
 {
     if (mBrushState != BrushState::Free)
         return;
 
     mBrushState = BrushState::Capture;
-    mCaptureStampHelper.beginCapture(tilePosition(), cut);
+    mCaptureStampHelper.beginCapture(tilePosition());
 
     setStamp(TileStamp());
 }
@@ -328,7 +325,8 @@ void StampBrush::endCapture()
 
     mBrushState = BrushState::Free;
 
-    TileStamp stamp = mCaptureStampHelper.endCapture(*mapDocument(), tilePosition());
+    const bool cut = mModifiers & Qt::ShiftModifier;
+    TileStamp stamp = mCaptureStampHelper.endCapture(*mapDocument(), tilePosition(), cut);
     if (!stamp.isEmpty())
         emit stampChanged(TileStamp(stamp));
     else

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -330,7 +330,7 @@ void StampBrush::endCapture()
     const bool cut = mModifiers & Qt::ShiftModifier;
     TileStamp stamp = mCaptureStampHelper.endCapture(*mapDocument(), tilePosition(), cut);
     if (!stamp.isEmpty())
-        emit stampChanged(TileStamp(stamp));
+        emit stampChanged(stamp);
     else
         updatePreview();
 }

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -142,7 +142,9 @@ void StampBrush::mousePressed(QGraphicsSceneMouseEvent *event)
                 break;
             }
             return;
-        } else if (event->button() == Qt::RightButton) {
+        } else if (event->button() == Qt::RightButton &&
+                   !(event->modifiers() & Qt::ControlModifier))
+        {
             beginCapture();
             return;
         }

--- a/src/tiled/stampbrush.h
+++ b/src/tiled/stampbrush.h
@@ -104,7 +104,7 @@ private:
     void doPaint(int flags = 0,
                  QHash<TileLayer *, QRegion> *paintedRegions = nullptr);
 
-    void beginCapture();
+    void beginCapture(bool cut);
     void endCapture();
 
     void updateBrushBehavior();
@@ -124,22 +124,26 @@ private:
      * There are several options how the stamp utility can be used.
      * It must be one of the following:
      */
-    enum BrushBehavior {
+    enum class BrushBehavior {
+        Neutral,        // nothing special
+        Line,           // hold shift: a line
+        Circle          // hold Shift + Ctrl: a circle
+    };
+
+    enum class BrushState {
         Free,           // nothing special: you can move the mouse,
                         // preview of the selection
-        Paint,          // left mouse pressed: free painting
         Capture,        // right mouse pressed: capture a rectangle
-        Line,           // hold shift: a line
-        LineStartSet,   // when you have defined a starting point,
+        Paint,          // left mouse pressed: free painting
+        StartSet        // when you have defined a starting point,
                         // cancel with right click
-        Circle,         // hold Shift + Ctrl: a circle
-        CircleMidSet
     };
 
     /**
      * This stores the current behavior.
      */
-    BrushBehavior mBrushBehavior = Free;
+    BrushBehavior mBrushBehavior = BrushBehavior::Neutral;
+    BrushState mBrushState = BrushState::Free;
     Qt::KeyboardModifiers mModifiers;
 
     /**

--- a/src/tiled/stampbrush.h
+++ b/src/tiled/stampbrush.h
@@ -104,7 +104,7 @@ private:
     void doPaint(int flags = 0,
                  QHash<TileLayer *, QRegion> *paintedRegions = nullptr);
 
-    void beginCapture(bool cut);
+    void beginCapture();
     void endCapture();
 
     void updateBrushBehavior();


### PR DESCRIPTION
Implements #3961

Implementing this required a refactor of the state system in StampBrush.  Behavior and State were previously handled in the same property, which resulted both in wrong behavior when using capture and pressing the behavior keys (replicate by holding right click, start holding shift, release right click, the behavior wasn't set to line as it should have). This commit refactors this system by splitting State and Behavior in two enums and two properties, resulting in making the implemented feature possible, fixing behavior bugs, and future-proofing this system for expansion.