### PR TITLE
Switch keyboard shortcut for "Save All" to "Save As"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Added lock icon to open tabs for which the file is read-only
 * Added Shift modifier to cut when capturing a tile stamp (by kdx2a, #3961)
 * Made adding "Copy" when duplicating optional and disabled by default (#3917)
+* Changed default shortcut for "Save As" to Ctrl+Shift+S and removed shortcut from "Save All" (#3933)
 * Layer names are now trimmed when edited in the UI, to avoid accidental whitespace
 * Scripting: Added API for working with worlds (#3539)
 * Scripting: Added Tile.image for accessing a tile's image data

--- a/docs/manual/keyboard-shortcuts.rst
+++ b/docs/manual/keyboard-shortcuts.rst
@@ -17,8 +17,7 @@ General
 -  ``Ctrl + Shift + P`` - Search for available actions
 -  ``Ctrl + Shift + T`` - Reopen a recently closed file
 -  ``Ctrl + S`` - Save current document
--  ``Ctrl + Alt + S`` - Save current document to another file
--  ``Ctrl + Shift + S`` - Save all documents
+-  ``Ctrl + Shift + S`` - Save current document to another file
 -  ``Ctrl + E`` - Export current document
 -  ``Ctrl + Shift + E`` - Export current document to another file
 -  ``Ctrl + R`` - Reload current document

--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -344,7 +344,7 @@
     <string>Save &amp;As...</string>
    </property>
    <property name="shortcut">
-    <string notr="true">Ctrl+Alt+S</string>
+    <string notr="true">Ctrl+Shift+S</string>
    </property>
   </action>
   <action name="actionNewTileset">
@@ -536,9 +536,6 @@
   <action name="actionSaveAll">
    <property name="text">
     <string>Save All</string>
-   </property>
-   <property name="shortcut">
-    <string notr="true">Ctrl+Shift+S</string>
    </property>
   </action>
   <action name="actionDocumentation">


### PR DESCRIPTION
Leaving "Save All" with no default shortcut.

Closes #3933