### PR TITLE
CI: Don't fail a build if upload to Sentry failed

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -115,7 +115,7 @@ jobs:
 
     - name: Upload symbols and sources to Sentry
       if: github.repository == 'mapeditor/tiled' && github.event_name == 'push'
-      continue-on-error: true
+      continue-on-error: ${{ needs.version.outputs.release == 'false' }}
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -115,11 +115,12 @@ jobs:
 
     - name: Upload symbols and sources to Sentry
       if: github.repository == 'mapeditor/tiled' && github.event_name == 'push'
+      continue-on-error: true
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       run: |
         curl -sL https://sentry.io/get-cli/ | bash
-        sentry-cli upload-dif --include-sources src .
+        sentry-cli upload-dif --log-level=info --include-sources src .
 
     - name: Build AppImage
       run: |


### PR DESCRIPTION
The Sentry upload is optional.

Also, increase the log level to possibly find out why the upload appears to have failed with "error: Invalid checksum" last time.