### PR TITLE
docs: Mention DotTiled library in C#/.NET section

### DIFF
--- a/docs/reference/support-for-tmx-maps.rst
+++ b/docs/reference/support-for-tmx-maps.rst
@@ -68,6 +68,7 @@ C++
 C#/.NET
 ~~~~~~~
 
+-  `DotTiled <https://github.com/dcronqvist/DotTiled>`__: A fast, memory-efficient, and easy to use .NET library for loading Tiled maps and tilesets with support for both TMX and JSON formats.
 -  `TiledCS <https://github.com/TheBoneJarmer/TiledCS>`__: A dotnet library for loading Tiled tilesets and maps (TMX/TSX or JSON).
 -  `MonoGame.Extended <https://github.com/craftworkgames/MonoGame.Extended>`__
    has a Tiled map loader and renderer that works with MonoGame on all

--- a/docs/reference/support-for-tmx-maps.rst
+++ b/docs/reference/support-for-tmx-maps.rst
@@ -69,11 +69,13 @@ C#/.NET
 ~~~~~~~
 
 -  `DotTiled <https://github.com/dcronqvist/DotTiled>`__: A fast, memory-efficient, and easy to use .NET library for loading Tiled maps and tilesets with support for both TMX and JSON formats.
--  `TiledCS <https://github.com/TheBoneJarmer/TiledCS>`__: A dotnet library for loading Tiled tilesets and maps (TMX/TSX or JSON).
+-  `TiledLib <https://github.com/Ragath/TiledLib.Net>`__: Cross-platform Tiled map parsing utilities.
+-  `TiledCSPlus <https://github.com/krnlexception/TiledCSPlus>`__: TiledCSPlus is an extended, and up to date fork of TiledCS, a .NET library for loading Tiled maps and tilesets.
 -  `MonoGame.Extended <https://github.com/craftworkgames/MonoGame.Extended>`__
    has a Tiled map loader and renderer that works with MonoGame on all
    platforms that support portable class libraries.
 -  The following projects appear to be no longer maintained, but might still be useful:
+   `TiledCS <https://github.com/TheBoneJarmer/TiledCS>`__,
    `TiledSharp <https://github.com/marshallward/TiledSharp>`__,
    `NTiled <https://github.com/patriksvensson/ntiled>`__,
    `tmx-mapper-pcl <https://github.com/aalmik/tmx-mapper-pcl>`__,


### PR DESCRIPTION
Hello! Due to the amount of unmaintained and/or relatively old libraries in the .NET ecosystem for Tiled parsers, I've decided to make my own ([DotTiled](https://github.com/dcronqvist/DotTiled)) that I aim to maintain actively :)

Some of the ideas I want to accomplish with this library:
- fast and memory-efficient (see benchmark results for current status)
- easy to use and flexible API
- support for custom types with (in the future) automatic mapping between classes and Tiled custom types
- detailed usage documentation
- abstract renderer with ability to hook in relevant rendering backend

Please let me know if the description I've entered is too positively biased or should occur later in the list of mentioned libraries.