### PR TITLE
Delay loading of tile stamps until after initializing the session

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Fixed error reporting when exporting on the command-line (by Shuhei Nagasawa, #4015)
 * Fixed updating of object label when text changes without changing size
 * Fixed minimum value of spinbox in Tile Animation Editor
+* Fixed loading of custom property types in tilesets referenced by tile stamps (#4044)
 * AppImage: Updated to Sentry 0.7.13
 
 ### Tiled 1.11.0 (27 June 2024)

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -68,6 +68,7 @@
 #include "tilesetdocument.h"
 #include "tileseteditor.h"
 #include "tilesetmanager.h"
+#include "tilestampmanager.h"
 #include "tmxmapformat.h"
 #include "utils.h"
 #include "world.h"
@@ -1016,6 +1017,11 @@ void MainWindow::initializeSession()
     // been loaded, to avoid immediately having to reset the engine again after
     // adding the project's extension path.
     ScriptManager::instance().ensureInitialized();
+
+    // Load tile stamps (delayed so that potential custom types and file
+    // formats can be supported by stamps - which isn't perfect since there
+    // will still be issues when the project isn't open on startup)
+    TileStampManager::instance()->loadStamps();
 
     if (projectLoaded || Preferences::instance()->restoreSessionOnStartup())
         restoreSession();

--- a/src/tiled/projectmanager.cpp
+++ b/src/tiled/projectmanager.cpp
@@ -37,6 +37,11 @@ ProjectManager::ProjectManager(QObject *parent)
     ourInstance = this;
 }
 
+ProjectManager::~ProjectManager()
+{
+    ourInstance = nullptr;
+}
+
 /**
  * Replaces the current project with the given \a project.
  */

--- a/src/tiled/projectmanager.h
+++ b/src/tiled/projectmanager.h
@@ -40,6 +40,7 @@ class TILED_EDITOR_EXPORT ProjectManager : public QObject
 
 public:
     explicit ProjectManager(QObject *parent = nullptr);
+    ~ProjectManager() override;
 
     static ProjectManager *instance();
 

--- a/src/tiled/tilestampmanager.h
+++ b/src/tiled/tilestampmanager.h
@@ -51,11 +51,15 @@ public:
     TileStampManager(const ToolManager &toolManager, QObject *parent = nullptr);
     ~TileStampManager() override;
 
+    static TileStampManager *instance();
+
     static QList<Qt::Key> quickStampKeys();
 
     TileStampModel *tileStampModel() const;
 
     SessionOption<QString> stampsDirectory;
+
+    void loadStamps();
 
 public slots:
     TileStamp createStamp();
@@ -76,8 +80,6 @@ private:
     void eraseQuickStamp(int index);
     void setQuickStamp(int index, TileStamp stamp);
 
-    void loadStamps();
-
 private:
     void stampAdded(TileStamp stamp);
     void stampRenamed(TileStamp stamp);
@@ -93,8 +95,15 @@ private:
     Session::CallbackIterator mRegisteredCb;
 
     const ToolManager &mToolManager;
+
+    static TileStampManager *ourInstance;
 };
 
+
+inline TileStampManager *TileStampManager::instance()
+{
+    return ourInstance;
+}
 
 /**
  * Returns the keys used for quickly accessible tile stamps.


### PR DESCRIPTION
The tilesets referenced by stored tile stamps may rely on custom types defined in the project and possibly even on custom tileset formats added by extensions. Hence, it is better to wait with loading them until after the project has been loaded and script manager is initialized.

The user will still run into issues when the project isn't loaded on startup, but this at least makes running into issues less likely.

It could help to force reloading of the stamps when switching projects.