### PR TITLE
GitHub Actions: Fixed workflow file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
     - 'docs/**'
-    paths-ignore:
-    - 'docs/scripting-doc/**'
 
 jobs:
   docs:


### PR DESCRIPTION
Because it reported:

    you may only define one of `paths` and `paths-ignore` for a single event

Unfortunately it had not said anything about that on the pull request, but apparently changes in paths are ignored for pull requests.

It's also quite annoying that this doesn't work...