### PR TITLE
Scripting: add addRadioButtonGroup to Dialog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
 * Scripting: Added `Tileset.transformationFlags` (#3753)
+* Scripting: Added `Dialog.addRadioButtonGroup` for selecting one of a list of mutually exclusive options. (#4107)
 * Fixed saving/loading of custom properties set on worlds (#4025)
 * Fixed issue with placing tile objects after switching maps (#3497)
 * Fixed crash when accessing a world through a symlink (#4042)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * Scripting: Added `MapEditor.currentBrushChanged` signal
 * Scripting: Added `tiled.cursor` to create mouse cursor values
 * Scripting: Added `Tileset.transformationFlags` (#3753)
-* Scripting: Added `Dialog.addRadioButtonGroup` for selecting one of a list of mutually exclusive options. (#4107)
+* Scripting: Added `Dialog.addRadioButtonGroup` for selecting one of a list of mutually exclusive options (#4107)
 * Fixed saving/loading of custom properties set on worlds (#4025)
 * Fixed issue with placing tile objects after switching maps (#3497)
 * Fixed crash when accessing a world through a symlink (#4042)

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -789,6 +789,12 @@ declare namespace Qt {
     readonly checkedButton: QRadioButton | undefined;
 
     /**
+     * ID / index into {@link QButtonGroup.buttons} that is currently selected.
+     * If no radio button is selected, -1 will be returned.
+     */
+    readonly checkedIndex: number;
+
+    /**
      * Add multiple radio buttons to this group.
      * @param values - Each entry in the array is the text that will appear on the radio button.
      * @param toolTips Optional list of tooltips, where each entry is a tooltip that corresponds to the radio button in the list of values with the same index.
@@ -802,6 +808,11 @@ declare namespace Qt {
      */
     addItem(value: String, toolTip: string | undefined) : QRadioButton;
    
+    /**
+     * Signal emitted when any radio button in this QButtonGroup is selected or deselected. 
+     * If the button that causes the signal to be emitted is now selected, checked will be true.
+     */
+    readonly idToggled: Signal<[index: number, checked: boolean]>;
   }
 }
 

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -763,11 +763,11 @@ declare namespace Qt {
 
   /**
    * This type is returned when calling {@link QButtonGroup.addItem} or {@link QButtonGroup.addItems}.
-   * 
+   *
    * You can set checked to true for a QRadioButton even if you have also set enabled to false on it,
-   * which could allow you to prevent the script user from selecting a radio button by clicking on it, 
+   * which could allow you to prevent the script user from selecting a radio button by clicking on it,
    * but still change the selection in your script.
-   * 
+   *
    * @since 1.11.1
    */
   class QRadioButton extends QAbstractButton {}
@@ -800,15 +800,15 @@ declare namespace Qt {
      * button. The optional list of tooltips specifies the tooltip for the
      * radio buttons at each index.
      */
-    addItems(values: string[], toolTips: string[] | undefined) :QRadioButton[];
+    addItems(values: string[], toolTips: string[] | undefined): QRadioButton[];
 
     /**
      * Add a radio button to this group with the given text and tooltip.
      */
-    addItem(text: string, toolTip: string | undefined) : QRadioButton;
-   
+    addItem(text: string, toolTip: string | undefined): QRadioButton;
+
     /**
-     * Signal emitted when any radio button in this QButtonGroup is selected or deselected. 
+     * Signal emitted when any radio button in this QButtonGroup is selected or deselected.
      * If the button that causes the signal to be emitted is now selected, checked will be true.
      */
     readonly idToggled: Signal<[index: number, checked: boolean]>;
@@ -5389,17 +5389,22 @@ declare class Dialog extends Qt.QWidget {
    *
    * If the labelText is non-empty, a label widget will be added to the left of
    * the widget.
-   * 
+   *
    * Each entry in the values array is the text that will appear on the radio button.
-   * 
+   *
    * labelToolTip is an optional tooltip for the label to the left of the radio button group.
-   * 
+   *
    * buttonToolTips is an optional list of tooltips, where each entry is a tooltip that corresponds
    * to the radio button in the list of values at each index.
    *
    * @since 1.11.1
    */
-  addRadioButtonGroup(labelText: string, values: string[], labelToolTip : string| undefined,  buttonToolTips : string[] | undefined): Qt.QButtonGroup;
+  addRadioButtonGroup(
+    labelText: string,
+    values: string[],
+    labelToolTip: string | undefined,
+    buttonToolTips: string[] | undefined,
+  ): Qt.QButtonGroup;
 
   /**
    * Erase all of the widgets that you have added to the dialog.

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -5387,11 +5387,15 @@ declare class Dialog extends Qt.QWidget {
    * Each radio button is a {@link QAbstractButton}. You can force selection of
    * a radio button by setting checked = true, and also disable
    *
-   * @param labelText - If the labelText is non-empty, a label widget will be added to the left of
-   *  the widget.
-   * @param values - Each entry in the array is the text that will appear on the radio button.
-   * @param labelToolTip - Optional tooltip for the label to the left of the radio button group.
-   * @param buttonToolTips - Optional list of tooltips, where each entry is a tooltip that corresponds to the radio button in the list of values with the same index.
+   * If the labelText is non-empty, a label widget will be added to the left of
+   * the widget.
+   * 
+   * Each entry in the values array is the text that will appear on the radio button.
+   * 
+   * labelToolTip is an optional tooltip for the label to the left of the radio button group.
+   * 
+   * buttonToolTips is an optional list of tooltips, where each entry is a tooltip that corresponds
+   * to the radio button in the list of values at each index.
    *
    * @since 1.11.1
    */

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -770,14 +770,13 @@ declare namespace Qt {
    * 
    * @since 1.11.1
    */
-  class QRadioButton extends QAbstractButton { }
+  class QRadioButton extends QAbstractButton {}
 
   /**
    * A group of radio buttons where only one button can be selected.
    * @since 1.11.1
    */
   class QButtonGroup {
-    
     /**
      * Retrieve a list of buttons added to this QButtonGroup.
      */
@@ -796,17 +795,17 @@ declare namespace Qt {
 
     /**
      * Add multiple radio buttons to this group.
-     * @param values - Each entry in the array is the text that will appear on the radio button.
-     * @param toolTips Optional list of tooltips, where each entry is a tooltip that corresponds to the radio button in the list of values with the same index.
+     *
+     * Each entry in the values array is the text that will appear on the radio
+     * button. The optional list of tooltips specifies the tooltip for the
+     * radio buttons at each index.
      */
     addItems(values: string[], toolTips: string[] | undefined) :QRadioButton[];
 
     /**
-     * Add a single radio button to this group.
-     * @param values - The text that will appear on the radio button.
-     * @param toolTips Optional tooltip for the radio button.
+     * Add a radio button to this group with the given text and tooltip.
      */
-    addItem(value: String, toolTip: string | undefined) : QRadioButton;
+    addItem(text: string, toolTip: string | undefined) : QRadioButton;
    
     /**
      * Signal emitted when any radio button in this QButtonGroup is selected or deselected. 
@@ -5381,20 +5380,21 @@ declare class Dialog extends Qt.QWidget {
    */
   addFilePicker(labelText?: string): FileEdit;
 
-    /**
-   * Add a {@link QButtonGroup} widget which allows you to add multiple radio buttons,
-   * where only one radio button can be selected at a time. 
-   * 
-   * Each radio button is a {@link QAbstractButton}. You can force selection of a radio button by 
-   * setting checked = true, and also disable
+  /**
+   * Add a {@link QButtonGroup} widget which allows you to add multiple radio
+   * buttons, where only one radio button can be selected at a time.
+   *
+   * Each radio button is a {@link QAbstractButton}. You can force selection of
+   * a radio button by setting checked = true, and also disable
    *
    * @param labelText - If the labelText is non-empty, a label widget will be added to the left of
    *  the widget.
    * @param values - Each entry in the array is the text that will appear on the radio button.
    * @param labelToolTip - Optional tooltip for the label to the left of the radio button group.
    * @param buttonToolTips - Optional list of tooltips, where each entry is a tooltip that corresponds to the radio button in the list of values with the same index.
+   *
+   * @since 1.11.1
    */
-
   addRadioButtonGroup(labelText: string, values: string[], labelToolTip : string| undefined,  buttonToolTips : string[] | undefined): Qt.QButtonGroup;
 
   /**

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -760,6 +760,49 @@ declare namespace Qt {
    * Qt documentation [QFrame](https://doc.qt.io/qt-6/qframe.html)
    */
   class QFrame extends QWidget {}
+
+  /**
+   * This type is returned when calling {@link QButtonGroup.addItem} or {@link QButtonGroup.addItems}.
+   * 
+   * You can set checked to true for a QRadioButton even if you have also set enabled to false on it,
+   * which could allow you to prevent the script user from selecting a radio button by clicking on it, 
+   * but still change the selection in your script.
+   * 
+   * @since 1.11.1
+   */
+  class QRadioButton extends QAbstractButton { }
+
+  /**
+   * A group of radio buttons where only one button can be selected.
+   * @since 1.11.1
+   */
+  class QButtonGroup {
+    
+    /**
+     * Retrieve a list of buttons added to this QButtonGroup.
+     */
+    readonly buttons: QRadioButton[];
+
+    /**
+     * The radio button that is currently selected, if any.
+     */
+    readonly checkedButton: QRadioButton | undefined;
+
+    /**
+     * Add multiple radio buttons to this group.
+     * @param values - Each entry in the array is the text that will appear on the radio button.
+     * @param toolTips Optional list of tooltips, where each entry is a tooltip that corresponds to the radio button in the list of values with the same index.
+     */
+    addItems(values: string[], toolTips: string[] | undefined) :QRadioButton[];
+
+    /**
+     * Add a single radio button to this group.
+     * @param values - The text that will appear on the radio button.
+     * @param toolTips Optional tooltip for the radio button.
+     */
+    addItem(value: String, toolTip: string | undefined) : QRadioButton;
+   
+  }
 }
 
 /**
@@ -5326,6 +5369,22 @@ declare class Dialog extends Qt.QWidget {
    * the widget.
    */
   addFilePicker(labelText?: string): FileEdit;
+
+    /**
+   * Add a {@link QButtonGroup} widget which allows you to add multiple radio buttons,
+   * where only one radio button can be selected at a time. 
+   * 
+   * Each radio button is a {@link QAbstractButton}. You can force selection of a radio button by 
+   * setting checked = true, and also disable
+   *
+   * @param labelText - If the labelText is non-empty, a label widget will be added to the left of
+   *  the widget.
+   * @param values - Each entry in the array is the text that will appear on the radio button.
+   * @param labelToolTip - Optional tooltip for the label to the left of the radio button group.
+   * @param buttonToolTips - Optional list of tooltips, where each entry is a tooltip that corresponds to the radio button in the list of values with the same index.
+   */
+
+  addRadioButtonGroup(labelText: string, values: string[], labelToolTip : string| undefined,  buttonToolTips : string[] | undefined): Qt.QButtonGroup;
 
   /**
    * Erase all of the widgets that you have added to the dialog.

--- a/src/tiled/scriptdialog.cpp
+++ b/src/tiled/scriptdialog.cpp
@@ -37,12 +37,11 @@
 #include <QLineEdit>
 #include <QPixmap>
 #include <QPushButton>
+#include <QRadioButton>
 #include <QSet>
 #include <QSize>
 #include <QSlider>
 #include <QTextEdit>
-
-#include <memory>
 
 static const int leftColumnStretch = 0;
 // stretch as much as we can so that the left column looks as close to zero width as possible when there is no content
@@ -105,6 +104,31 @@ public:
     Q_INVOKABLE void addItems(const QStringList &texts)
     { QComboBox::addItems(texts); }
 };
+
+
+void ScriptButtonGroup::addItems(const QStringList &values, const QStringList &toolTips)
+{
+    int toolTipIndex = 0;
+    for (const QString &value : values) {
+        addItem(value, toolTips.value(toolTipIndex));
+        toolTipIndex++;
+    }
+}
+
+QAbstractButton *ScriptButtonGroup::addItem(const QString &value, const QString &toolTip)
+{
+    QRadioButton *radioButton = new QRadioButton(mLayout->parentWidget());
+    radioButton->setText(value);
+    if (!toolTip.isEmpty())
+        radioButton->setToolTip(toolTip);
+
+    mLayout->addWidget(radioButton);
+
+    QButtonGroup::addButton(radioButton, QButtonGroup::buttons().length());
+
+    return radioButton;
+}
+
 
 ScriptDialog::ScriptDialog(const QString &title)
     : QDialog(MainWindow::maybeInstance())
@@ -267,7 +291,10 @@ ScriptDialog::NewRowMode ScriptDialog::newRowMode() const
     return m_newRowMode;
 }
 
-ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText, const QStringList &values, const QString &toolTip, const QStringList &buttonToolTips)
+ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText,
+                                                     const QStringList &values,
+                                                     const QString &toolTip,
+                                                     const QStringList &buttonToolTips)
 {
     QGroupBox *groupParent = new QGroupBox(this);
     QHBoxLayout *hBox = new QHBoxLayout(groupParent);
@@ -290,7 +317,9 @@ int ScriptDialog::exec()
     return QDialog::exec();
 }
 
-QWidget *ScriptDialog::addDialogWidget(QWidget *widget, const QString &label, const QString &labelToolTip)
+QWidget *ScriptDialog::addDialogWidget(QWidget *widget,
+                                       const QString &label,
+                                       const QString &labelToolTip)
 {
     determineWidgetGrouping(widget);
     if (m_widgetsInRow == 0)

--- a/src/tiled/scriptdialog.cpp
+++ b/src/tiled/scriptdialog.cpp
@@ -267,7 +267,7 @@ ScriptDialog::NewRowMode ScriptDialog::newRowMode() const
     return m_newRowMode;
 }
 
-ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText, const QStringList &values)
+ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText, const QStringList &values, const QString &toolTip)
 {
     QGroupBox *groupParent = new QGroupBox(this);
     groupParent->setFlat(true);
@@ -276,6 +276,8 @@ ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText, c
     buttonGroup->addItems(values);
     hBox->addStretch(rightColumnStretch);
     groupParent->setLayout(hBox);
+    if (!toolTip.isEmpty())
+        groupParent->setToolTip(toolTip);
     addDialogWidget(groupParent, labelText);
     return buttonGroup;
 }

--- a/src/tiled/scriptdialog.cpp
+++ b/src/tiled/scriptdialog.cpp
@@ -301,7 +301,6 @@ ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText,
     ScriptButtonGroup *buttonGroup = new ScriptButtonGroup(groupParent, hBox);
     buttonGroup->addItems(values, buttonToolTips);
     hBox->addStretch(rightColumnStretch);
-    groupParent->setLayout(hBox);
     addDialogWidget(groupParent, labelText, toolTip);
     return buttonGroup;
 }

--- a/src/tiled/scriptdialog.cpp
+++ b/src/tiled/scriptdialog.cpp
@@ -267,18 +267,15 @@ ScriptDialog::NewRowMode ScriptDialog::newRowMode() const
     return m_newRowMode;
 }
 
-ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText, const QStringList &values, const QString &toolTip)
+ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText, const QStringList &values, const QString &toolTip, const QStringList &buttonToolTips)
 {
     QGroupBox *groupParent = new QGroupBox(this);
-    groupParent->setFlat(true);
     QHBoxLayout *hBox = new QHBoxLayout(groupParent);
     ScriptButtonGroup *buttonGroup = new ScriptButtonGroup(groupParent, hBox);
-    buttonGroup->addItems(values);
+    buttonGroup->addItems(values, buttonToolTips);
     hBox->addStretch(rightColumnStretch);
     groupParent->setLayout(hBox);
-    if (!toolTip.isEmpty())
-        groupParent->setToolTip(toolTip);
-    addDialogWidget(groupParent, labelText);
+    addDialogWidget(groupParent, labelText, toolTip);
     return buttonGroup;
 }
 
@@ -293,7 +290,7 @@ int ScriptDialog::exec()
     return QDialog::exec();
 }
 
-QWidget *ScriptDialog::addDialogWidget(QWidget *widget, const QString &label)
+QWidget *ScriptDialog::addDialogWidget(QWidget *widget, const QString &label, const QString &labelToolTip)
 {
     determineWidgetGrouping(widget);
     if (m_widgetsInRow == 0)
@@ -307,6 +304,8 @@ QWidget *ScriptDialog::addDialogWidget(QWidget *widget, const QString &label)
 
     if (!label.isEmpty()) {
         QLabel *widgetLabel = newLabel(label);
+        if (!labelToolTip.isEmpty())
+            widgetLabel->setToolTip(labelToolTip);
         widgetLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
         widgetLabel->setBuddy(widget);
         m_rowLayout->addWidget(widgetLabel);

--- a/src/tiled/scriptdialog.cpp
+++ b/src/tiled/scriptdialog.cpp
@@ -300,7 +300,6 @@ ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText,
     QHBoxLayout *hBox = new QHBoxLayout(groupParent);
     ScriptButtonGroup *buttonGroup = new ScriptButtonGroup(groupParent, hBox);
     buttonGroup->addItems(values, buttonToolTips);
-    hBox->addStretch(rightColumnStretch);
     addDialogWidget(groupParent, labelText, toolTip);
     return buttonGroup;
 }

--- a/src/tiled/scriptdialog.cpp
+++ b/src/tiled/scriptdialog.cpp
@@ -31,6 +31,7 @@
 #include <QComboBox>
 #include <QCoreApplication>
 #include <QDoubleSpinBox>
+#include <QGroupBox>
 #include <QHBoxLayout>
 #include <QJSEngine>
 #include <QLineEdit>
@@ -104,7 +105,6 @@ public:
     Q_INVOKABLE void addItems(const QStringList &texts)
     { QComboBox::addItems(texts); }
 };
-
 
 ScriptDialog::ScriptDialog(const QString &title)
     : QDialog(MainWindow::maybeInstance())
@@ -265,6 +265,19 @@ QWidget *ScriptDialog::addColorButton(const QString &labelText)
 ScriptDialog::NewRowMode ScriptDialog::newRowMode() const
 {
     return m_newRowMode;
+}
+
+ScriptButtonGroup *ScriptDialog::addRadioButtonGroup(const QString &labelText, const QStringList &values)
+{
+    QGroupBox *groupParent = new QGroupBox(this);
+    groupParent->setFlat(true);
+    QHBoxLayout *hBox = new QHBoxLayout(groupParent);
+    ScriptButtonGroup *buttonGroup = new ScriptButtonGroup(groupParent, hBox);
+    buttonGroup->addItems(values);
+    hBox->addStretch(rightColumnStretch);
+    groupParent->setLayout(hBox);
+    addDialogWidget(groupParent, labelText);
+    return buttonGroup;
 }
 
 void ScriptDialog::setNewRowMode(NewRowMode mode)

--- a/src/tiled/scriptdialog.h
+++ b/src/tiled/scriptdialog.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "qboxlayout.h"
+#include <QAbstractButton>
 #include <QButtonGroup>
 #include <QLabel>
 #include <QDialog>
@@ -55,6 +56,8 @@ public:
 class ScriptButtonGroup : public QButtonGroup
 {
     Q_OBJECT
+    Q_PROPERTY(QList<QAbstractButton *> buttons READ buttons)
+    Q_PROPERTY(QAbstractButton * checkedButton READ checkedButton)
 
 public:
     ScriptButtonGroup(QWidget * parent, QHBoxLayout *layout)
@@ -64,13 +67,27 @@ public:
 
     Q_INVOKABLE void addItems(const QStringList &values)
     {
+        int nextIndex = QButtonGroup::buttons().length();
         for (const QString &value : values) {
-            QRadioButton radioButton = QRadioButton();
-            mLayout->addWidget(&radioButton);
-            radioButton.setText(value);
-            QButtonGroup::addButton(&radioButton);
+            QRadioButton *radioButton = new QRadioButton;
+            mLayout->addWidget(radioButton);
+            radioButton->setText(value);
+            QButtonGroup::addButton(radioButton, nextIndex);
+            nextIndex++;
         }
     }
+
+    QList<QAbstractButton *> buttons() const
+    {
+        return QButtonGroup::buttons();
+    }
+
+
+    QAbstractButton * checkedButton() const
+    {
+        return QButtonGroup::checkedButton();
+    }
+
 private:
     QHBoxLayout *mLayout;
 };

--- a/src/tiled/scriptdialog.h
+++ b/src/tiled/scriptdialog.h
@@ -56,8 +56,9 @@ public:
 class ScriptButtonGroup : public QButtonGroup
 {
     Q_OBJECT
-    Q_PROPERTY(QList<QAbstractButton *> buttons READ buttons)
-    Q_PROPERTY(QAbstractButton * checkedButton READ checkedButton)
+    Q_PROPERTY(QList<QAbstractButton *> buttons READ buttons CONSTANT)
+    Q_PROPERTY(QAbstractButton * checkedButton READ checkedButton CONSTANT)
+    Q_PROPERTY(int checkedIndex READ checkedIndex CONSTANT)
 
 public:
     ScriptButtonGroup(QWidget * parent, QHBoxLayout *layout)
@@ -98,6 +99,11 @@ public:
     QAbstractButton * checkedButton() const
     {
         return QButtonGroup::checkedButton();
+    }
+
+    int checkedIndex() const
+    {
+        return QButtonGroup::checkedId();
     }
 
 private:

--- a/src/tiled/scriptdialog.h
+++ b/src/tiled/scriptdialog.h
@@ -21,8 +21,11 @@
 
 #pragma once
 
+#include "qboxlayout.h"
+#include <QButtonGroup>
 #include <QLabel>
 #include <QDialog>
+#include <QRadioButton>
 
 class QGridLayout;
 class QHBoxLayout;
@@ -49,6 +52,28 @@ public:
     void setImage(ScriptImage *image);
 };
 
+class ScriptButtonGroup : public QButtonGroup
+{
+    Q_OBJECT
+
+public:
+    ScriptButtonGroup(QWidget * parent, QHBoxLayout *layout)
+        : QButtonGroup(parent),
+        mLayout(layout)
+    {}
+
+    Q_INVOKABLE void addItems(const QStringList &values)
+    {
+        for (const QString &value : values) {
+            QRadioButton radioButton = QRadioButton();
+            mLayout->addWidget(&radioButton);
+            radioButton.setText(value);
+            QButtonGroup::addButton(&radioButton);
+        }
+    }
+private:
+    QHBoxLayout *mLayout;
+};
 
 class ScriptDialog : public QDialog
 {
@@ -84,6 +109,7 @@ public:
     Q_INVOKABLE QWidget *addFilePicker(const QString &labelText = QString());
     Q_INVOKABLE QWidget *addColorButton(const QString &labelText = QString());
     Q_INVOKABLE QWidget *addImage(const QString &labelText, Tiled::ScriptImage *image);
+    Q_INVOKABLE ScriptButtonGroup *addRadioButtonGroup(const QString &labelText, const QStringList &values);
     Q_INVOKABLE void clear();
     Q_INVOKABLE void addNewRow();
 

--- a/src/tiled/scriptdialog.h
+++ b/src/tiled/scriptdialog.h
@@ -109,7 +109,7 @@ public:
     Q_INVOKABLE QWidget *addFilePicker(const QString &labelText = QString());
     Q_INVOKABLE QWidget *addColorButton(const QString &labelText = QString());
     Q_INVOKABLE QWidget *addImage(const QString &labelText, Tiled::ScriptImage *image);
-    Q_INVOKABLE ScriptButtonGroup *addRadioButtonGroup(const QString &labelText, const QStringList &values);
+    Q_INVOKABLE ScriptButtonGroup *addRadioButtonGroup(const QString &labelText, const QStringList &values, const QString &toolTip);
     Q_INVOKABLE void clear();
     Q_INVOKABLE void addNewRow();
 

--- a/src/tiled/scriptdialog.h
+++ b/src/tiled/scriptdialog.h
@@ -65,16 +65,28 @@ public:
         mLayout(layout)
     {}
 
-    Q_INVOKABLE void addItems(const QStringList &values)
+    Q_INVOKABLE void addItems(const QStringList &values, const QStringList &toolTips)
+    {
+        int toolTipIndex = 0;
+        for (const QString &value : values) {
+
+            QString toolTip = toolTipIndex < toolTips.count() ?
+                                   toolTips.at(toolTipIndex) : QString();
+            addItem(value, toolTip);
+            toolTipIndex++;
+        }
+    }
+
+    Q_INVOKABLE QAbstractButton *addItem(const QString &value, const QString &toolTip = QString())
     {
         int nextIndex = QButtonGroup::buttons().length();
-        for (const QString &value : values) {
-            QRadioButton *radioButton = new QRadioButton;
-            mLayout->addWidget(radioButton);
-            radioButton->setText(value);
-            QButtonGroup::addButton(radioButton, nextIndex);
-            nextIndex++;
-        }
+        QRadioButton *radioButton = new QRadioButton;
+        mLayout->addWidget(radioButton);
+        radioButton->setText(value);
+        if (!toolTip.isEmpty())
+            radioButton->setToolTip(toolTip);
+        QButtonGroup::addButton(radioButton, nextIndex);
+        return radioButton;
     }
 
     QList<QAbstractButton *> buttons() const
@@ -126,7 +138,7 @@ public:
     Q_INVOKABLE QWidget *addFilePicker(const QString &labelText = QString());
     Q_INVOKABLE QWidget *addColorButton(const QString &labelText = QString());
     Q_INVOKABLE QWidget *addImage(const QString &labelText, Tiled::ScriptImage *image);
-    Q_INVOKABLE ScriptButtonGroup *addRadioButtonGroup(const QString &labelText, const QStringList &values, const QString &toolTip);
+    Q_INVOKABLE ScriptButtonGroup *addRadioButtonGroup(const QString &labelText, const QStringList &values, const QString &toolTip = QString(), const QStringList &buttonToolTips = QStringList());
     Q_INVOKABLE void clear();
     Q_INVOKABLE void addNewRow();
 
@@ -141,7 +153,7 @@ private:
     QLabel *newLabel(const QString &labelText);
     void initializeLayout();
     void determineWidgetGrouping(QWidget *widget);
-    QWidget *addDialogWidget(QWidget * widget, const QString &label = QString());
+    QWidget *addDialogWidget(QWidget * widget, const QString &label = QString(), const QString &labelToolTip = QString());
 
     int m_rowIndex = 0;
     int m_widgetsInRow = 0;

--- a/src/tiled/scriptdialog.h
+++ b/src/tiled/scriptdialog.h
@@ -21,12 +21,11 @@
 
 #pragma once
 
-#include "qboxlayout.h"
 #include <QAbstractButton>
+#include <QBoxLayout>
 #include <QButtonGroup>
-#include <QLabel>
 #include <QDialog>
-#include <QRadioButton>
+#include <QLabel>
 
 class QGridLayout;
 class QHBoxLayout;
@@ -53,6 +52,7 @@ public:
     void setImage(ScriptImage *image);
 };
 
+
 class ScriptButtonGroup : public QButtonGroup
 {
     Q_OBJECT
@@ -61,54 +61,20 @@ class ScriptButtonGroup : public QButtonGroup
     Q_PROPERTY(int checkedIndex READ checkedIndex CONSTANT)
 
 public:
-    ScriptButtonGroup(QWidget * parent, QHBoxLayout *layout)
-        : QButtonGroup(parent),
-        mLayout(layout)
+    ScriptButtonGroup(QWidget *parent, QHBoxLayout *layout)
+        : QButtonGroup(parent)
+        , mLayout(layout)
     {}
 
-    Q_INVOKABLE void addItems(const QStringList &values, const QStringList &toolTips)
-    {
-        int toolTipIndex = 0;
-        for (const QString &value : values) {
+    Q_INVOKABLE void addItems(const QStringList &values, const QStringList &toolTips);
+    Q_INVOKABLE QAbstractButton *addItem(const QString &value, const QString &toolTip = QString());
 
-            QString toolTip = toolTipIndex < toolTips.count() ?
-                                   toolTips.at(toolTipIndex) : QString();
-            addItem(value, toolTip);
-            toolTipIndex++;
-        }
-    }
-
-    Q_INVOKABLE QAbstractButton *addItem(const QString &value, const QString &toolTip = QString())
-    {
-        int nextIndex = QButtonGroup::buttons().length();
-        QRadioButton *radioButton = new QRadioButton;
-        mLayout->addWidget(radioButton);
-        radioButton->setText(value);
-        if (!toolTip.isEmpty())
-            radioButton->setToolTip(toolTip);
-        QButtonGroup::addButton(radioButton, nextIndex);
-        return radioButton;
-    }
-
-    QList<QAbstractButton *> buttons() const
-    {
-        return QButtonGroup::buttons();
-    }
-
-
-    QAbstractButton * checkedButton() const
-    {
-        return QButtonGroup::checkedButton();
-    }
-
-    int checkedIndex() const
-    {
-        return QButtonGroup::checkedId();
-    }
+    int checkedIndex() const { return QButtonGroup::checkedId(); }
 
 private:
     QHBoxLayout *mLayout;
 };
+
 
 class ScriptDialog : public QDialog
 {
@@ -144,7 +110,10 @@ public:
     Q_INVOKABLE QWidget *addFilePicker(const QString &labelText = QString());
     Q_INVOKABLE QWidget *addColorButton(const QString &labelText = QString());
     Q_INVOKABLE QWidget *addImage(const QString &labelText, Tiled::ScriptImage *image);
-    Q_INVOKABLE ScriptButtonGroup *addRadioButtonGroup(const QString &labelText, const QStringList &values, const QString &toolTip = QString(), const QStringList &buttonToolTips = QStringList());
+    Q_INVOKABLE ScriptButtonGroup *addRadioButtonGroup(const QString &labelText,
+                                                       const QStringList &values,
+                                                       const QString &toolTip = QString(),
+                                                       const QStringList &buttonToolTips = QStringList());
     Q_INVOKABLE void clear();
     Q_INVOKABLE void addNewRow();
 
@@ -159,7 +128,9 @@ private:
     QLabel *newLabel(const QString &labelText);
     void initializeLayout();
     void determineWidgetGrouping(QWidget *widget);
-    QWidget *addDialogWidget(QWidget * widget, const QString &label = QString(), const QString &labelToolTip = QString());
+    QWidget *addDialogWidget(QWidget * widget,
+                             const QString &label = QString(),
+                             const QString &labelToolTip = QString());
 
     int m_rowIndex = 0;
     int m_widgetsInRow = 0;


### PR DESCRIPTION
Fix #3478 

TODO @dogboydog 
- [x] Update scripting API doc 
- [x] Update News.md
- [x] Fix radio buttons being invisible 
- [x] Provide example of responding to selected option changes
- [x] Provide a way to select one of the radio buttons from the script? 
- [x] Decide  on tooltip API

 Examples: https://github.com/dogboydog/tiled-dialog-scripts Radio*.mjs

https://github.com/user-attachments/assets/175361e9-34ea-4f2e-ac0b-1296fecc9c64

