### PR TITLE
Qbs: Use pkg-config to depend on zlib

### DIFF
--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -6,6 +6,10 @@ DynamicLibrary {
 
     Depends { name: "cpp" }
     Depends { name: "Qt"; submodules: "gui"; versionAtLeast: "5.12" }
+    Depends {
+        condition: !qbs.toolchain.contains("msvc")
+        name: "zlib"
+    }
 
     Probes.PkgConfigProbe {
         id: pkgConfigZstd
@@ -45,9 +49,6 @@ DynamicLibrary {
     }
     cpp.dynamicLibraries: {
         var libs = base;
-
-        if (!qbs.toolchain.contains("msvc"))
-            libs.push("z");
 
         if (pkgConfigZstd.found && !project.staticZstd)
             libs = libs.concat(pkgConfigZstd.libraries);

--- a/tiled.qbs
+++ b/tiled.qbs
@@ -3,8 +3,10 @@ import qbs.Environment
 Project {
     name: "Tiled"
 
-    qbsSearchPaths: "qbs"
-    minimumQbsVersion: "1.13"
+    minimumQbsVersion: "1.21"
+
+    qbsModuleProviders: ["Qt", "qbspkgconfig"]
+    qbsSearchPaths: ["qbs"]
 
     property string version: Environment.getEnv("TILED_VERSION") || "1.11.0";
     property bool snapshot: Environment.getEnv("TILED_SNAPSHOT") == "true"


### PR DESCRIPTION
This way we should support building Tiled with zlib in some strange location, like on NixOS.

To support this on the latest version of Qbs, we need to set `Project.qbsModuleProviders` since it no longer falls back on `pkg-config` by default. Since this property was introduced in Qbs 1.21, this becomes the minimum Qbs version.