### PR TITLE
docs: Some small fixes

### DIFF
--- a/docs/manual/export-tscn.rst
+++ b/docs/manual/export-tscn.rst
@@ -102,7 +102,7 @@ Objects support the following property:
 
 * string ``resPath`` (required)
 
-The ``resPath`` property takes the form of 'res://<pbject path>.tscn' and must
+The ``resPath`` property takes the form of 'res://<object path>.tscn' and must
 be set to the path of the Godot object you wish to replace the object with.
 Objects without this property set will not be exported.
 

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1051,10 +1051,10 @@ declare class TiledObject {
   setProperty(name: string, value: TiledObjectPropertyValue): void;
 
   /**
-   * Sets the value of an object's property identified the given \a path
-   * to \a value.
+   * Sets the value of an object's property identified by the given path
+   * to the given value.
    *
-   * The \a path is a list of property names, where each name identifies
+   * The path is a list of property names, where each name identifies
    * a member of the previous member's value. The last name in the list
    * identifies the property to set.
    *


### PR DESCRIPTION
* Typo in export-tscn manual page
* \a doesn't work for referring to arguments in JS docs