### PR TITLE
AppImage: Updated to Sentry 0.7.6

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   QBS_VERSION: 2.2.1
-  SENTRY_VERSION: 0.6.7
+  SENTRY_VERSION: 0.7.6
   SENTRY_ORG: mapeditor
   SENTRY_PROJECT: tiled
   TILED_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -104,7 +104,7 @@ jobs:
         mkdir sentry-native
         pushd sentry-native
         unzip -q ../sentry-native.zip
-        cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSENTRY_BACKEND=breakpad
         cmake --build build --parallel
         sudo cmake --install build --prefix /usr --config RelWithDebInfo
         popd

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,7 +40,7 @@
 * Fixed alignment of shortcuts in action search
 * Fixed object assignment buttons in tile collision editor (#3399)
 * AppImage: Fixed ability to open paths with spaces from the CLI (#3914)
-* AppImage: Updated to Sentry 0.6.7
+* AppImage: Updated to Sentry 0.7.6
 
 ### Tiled 1.10.2 (4 August 2023)
 


### PR DESCRIPTION
In Sentry 0.7, the crashpad backend became the default, so now we explicitly select the breakpad backend.

Using crashpad requires shipping the crash handler as an additional executable and it will take some investigation how that can work with an AppImage.