### PR TITLE
Refactored World management

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Scripting: Added `FileFormat.nameFilter`
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
+* Fixed crash when accessing a world through a symlink (#4042)
 
 ### Tiled 1.11.0 (27 June 2024)
 

--- a/src/libtiled/world.cpp
+++ b/src/libtiled/world.cpp
@@ -46,10 +46,7 @@ namespace Tiled {
 
 void World::setMapRect(int mapIndex, const QRect &rect)
 {
-    if (maps[mapIndex].rect != rect) {
-        maps[mapIndex].rect = rect;
-        hasUnsavedChanges = true;
-    }
+    maps[mapIndex].rect = rect;
 }
 
 void World::removeMap(int mapIndex)
@@ -379,8 +376,6 @@ bool World::save(World &world, QString *errorString)
 
     file.write(doc.toJson());
     file.close();
-
-    world.hasUnsavedChanges = false;
 
     return true;
 }

--- a/src/libtiled/world.cpp
+++ b/src/libtiled/world.cpp
@@ -268,7 +268,7 @@ std::unique_ptr<World> World::load(const QString &fileName,
     QDir dir = QFileInfo(fileName).dir();
     std::unique_ptr<World> world(new World);
 
-    world->fileName = QFileInfo(fileName).canonicalFilePath();
+    world->fileName = fileName;
 
     const QJsonArray maps = object.value(QLatin1String("maps")).toArray();
     for (const QJsonValue &value : maps) {

--- a/src/libtiled/world.h
+++ b/src/libtiled/world.h
@@ -80,7 +80,6 @@ public:
     QVector<WorldMapEntry> maps;
     QVector<WorldPattern> patterns;
     bool onlyShowAdjacentMaps = false;
-    bool hasUnsavedChanges = false;
 
     int mapIndex(const QString &fileName) const;
     void setMapRect(int mapIndex, const QRect &rect);

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -30,6 +30,7 @@ namespace Tiled {
 class World;
 
 class SelectionRectangle;
+class WorldDocument;
 
 /**
  * A convenient base class for tools that work on object layers. Implements
@@ -74,8 +75,8 @@ protected:
     void addAnotherMapToWorldAtCenter();
     void addAnotherMapToWorld(QPoint insertPos);
     void removeCurrentMapFromWorld();
-    void removeFromWorld(const QString &mapFileName);
-    void addToWorld(const World *world);
+    void removeFromWorld(WorldDocument *worldDocument, const QString &mapFileName);
+    void addToWorld(WorldDocument *worldDocument);
 
     QPoint snapPoint(QPoint point, MapDocument *document) const;
 
@@ -85,7 +86,7 @@ protected:
 
     bool mapCanBeMoved(MapDocument *mapDocument) const;
     QRect mapRect(MapDocument *mapDocument) const;
-    const World *constWorld(MapDocument *mapDocument) const;
+    WorldDocument *worldForMap(MapDocument *mapDocument) const;
 
     void showContextMenu(QGraphicsSceneMouseEvent *);
 

--- a/src/tiled/changeworld.h
+++ b/src/tiled/changeworld.h
@@ -26,43 +26,59 @@
 
 namespace Tiled {
 
-class AddMapCommand : public QUndoCommand
+class WorldDocument;
+
+class AddRemoveMapCommand : public QUndoCommand
 {
 public:
-    AddMapCommand(const QString &worldName, const QString &mapName, const QRect &rect);
+    AddRemoveMapCommand(WorldDocument *worldDocument,
+                        const QString &mapName,
+                        const QRect &rect,
+                        QUndoCommand *parent = nullptr);
 
-    void undo() override;
-    void redo() override;
+protected:
+    void addMap();
+    void removeMap();
 
-private:
-    QString mWorldName;
+    WorldDocument *mWorldDocument;
     QString mMapName;
     QRect mRect;
 };
 
-class RemoveMapCommand : public QUndoCommand
+class AddMapCommand : public AddRemoveMapCommand
 {
 public:
-    RemoveMapCommand(const QString &mapName);
+    AddMapCommand(WorldDocument *worldDocument,
+                  const QString &mapName,
+                  const QRect &rect);
 
-    void undo() override;
+    void undo() override { removeMap(); }
+    void redo() override { addMap(); }
+};
+
+class RemoveMapCommand : public AddRemoveMapCommand
+{
+public:
+    RemoveMapCommand(WorldDocument *worldDocument, const QString &mapName);
+
+    void undo() override { addMap(); }
     void redo() override;
-
-private:
-    QString mWorldName;
-    QString mMapName;
-    QRect mPreviousRect;
 };
 
 class SetMapRectCommand : public QUndoCommand
 {
 public:
-    SetMapRectCommand(const QString &mapName, QRect rect);
+    SetMapRectCommand(WorldDocument *worldDocument,
+                      const QString &mapName,
+                      const QRect &rect);
 
-    void undo() override;
-    void redo() override;
+    void undo() override { setMapRect(mPreviousRect); }
+    void redo() override { setMapRect(mRect); }
 
 private:
+    void setMapRect(const QRect &rect);
+
+    WorldDocument *mWorldDocument;
     QString mMapName;
     QRect mRect;
     QRect mPreviousRect;

--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -27,8 +27,6 @@
 #include "mapdocument.h"
 #include "mapobject.h"
 #include "projectmanager.h"
-#include "world.h"
-#include "worlddocument.h"  // used to know that WorldDocument is a Document
 #include "worldmanager.h"
 
 #include <QAction>
@@ -107,8 +105,8 @@ static QString replaceVariables(const QString &string, bool quoteValues = true)
                                 replaceString.arg(currentObject->id()));
         }
 
-        if (const World *world = WorldManager::instance().worldForMap(fileName)) {
-            finalString.replace(QLatin1String("%worldfile"), replaceString.arg(world->fileName));
+        if (auto worldDocument = WorldManager::instance().worldForMap(fileName)) {
+            finalString.replace(QLatin1String("%worldfile"), replaceString.arg(worldDocument->fileName()));
         }
     }
 
@@ -160,10 +158,8 @@ void Command::execute(bool inTerminal) const
 
         if (Document *document = DocumentManager::instance()->currentDocument()) {
             if (document->type() == Document::MapDocumentType) {
-                if (const World *world = WorldManager::instance().worldForMap(document->fileName())) {
-                    auto worldDocument = DocumentManager::instance()->ensureWorldDocument(world->fileName);
-                    DocumentManager::instance()->saveDocument(worldDocument);
-                }
+                if (auto worldDocument = WorldManager::instance().worldForMap(document->fileName()))
+                    DocumentManager::instance()->saveDocument(worldDocument.data());
             }
         }
     }

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -140,9 +140,7 @@ public:
 
     void abortMultiDocumentClose();
 
-    WorldDocument *ensureWorldDocument(const QString &fileName);
     bool isAnyWorldModified() const;
-    bool isWorldModified(const QString &fileName) const;
 
     QString fileDialogStartLocation() const;
 
@@ -194,8 +192,8 @@ public slots:
     void saveFile();
 
 private:
-    void onWorldLoaded(const QString &worldFile);
-    void onWorldUnloaded(const QString &worldFile);
+    void onWorldLoaded(WorldDocument *worldDocument);
+    void onWorldUnloaded(WorldDocument *worldDocument);
 
     void currentIndexChanged();
     void fileNameChanged(const QString &fileName,
@@ -233,7 +231,6 @@ private:
     QIcon mLockedIcon;
 
     QVector<DocumentPtr> mDocuments;
-    QMap<QString, WorldDocument*> mWorldDocuments;
     TilesetDocumentsModel *mTilesetDocumentsModel;
 
     // Pointer becomes null when deleted as part of the UI, to prevent double-deletion

--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -667,7 +667,7 @@ QSharedPointer<Document> EditableMap::createDocument()
 
     mSelectedArea = new EditableSelectedArea(document.data(), this);
 
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
+    moveOwnershipToCpp();
 
     return document;
 }

--- a/src/tiled/editableworld.cpp
+++ b/src/tiled/editableworld.cpp
@@ -21,6 +21,7 @@
 
 #include "editableworld.h"
 
+#include "changeevents.h"
 #include "changeworld.h"
 #include "maprenderer.h"
 #include "scriptmanager.h"
@@ -142,6 +143,20 @@ QSharedPointer<Document> EditableWorld::createDocument()
     // We don't currently support opening a world in its own tab, which this
     // function is meant for.
     return nullptr;
+}
+
+void EditableWorld::documentChanged(const ChangeEvent &event)
+{
+    switch (event.type) {
+    case ChangeEvent::DocumentAboutToReload:
+        setObject(nullptr);
+        break;
+    case ChangeEvent::DocumentReloaded:
+        setObject(worldDocument()->world());
+        break;
+    default:
+        break;
+    }
 }
 
 } // namespace Tiled

--- a/src/tiled/editableworld.cpp
+++ b/src/tiled/editableworld.cpp
@@ -33,13 +33,8 @@ namespace Tiled {
 EditableWorld::EditableWorld(WorldDocument *worldDocument, QObject *parent)
     : EditableAsset(nullptr, parent)
 {
-    setObject(WorldManager::instance().worlds().value(worldDocument->fileName()));
+    setObject(worldDocument->world());
     setDocument(worldDocument);
-}
-
-bool EditableWorld::containsMap(const QString &fileName) const
-{
-    return world()->containsMap(fileName);
 }
 
 bool EditableWorld::containsMap(EditableMap *map) const
@@ -56,26 +51,6 @@ bool EditableWorld::containsMap(EditableMap *map) const
     return containsMap(map->fileName());
 }
 
-QVector<WorldMapEntry> EditableWorld::maps() const
-{
-    return world()->maps;
-}
-
-QVector<WorldMapEntry> EditableWorld::mapsInRect(const QRect &rect) const
-{
-    return world()->mapsInRect(rect);
-}
-
-QVector<WorldMapEntry> EditableWorld::allMaps() const
-{
-    return world()->allMaps();
-}
-
-QVector<WorldPattern> EditableWorld::patterns() const
-{
-    return world()->patterns;
-}
-
 bool EditableWorld::isReadOnly() const
 {
     return !world()->canBeModified();
@@ -89,7 +64,7 @@ void EditableWorld::setMapRect(const QString &mapFileName, const QRect &rect)
         return;
     }
 
-    document()->undoStack()->push(new SetMapRectCommand(mapFileName, rect));
+    document()->undoStack()->push(new SetMapRectCommand(worldDocument(), mapFileName, rect));
 }
 
 void EditableWorld::setMapPos(EditableMap *map, int x, int y)
@@ -107,7 +82,7 @@ void EditableWorld::setMapPos(EditableMap *map, int x, int y)
 
     QRect rect = world()->maps.at(mapIndex).rect;
     rect.moveTo(x, y);
-    document()->undoStack()->push(new SetMapRectCommand(map->fileName(), rect));
+    document()->undoStack()->push(new SetMapRectCommand(worldDocument(), map->fileName(), rect));
 }
 
 void EditableWorld::addMap(const QString &mapFileName, const QRect &rect)
@@ -122,7 +97,7 @@ void EditableWorld::addMap(const QString &mapFileName, const QRect &rect)
         return;
     }
 
-    document()->undoStack()->push(new AddMapCommand(fileName(), mapFileName, rect));
+    document()->undoStack()->push(new AddMapCommand(worldDocument(), mapFileName, rect));
 }
 
 void EditableWorld::addMap(EditableMap *map, int x, int y)
@@ -149,7 +124,7 @@ void EditableWorld::removeMap(const QString &mapFileName)
         return;
     }
 
-    document()->undoStack()->push(new RemoveMapCommand(mapFileName));
+    document()->undoStack()->push(new RemoveMapCommand(worldDocument(), mapFileName));
 }
 
 void EditableWorld::removeMap(EditableMap *map)

--- a/src/tiled/editableworld.h
+++ b/src/tiled/editableworld.h
@@ -61,6 +61,9 @@ public:
     Q_INVOKABLE void removeMap(EditableMap *map);
 
     QSharedPointer<Document> createDocument() override;
+
+private:
+    void documentChanged(const ChangeEvent &event);
 };
 
 inline World *EditableWorld::world() const

--- a/src/tiled/editableworld.h
+++ b/src/tiled/editableworld.h
@@ -44,6 +44,7 @@ public:
     AssetType::Value assetType() const override { return AssetType::World; }
 
     World *world() const;
+    WorldDocument *worldDocument() const;
 
     QVector<WorldMapEntry> maps() const;
     QVector<WorldPattern> patterns() const;
@@ -65,6 +66,36 @@ public:
 inline World *EditableWorld::world() const
 {
     return static_cast<World*>(object());
+}
+
+inline WorldDocument *EditableWorld::worldDocument() const
+{
+    return static_cast<WorldDocument*>(document());
+}
+
+inline QVector<WorldMapEntry> EditableWorld::maps() const
+{
+    return world()->maps;
+}
+
+inline QVector<WorldPattern> EditableWorld::patterns() const
+{
+    return world()->patterns;
+}
+
+inline QVector<WorldMapEntry> EditableWorld::mapsInRect(const QRect &rect) const
+{
+    return world()->mapsInRect(rect);
+}
+
+inline QVector<WorldMapEntry> EditableWorld::allMaps() const
+{
+    return world()->allMaps();
+}
+
+inline bool EditableWorld::containsMap(const QString &fileName) const
+{
+    return world()->containsMap(fileName);
 }
 
 } // namespace Tiled

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -64,6 +64,7 @@ class ProjectDock;
 class ProjectModel;
 class TilesetDocument;
 class TilesetEditor;
+class WorldDocument;
 class Zoomable;
 
 /**
@@ -212,7 +213,7 @@ private:
       */
     bool confirmAllSave();
 
-    bool confirmSaveWorld(const QString &fileName);
+    bool confirmSaveWorld(WorldDocument *worldDocument);
 
     void writeSettings();
     void readSettings();

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -84,7 +84,7 @@ public:
     /**
      * Constructs a map document around the given map.
      */
-    MapDocument(std::unique_ptr<Map> map);
+    explicit MapDocument(std::unique_ptr<Map> map);
 
     ~MapDocument() override;
 

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -295,7 +295,8 @@ void MapScene::refreshScene()
     const WorldManager &worldManager = WorldManager::instance();
     const QString &currentMapFile = mMapDocument->canonicalFilePath();
 
-    if (const World *world = worldManager.worldForMap(currentMapFile)) {
+    if (auto worldDocument = worldManager.worldForMap(currentMapFile)) {
+        const auto world = worldDocument->world();
         const QPoint currentMapPosition = world->mapRect(currentMapFile).topLeft();
         auto const contextMaps = world->contextMaps(currentMapFile);
 

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -293,7 +293,7 @@ void MapScene::refreshScene()
     }
 
     const WorldManager &worldManager = WorldManager::instance();
-    const QString &currentMapFile = mMapDocument->canonicalFilePath();
+    const QString &currentMapFile = mMapDocument->fileName();
 
     if (auto worldDocument = worldManager.worldForMap(currentMapFile)) {
         const auto world = worldDocument->world();

--- a/src/tiled/projectdocument.h
+++ b/src/tiled/projectdocument.h
@@ -31,7 +31,7 @@ class ProjectDocument final : public Document
     Q_OBJECT
 
 public:
-    ProjectDocument(std::unique_ptr<Project> project, QObject *parent = nullptr);
+    explicit ProjectDocument(std::unique_ptr<Project> project, QObject *parent = nullptr);
     ~ProjectDocument() override;
 
     QString displayName() const override;

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -39,7 +39,6 @@
 #include "scriptmanager.h"
 #include "tilesetdocument.h"
 #include "tileseteditor.h"
-#include "world.h"
 #include "worlddocument.h"
 #include "worldmanager.h"
 
@@ -746,10 +745,8 @@ QList<QObject *> ScriptModule::worlds() const
     if (!documentManager)
         return worlds;
 
-    for (const World *world : WorldManager::instance().worlds()) {
-        WorldDocument *worldDocument = documentManager->ensureWorldDocument(world->fileName);
+    for (auto &worldDocument : WorldManager::instance().worlds())
         worlds.append(worldDocument->editable());
-    }
 
     return worlds;
 }
@@ -761,7 +758,8 @@ void ScriptModule::loadWorld(const QString &fileName) const
 
 void ScriptModule::unloadWorld(const QString &fileName) const
 {
-    WorldManager::instance().unloadWorld(fileName);
+    if (auto worldDocument = WorldManager::instance().findWorld(fileName))
+        WorldManager::instance().unloadWorld(worldDocument);
 }
 
 void ScriptModule::unloadAllWorlds() const

--- a/src/tiled/tilesetdocument.h
+++ b/src/tiled/tilesetdocument.h
@@ -51,7 +51,7 @@ class TilesetDocument final : public Document
     Q_OBJECT
 
 public:
-    TilesetDocument(const SharedTileset &tileset);
+    explicit TilesetDocument(const SharedTileset &tileset);
     ~TilesetDocument() override;
 
     TilesetDocumentPtr sharedFromThis() { return qSharedPointerCast<TilesetDocument>(Document::sharedFromThis()); }

--- a/src/tiled/worlddocument.h
+++ b/src/tiled/worlddocument.h
@@ -69,6 +69,8 @@ public:
 
     World *world() const { return mWorld.get(); }
 
+    void swapWorld(std::unique_ptr<World> &other);
+
 signals:
     void worldChanged();
 

--- a/src/tiled/worlddocument.h
+++ b/src/tiled/worlddocument.h
@@ -28,6 +28,12 @@ class WorldManager;
 
 namespace Tiled {
 
+class World;
+
+class WorldDocument;
+
+using WorldDocumentPtr = QSharedPointer<WorldDocument>;
+
 /**
  * Represents an editable world document.
  */
@@ -36,15 +42,24 @@ class WorldDocument final : public Document
     Q_OBJECT
 
 public:
-    WorldDocument(const QString &fileName, QObject *parent = nullptr);
+    explicit WorldDocument(std::unique_ptr<World> world, QObject *parent = nullptr);
+    ~WorldDocument();
 
     // Document interface
     QString displayName() const override;
     bool save(const QString &fileName, QString *error) override;
 
-    FileFormat *writerFormat() const override { return nullptr; }
+    bool canReload() const override;
+    bool reload(QString *error);
 
-    std::unique_ptr<EditableAsset> createEditable() override;
+    /**
+     * Loads a world and returns a WorldDocument instance on success. Returns
+     * null on error and sets the \a error message.
+     */
+    static WorldDocumentPtr load(const QString &fileName,
+                                 QString *error = nullptr);
+
+    FileFormat *writerFormat() const override { return nullptr; }
 
     // Exporting not supported for worlds
     QString lastExportFileName() const override { return QString(); }
@@ -52,13 +67,16 @@ public:
     FileFormat *exportFormat() const override { return nullptr; }
     void setExportFormat(FileFormat *) override {}
 
-private:
-    void onWorldsChanged();
-    void onWorldReloaded(const QString &filename);
-    void onWorldSaved(const QString &fileName);
+    World *world() const { return mWorld.get(); }
 
+signals:
+    void worldChanged();
+
+private:
     // Document interface
-    bool isModifiedImpl() const override;
+    std::unique_ptr<EditableAsset> createEditable() override;
+
+    std::unique_ptr<World> mWorld;
 };
 
 } // namespace Tiled

--- a/src/tiled/worldmanager.h
+++ b/src/tiled/worldmanager.h
@@ -22,7 +22,7 @@
 
 #include "tilededitor_global.h"
 
-#include "filesystemwatcher.h"
+#include "worlddocument.h"
 
 #include <QMap>
 #include <QObject>
@@ -42,38 +42,28 @@ public:
     static WorldManager &instance();
     static void deleteInstance();
 
-    World *addEmptyWorld(const QString &fileName, QString *errorString);
-    World *loadWorld(const QString &fileName, QString *errorString = nullptr);
+    WorldDocumentPtr findWorld(const QString &fileName) const;
+
+    WorldDocumentPtr addEmptyWorld(const QString &fileName, QString *errorString);
+    WorldDocumentPtr loadWorld(const QString &fileName, QString *errorString = nullptr);
     void loadWorlds(const QStringList &fileNames);
-    void unloadWorld(const QString &fileName);
+    void unloadWorld(const WorldDocumentPtr &worldDocument);
     void unloadAllWorlds();
-    bool saveWorld(const QString &fileName, QString *errorString = nullptr);
 
-    const QMap<QString, World*> &worlds() const { return mWorlds; }
+    const QVector<WorldDocumentPtr> &worlds() const { return mWorldDocuments; }
+    const QStringList worldFileNames() const;
 
-    const World *worldForMap(const QString &fileName) const;
-
-    void setMapRect(const QString &fileName, const QRect &rect);
-    bool mapCanBeModified(const QString &fileName) const;
-    bool removeMap(const QString &fileName);
-    bool addMap(const QString &worldFileName, const QString &mapFileName, const QRect &rect);
+    WorldDocumentPtr worldForMap(const QString &fileName) const;
 
 signals:
     void worldsChanged();
-    void worldLoaded(const QString &fileName);
-    void worldReloaded(const QString &fileName);
-    void worldUnloaded(const QString &fileName);
-    void worldSaved(const QString &fileName);
+    void worldLoaded(WorldDocument *worldDocument);
+    void worldUnloaded(WorldDocument *worldDocument);
 
 private:
-    bool saveWorld(World &world, QString *errorString = nullptr);
-    World *loadAndStoreWorld(const QString &fileName, QString *errorString = nullptr);
-    void reloadWorldFiles(const QStringList &fileNames);
+    WorldDocumentPtr loadAndStoreWorld(const QString &fileName, QString *errorString = nullptr);
 
-    QMap<QString, World*> mWorlds;
-
-    FileSystemWatcher mFileSystemWatcher;
-    QString mIgnoreFileChangeEventForFile;
+    QVector<WorldDocumentPtr> mWorldDocuments;
 
     static WorldManager *mInstance;
 };

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -32,6 +32,7 @@
 #include "toolmanager.h"
 #include "utils.h"
 #include "world.h"
+#include "worlddocument.h"
 #include "zoomable.h"
 
 #include <QApplication>
@@ -102,15 +103,18 @@ void WorldMoveMapTool::keyPressed(QKeyEvent *event)
 
 void WorldMoveMapTool::moveMap(MapDocument *document, QPoint moveBy)
 {
+    auto worldDocument = worldForMap(document);
+    if (!worldDocument)
+        return;
+
+    const auto prevRect = worldDocument->world()->mapRect(document->fileName());
     QPoint offset = QPoint(document->map()->tileWidth() * static_cast<int>(moveBy.x()),
                            document->map()->tileHeight() * static_cast<int>(moveBy.y()));
     QRect rect = document->renderer()->mapBoundingRect();
-    if (const World *world = constWorld(document))
-        rect.moveTo(world->mapRect(document->fileName()).topLeft());
+    rect.moveTo(snapPoint(prevRect.topLeft() + offset, document));
 
-    rect.moveTo(snapPoint(rect.topLeft() + offset, document));
-
-    undoStack()->push(new SetMapRectCommand(document->fileName(), rect));
+    auto undoStack = worldDocument->undoStack();
+    undoStack->push(new SetMapRectCommand(worldDocument, document->fileName(), rect));
 
     if (document == mapDocument()) {
         // undo camera movement
@@ -148,8 +152,7 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
 void WorldMoveMapTool::mouseMoved(const QPointF &pos,
                                   Qt::KeyboardModifiers modifiers)
 {    
-    const World *world = constWorld(mDraggingMap);
-    if (!world || !mDraggingMap) {
+    if (!worldForMap(mDraggingMap) || !mDraggingMap) {
         AbstractWorldTool::mouseMoved(pos, modifiers);
         return;
     }
@@ -190,15 +193,20 @@ void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
         mDraggingMapItem = nullptr;
 
         if (!mDragOffset.isNull()) {
-            QRect rect = draggedMap->renderer()->mapBoundingRect();
-            if (const World *world = constWorld(draggedMap))
-                rect.moveTo(world->mapRect(draggedMap->fileName()).topLeft());
-            rect.translate(mDragOffset);
+            if (auto worldDocument = worldForMap(draggedMap)) {
+                QRect rect = draggedMap->renderer()->mapBoundingRect();
 
-            undoStack()->push(new SetMapRectCommand(draggedMap->fileName(), rect));
-            if (draggedMap == mapDocument()) {
-                // undo camera movement
-                view->forceCenterOn(sceneViewRect.center() - mDragOffset);
+                auto world = worldDocument->world();
+                rect.moveTo(world->mapRect(draggedMap->fileName()).topLeft());
+                rect.translate(mDragOffset);
+
+                auto undoStack = worldDocument->undoStack();
+                undoStack->push(new SetMapRectCommand(worldDocument, draggedMap->fileName(), rect));
+
+                if (draggedMap == mapDocument()) {
+                    // undo camera movement
+                    view->forceCenterOn(sceneViewRect.center() - mDragOffset);
+                }
             }
         } else {
             // switch to the document


### PR DESCRIPTION
This way it is more inline with how the other assets are managed. It also avoids silly issues, like a `WorldDocument` pointer not getting looked up successfully due to a file name mismatch.

Fixes #4042