### PR TITLE
[Draft] Added missing EditableWangSet::SetColorImageTile and EditableWangSet::SetColorProbability

### DIFF
--- a/src/tiled/editablewangset.cpp
+++ b/src/tiled/editablewangset.cpp
@@ -154,6 +154,20 @@ void EditableWangSet::setColorImageTile(int colorIndex, EditableTile *imageTile)
         wangSet()->colorAt(colorIndex)->setImageId(name);
 }
 
+void EditableWangSet::setColorProbability(int colorIndex, qreal probability)
+{
+    if (colorIndex <= 0 || colorIndex > colorCount()) {
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Index out of range"));
+        return;
+    }
+
+    int tileId = imageTile ? imageTile->id() : -1;
+    if (auto doc = tilesetDocument())
+        asset()->push(new ChangeWangColorProbability(doc, wangSet()->colorAt(colorIndex).data(), probability));
+    else if (!checkReadOnly())
+        wangSet()->colorAt(colorIndex)->setProbability(probability);
+}
+
 void EditableWangSet::setType(EditableWangSet::Type type)
 {
     if (auto document = tilesetDocument()) {

--- a/src/tiled/editablewangset.cpp
+++ b/src/tiled/editablewangset.cpp
@@ -140,6 +140,20 @@ void EditableWangSet::setName(const QString &name)
         wangSet()->setName(name);
 }
 
+void EditableWangSet::setColorImageTile(int colorIndex, EditableTile *imageTile)
+{
+    if (colorIndex <= 0 || colorIndex > colorCount()) {
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Index out of range"));
+        return;
+    }
+
+    int tileId = imageTile ? imageTile->id() : -1;
+    if (auto doc = tilesetDocument())
+        asset()->push(new ChangeWangColorImage(doc, wangSet()->colorAt(colorIndex).data(), tileId));
+    else if (!checkReadOnly())
+        wangSet()->colorAt(colorIndex)->setImageId(name);
+}
+
 void EditableWangSet::setType(EditableWangSet::Type type)
 {
     if (auto document = tilesetDocument()) {

--- a/src/tiled/editablewangset.h
+++ b/src/tiled/editablewangset.h
@@ -65,6 +65,7 @@ public:
 
     Q_INVOKABLE QString colorName(int colorIndex) const;
     Q_INVOKABLE void setColorName(int colorIndex, const QString &name);
+	Q_INVOKABLE void setColorImageTile(int colorIndex, Tiled::EditableTile *imageTile);
 
     Q_INVOKABLE Type effectiveTypeForColor(int color) const;
 

--- a/src/tiled/editablewangset.h
+++ b/src/tiled/editablewangset.h
@@ -66,6 +66,7 @@ public:
     Q_INVOKABLE QString colorName(int colorIndex) const;
     Q_INVOKABLE void setColorName(int colorIndex, const QString &name);
 	Q_INVOKABLE void setColorImageTile(int colorIndex, Tiled::EditableTile *imageTile);
+	Q_INVOKABLE void setColorProbability(int colorIndex, qreal probability);
 
     Q_INVOKABLE Type effectiveTypeForColor(int color) const;
 


### PR DESCRIPTION
It's seems there is no way in the current api to edit wangcolor tile preview and probability: https://discord.com/channels/524610627545595904/524610627545595906/1292100220569653248

I added them in this PR but this has **not been tested**.
However, after a discussion with eishiya on discord, a better way to expose these features is described here: https://github.com/mapeditor/tiled/issues/3900