### PR TITLE
snap: Migrate to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: tiled
 adopt-info: tiled
 license: GPL-2.0
-base: core22
+base: core24
 
 grade: stable
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,7 +85,6 @@ parts:
       - dmz-cursor-theme
       - light-themes
       - adwaita-icon-theme
-      - gnome-themes-standard
       - shared-mime-info
       - libqt5concurrent5
       - libqt5gui5


### PR DESCRIPTION
When this works, look into updating from Qt 5 to Qt 6 as well.

I went through https://snapcraft.io/docs/migrate-core24 but there didn't seem to be any relevant actions required.