### PR TITLE
Automapping: Fixed adding of new tilesets used by applied changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 * AutoMapping: Ignore empty outputs per-rule (#3523)
 * Automapping: Added per-input-layer properties for ignoring flip flags (#3803)
 * AutoMapping: Always apply output sets with empty index
+* AutoMapping: Fixed adding of new tilesets used by applied changes
 * Windows: Fixed the support for WebP images (updated to Qt 6.6.1, #3661)
 * Fixed issues related to map and tileset reloading
 * Fixed possible crash after assigning to tiled.activeAsset

--- a/tests/automapping/add-tileset/map-result.tmx
+++ b/tests/automapping/add-tileset/map-result.tmx
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="1">
+ <tileset firstgid="1" source="../spr_test_tileset.tsx"/>
+ <layer id="1" name="set" width="5" height="5">
+  <data encoding="csv">
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0
+</data>
+ </layer>
+ <layer id="8" name="auto" width="5" height="5">
+  <data encoding="csv">
+2,2,2,2,2,
+2,2,2,2,2,
+2,2,2,2,2,
+2,2,2,2,2,
+2,2,2,2,2
+</data>
+ </layer>
+</map>

--- a/tests/automapping/add-tileset/map.tmx
+++ b/tests/automapping/add-tileset/map.tmx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="9" nextobjectid="1">
+ <layer id="1" name="set" width="5" height="5">
+  <data encoding="csv">
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0
+</data>
+ </layer>
+ <layer id="8" name="auto" width="5" height="5">
+  <data encoding="csv">
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0
+</data>
+ </layer>
+</map>

--- a/tests/automapping/add-tileset/rules.tmx
+++ b/tests/automapping/add-tileset/rules.tmx
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="3" height="3" tilewidth="16" tileheight="16" infinite="0" nextlayerid="5" nextobjectid="5">
+ <tileset firstgid="1" source="../spr_test_tileset.tsx"/>
+ <tileset firstgid="17" source=":/automap-tiles.tsx"/>
+ <layer id="1" name="input_set" width="3" height="3">
+  <data encoding="csv">
+0,0,0,
+0,20,0,
+0,0,0
+</data>
+ </layer>
+ <layer id="2" name="output_auto" width="3" height="3">
+  <data encoding="csv">
+0,0,0,
+0,2,0,
+0,0,0
+</data>
+ </layer>
+</map>

--- a/tests/automapping/add-tileset/rules.txt
+++ b/tests/automapping/add-tileset/rules.txt
@@ -1,0 +1,1 @@
+./rules.tmx


### PR DESCRIPTION
There was some code that should have done this, but it was checking which new tilesets were used before that actual changes had been applied, which entirely broke it. It was probably broken since Tiled 1.9.