### PR TITLE
GitHub Actions: Updated builds to Qt 6.7.2

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -15,7 +15,7 @@ on:
     - '.travis.yml'
 
 env:
-  QBS_VERSION: 2.2.1
+  QBS_VERSION: 2.3.1
   SENTRY_VERSION: 0.7.6
   SENTRY_ORG: mapeditor
   SENTRY_PROJECT: tiled
@@ -48,13 +48,13 @@ jobs:
         include:
         - qt_version: 5.15.2
           qt_version_major: 5
-        - qt_version: 6.7.0
+        - qt_version: 6.7.2
           qt_version_major: 6
 
     env:
       TILED_VERSION: ${{ needs.version.outputs.version }}
       QT_VERSION: ${{ matrix.qt_version }}
-      QTCREATOR_VERSION: 12.0.1
+      QTCREATOR_VERSION: 13.0.2
 
     steps:
     - name: Checkout repository
@@ -194,14 +194,14 @@ jobs:
         - qt_version: 5.12.12
           version_suffix: "10.12-10.15"
           architectures: x86_64
-        - qt_version: 6.7.0
+        - qt_version: 6.7.2
           version_suffix: "11+"
           architectures: x86_64,arm64
 
     env:
       TILED_VERSION: ${{ needs.version.outputs.version }}
       QT_VERSION: ${{ matrix.qt_version }}
-      QTCREATOR_VERSION: 12.0.1
+      QTCREATOR_VERSION: 13.0.2
 
     steps:
     - name: Checkout repository
@@ -286,7 +286,7 @@ jobs:
           mingw_version: 8.1.0
           mingw_component: mingw
           mingw_path: /c/Qt/Tools/mingw810_32/bin
-        - qt_version: 6.7.0
+        - qt_version: 6.7.2
           qt_version_major: 6
           qt_toolchain: win64_mingw
           arch: 64


### PR DESCRIPTION
Should be a relatively painless upgrade, though there was some [breakage with Qbs](https://bugreports.qt.io/browse/QTBUG-124903) in the 6.7.1 release regarding setting the minimum macOS version.