### PR TITLE
Renamed usages of deprecated Q_OS_OSX define

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -358,9 +358,9 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     mUi->actionPaste->setShortcuts(QKeySequence::Paste);
     QList<QKeySequence> deleteKeys = QKeySequence::keyBindings(QKeySequence::Delete);
     deleteKeys.removeAll(Qt::Key_D | Qt::ControlModifier);  // used as "duplicate" shortcut
-#ifdef Q_OS_OSX
+#ifdef Q_OS_MACOS
     // Add the Backspace key as primary shortcut for Delete, which seems to be
-    // the expected one for OS X.
+    // the expected one for macOS.
     if (!deleteKeys.contains(QKeySequence(Qt::Key_Backspace)))
         deleteKeys.prepend(QKeySequence(Qt::Key_Backspace));
 #endif

--- a/src/tiled/tabbar.cpp
+++ b/src/tiled/tabbar.cpp
@@ -51,7 +51,7 @@ void TabBar::mouseReleaseEvent(QMouseEvent *event)
 
 void TabBar::wheelEvent(QWheelEvent *event)
 {
-    // Qt excludes OS X when implementing mouse wheel for switching tabs.
+    // Qt excludes macOS when implementing mouse wheel for switching tabs.
     // However, we explicitly want this feature on the tilesets and open
     // documents tab bars as a possible means of navigation.
 

--- a/src/tiled/tiledapplication.cpp
+++ b/src/tiled/tiledapplication.cpp
@@ -83,7 +83,7 @@ NewsFeed &TiledApplication::newsFeed()
 
 bool TiledApplication::event(QEvent *event)
 {
-    // Handle the QFileOpenEvent to open files on MacOS X.
+    // Handle the QFileOpenEvent to open files on macOS.
     if (event->type() == QEvent::FileOpen) {
         QFileOpenEvent *fileOpenEvent = static_cast<QFileOpenEvent*>(event);
         emit fileOpenRequest(fileOpenEvent->file());

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -308,8 +308,8 @@ void TilesetDock::setMapDocument(MapDocument *mapDocument)
         return;
 
     // Hide while we update the tab bar, to avoid repeated layouting
-    // But, this causes problems on OS X (issue #1055)
-#ifndef Q_OS_OSX
+    // But, this causes problems on macOS (issue #1055)
+#ifndef Q_OS_MACOS
     widget()->hide();
 #endif
 
@@ -339,7 +339,7 @@ void TilesetDock::setMapDocument(MapDocument *mapDocument)
 
     updateActions();
 
-#ifndef Q_OS_OSX
+#ifndef Q_OS_MACOS
     widget()->show();
 #endif
 }


### PR DESCRIPTION
Also updated a bunch of comments using the old name for macOS.