### PR TITLE
YY plugin: Adjusted to changes in GameMaker file format

### DIFF
--- a/src/plugins/yy/jsonwriter.cpp
+++ b/src/plugins/yy/jsonwriter.cpp
@@ -255,7 +255,7 @@ void JsonWriter::writeKey(const char *key)
     prepareNewLine();
     write('"');
     write(key);
-    write(m_minimize ? "\":" : "\": ");
+    write("\":");
 }
 
 void JsonWriter::write(const char *bytes, qint64 length)


### PR DESCRIPTION
It seems an update to GameMaker in late 2024 has broken compatibility in several ways:

* It now requires a "type tag field" at the start of applicable JSON records.

* The name is expected to follow the "type tag field" as a "%Name" field, in addition to the regular "name" field.

* Except for these special properties, the JSON fields are now required to be ordered alphabetically.

Other minor differences include:

* The "tags" field is left out when there are no tags.
* There is no longer a space included after JSON field names.
* Some new fields were added.

This patch does not address all alphabetical ordering issues. Propably the preferred way will be to collect the fields in a QJsonObject first and rely on automatic sorting of the fields while serializing.

Closes #4132