### PR TITLE
Tiled Quick: Updated to require Qt 6.5

### DIFF
--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -1,10 +1,13 @@
+import qbs.Utilities
+
 DynamicLibrary {
     targetName: "tiledquick"
     builtByDefault: false
+    condition: Utilities.versionCompare(Qt.core.version, "6.5") >= 0
 
     Depends { name: "libtiled" }
     Depends { name: "cpp" }
-    Depends { name: "Qt"; submodules: ["quick"]; versionAtLeast: "5.15" }
+    Depends { name: "Qt"; submodules: ["quick"]; versionAtLeast: "6.5" }
 
     cpp.cxxLanguageVersion: "c++17"
     cpp.cxxFlags: {
@@ -21,7 +24,7 @@ DynamicLibrary {
         "QT_NO_CAST_FROM_ASCII",
         "QT_NO_CAST_TO_ASCII",
         "QT_NO_URL_CAST_FROM_STRING",
-        "QT_DISABLE_DEPRECATED_BEFORE=0x050F00",
+        "QT_DISABLE_DEPRECATED_BEFORE=0x060500",
         "QT_NO_DEPRECATED_WARNINGS",
         "QT_NO_FOREACH"
     ]

--- a/src/tiledquick/main.cpp
+++ b/src/tiledquick/main.cpp
@@ -1,18 +1,14 @@
 #include <QApplication>
 #include <QQmlApplicationEngine>
+#include <QSurfaceFormat>
 
 int main(int argc, char *argv[])
 {
     QCoreApplication::setOrganizationDomain("mapeditor.org");
     QCoreApplication::setApplicationName("TiledQuick");
 
-    // High-DPI scaling is always enabled in Qt 6
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
-
-    // We don't need the scaling factor to be rounded
-    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+    // Not rounding causes pixel movement during panning and window resizing
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
 
     QApplication app(argc, argv);
 
@@ -23,9 +19,14 @@ int main(int argc, char *argv[])
     qmlDir += QStringLiteral("/../qml");
 #endif
 
+    QSurfaceFormat format = QSurfaceFormat::defaultFormat();
+    // format.setSamples(8);       // Increase quality of lines and edges when UI is scaled down
+    format.setSwapInterval(0);  // Disable vsync
+    QSurfaceFormat::setDefaultFormat(format);
+
     QQmlApplicationEngine engine;
     engine.addImportPath(qmlDir);
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
 
-    return app.exec();
+    return QApplication::exec();
 }

--- a/src/tiledquick/qml/DragArea.qml
+++ b/src/tiledquick/qml/DragArea.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick
 
 MouseArea {
     property var lastDragPos
@@ -6,9 +6,11 @@ MouseArea {
     signal dragged(var dx, var dy)
 
     hoverEnabled: true
-    onPressed: lastDragPos = mapToItem(null, mouse.x, mouse.y)
+    onPressed: function(mouse) {
+        lastDragPos = mapToItem(null, mouse.x, mouse.y)
+    }
 
-    onPositionChanged: {
+    onPositionChanged: function(mouse) {
         if (!pressed)
             return;
 

--- a/src/tiledquick/qml/FontAwesome.qml
+++ b/src/tiledquick/qml/FontAwesome.qml
@@ -1,5 +1,5 @@
 pragma Singleton
-import QtQml 2.3
+import QtQml
 
 QtObject {
     readonly property string open: "\uE800"

--- a/src/tiledquick/qml/main.qml
+++ b/src/tiledquick/qml/main.qml
@@ -1,10 +1,10 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
-import QtQuick.Window 2.11
-import org.mapeditor.Tiled 1.0 as Tiled
-import Qt.labs.settings 1.0
-import Qt.labs.platform 1.0 as Platform
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+import QtQuick.Dialogs
+import org.mapeditor.Tiled as Tiled
+import QtCore
 
 // For access to FontAwesome Singleton
 import "."
@@ -23,20 +23,20 @@ ApplicationWindow {
         source: "fonts/fontawesome.ttf"
     }
 
-    Platform.FileDialog {
+    FileDialog {
         id: fileDialog
         nameFilters: [ "TMX files (*.tmx)", "All files (*)" ]
         onAccepted: {
-            mapLoader.source = fileDialog.file
-            settings.mapsFolder = fileDialog.folder
+            mapLoader.source = fileDialog.selectedFile
+            settings.mapsFolder = fileDialog.currentFolder
             fitMapInView(false);
         }
     }
 
-    Platform.MessageDialog {
+    MessageDialog {
         id: aboutBox
         title: "About Tiled Quick"
-        text: "This is an experimental Qt Quick version of Tiled,\na generic 2D map editor"
+        text: "This is an experimental Qt Quick version of Tiled, a generic 2D map editor"
     }
 
     Settings {
@@ -71,7 +71,7 @@ ApplicationWindow {
         text: qsTr("Open...")
         shortcut: StandardKey.Open
         onTriggered: {
-            fileDialog.folder = settings.mapsFolder
+            fileDialog.currentFolder = settings.mapsFolder
             fileDialog.open()
         }
     }
@@ -167,7 +167,7 @@ ApplicationWindow {
         id: singleFingerPanArea
         anchors.fill: parent
 
-        onDragged: {
+        onDragged: function(dx, dy) {
             dx *= Screen.devicePixelRatio
             dy *= Screen.devicePixelRatio
 
@@ -184,7 +184,7 @@ ApplicationWindow {
             }
         }
 
-        onWheel: {
+        onWheel: function(wheel) {
             const scaleFactor = Math.pow(1.4, wheel.angleDelta.y / 120)
 
             let targetScale = containerAnimation.running ? containerAnimation.scale : mapContainer.scale

--- a/src/tiledquick/tiledquick.qbs
+++ b/src/tiledquick/tiledquick.qbs
@@ -1,17 +1,19 @@
 import qbs.Environment
 import qbs.File
+import qbs.Utilities
 
 QtGuiApplication {
     name: "tiledquick"
     targetName: name
     builtByDefault: Environment.getEnv("BUILD_TILEDQUICK") == "true"
+    condition: Utilities.versionCompare(Qt.core.version, "6.5") >= 0
 
     readonly property bool qtcRunnable: builtByDefault
 
     Depends {
         name: "Qt"
         submodules: ["core", "quick", "widgets"]
-        versionAtLeast: "5.15"
+        versionAtLeast: "6.5"
     }
     Depends {
         name: "tiledquickplugin"
@@ -23,12 +25,16 @@ QtGuiApplication {
     cpp.cxxLanguageVersion: "c++17"
     cpp.cxxFlags: {
         var flags = base;
-        if (qbs.toolchain.contains("msvc")) {
-            if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
-                flags.push("/permissive-");
-        }
+        if (qbs.toolchain.contains("msvc"))
+            flags.push("/permissive-");
         return flags;
     }
+    cpp.defines: [
+        "QT_DISABLE_DEPRECATED_BEFORE=QT_VERSION_CHECK(6,5,0)",
+        "QT_NO_DEPRECATED_WARNINGS",
+        "QT_NO_FOREACH",
+        "QT_NO_URL_CAST_FROM_STRING"
+    ]
 
     files: [
         "fonts/fonts.qrc",

--- a/src/tiledquickplugin/tiledquickplugin.qbs
+++ b/src/tiledquickplugin/tiledquickplugin.qbs
@@ -1,12 +1,15 @@
+import qbs.Utilities
+
 DynamicLibrary {
     targetName: "tiledquickplugin"
     builtByDefault: false
+    condition: Utilities.versionCompare(Qt.core.version, "6.5") >= 0
 
     Depends { name: "libtiled" }
     Depends { name: "libtiledquick" }
     Depends {
         name: "Qt"; submodules: ["qml", "quick"]
-        versionAtLeast: "5.15"
+        versionAtLeast: "6.5"
     }
 
     cpp.cxxLanguageVersion: "c++17"
@@ -19,7 +22,7 @@ DynamicLibrary {
         return flags;
     }
     cpp.defines: [
-        "QT_DISABLE_DEPRECATED_BEFORE=0x050F00",
+        "QT_DISABLE_DEPRECATED_BEFORE=0x060500",
         "QT_NO_DEPRECATED_WARNINGS",
         "QT_NO_CAST_FROM_ASCII",
         "QT_NO_CAST_TO_ASCII",


### PR DESCRIPTION
* Migrated to new signal handling syntax.
* Removed version numbers from imports.
* Migrated to Settings from QtCore.
* Migrated to dialogs from QtQuick.Dialogs.

Some small other changes:

* Disable VSync since it makes things move erratically during resizing and delays response times.

* Round scaling factor since a fractional factor causes pixel movement during panning and window resizing.