### PR TITLE
Sentry: Upload only the .debug files and not all .o files

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -120,7 +120,7 @@ jobs:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       run: |
         curl -sL https://sentry.io/get-cli/ | bash
-        sentry-cli upload-dif --log-level=info --include-sources src .
+        sentry-cli debug-files upload --include-sources src AppDir
 
     - name: Build AppImage
       run: |


### PR DESCRIPTION
This appears to help with the "error: Invalid checksum" error encountered since Sentry Native 0.7.0.