### PR TITLE
Implemented saving/loading of custom properties on worlds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Scripting: Added `FileFormat.nameFilter`
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
+* Fixed saving/loading of custom properties set on worlds (#4025)
 * Fixed crash when accessing a world through a symlink (#4042)
 * Fixed error reporting when exporting on the command-line (by Shuhei Nagasawa, #4015)
 

--- a/src/libtiled/world.cpp
+++ b/src/libtiled/world.cpp
@@ -311,6 +311,10 @@ std::unique_ptr<World> World::load(const QString &fileName,
             world->patterns.append(pattern);
     }
 
+    const QJsonArray properties = object.value(QLatin1String("properties")).toArray();
+    const ExportContext context(dir.path());
+    world->setProperties(propertiesFromJson(properties, context));
+
     world->onlyShowAdjacentMaps = object.value(QLatin1String("onlyShowAdjacentMaps")).toBool();
 
     if (world->maps.isEmpty() && world->patterns.isEmpty())
@@ -357,11 +361,16 @@ bool World::save(World &world, QString *errorString)
         patterns.append(jsonPattern);
     }
 
+    const ExportContext context(worldDir.path());
+    const QJsonArray properties = propertiesToJson(world.properties(), context);
+
     QJsonObject document;
     if (!maps.isEmpty())
         document.insert(QLatin1String("maps"), maps);
     if (!patterns.isEmpty())
         document.insert(QLatin1String("patterns"), patterns);
+    if (!properties.isEmpty())
+        document.insert(QLatin1String("properties"), properties);
     document.insert(QLatin1String("type"), QLatin1String("world"));
     document.insert(QLatin1String("onlyShowAdjacentMaps"), world.onlyShowAdjacentMaps);
 


### PR DESCRIPTION
Custom properties on worlds can only be accessed and modified through the scripting API at the moment, but since this is possible we better also save them.

Closes #4025