### PR TITLE
Raised the minimum Qt version to 5.15

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -218,9 +218,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - qt_version: 5.12.12
+        - qt_version: 5.15.2
           qt_modules: ""
-          version_suffix: "10.12-10.15"
+          version_suffix: "10.13-10.15"
           architectures: x86_64
           cmake_architectures: x86_64
         - qt_version: 6.8.1
@@ -460,7 +460,7 @@ jobs:
           Tiled-${{ needs.version.outputs.version }}_Windows-7-8_x86.msi/*.msi
           Tiled-${{ needs.version.outputs.version }}_Linux_Qt-5_x86_64.AppImage/*.AppImage
           Tiled-${{ needs.version.outputs.version }}_Linux_Qt-6_x86_64.AppImage/*.AppImage
-          Tiled-${{ needs.version.outputs.version }}_macOS-10.12-10.15.app/*.zip
+          Tiled-${{ needs.version.outputs.version }}_macOS-10.13-10.15.app/*.zip
           Tiled-${{ needs.version.outputs.version }}_macOS-11+.app/*.zip
 
   sentry:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Raised minimum supported Qt version from 5.12 to 5.15
+
 ### Tiled 1.11.1 (11 Jan 2025)
 
 * Releases now ship with support for loading Aseprite images (#4109)

--- a/dist/distribute.qbs
+++ b/dist/distribute.qbs
@@ -43,12 +43,7 @@ Product {
                 return Qt.core.libPath + "/lib"
             }
         }
-        property string postfix: {
-            var suffix = "";
-            if (qbs.targetOS.contains("windows") && qbs.debugInformation && Qt.core.versionMajor < 6 && Qt.core.versionMinor < 15)
-                suffix += "d";
-            return suffix + cpp.dynamicLibrarySuffix;
-        }
+        property string postfix: cpp.dynamicLibrarySuffix
         files: {
             function addQtVersions(libs) {
                 var result = [];

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -5,7 +5,7 @@ DynamicLibrary {
     cpp.dynamicLibraryPrefix: "lib"
 
     Depends { name: "cpp" }
-    Depends { name: "Qt"; submodules: "gui"; versionAtLeast: "5.12" }
+    Depends { name: "Qt"; submodules: "gui"; versionAtLeast: "5.15" }
 
     Probes.PkgConfigProbe {
         id: pkgConfigZstd

--- a/src/libtiled/map.h
+++ b/src/libtiled/map.h
@@ -743,15 +743,7 @@ inline bool Map::LayerIteratorHelper::isEmpty() const
 
 inline QList<Layer *> Map::LayerIteratorHelper::toList() const
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     return QList<Layer *>(begin(), end());
-#else
-    LayerIterator iterator(&mMap, mLayerTypes);
-    QList<Layer *> layers;
-    while (Layer *layer = iterator.next())
-        layers.append(layer);
-    return layers;
-#endif
 }
 
 

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -1273,13 +1273,8 @@ QPolygonF MapReaderPrivate::readPolygon()
 
     const QXmlStreamAttributes atts = xml.attributes();
     const QString points = atts.value(QLatin1String("points")).toString();
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    const QStringList pointsList = points.split(QLatin1Char(' '),
-                                                QString::SkipEmptyParts);
-#else
     const QStringList pointsList = points.split(QLatin1Char(' '),
                                                 Qt::SkipEmptyParts);
-#endif
 
     QPolygonF polygon;
     bool ok = true;

--- a/src/libtiled/minimaprenderer.h
+++ b/src/libtiled/minimaprenderer.h
@@ -77,11 +77,7 @@ public:
 private:
     const Map *mMap;
     std::unique_ptr<MapRenderer> mRenderer;
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    QColor mGridColor = Qt::black;
-#else
     QColor mGridColor = QColorConstants::Black;
-#endif
     RenderObjectLabelCallback mRenderObjectLabelCallback;
 };
 

--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -125,17 +125,7 @@ void mergeProperties(Properties &target, const Properties &source)
         return;
     }
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-    // Based on QMap::unite, but using insert instead of insertMulti
-    Properties::const_iterator it = source.constEnd();
-    const Properties::const_iterator b = source.constBegin();
-    while (it != b) {
-        --it;
-        target.insert(it.key(), it.value());
-    }
-#else
     target.insert(source);
-#endif
 }
 
 QJsonArray propertiesToJson(const Properties &properties, const ExportContext &context)

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -171,9 +171,7 @@ QVariant EnumPropertyType::toPropertyValue(const QVariant &value, const ExportCo
         if (valuesAsFlags) {
             int flags = 0;
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-            const QVector<QStringRef> stringValues = stringValue.splitRef(QLatin1Char(','), QString::SkipEmptyParts);
-#elif QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
             const QVector<QStringRef> stringValues = stringValue.splitRef(QLatin1Char(','), Qt::SkipEmptyParts);
 #else
             const QList<QStringView> stringValues = QStringView(stringValue).split(QLatin1Char(','), Qt::SkipEmptyParts);

--- a/src/libtiled/qtcompat_p.h
+++ b/src/libtiled/qtcompat_p.h
@@ -21,12 +21,6 @@
 
 #include <QTextStream>
 
-#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
-namespace Qt {
-using ::endl;
-}
-#endif
-
 #if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
 using QStringRef = QStringView;
 #endif

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -4,7 +4,7 @@ DynamicLibrary {
 
     Depends { name: "libtiled" }
     Depends { name: "cpp" }
-    Depends { name: "Qt"; submodules: ["quick"]; versionAtLeast: "5.12" }
+    Depends { name: "Qt"; submodules: ["quick"]; versionAtLeast: "5.15" }
 
     cpp.cxxLanguageVersion: "c++17"
     cpp.cxxFlags: {

--- a/src/plugins/yy/yyplugin.cpp
+++ b/src/plugins/yy/yyplugin.cpp
@@ -390,11 +390,7 @@ static void writeProperty(JsonWriter &json,
 static QStringList readTags(const Object *object)
 {
     const QString tags = optionalProperty(object, "tags", QString());
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    const QStringList tagList = tags.split(QLatin1Char(','), QString::SkipEmptyParts);
-#else
     const QStringList tagList = tags.split(QLatin1Char(','), Qt::SkipEmptyParts);
-#endif
     return tagList;
 }
 

--- a/src/tiled/brokenlinks.cpp
+++ b/src/tiled/brokenlinks.cpp
@@ -557,11 +557,7 @@ void LinkFixer::tryFixLinks(const QVector<BrokenLink> &links)
     const auto entryList = dir.entryList(QDir::Files |
                                          QDir::Readable |
                                          QDir::NoDotAndDotDot);
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    const auto files = entryList.toSet();
-#else
     const QSet<QString> files { entryList.begin(), entryList.end() };
-#endif
 
     // See if any of the links we're looking for is located in this directory
     for (const BrokenLink &link : links) {

--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -108,11 +108,7 @@ Properties ClipboardManager::properties() const
     const QMimeData *mimeData = mClipboard->mimeData();
     const QByteArray data = mimeData->data(QLatin1String(PROPERTIES_MIMETYPE));
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-    const QJsonArray array = QJsonDocument::fromBinaryData(data).array();
-#else
     const QJsonArray array = QCborValue::fromCbor(data).toArray().toJsonArray();
-#endif
 
     return propertiesFromJson(array);
 }
@@ -125,12 +121,7 @@ void ClipboardManager::setProperties(const Properties &properties)
     const QJsonDocument document(propertiesJson);
 
     mimeData->setText(QString::fromUtf8(document.toJson()));
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-    mimeData->setData(QLatin1String(PROPERTIES_MIMETYPE), document.toBinaryData());
-#else
     mimeData->setData(QLatin1String(PROPERTIES_MIMETYPE), QCborArray::fromJsonArray(propertiesJson).toCborValue().toCbor());
-#endif
 
     mClipboard->setMimeData(mimeData);
 }

--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -297,9 +297,7 @@ CommandProcess::CommandProcess(const Command &command, bool inTerminal, bool sho
     if (!finalWorkingDirectory.trimmed().isEmpty())
         setWorkingDirectory(finalWorkingDirectory);
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-    start(mFinalCommand);
-#elif QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QStringList args = QProcess::splitCommand(mFinalCommand);
     const QString executable = args.takeFirst();
     start(executable, args);

--- a/src/tiled/commanddatamodel.cpp
+++ b/src/tiled/commanddatamodel.cpp
@@ -462,11 +462,7 @@ bool CommandDataModel::move(int commandIndex, int newIndex)
 
     if (commandIndex - newIndex == 1 || newIndex - commandIndex == 1) {
         // Swapping is probably more efficient than removing/inserting
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-        qSwap(mCommands[commandIndex], mCommands[newIndex]);
-#else
         mCommands.swapItemsAt(commandIndex, newIndex);
-#endif
     } else {
         const Command command = mCommands.at(commandIndex);
         mCommands.removeAt(commandIndex);

--- a/src/tiled/geometry.cpp
+++ b/src/tiled/geometry.cpp
@@ -204,14 +204,7 @@ static bool isCoherentTo(const QRect &rect, const QRegion &region)
 QVector<QRegion> coherentRegions(const QRegion &region)
 {
     QVector<QRegion> result;
-    QVector<QRect> rects;
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    rects.reserve(static_cast<int>(region.end() - region.begin()));
-    for (const QRect &rect : region)
-        rects.append(rect);
-#else
-    rects = QVector<QRect>(region.begin(), region.end());
-#endif
+    QVector<QRect> rects(region.begin(), region.end());
 
     while (!rects.isEmpty()) {
         QRegion newCoherentRegion = rects.takeLast();

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -8,7 +8,7 @@ DynamicLibrary {
     Depends { name: "libtiled" }
     Depends { name: "translations" }
     Depends { name: "qtsingleapplication" }
-    Depends { name: "Qt"; submodules: ["core", "widgets", "concurrent", "qml", "svg"]; versionAtLeast: "5.12" }
+    Depends { name: "Qt"; submodules: ["core", "widgets", "concurrent", "qml", "svg"]; versionAtLeast: "5.15" }
     Depends { name: "Qt.openglwidgets"; condition: Qt.core.versionMajor >= 6; required: false }
     Depends { name: "Qt.dbus"; condition: qbs.targetOS.contains("linux") && project.dbus; required: false }
     Depends { name: "Qt.gui-private"; condition: qbs.targetOS.contains("windows") && Qt.core.versionMajor >= 6 }

--- a/src/tiled/locatorwidget.cpp
+++ b/src/tiled/locatorwidget.cpp
@@ -321,11 +321,7 @@ void LocatorWidget::setVisible(bool visible)
 void LocatorWidget::setFilterText(const QString &text)
 {
     const QString normalized = QDir::fromNativeSeparators(text);
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    const QStringList words = normalized.split(QLatin1Char(' '), QString::SkipEmptyParts);
-#else
     const QStringList words = normalized.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-#endif
 
     mLocatorSource->setFilterWords(words);
 

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -214,11 +214,7 @@ void MiniMap::redrawTimeout()
 void MiniMap::wheelEvent(QWheelEvent *event)
 {
     if (event->angleDelta().y()) {
-#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
-        centerViewOnLocalPixel(event->pos(), event->angleDelta().y());
-#else
         centerViewOnLocalPixel(event->position(), event->angleDelta().y());
-#endif
         return;
     }
 

--- a/src/tiled/projectdock.cpp
+++ b/src/tiled/projectdock.cpp
@@ -234,11 +234,7 @@ void ProjectView::setModel(QAbstractItemModel *model)
 
 void ProjectView::setExpandedPaths(const QStringList &paths)
 {
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    mExpandedPaths = paths.toSet();
-#else
     mExpandedPaths = QSet<QString>(paths.begin(), paths.end());
-#endif
 }
 
 void ProjectView::addExpandedPath(const QString &path)

--- a/src/tiled/projectmodel.h
+++ b/src/tiled/projectmodel.h
@@ -69,11 +69,7 @@ public:
         int offset;
         QString path;
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-        QStringRef relativePath() const { return path.midRef(offset); }
-#else
         QStringView relativePath() const { return QStringView(path).mid(offset); }
-#endif
     };
 
     QVector<Match> findFiles(const QStringList &words) const;

--- a/src/tiled/propertyeditorwidgets.cpp
+++ b/src/tiled/propertyeditorwidgets.cpp
@@ -133,14 +133,7 @@ QSize PairwiseWrappingLayout::minimumSize() const
     QSize size;
     size.setWidth(minimumTwoColumnWidth());
     size.setHeight(doLayout(QRect(0, 0, size.width(), 0), true));
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    const auto margins = contentsMargins();
-    return QSize(size.width() + margins.left() + margins.right(),
-                 size.height() + margins.top() + margins.bottom());
-#else
     return size.grownBy(contentsMargins());
-#endif
 }
 
 int PairwiseWrappingLayout::doLayout(const QRect &rect, bool testOnly) const

--- a/src/tiled/regionvaluetype.cpp
+++ b/src/tiled/regionvaluetype.cpp
@@ -65,15 +65,7 @@ QVector<RegionValueType> RegionValueType::contiguousRegions() const
 
 QVector<QRect> RegionValueType::rects() const
 {
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    QVector<QRect> rects;
-    rects.reserve(static_cast<int>(mRegion.end() - mRegion.begin()));
-    for (const QRect &rect : mRegion)
-        rects.append(rect);
-    return rects;
-#else
     return QVector<QRect>(mRegion.begin(), mRegion.end());
-#endif
 }
 
 } // namespace Tiled

--- a/src/tiled/scriptdialog.cpp
+++ b/src/tiled/scriptdialog.cpp
@@ -60,14 +60,7 @@ ScriptImageWidget::ScriptImageWidget(Tiled::ScriptImage *image, QWidget *parent)
 
 ScriptImage *ScriptImageWidget::image() const
 {
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-    if (auto p = pixmap())
-        return new ScriptImage(p->toImage());
-    else
-        return nullptr;
-#else
     return new ScriptImage(pixmap().toImage());
-#endif
 }
 
 void ScriptImageWidget::setImage(ScriptImage *image)

--- a/src/tiled/scriptfile.cpp
+++ b/src/tiled/scriptfile.cpp
@@ -345,11 +345,7 @@ static bool copyRecursively(const QString &srcFilePath,
         return false;
     }
 #ifdef Q_OS_UNIX
-#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
-    if (srcFileInfo.isSymLink()) {
-#else
     if (srcFileInfo.isSymbolicLink()) {
-#endif
         // For now, disable symlink preserving copying on Windows.
         // MS did a good job to prevent people from using symlinks - even if they are supported.
         if (!createSymLink(storedLinkTarget(srcFilePath), tgtFilePath)) {
@@ -784,11 +780,8 @@ void registerFile(QJSEngine *jsEngine)
 {
     QJSValue globalObject = jsEngine->globalObject();
     globalObject.setProperty(QStringLiteral("File"), jsEngine->newQObject(new ScriptFile));
-
-#if QT_VERSION >= 0x050800
     globalObject.setProperty(QStringLiteral("TextFile"), jsEngine->newQMetaObject<ScriptTextFile>());
     globalObject.setProperty(QStringLiteral("BinaryFile"), jsEngine->newQMetaObject<ScriptBinaryFile>());
-#endif
 }
 
 } // namespace Tiled

--- a/src/tiled/stylehelper.cpp
+++ b/src/tiled/stylehelper.cpp
@@ -93,9 +93,7 @@ void StyleHelper::initialize()
 StyleHelper::StyleHelper()
     : mDefaultStyle(QApplication::style()->objectName())
     , mDefaultPalette(QApplication::palette())
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     , mDefaultShowShortcutsInContextMenus(QGuiApplication::styleHints()->showShortcutsInContextMenus())
-#endif
 {
     apply();
     applyFont();
@@ -134,11 +132,7 @@ void StyleHelper::apply()
         break;
     }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
     QGuiApplication::styleHints()->setShowShortcutsInContextMenus(showShortcutsInContextMenus);
-#else
-    Q_UNUSED(showShortcutsInContextMenus)
-#endif
 
     if (QApplication::style()->objectName() != desiredStyle) {
         QStyle *style;

--- a/src/tiled/tiledproxystyle.cpp
+++ b/src/tiled/tiledproxystyle.cpp
@@ -20,10 +20,6 @@
 
 #include "tiledproxystyle.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-#include "utils.h"
-#endif
-
 #include <QAbstractScrollArea>
 #include <QApplication>
 #include <QComboBox>
@@ -131,15 +127,10 @@ static const qreal baseDpi = 96;
 
 static qreal dpi(const QStyleOption *option)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     // Expect that QStyleOption::QFontMetrics::QFont has the correct DPI set
     if (option)
         return option->fontMetrics.fontDpi();
     return baseDpi;
-#else
-    Q_UNUSED(option)
-    return Utils::defaultDpi();
-#endif
 }
 
 static qreal dpiScaled(qreal value, qreal dpi)

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -696,11 +696,7 @@ void TilesetView::wheelEvent(QWheelEvent *event)
 
     if ((wheelZoomsByDefault != control) && event->angleDelta().y()) {
 
-#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
-        const QPointF &viewportPos = event->posF();
-#else
         const QPointF &viewportPos = event->position();
-#endif
         const QPointF contentPos(viewportPos.x() + hor->value(),
                                  viewportPos.y() + ver->value());
 

--- a/src/tiled/transformmapobjects.h
+++ b/src/tiled/transformmapobjects.h
@@ -30,10 +30,6 @@ class Document;
 
 struct TransformState
 {
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0) // required by QVector::reallocData
-    TransformState() = default;
-#endif
-
     explicit TransformState(const MapObject *mapObject)
         : mPosition(mapObject->position())
         , mSize(mapObject->size())

--- a/src/tiled/utils.cpp
+++ b/src/tiled/utils.cpp
@@ -31,9 +31,6 @@
 #include <QDBusMessage>
 #endif
 #include <QDesktopServices>
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-#include <QDesktopWidget>
-#endif
 #include <QDir>
 #include <QFileInfo>
 #include <QGuiApplication>
@@ -48,9 +45,6 @@
 #include <QPainter>
 #include <QProcess>
 #include <QRegularExpression>
-#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
-#include <QRegExp>
-#endif
 #include <QScreen>
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0) && QT_VERSION < QT_VERSION_CHECK(6, 5, 1)
@@ -113,11 +107,7 @@ QStringList cleanFilterList(const QString &filter)
     QRegularExpressionMatch match = regexp.match(filter);
     if (match.hasMatch())
         f = match.captured(2);
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    return f.split(QLatin1Char(' '), QString::SkipEmptyParts);
-#else
     return f.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-#endif
 }
 
 /**
@@ -127,25 +117,14 @@ QStringList cleanFilterList(const QString &filter)
 bool fileNameMatchesNameFilter(const QString &filePath,
                                const QString &nameFilter)
 {
-#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
-    QRegExp rx;
-    rx.setCaseSensitivity(Qt::CaseInsensitive);
-    rx.setPatternSyntax(QRegExp::Wildcard);
-#else
     QRegularExpression rx;
     rx.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
-#endif
 
     const QStringList filterList = cleanFilterList(nameFilter);
     const QString fileName = QFileInfo(filePath).fileName();
     for (const QString &filter : filterList) {
-#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
-        rx.setPattern(filter);
-        if (rx.exactMatch(fileName))
-#else
         rx.setPattern(QRegularExpression::wildcardToRegularExpression(filter));
         if (rx.match(fileName).hasMatch())
-#endif
             return true;
     }
     return false;
@@ -327,15 +306,11 @@ QIcon colorIcon(const QColor &color, QSize size)
  */
 QRect screenRect(const QWidget *widget)
 {
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    return QApplication::desktop()->availableGeometry(widget);
-#else
     const QPoint center = widget->mapToGlobal(widget->rect().center());
     const QScreen *screen = widget->screen()->virtualSiblingAt(center);
     if (!screen)
         screen = widget->screen();
     return screen->availableGeometry();
-#endif
 }
 
 /**

--- a/src/tiledapp/main.cpp
+++ b/src/tiledapp/main.cpp
@@ -424,13 +424,11 @@ int main(int argc, char *argv[])
     }
 #endif
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
 
     // High-DPI scaling is always enabled in Qt 6
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
 #endif
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/tiledquick/main.cpp
+++ b/src/tiledquick/main.cpp
@@ -12,9 +12,7 @@ int main(int argc, char *argv[])
 #endif
 
     // We don't need the scaling factor to be rounded
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
-#endif
 
     QApplication app(argc, argv);
 

--- a/src/tiledquick/tiledquick.qbs
+++ b/src/tiledquick/tiledquick.qbs
@@ -11,7 +11,7 @@ QtGuiApplication {
     Depends {
         name: "Qt"
         submodules: ["core", "quick", "widgets"]
-        versionAtLeast: "5.12"
+        versionAtLeast: "5.15"
     }
     Depends {
         name: "tiledquickplugin"

--- a/src/tiledquickplugin/tiledquickplugin.cpp
+++ b/src/tiledquickplugin/tiledquickplugin.cpp
@@ -32,11 +32,7 @@ void TiledQuickPlugin::registerTypes(const char *uri)
 {
     // @uri org.mapeditor.Tiled
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    qmlRegisterType<MapRef>();
-#else
     qmlRegisterAnonymousType<MapRef>(uri, 1);
-#endif
 
     qmlRegisterType<MapLoader>(uri, 1, 0, "MapLoader");
     qmlRegisterType<MapItem>(uri, 1, 0, "MapItem");

--- a/src/tiledquickplugin/tiledquickplugin.qbs
+++ b/src/tiledquickplugin/tiledquickplugin.qbs
@@ -6,7 +6,7 @@ DynamicLibrary {
     Depends { name: "libtiledquick" }
     Depends {
         name: "Qt"; submodules: ["qml", "quick"]
-        versionAtLeast: "5.12"
+        versionAtLeast: "5.15"
     }
 
     cpp.cxxLanguageVersion: "c++17"

--- a/src/tmxviewer/tmxviewer.qbs
+++ b/src/tmxviewer/tmxviewer.qbs
@@ -2,7 +2,7 @@ TiledQtGuiApplication {
     name: "tmxviewer"
 
     Depends { name: "libtiled" }
-    Depends { name: "Qt"; submodules: ["widgets"]; versionAtLeast: "5.12" }
+    Depends { name: "Qt"; submodules: ["widgets"]; versionAtLeast: "5.15" }
 
     cpp.includePaths: ["."]
 


### PR DESCRIPTION
Even Qt 5.15's "[extended lifetime](https://www.qt.io/blog/qt-5.15-extended-support-for-subscription-license-holders)" will end 26th of May 2025. Before we stop supporting Qt 5 entirely, I'm dropping support for all but the last version.

Minimum version of macOS supported is now 10.13 rather than 10.12.