### PR TITLE
tiled-api: Fixed strict mode error

### DIFF
--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -5022,7 +5022,7 @@ declare class Process {
   /**
    * Executes the program at filePath with the given argument list and blocks until the process is finished. If an error occurs (for example, there is no executable file at filePath) and throwOnError is true (the default), then a JavaScript exception will be thrown. Otherwise, -1 will be returned in case of an error. The normal return code is the exit code of the process.
    */
-  exec(filePath: string, args: string[] , throwOnError?: boolean): number;
+  exec(filePath: string, args: string[], throwOnError?: boolean): number;
 
   /**
    * Returns the value of the variable varName in the process’ environment.

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -5022,7 +5022,7 @@ declare class Process {
   /**
    * Executes the program at filePath with the given argument list and blocks until the process is finished. If an error occurs (for example, there is no executable file at filePath) and throwOnError is true (the default), then a JavaScript exception will be thrown. Otherwise, -1 will be returned in case of an error. The normal return code is the exit code of the process.
    */
-  exec(filePath: string, arguments: string[], throwOnError?: boolean): number;
+  exec(filePath: string, args: string[] , throwOnError?: boolean): number;
 
   /**
    * Returns the value of the variable varName in the process’ environment.
@@ -5059,7 +5059,7 @@ declare class Process {
    *
    * Note: This call returns right after starting the process and should be used only if you need to interact with the process while it is running. Most of the time, you want to use exec() instead.
    */
-  start(filePath: string, arguments: string[]): boolean;
+  start(filePath: string, args: string[]): boolean;
 
   /**
    * Tries to terminate the process. This is not guaranteed to make the process exit immediately; if you need that, use kill().


### PR DESCRIPTION
While trying to publish to [jsr.io](https://jsr.io/), it reported:

    error[syntax-error]: 'eval' and 'arguments' cannot be used as a binding identifier in strict mode