### PR TITLE
Qbs: Add option to specify custom Python pkg-config name

### DIFF
--- a/src/plugins/python/python.qbs
+++ b/src/plugins/python/python.qbs
@@ -22,7 +22,7 @@ TiledPlugin {
 
     Probes.PkgConfigProbe {
         id: pkgConfigPython3
-        name: "python3-embed"
+        name: project.pythonPkgConfigName
         minVersion: "3.8"
     }
 

--- a/tiled.qbs
+++ b/tiled.qbs
@@ -18,6 +18,7 @@ Project {
     property bool sentry: false
     property bool dbus: true
     property string openSslPath: Environment.getEnv("OPENSSL_PATH")
+    property string pythonPkgConfigName: "python3-embed"
 
     references: [
         "dist/archive.qbs",


### PR DESCRIPTION
I am Gentoo maintainer of Tiled. In Gentoo, there may be many Python versions installed at the same time for compatibility reasons, and each version has separate name in pkg-config.

For example, for Python 3.12 it would be named python-3.12-embed, so running pkg-config for python-embed will fail. Adding this option so it's possible to specify the correct name from build script.
