### PR TITLE
Scripting: Fixed setting/getting nested object reference values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Scripting: Made Tileset.margin and Tileset.tileSpacing writable
 * Scripting: Restored compatibility for MapObject.polygon (#3845)
 * Scripting: Fixed issues with editing properties after setting class values from script
+* Scripting: Fixed setting/getting object reference values when nested as a class member
 * TMX format: Embedded images are now also supported on tilesets and image layers
 * JSON format: Fixed tile order when loading a tileset using the old format
 * Godot 4 plugin: Added support for exporting objects (by Rick Yorgason, #3615)

--- a/src/tiled/editableobject.cpp
+++ b/src/tiled/editableobject.cpp
@@ -193,16 +193,30 @@ QVariant EditableObject::toScript(const QVariant &value) const
         }
     }
 
+    if (type == propertyValueId()) {
+        auto propertyValue = value.value<PropertyValue>();
+        propertyValue.value = toScript(propertyValue.value);
+        return QVariant::fromValue(propertyValue);
+    }
+
     return value;
 }
 
 QVariant EditableObject::fromScript(const QVariant &value) const
 {
-    if (value.userType() == QMetaType::QVariantMap)
+    const int type = value.userType();
+
+    if (type == QMetaType::QVariantMap)
         return fromScript(value.toMap());
 
     if (auto editableMapObject = value.value<EditableMapObject*>())
         return QVariant::fromValue(ObjectRef { editableMapObject->id() });
+
+    if (type == propertyValueId()) {
+        auto propertyValue = value.value<PropertyValue>();
+        propertyValue.value = fromScript(propertyValue.value);
+        return QVariant::fromValue(propertyValue);
+    }
 
     return value;
 }


### PR DESCRIPTION
When the object reference was nested in a custom class, it was not getting converted between `EditableMapObject*` and `ObjectRef`.