### PR TITLE
GitHub Actions: Updated macOS and Windows images

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -184,7 +184,7 @@ jobs:
 
   macos:
     name: macOS (${{ matrix.version_suffix }})
-    runs-on: macos-11
+    runs-on: macos-latest
     needs: version
 
     strategy:
@@ -271,7 +271,7 @@ jobs:
 
   windows:
     name: Windows (${{ matrix.arch }}-bit, Qt ${{ matrix.qt_version_major }})
-    runs-on: windows-2019
+    runs-on: windows-latest
     needs: version
 
     strategy:


### PR DESCRIPTION
The `macos-11` image is now deprecated and doing blackouts.

Switched both to 'latest' to avoid them going stale again in the future.

AppImage remains on `ubuntu-20.04`, since it should generally be built on the oldest still supported version.