### PR TITLE
Scripting: Added MapEditor.currentBrushChanged signal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Scripting: Added `FileFormat.nameFilter`
+* Scripting: Added `MapEditor.currentBrushChanged` signal
 
 ### Tiled 1.11.0 (27 June 2024)
 

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1562,7 +1562,7 @@ declare class Asset extends TiledObject {
   /**
    * The signal emitted when {@link modified} changes.
    */
-  readonly modifiedChanged: Signal<null>;
+  readonly modifiedChanged: Signal<void>;
 
   /**
    * Whether the asset is a {@link TileMap}.
@@ -2370,6 +2370,16 @@ interface MapEditor {
   currentBrush : TileMap
 
   /**
+   * Signal emitted when the current brush has changed.
+   *
+   * This signal is also emitted when assigning to {@link currentBrush}, so be
+   * careful not to cause an infinite loop.
+   *
+   * @since 1.11.1
+   */
+  currentBrushChanged : Signal<void>;
+
+  /**
    * Gets the currently selected {@link WangSet} in the "Terrain Sets" view.
    *
    * See also {@link TileLayerWangEdit}.
@@ -2383,7 +2393,7 @@ interface MapEditor {
    *
    * @since 1.8
    */
-  readonly currentWangSetChanged: Signal<null>;
+  readonly currentWangSetChanged: Signal<void>;
 
   /**
    * Gets the currently selected Wang color index in the "Terrain Sets" view.
@@ -2430,7 +2440,7 @@ interface TilesetsView {
    *
    * @since 1.9.1
    */
-  readonly currentTilesetChanged: Signal<null>;
+  readonly currentTilesetChanged: Signal<void>;
 
   /**
    * A list of the tiles that are selected in the current tileset.
@@ -2876,7 +2886,7 @@ declare class TileMap extends Asset {
   /**
    * The signal emitted when {@link currentLayer} changes.
    */
-  readonly currentLayerChanged: Signal<null>;
+  readonly currentLayerChanged: Signal<void>;
 
   /**
    * Selected layers.
@@ -2889,7 +2899,7 @@ declare class TileMap extends Asset {
   /**
    * The signal emitted when {@link selectedLayers} changes.
    */
-  readonly selectedLayersChanged: Signal<null>;
+  readonly selectedLayersChanged: Signal<void>;
 
   /**
    * Selected objects.
@@ -2902,7 +2912,7 @@ declare class TileMap extends Asset {
   /**
    * The signal emitted when {@link selectedObjects} changes.
    */
-  readonly selectedObjectsChanged: Signal<null>;
+  readonly selectedObjectsChanged: Signal<void>;
 
   /**
    * Constructs a new map.
@@ -3880,7 +3890,7 @@ interface TilesetEditor {
    *
    * @since 1.9
    */
-  readonly currentWangSetChanged: Signal<null>;
+  readonly currentWangSetChanged: Signal<void>;
 
   /**
    * Gets the currently selected Wang color index in the "Terrain Sets" view.

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -783,6 +783,8 @@ void MapEditor::setStamp(const TileStamp &stamp)
         mToolManager->selectTool(mStampBrush);
 
     mTilesetDock->selectTilesInStamp(stamp);
+
+    emit currentBrushChanged();
 }
 
 void MapEditor::selectWangBrush()

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -73,7 +73,7 @@ class MapEditor final : public Editor
     Q_OBJECT
 
     Q_PROPERTY(Tiled::TilesetDock *tilesetsView READ tilesetDock CONSTANT)
-    Q_PROPERTY(Tiled::EditableMap *currentBrush READ currentBrush WRITE setCurrentBrush)
+    Q_PROPERTY(Tiled::EditableMap *currentBrush READ currentBrush WRITE setCurrentBrush NOTIFY currentBrushChanged)
     Q_PROPERTY(Tiled::EditableWangSet *currentWangSet READ currentWangSet NOTIFY currentWangSetChanged)
     Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex NOTIFY currentWangColorIndexChanged)
     Q_PROPERTY(Tiled::MapView *currentMapView READ currentMapView CONSTANT)
@@ -130,6 +130,7 @@ public:
     AbstractTool *selectedTool() const;
 
 signals:
+    void currentBrushChanged();
     void currentWangSetChanged();
     void currentWangColorIndexChanged(int colorIndex);
 


### PR DESCRIPTION
So scripts can respond to brush changes. If they are careful, they can also adjust the brush, though this will trigger another `currentBrushChanged` call.