### PR TITLE
Added metadata about hardware support

### DIFF
--- a/org.mapeditor.Tiled.appdata.xml
+++ b/org.mapeditor.Tiled.appdata.xml
@@ -362,6 +362,14 @@
    <binary>tiled</binary>
    <id>tiled.desktop</id>
  </provides>
+ <requires>
+  <control>pointing</control>
+  <control>keyboard</control>
+ </requires>
+ <supports>
+  <control>tablet</control>
+  <control>touch</control>
+ </supports>
  <translation type="qt">tiled</translation>
  <update_contact>tingping@fedoraproject.org</update_contact>
 </component>


### PR DESCRIPTION
* Tiled requires a keyboard and a mouse to use.
* It supports tablet and touch input (or should, at least).