### PR TITLE
Allow --project to be used alongside the --evaluate CLI parameter

### DIFF
--- a/src/tiled/document.cpp
+++ b/src/tiled/document.cpp
@@ -47,7 +47,8 @@ Document::Document(DocumentType type, const QString &fileName,
     mCanonicalFilePath = fileInfo.canonicalFilePath();
     mReadOnly = fileInfo.exists() && !fileInfo.isWritable();
 
-    DocumentManager::instance()->registerDocument(this);
+    if (auto manager = DocumentManager::maybeInstance())
+        manager->registerDocument(this);
 
     connect(mUndoStack, &QUndoStack::indexChanged, this, &Document::updateIsModified);
     connect(mUndoStack, &QUndoStack::cleanChanged, this, &Document::updateIsModified);

--- a/src/tiledapp/main.cpp
+++ b/src/tiledapp/main.cpp
@@ -389,13 +389,9 @@ void CommandLineHandler::evaluateScript()
     for (QString argument = nextArgument(); !argument.isNull(); argument = nextArgument())
         arguments.append(argument);
 
-    ScriptManager &scriptManager = ScriptManager::instance();
-
     static bool initialized = false;
     if (!initialized) {
         initialized = true;
-
-        PluginManager::instance()->loadPlugins();
 
         // Output messages to command-line
         auto& logger = LoggingInterface::instance();
@@ -403,9 +399,10 @@ void CommandLineHandler::evaluateScript()
         QObject::connect(&logger, &LoggingInterface::warning, [] (const QString &message) { qWarning() << message; });
         QObject::connect(&logger, &LoggingInterface::error, [] (const QString &message) { qWarning() << message; });
 
-        scriptManager.ensureInitialized();
+        initializePluginsAndExtensions();
     }
 
+    ScriptManager &scriptManager = ScriptManager::instance();
     scriptManager.setScriptArguments(arguments);
     scriptManager.evaluateFileOrLoadModule(scriptFile);
 }


### PR DESCRIPTION
It is useful to be able to load a project and its extensions when using the `--evaluate` parameter to execute a particular script.

Also fixed a crash in `Document` constructor when using the `--project` parameter, since it would generally cause a project to get loaded without there being a `DocumentManager`.