### PR TITLE
Flare plugin: Made error message a little less specific

### DIFF
--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -162,7 +162,7 @@ std::unique_ptr<Tiled::Map> FlarePlugin::read(const QString &fileName)
                 bool ok = tileset->loadFromImage(absoluteSource);
 
                 if (!ok) {
-                    mError = tr("Error loading tileset %1, which expands to %2. Path not found!")
+                    mError = tr("Error loading tileset image %1, which expands to %2!")
                             .arg(list.first().toString(), absoluteSource);
                     return nullptr;
                 } else {


### PR DESCRIPTION
When loading of a tileset image fails, it doesn't necessarily mean the file wasn't found.