### PR TITLE
Scripting : Make MapEditor|TilesetEditor.currentWangSet and MapEditor|TilesetEditor.currentWangColorIndex writeable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ default/
 *.user*
 *.creator.*
 *.autosave
+build/ 
 
 # Visual Studio
 *.sln

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
 * Scripting: Added `Tileset.transformationFlags` (#3753)
-* Scripting: Made `MapEditor.currentWangSet` and `MapEditor.currentWangColorIndex` writeable (#4105)
+* Scripting: Made `MapEditor.currentWangSet`, `TilesetEditor.currentWangSet`, `MapEditor.currentWangColorIndex`, and `TilesetEditor.currentWangColorIndex`  writeable (#4105)
 * Fixed saving/loading of custom properties set on worlds (#4025)
 * Fixed issue with placing tile objects after switching maps (#3497)
 * Fixed crash when accessing a world through a symlink (#4042)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
 * Scripting: Added `Tileset.transformationFlags` (#3753)
+* Scripting: Make MapEditor.currentWangSet and MapEditor.currentWangColorIndex writeable (#4105)
 * Fixed saving/loading of custom properties set on worlds (#4025)
 * Fixed issue with placing tile objects after switching maps (#3497)
 * Fixed crash when accessing a world through a symlink (#4042)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
 * Scripting: Added `Tileset.transformationFlags` (#3753)
-* Scripting: Make MapEditor.currentWangSet and MapEditor.currentWangColorIndex writeable (#4105)
+* Scripting: Made `MapEditor.currentWangSet` and `MapEditor.currentWangColorIndex` writeable (#4105)
 * Fixed saving/loading of custom properties set on worlds (#4025)
 * Fixed issue with placing tile objects after switching maps (#3497)
 * Fixed crash when accessing a world through a symlink (#4042)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
 * Scripting: Added `Tileset.transformationFlags` (#3753)
-* Scripting: Made `MapEditor.currentWangSet`, `TilesetEditor.currentWangSet`, `MapEditor.currentWangColorIndex`, and `TilesetEditor.currentWangColorIndex`  writeable (#4105)
+* Scripting: Made `currentWangSet` and `currentWangColorIndex` properties writeable (#4105)
 * Fixed saving/loading of custom properties set on worlds (#4025)
 * Fixed issue with placing tile objects after switching maps (#3497)
 * Fixed crash when accessing a world through a symlink (#4042)

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -2480,13 +2480,13 @@ interface MapEditor {
   currentBrushChanged: Signal<void>;
 
   /**
-   * Gets the currently selected {@link WangSet} in the "Terrain Sets" view.
+   * The currently selected {@link WangSet} in the "Terrain Sets" view.
    *
    * See also {@link TileLayerWangEdit}.
    *
-   * @since 1.8
+   * @since 1.8 (writable since 1.11.1)
    */
-  readonly currentWangSet: WangSet;
+  currentWangSet: WangSet;
 
   /**
    * The signal emitted when {@link currentWangSet} changes.
@@ -2496,15 +2496,15 @@ interface MapEditor {
   readonly currentWangSetChanged: Signal<void>;
 
   /**
-   * Gets the currently selected Wang color index in the "Terrain Sets" view.
+   * The currently selected Wang color index in the "Terrain Sets" view.
    * The value 0 is used to represent the eraser mode, and the first Wang color
    * has index 1.
    *
    * See also {@link TileLayerWangEdit}.
    *
-   * @since 1.8
+   * @since 1.8 (writable since 1.11.1)
    */
-  readonly currentWangColorIndex: number;
+  currentWangColorIndex: number;
 
   /**
    * The signal emitted when {@link currentWangColorIndex} changes.

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -4038,11 +4038,12 @@ interface TilesetEditor {
   readonly collisionEditor: TileCollisionEditor;
 
   /**
-   * Gets the currently selected {@link WangSet} in the "Terrain Sets" view.
+   * Get or set the currently selected {@link WangSet} in the "Terrain Sets" view.
    *
    * @since 1.9
+   * Writable since 1.11.1
    */
-  readonly currentWangSet: WangSet;
+  currentWangSet: WangSet;
 
   /**
    * The signal emitted when {@link currentWangSet} changes.
@@ -4057,8 +4058,9 @@ interface TilesetEditor {
    * has index 1.
    *
    * @since 1.9
+   * Writable since 1.11.1
    */
-  readonly currentWangColorIndex: number;
+   currentWangColorIndex: number;
 
   /**
    * The signal emitted when {@link currentWangColorIndex} changes.

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -4038,10 +4038,9 @@ interface TilesetEditor {
   readonly collisionEditor: TileCollisionEditor;
 
   /**
-   * Get or set the currently selected {@link WangSet} in the "Terrain Sets" view.
+   * The currently selected {@link WangSet} in the "Terrain Sets" view.
    *
-   * @since 1.9
-   * Writable since 1.11.1
+   * @since 1.9 (writable since 1.11.1)
    */
   currentWangSet: WangSet;
 
@@ -4053,12 +4052,11 @@ interface TilesetEditor {
   readonly currentWangSetChanged: Signal<void>;
 
   /**
-   * Gets the currently selected Wang color index in the "Terrain Sets" view.
+   * The currently selected Wang color index in the "Terrain Sets" view.
    * The value 0 is used to represent the eraser mode, and the first Wang color
    * has index 1.
    *
-   * @since 1.9
-   * Writable since 1.11.1
+   * @since 1.9 (writable since 1.11.1)
    */
    currentWangColorIndex: number;
 

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -1083,7 +1083,7 @@ int MapEditor::currentWangColorIndex() const
 
 void MapEditor::setCurrentWangColorIndex(int newIndex)
 {
-    mWangDock->setCurrentWangColor(newIndex);
+    mWangDock->onColorCaptured(newIndex);
 }
 AbstractTool *MapEditor::selectedTool() const
 {

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -1067,11 +1067,24 @@ EditableWangSet *MapEditor::currentWangSet() const
     return EditableWangSet::get(mWangDock->currentWangSet());
 }
 
+void MapEditor::setCurrentWangSet(EditableWangSet *wangSet)
+{
+    if (!wangSet) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
+    mWangDock->setCurrentWangSet(wangSet->wangSet());
+}
+
 int MapEditor::currentWangColorIndex() const
 {
     return mWangDock->currentWangColor();
 }
 
+void MapEditor::setCurrentWangColorIndex(int newIndex)
+{
+    mWangDock->setCurrentWangColor(newIndex);
+}
 AbstractTool *MapEditor::selectedTool() const
 {
     return mSelectedTool;

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -281,7 +281,7 @@ MapEditor::MapEditor(QObject *parent)
     connect(mWangDock, &WangDock::wangColorChanged,
             mWangBrush, &WangBrush::setColor);
     connect(mWangBrush, &WangBrush::colorCaptured,
-            mWangDock, &WangDock::onColorCaptured);
+            mWangDock, &WangDock::setCurrentWangColor);
 
     connect(mTileStampsDock, &TileStampsDock::setStamp,
             this, &MapEditor::setStamp);
@@ -1083,16 +1083,17 @@ int MapEditor::currentWangColorIndex() const
 
 void MapEditor::setCurrentWangColorIndex(int newIndex)
 {
-    if(!mWangDock->currentWangSet()) {
-        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "No wangset is loaded"));
+    if (!mWangDock->currentWangSet()) {
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "No current Wang set"));
         return;
     }
-    if(newIndex < 0 || newIndex > mWangDock->currentWangSet()->colorCount()) {
-        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "An invalid wang color index was provided"));
+    if (newIndex < 0 || newIndex > mWangDock->currentWangSet()->colorCount()) {
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "An invalid index was provided"));
         return;
     }
-    mWangDock->onColorCaptured(newIndex);
+    mWangDock->setCurrentWangColor(newIndex);
 }
+
 AbstractTool *MapEditor::selectedTool() const
 {
     return mSelectedTool;

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -1083,6 +1083,8 @@ int MapEditor::currentWangColorIndex() const
 
 void MapEditor::setCurrentWangColorIndex(int newIndex)
 {
+    if(newIndex < 0 || newIndex > mWangDock->currentWangSet()->colorCount())
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "An invalid wang color index was provided"));
     mWangDock->onColorCaptured(newIndex);
 }
 AbstractTool *MapEditor::selectedTool() const

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -1083,8 +1083,14 @@ int MapEditor::currentWangColorIndex() const
 
 void MapEditor::setCurrentWangColorIndex(int newIndex)
 {
-    if(newIndex < 0 || newIndex > mWangDock->currentWangSet()->colorCount())
+    if(!mWangDock->currentWangSet()) {
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "No wangset is loaded"));
+        return;
+    }
+    if(newIndex < 0 || newIndex > mWangDock->currentWangSet()->colorCount()) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "An invalid wang color index was provided"));
+        return;
+    }
     mWangDock->onColorCaptured(newIndex);
 }
 AbstractTool *MapEditor::selectedTool() const

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -74,8 +74,8 @@ class MapEditor final : public Editor
 
     Q_PROPERTY(Tiled::TilesetDock *tilesetsView READ tilesetDock CONSTANT)
     Q_PROPERTY(Tiled::EditableMap *currentBrush READ currentBrush WRITE setCurrentBrush NOTIFY currentBrushChanged)
-    Q_PROPERTY(Tiled::EditableWangSet *currentWangSet READ currentWangSet NOTIFY currentWangSetChanged)
-    Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex NOTIFY currentWangColorIndexChanged)
+    Q_PROPERTY(Tiled::EditableWangSet *currentWangSet READ currentWangSet WRITE setCurrentWangSet NOTIFY currentWangSetChanged)
+    Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex WRITE setCurrentWangColorIndex NOTIFY currentWangColorIndexChanged)
     Q_PROPERTY(Tiled::MapView *currentMapView READ currentMapView CONSTANT)
 
 public:
@@ -120,7 +120,9 @@ public:
     void setCurrentBrush(EditableMap *editableMap);
 
     EditableWangSet *currentWangSet() const;
+    void setCurrentWangSet(EditableWangSet *wangSet);
     int currentWangColorIndex() const;
+    void setCurrentWangColorIndex(int newIndex);
 
     void addExternalTilesets(const QStringList &fileNames);
 

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -121,6 +121,7 @@ public:
 
     EditableWangSet *currentWangSet() const;
     void setCurrentWangSet(EditableWangSet *wangSet);
+
     int currentWangColorIndex() const;
     void setCurrentWangColorIndex(int newIndex);
 

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -37,6 +37,7 @@
 #include "objecttemplate.h"
 #include "preferences.h"
 #include "propertiesdock.h"
+#include "scriptmanager.h"
 #include "session.h"
 #include "templatesdock.h"
 #include "tile.h"
@@ -510,9 +511,31 @@ EditableWangSet *TilesetEditor::currentWangSet() const
     return EditableWangSet::get(mWangDock->currentWangSet());
 }
 
+void TilesetEditor::setCurrentWangSet(EditableWangSet *wangSet)
+{
+    if (!wangSet) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
+    mWangDock->setCurrentWangSet(wangSet->wangSet());
+}
+
 int TilesetEditor::currentWangColorIndex() const
 {
     return mWangDock->currentWangColor();
+}
+
+void TilesetEditor::setCurrentWangColorIndex(int newIndex)
+{
+    if (!mWangDock->currentWangSet()) {
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "No current Wang set"));
+        return;
+    }
+    if (newIndex < 0 || newIndex > mWangDock->currentWangSet()->colorCount()) {
+        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "An invalid index was provided"));
+        return;
+    }
+    mWangDock->setCurrentWangColor(newIndex);
 }
 
 void TilesetEditor::currentWidgetChanged()

--- a/src/tiled/tileseteditor.h
+++ b/src/tiled/tileseteditor.h
@@ -57,8 +57,8 @@ class TilesetEditor final : public Editor
     Q_OBJECT
 
     Q_PROPERTY(Tiled::TileCollisionDock *collisionEditor READ collisionEditor CONSTANT)
-    Q_PROPERTY(Tiled::EditableWangSet *currentWangSet READ currentWangSet NOTIFY currentWangSetChanged)
-    Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex NOTIFY currentWangColorIndexChanged)
+    Q_PROPERTY(Tiled::EditableWangSet *currentWangSet READ currentWangSet  WRITE setCurrentWangSet NOTIFY currentWangSetChanged)
+    Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex WRITE setCurrentWangColorIndex  NOTIFY currentWangColorIndexChanged)
 
 public:
     explicit TilesetEditor(QObject *parent = nullptr);
@@ -101,7 +101,10 @@ public:
     TileCollisionDock *collisionEditor() const;
 
     EditableWangSet *currentWangSet() const;
+    void setCurrentWangSet(EditableWangSet *wangSet);
+
     int currentWangColorIndex() const;
+    void setCurrentWangColorIndex(int newIndex);
 
 signals:
     void currentTileChanged(Tile *tile);

--- a/src/tiled/wangcolormodel.cpp
+++ b/src/tiled/wangcolormodel.cpp
@@ -42,9 +42,7 @@ WangColorModel::WangColorModel(TilesetDocument *tilesetDocument,
 
 QModelIndex WangColorModel::colorIndex(int color) const
 {
-    if (mWangSet)
-        Q_ASSERT(color <= mWangSet->colorCount());
-    else
+    if (!mWangSet || color > mWangSet->colorCount())
         return QModelIndex();
 
     return createIndex(color - 1, 0);

--- a/src/tiled/wangdock.cpp
+++ b/src/tiled/wangdock.cpp
@@ -384,6 +384,17 @@ int WangDock::currentWangColor() const
     return color;
 }
 
+void WangDock::setCurrentWangColor(int colorIndex)
+{
+    const QModelIndex index = mWangColorModel->colorIndex(colorIndex);
+    if (!index.isValid())
+        return;
+    QItemSelectionModel *selectionModel = mWangColorView->selectionModel();
+    selectionModel->setCurrentIndex(index,
+                                        QItemSelectionModel::ClearAndSelect |
+                                        QItemSelectionModel::Rows );
+}
+
 void WangDock::editWangSetName(WangSet *wangSet)
 {
     const QModelIndex index = wangSetIndex(wangSet);

--- a/src/tiled/wangdock.cpp
+++ b/src/tiled/wangdock.cpp
@@ -384,17 +384,6 @@ int WangDock::currentWangColor() const
     return color;
 }
 
-void WangDock::setCurrentWangColor(int colorIndex)
-{
-    const QModelIndex index = mWangColorModel->colorIndex(colorIndex);
-    if (!index.isValid())
-        return;
-    QItemSelectionModel *selectionModel = mWangColorView->selectionModel();
-    selectionModel->setCurrentIndex(index,
-                                        QItemSelectionModel::ClearAndSelect |
-                                        QItemSelectionModel::Rows );
-}
-
 void WangDock::editWangSetName(WangSet *wangSet)
 {
     const QModelIndex index = wangSetIndex(wangSet);

--- a/src/tiled/wangdock.cpp
+++ b/src/tiled/wangdock.cpp
@@ -678,7 +678,7 @@ void WangDock::onWangIdUsedChanged(WangId wangId)
         mWangTemplateView->update(index);
 }
 
-void WangDock::onColorCaptured(int color)
+void WangDock::setCurrentWangColor(int color)
 {
     const QModelIndex index = mWangColorModel->colorIndex(color);
 

--- a/src/tiled/wangdock.h
+++ b/src/tiled/wangdock.h
@@ -62,6 +62,7 @@ public:
     WangSet *currentWangSet() const { return mCurrentWangSet; }
     WangId currentWangId() const { return mCurrentWangId; }
     int currentWangColor() const;
+
     void editWangSetName(WangSet *wangSet);
     void editWangColorName(int colorIndex);
 
@@ -87,7 +88,7 @@ public slots:
     void setCurrentWangSet(WangSet *wangSet);
     void onCurrentWangIdChanged(WangId wangId);
     void onWangIdUsedChanged(WangId wangId);
-    void onColorCaptured(int color);
+    void setCurrentWangColor(int color);
 
 protected:
     void changeEvent(QEvent *event) override;

--- a/src/tiled/wangdock.h
+++ b/src/tiled/wangdock.h
@@ -62,7 +62,6 @@ public:
     WangSet *currentWangSet() const { return mCurrentWangSet; }
     WangId currentWangId() const { return mCurrentWangId; }
     int currentWangColor() const;
-    void setCurrentWangColor(int colorIndex);
     void editWangSetName(WangSet *wangSet);
     void editWangColorName(int colorIndex);
 

--- a/src/tiled/wangdock.h
+++ b/src/tiled/wangdock.h
@@ -62,7 +62,7 @@ public:
     WangSet *currentWangSet() const { return mCurrentWangSet; }
     WangId currentWangId() const { return mCurrentWangId; }
     int currentWangColor() const;
-
+    void setCurrentWangColor(int colorIndex);
     void editWangSetName(WangSet *wangSet);
     void editWangColorName(int colorIndex);
 


### PR DESCRIPTION
Fix #4101

currentWangSet setter: seems to be working: 
```js
tiled.mapEditor.currentWangSet = tiled.activeAsset.tilesets[0].wangSets[0] 
```
~~Currently crashing,  I'm doing something wrong setting the currentWangColorIndex~~ Edit: working :

```
tiled.mapEditor.currentWangColorIndex  = 2 
```
I didn't see an existing public method to  change the selection so I tried to make one based on reading the rest of the code in wangdock.cpp . Maybe I missed something existing or just have  a logic error in my setter. Visually at least, it seems to change the color selection though. 

Causes crash: 
![image](https://github.com/user-attachments/assets/c2827a52-dd7b-4f6f-b948-0053ec8f644a) 

TODO (@dogboydog ) 

- [x] Update NEWS 
- [x] Update scripting doc 