### PR TITLE
Added Expand/Collapse API to GroupLayer

### DIFF
--- a/src/libtiled/grouplayer.h
+++ b/src/libtiled/grouplayer.h
@@ -56,6 +56,8 @@ public:
     QList<Layer*>::const_iterator begin() const { return mLayers.begin(); }
     QList<Layer*>::const_iterator end() const { return mLayers.end(); }
 
+    bool isExpanded() const;
+    void setExpanded(bool expanded);
 protected:
     void setMap(Map *map) override;
     GroupLayer *initializeClone(GroupLayer *clone) const;
@@ -64,8 +66,19 @@ private:
     void adoptLayer(Layer &layer);
 
     QList<Layer*> mLayers;
+
+    bool mExpanded = true;
 };
 
+
+inline bool GroupLayer::isExpanded() const
+{
+    return mExpanded;
+}
+
+inline void GroupLayer::setExpanded(bool expanded)  {
+    mExpanded = expanded;
+}
 
 inline int GroupLayer::layerCount() const
 {

--- a/src/tiled/changelayer.cpp
+++ b/src/tiled/changelayer.cpp
@@ -24,6 +24,7 @@
 #include "document.h"
 #include "layer.h"
 #include "map.h"
+#include "grouplayer.h"
 
 #include <QCoreApplication>
 
@@ -210,6 +211,26 @@ void SetTileLayerSize::setValue(TileLayer *layer, const QSize &value) const
 {
     layer->setSize(value);
     emit document()->changed(TileLayerChangeEvent(layer, TileLayerChangeEvent::SizeProperty));
+}
+
+SetGroupLayerExpanded::SetGroupLayerExpanded(Document *document,
+                                 QList<GroupLayer *> layers,
+                                 bool expanded)
+    : ChangeValue<GroupLayer, bool>(document, std::move(layers), expanded)
+{
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Group Layer Expanded State"));
+}
+
+bool SetGroupLayerExpanded::getValue(const GroupLayer *layer) const
+{
+    return layer->isExpanded();
+}
+
+void SetGroupLayerExpanded::setValue(GroupLayer *layer, const bool &value) const
+{
+    layer->setExpanded(value);
+//    emit document()->changed(LayerChangeEvent(layer, LayerChangeEvent::OpacityProperty));
 }
 
 } // namespace Tiled

--- a/src/tiled/changelayer.h
+++ b/src/tiled/changelayer.h
@@ -31,6 +31,7 @@ namespace Tiled {
 
 class Layer;
 class TileLayer;
+class GroupLayer;
 
 class SetLayerName : public ChangeValue<Layer, QString>
 {
@@ -170,6 +171,23 @@ public:
 private:
     QSize getValue(const TileLayer *layer) const override;
     void setValue(TileLayer *layer, const QSize &value) const override;
+};
+
+/**
+ * Used for changing group layer expanded state.
+ */
+class SetGroupLayerExpanded : public ChangeValue<GroupLayer, bool>
+{
+public:
+    SetGroupLayerExpanded(Document *document,
+                    QList<GroupLayer *> layers,
+                    bool expanded);
+
+    int id() const override { return Cmd_ChangeGroupLayerExpanded; }
+
+private:
+    bool getValue(const GroupLayer *layer) const override;
+    void setValue(GroupLayer *layer, const bool &value) const override;
 };
 
 } // namespace Tiled

--- a/src/tiled/editablegrouplayer.cpp
+++ b/src/tiled/editablegrouplayer.cpp
@@ -20,10 +20,16 @@
 
 #include "editablegrouplayer.h"
 
+#include "changelayer.h"
 #include "addremovelayer.h"
 #include "addremovetileset.h"
 #include "editablemap.h"
 #include "scriptmanager.h"
+#include "documentmanager.h"
+#include "mapeditor.h"
+#include "layerdock.h"
+#include "layermodel.h"
+#include "qabstractproxymodel.h"
 
 #include <QCoreApplication>
 
@@ -134,6 +140,28 @@ void EditableGroupLayer::addLayer(EditableLayer *editableLayer)
     }
 
     insertLayerAt(layerCount(), editableLayer);
+}
+
+inline bool EditableGroupLayer::isExpanded() const
+{
+
+    return groupLayer()->isExpanded();
+}
+
+inline void EditableGroupLayer::setExpanded(bool expanded)
+{
+    if (auto doc = document()){
+        auto documentManager = DocumentManager::instance();
+        auto mapEditor = static_cast<MapEditor*>(documentManager->editor(Document::MapDocumentType));
+
+        auto sourceIndex = mapDocument()->layerModel()->index(layer());
+        auto layerView = mapEditor->layerDock()->layerView();
+
+        auto index = layerView->proxyModel()->mapFromSource(sourceIndex);
+        layerView->setExpanded(index, expanded);
+        asset()->push(new SetGroupLayerExpanded(doc, { groupLayer() }, expanded));
+    }else if (!checkReadOnly())
+        groupLayer()->setExpanded(expanded);
 }
 
 } // namespace Tiled

--- a/src/tiled/editablegrouplayer.h
+++ b/src/tiled/editablegrouplayer.h
@@ -31,6 +31,7 @@ class EditableGroupLayer : public EditableLayer
 
     Q_PROPERTY(int layerCount READ layerCount)
     Q_PROPERTY(QList<QObject*> layers READ layers)
+    Q_PROPERTY(bool expanded READ isExpanded WRITE setExpanded)
 
 public:
     Q_INVOKABLE explicit EditableGroupLayer(const QString &name = QString(),
@@ -48,6 +49,10 @@ public:
     Q_INVOKABLE void removeLayer(Tiled::EditableLayer *editableLayer);
     Q_INVOKABLE void insertLayerAt(int index, Tiled::EditableLayer *editableLayer);
     Q_INVOKABLE void addLayer(Tiled::EditableLayer *editableLayer);
+
+    bool isExpanded() const;
+public slots:
+    void setExpanded(bool expanded);
 
 private:
     GroupLayer *groupLayer() const;

--- a/src/tiled/layerdock.h
+++ b/src/tiled/layerdock.h
@@ -54,6 +54,8 @@ public:
      */
     void setMapDocument(MapDocument *mapDocument);
 
+    LayerView *layerView() const { return mLayerView; };
+
 protected:
     void changeEvent(QEvent *e) override;
 
@@ -89,6 +91,8 @@ public:
     void setMapDocument(MapDocument *mapDocument);
 
     void editLayerModelIndex(const QModelIndex &layerModelIndex);
+
+    QAbstractProxyModel *proxyModel() { return mProxyModel; }
 
 protected:
     bool event(QEvent *event) override;

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -83,6 +83,7 @@ public:
     ~MapEditor() override;
 
     TilesetDock *tilesetDock() const { return mTilesetDock; }
+    LayerDock *layerDock() const { return mLayerDock; }
     TemplatesDock *templatesDock() const { return mTemplatesDock; }
 
     void saveState() override;

--- a/src/tiled/undocommands.h
+++ b/src/tiled/undocommands.h
@@ -52,6 +52,8 @@ enum UndoCommands {
     Cmd_EraseTiles,
     Cmd_PaintTileLayer,
     Cmd_SetProperty,
+    Cmd_ChangeGroupLayerExpanded,
+    Cmd_ChangeObjectGroupExpanded,
 };
 
 /**


### PR DESCRIPTION
Related issue: #3997

Added a new scripting field in GroupLayer called expanded that controls the layer's expand state.

From what I'd been able to gather, in order to expand/collapse layers I would need access to LayerView(QTreeView) which controls layer expansion with setExpanded. It wasn't possible since those properties were privated so I added getters to access [LayerDock](https://github.com/PalaBeaveR/tiled/blob/d684b2810cf5b1aeb9d70a9e91bcb98ee935de0d/src/tiled/mapeditor.h#L86), [LayerView](https://github.com/PalaBeaveR/tiled/blob/d684b2810cf5b1aeb9d70a9e91bcb98ee935de0d/src/tiled/layerdock.h#L57), [QAbstractProxyModel](https://github.com/PalaBeaveR/tiled/blob/d684b2810cf5b1aeb9d70a9e91bcb98ee935de0d/src/tiled/layerdock.h#L95).

Right now the expanded state is stored in [GroupLayer](https://github.com/PalaBeaveR/tiled/blob/d684b2810cf5b1aeb9d70a9e91bcb98ee935de0d/src/libtiled/grouplayer.h#L70) and is not synced, however since Qt already stores that state itself, the scripting interface can be made to use that instead.

I also don't know if the same API is appropriate for ObjectGroup(as requested by #3997), but i have that code made in the same way as GroupLayer if it is needed.

I'm not sure if the new definitions in changelayer.h/undocommands.h are needed since i was just copying code from other places in the repo so it would be nice to have that clarified.

