### PR TITLE
Removed superfluous Q_DECLARE_METATYPE usages

### DIFF
--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -195,6 +195,3 @@ TILEDSHARED_EXPORT QString typeName(const QVariant &value);
 TILEDSHARED_EXPORT void initializeMetatypes();
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::FilePath)
-Q_DECLARE_METATYPE(Tiled::ObjectRef)

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -664,5 +664,3 @@ inline void TileLayer::setCells(int x, int y, const TileLayer *tileLayer)
 using SharedTileLayer = QSharedPointer<TileLayer>;
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::Cell)

--- a/src/libtiled/world.h
+++ b/src/libtiled/world.h
@@ -113,6 +113,3 @@ public:
 };
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::WorldPattern)
-Q_DECLARE_METATYPE(Tiled::WorldMapEntry)

--- a/src/libtiledquick/mapref.h
+++ b/src/libtiledquick/mapref.h
@@ -45,5 +45,3 @@ public:
 };
 
 } // namespace TiledQuick
-
-Q_DECLARE_METATYPE(TiledQuick::MapRef)

--- a/src/tiled/abstracttool.h
+++ b/src/tiled/abstracttool.h
@@ -324,5 +324,3 @@ inline ToolManager *AbstractTool::toolManager() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::AbstractTool*)

--- a/src/tiled/colorbutton.h
+++ b/src/tiled/colorbutton.h
@@ -55,5 +55,3 @@ private:
 };
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::ColorButton*);

--- a/src/tiled/editableasset.h
+++ b/src/tiled/editableasset.h
@@ -104,5 +104,3 @@ inline Document *EditableAsset::document() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::EditableAsset*)

--- a/src/tiled/editablelayer.h
+++ b/src/tiled/editablelayer.h
@@ -191,5 +191,3 @@ inline EditableLayer *EditableLayer::find(Layer *layer)
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::EditableLayer*)

--- a/src/tiled/editablemap.h
+++ b/src/tiled/editablemap.h
@@ -384,5 +384,3 @@ inline MapDocument *EditableMap::mapDocument() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::EditableMap*)

--- a/src/tiled/editablemapobject.h
+++ b/src/tiled/editablemapobject.h
@@ -295,5 +295,3 @@ inline void EditableMapObject::setHeight(qreal height)
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::Font)

--- a/src/tiled/editableproject.h
+++ b/src/tiled/editableproject.h
@@ -61,5 +61,3 @@ inline Project *EditableProject::project() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::EditableProject*)

--- a/src/tiled/editabletile.h
+++ b/src/tiled/editabletile.h
@@ -166,5 +166,3 @@ inline EditableTile *EditableTile::find(Tile *tile)
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::EditableTile*)

--- a/src/tiled/editabletilelayer.h
+++ b/src/tiled/editabletilelayer.h
@@ -115,5 +115,3 @@ inline TileLayer *EditableTileLayer::tileLayer() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::EditableTileLayer*)

--- a/src/tiled/editabletileset.h
+++ b/src/tiled/editabletileset.h
@@ -331,5 +331,3 @@ inline void EditableTileset::setTileSize(int width, int height)
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::EditableTileset*)

--- a/src/tiled/editablewangset.h
+++ b/src/tiled/editablewangset.h
@@ -122,5 +122,3 @@ inline EditableWangSet *EditableWangSet::find(WangSet *wangSet)
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::EditableWangSet*)

--- a/src/tiled/editableworld.h
+++ b/src/tiled/editableworld.h
@@ -68,5 +68,3 @@ inline World *EditableWorld::world() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::EditableWorld*)

--- a/src/tiled/fileedit.h
+++ b/src/tiled/fileedit.h
@@ -88,5 +88,3 @@ inline bool FileEdit::isDirectory() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::FileEdit*)

--- a/src/tiled/mapview.h
+++ b/src/tiled/mapview.h
@@ -159,5 +159,3 @@ inline QPointF MapView::viewCenter() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::MapView*)

--- a/src/tiled/regionvaluetype.h
+++ b/src/tiled/regionvaluetype.h
@@ -132,5 +132,3 @@ inline const QRegion &RegionValueType::region() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::RegionValueType)

--- a/src/tiled/scriptdialog.h
+++ b/src/tiled/scriptdialog.h
@@ -114,6 +114,3 @@ private:
 void registerDialog(QJSEngine *jsEngine);
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::ScriptDialog*);
-Q_DECLARE_METATYPE(Tiled::ScriptImageWidget*)

--- a/src/tiled/scriptedaction.h
+++ b/src/tiled/scriptedaction.h
@@ -68,5 +68,3 @@ inline QString ScriptedAction::iconFileName() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::ScriptedAction*)

--- a/src/tiled/scriptedtool.h
+++ b/src/tiled/scriptedtool.h
@@ -94,5 +94,3 @@ inline QString ScriptedTool::iconFileName() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::ScriptedTool*)

--- a/src/tiled/scriptfile.cpp
+++ b/src/tiled/scriptfile.cpp
@@ -793,7 +793,4 @@ void registerFile(QJSEngine *jsEngine)
 
 } // namespace Tiled
 
-Q_DECLARE_METATYPE(Tiled::ScriptBinaryFile*)
-Q_DECLARE_METATYPE(Tiled::ScriptTextFile*)
-
 #include "scriptfile.moc"

--- a/src/tiled/scriptfileformatwrappers.h
+++ b/src/tiled/scriptfileformatwrappers.h
@@ -77,6 +77,3 @@ public:
 };
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::ScriptTilesetFormatWrapper*)
-Q_DECLARE_METATYPE(Tiled::ScriptMapFormatWrapper*)

--- a/src/tiled/scriptimage.h
+++ b/src/tiled/scriptimage.h
@@ -161,5 +161,3 @@ private:
 };
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::ScriptImage*)

--- a/src/tiled/tilecollisiondock.h
+++ b/src/tiled/tilecollisiondock.h
@@ -169,5 +169,3 @@ inline bool TileCollisionDock::hasSelectedObjects() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::TileCollisionDock*)

--- a/src/tiled/tilelayeredit.h
+++ b/src/tiled/tilelayeredit.h
@@ -79,5 +79,3 @@ inline EditableTileLayer *TileLayerEdit::target() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::TileLayerEdit*)

--- a/src/tiled/tilelayerwangedit.h
+++ b/src/tiled/tilelayerwangedit.h
@@ -148,5 +148,3 @@ inline void TileLayerWangEdit::setEdge(int x, int y, WangIndex::Value edge, int 
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::TileLayerWangEdit*)

--- a/src/tiled/tileseteditor.h
+++ b/src/tiled/tileseteditor.h
@@ -209,5 +209,3 @@ inline TileCollisionDock *TilesetEditor::collisionEditor() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::TilesetEditor*)

--- a/src/tiled/tilesetview.h
+++ b/src/tiled/tilesetview.h
@@ -173,5 +173,3 @@ inline bool TilesetView::markAnimatedTiles() const
 }
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::TilesetView *)

--- a/src/tiled/wangsetview.h
+++ b/src/tiled/wangsetview.h
@@ -58,5 +58,3 @@ private:
 };
 
 } // namespace Tiled
-
-Q_DECLARE_METATYPE(Tiled::WangSetView *)


### PR DESCRIPTION
This macro is not needed in a bunch of cases, in particular, the meta type is automatically declared for `Q_GADGET` types and pointers to types derived from `QObject`.