### PR TITLE
Fixed minimum value of spinbox in Tile Animation Editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Fixed saving/loading of custom properties set on worlds (#4025)
 * Fixed crash when accessing a world through a symlink (#4042)
 * Fixed error reporting when exporting on the command-line (by Shuhei Nagasawa, #4015)
+* Fixed minimum value of spinbox in Tile Animation Editor
 
 ### Tiled 1.11.0 (27 June 2024)
 

--- a/src/tiled/tileanimationeditor.ui
+++ b/src/tiled/tileanimationeditor.ui
@@ -32,7 +32,7 @@
         <string> ms</string>
        </property>
        <property name="minimum">
-        <number>1</number>
+        <number>0</number>
        </property>
        <property name="maximum">
         <number>10000</number>


### PR DESCRIPTION
0 is a valid value for the duration of an animation frame, so it should be possible to set the spinbox to 0 in order to apply this value to multiple selected frames at once.