### PR TITLE
Allow drawing lines by holding shift while painting

### DIFF
--- a/src/tiled/stampbrush.h
+++ b/src/tiled/stampbrush.h
@@ -135,8 +135,9 @@ private:
                         // preview of the selection
         Capture,        // right mouse pressed: capture a rectangle
         Paint,          // left mouse pressed: free painting
-        StartSet        // when you have defined a starting point,
+        StartSet,       // when you have defined a starting point,
                         // cancel with right click
+        PaintStartSet   // starting point set while painting
     };
 
     /**


### PR DESCRIPTION
Allows starting to draw, holding shift to preview a straight line, and releasing to draw it. This is enabled by the addition of a `PaintStartSet` state. Pressing right click during `StartSet` or `PaintStartSet` cancels the operation and returns to Free. This is inspired by the behavior of the pencil in some image editing software. Thinking about the issue #3642 while working on this, I made sure than clicking, holding shift, then releasing shift, switches from `PaintStartSet` to `StartSet` to avoid user confusion.

I invite the reader to test this feature. I think it is good, since it's non intrusive and eases the better flow when mixing many organic and straight lines. But I understand how this might be controversial.

closes #3642