### PR TITLE
Scripting: Expose Tileset.transformationFlags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Scripting: Added `FileFormat.nameFilter`
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
+* Scripting: Added `Tileset.transformationFlags` (#3753)
 * Fixed saving/loading of custom properties set on worlds (#4025)
 * Fixed issue with placing tile objects after switching maps (#3497)
 * Fixed crash when accessing a world through a symlink (#4042)

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -3670,6 +3670,12 @@ declare class Tileset extends Asset {
 
   static readonly Stretch: unique symbol;
   static readonly PreserveAspectFit: unique symbol;
+  
+  static readonly NoTransformation: unique symbol;
+  static readonly AllowFlipHorizontally: unique symbol;
+  static readonly AllowFlipVertically: unique symbol;
+  static readonly AllowRotate: unique symbol;
+  static readonly PreferUntransformed: unique symbol;
 
   /**
    * Name of the tileset.
@@ -3840,6 +3846,14 @@ declare class Tileset extends Asset {
    * Background color for this tileset in the Tilesets view.
    */
   backgroundColor: color;
+
+  /**
+   * Flags describing transformations of tiles in this tileset that will be 
+   * allowed when using the [Terrains](https://doc.mapeditor.org/en/stable/manual/terrain/#tile-transformations)
+   *  feature with this tileset. 
+   * 
+   */
+  transformationFlags: number;
 
   /**
    * Whether this tileset is a collection of images (same as checking whether image is an empty string).

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -3851,7 +3851,7 @@ declare class Tileset extends Asset {
    * Flags describing transformations of tiles in this tileset that will be 
    * allowed when using the [Terrains](https://doc.mapeditor.org/en/stable/manual/terrain/#tile-transformations)
    *  feature with this tileset. 
-   * 
+   * @since 1.11.1
    */
   transformationFlags: number;
 

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -3848,9 +3848,10 @@ declare class Tileset extends Asset {
   backgroundColor: color;
 
   /**
-   * Flags describing transformations of tiles in this tileset that will be 
-   * allowed when using the [Terrains](https://doc.mapeditor.org/en/stable/manual/terrain/#tile-transformations)
-   *  feature with this tileset. 
+   * Flags describing transformations of tiles in this tileset that will be
+   * allowed when using the [terrains feature](https://doc.mapeditor.org/en/stable/manual/terrain/#tile-transformations)
+   * with this tileset. 
+   *
    * @since 1.11.1
    */
   transformationFlags: number;

--- a/src/tiled/editabletileset.cpp
+++ b/src/tiled/editabletileset.cpp
@@ -391,7 +391,13 @@ void EditableTileset::setBackgroundColor(const QColor &color)
     else if (!checkReadOnly())
         tileset()->setBackgroundColor(color);
 }
-
+void EditableTileset::setTransformationFlags(Tileset::TransformationFlags flags)
+{
+    if (auto doc = tilesetDocument())
+        push(new ChangeTilesetTransformationFlags(doc, flags));
+    else if (!checkReadOnly())
+        tileset()->setTransformationFlags(flags);
+}
 void EditableTileset::setDocument(Document *document)
 {
     Q_ASSERT(!document || document->type() == Document::TilesetDocumentType);

--- a/src/tiled/editabletileset.cpp
+++ b/src/tiled/editabletileset.cpp
@@ -391,6 +391,7 @@ void EditableTileset::setBackgroundColor(const QColor &color)
     else if (!checkReadOnly())
         tileset()->setBackgroundColor(color);
 }
+
 void EditableTileset::setTransformationFlags(Tileset::TransformationFlags flags)
 {
     if (auto doc = tilesetDocument())
@@ -398,6 +399,7 @@ void EditableTileset::setTransformationFlags(Tileset::TransformationFlags flags)
     else if (!checkReadOnly())
         tileset()->setTransformationFlags(flags);
 }
+
 void EditableTileset::setDocument(Document *document)
 {
     Q_ASSERT(!document || document->type() == Document::TilesetDocumentType);

--- a/src/tiled/editabletileset.h
+++ b/src/tiled/editabletileset.h
@@ -317,10 +317,12 @@ inline bool EditableTileset::isCollection() const
 {
     return tileset()->isCollection();
 }
+
 inline Tileset::TransformationFlags EditableTileset::transformationFlags() const
 {
     return tileset()->transformationFlags();
 }
+
 inline Tileset *EditableTileset::tileset() const
 {
     return static_cast<Tileset*>(object());

--- a/src/tiled/editabletileset.h
+++ b/src/tiled/editabletileset.h
@@ -100,6 +100,16 @@ public:
     };
     Q_ENUM(FillMode)
 
+    // Synchronized with Tileset::TransformationFlag
+    enum TransformationFlag {
+        NoTransformation        = 0,
+        AllowFlipHorizontally   = 1 << 0,
+        AllowFlipVertically     = 1 << 1,
+        AllowRotate             = 1 << 2,
+        PreferUntransformed     = 1 << 3,
+    };
+    Q_ENUM(TransformationFlag)
+
     Q_INVOKABLE explicit EditableTileset(const QString &name = QString(),
                                          QObject *parent = nullptr);
     explicit EditableTileset(const Tileset *tileset, QObject *parent = nullptr);

--- a/src/tiled/editabletileset.h
+++ b/src/tiled/editabletileset.h
@@ -61,6 +61,7 @@ class EditableTileset final : public EditableAsset
     Q_PROPERTY(bool collection READ isCollection)   // deprecated
     Q_PROPERTY(bool isCollection READ isCollection)
     Q_PROPERTY(QList<QObject*> selectedTiles READ selectedTiles WRITE setSelectedTiles)
+    Q_PROPERTY(Tileset::TransformationFlags transformationFlags READ transformationFlags WRITE setTransformationFlags)
 
 public:
     // Synchronized with Tiled::Alignment
@@ -130,6 +131,7 @@ public:
     QColor transparentColor() const;
     QColor backgroundColor() const;
     bool isCollection() const;
+    Tileset::TransformationFlags transformationFlags() const;
 
     Q_INVOKABLE void loadFromImage(Tiled::ScriptImage *image,
                                    const QString &source = QString());
@@ -173,6 +175,7 @@ public slots:
     void setOrientation(Orientation orientation);
     void setTransparentColor(const QColor &color);
     void setBackgroundColor(const QColor &color);
+    void setTransformationFlags(Tileset::TransformationFlags flags);
 
 protected:
     void setDocument(Document *document) override;
@@ -304,7 +307,10 @@ inline bool EditableTileset::isCollection() const
 {
     return tileset()->isCollection();
 }
-
+inline Tileset::TransformationFlags EditableTileset::transformationFlags() const
+{
+    return tileset()->transformationFlags();
+}
 inline Tileset *EditableTileset::tileset() const
 {
     return static_cast<Tileset*>(object());


### PR DESCRIPTION
Fix #3753 

Examples (scripting console with a Tileset as the active asset)
```
>tiled.activeAsset.transformationFlags |= Tileset.AllowFlipVertically
2
> tiled.activeAsset.transformationFlags
$8 = 2
> if ((tiled.activeAsset.transformationFlags | Tileset.AllowFlipVertically) > 0) { tiled.log('vertical flip enabled'); } 
vertical flip enabled
```