### PR TITLE
Fixed issue with placing tile objects after switching maps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
 * Fixed saving/loading of custom properties set on worlds (#4025)
+* Fixed issue with placing tile objects after switching maps (#3497)
 * Fixed crash when accessing a world through a symlink (#4042)
 * Fixed error reporting when exporting on the command-line (by Shuhei Nagasawa, #4015)
 * Fixed minimum value of spinbox in Tile Animation Editor

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -325,9 +325,7 @@ void TilesetDock::setMapDocument(MapDocument *mapDocument)
     mTilesetDocumentsFilterModel->setMapDocument(mapDocument);
 
     if (mMapDocument) {
-        if (Object *object = mMapDocument->currentObject())
-            if (object->typeId() == Object::TileType)
-                setCurrentTile(static_cast<Tile*>(object));
+        restoreCurrentTile();
 
         connect(mMapDocument, &MapDocument::tilesetAdded,
                 this, &TilesetDock::updateActions);
@@ -483,6 +481,23 @@ void TilesetDock::currentChanged(const QModelIndex &index)
 
     const TilesetModel *model = static_cast<const TilesetModel*>(index.model());
     setCurrentTile(model->tileAt(index));
+}
+
+void TilesetDock::restoreCurrentTile()
+{
+    if (!mMapDocument)
+        return;
+
+    if (auto object = mMapDocument->currentObject()) {
+        if (object->typeId() == Object::TileType) {
+            setCurrentTile(static_cast<Tile*>(object));
+            return;
+        }
+    }
+
+    if (auto view = currentTilesetView())
+        if (view->model())
+            currentChanged(view->selectionModel()->currentIndex());
 }
 
 void TilesetDock::updateActions()

--- a/src/tiled/tilesetdock.h
+++ b/src/tiled/tilesetdock.h
@@ -129,6 +129,7 @@ private:
     void onCurrentTilesetChanged();
     void selectionChanged();
     void currentChanged(const QModelIndex &index);
+    void restoreCurrentTile();
 
     void updateActions();
     void updateCurrentTiles();

--- a/src/tiled/tilesetdock.h
+++ b/src/tiled/tilesetdock.h
@@ -206,6 +206,7 @@ private:
 
     bool mEmittingStampCaptured = false;
     bool mSynchronizingSelection = false;
+    bool mNoChangeCurrentObject = false;
 };
 
 } // namespace Tiled


### PR DESCRIPTION
The "current tile" was not being restored correctly after switching maps, when another type of object had been focused (for example due to switching layers or placing objects).

Now, when there is no "current tile" referenced by the `MapDocument`, it is set based on the tile selected in the current tileset view.

Closes #3497
Closes #3681