### PR TITLE
snap: Try to remove Wayland support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* snap: Fixed crash on startup on Wayland
 * Raised minimum supported Qt version from 5.12 to 5.15
 
 ### Tiled 1.11.1 (11 Jan 2025)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,6 +69,7 @@ parts:
       - qtwayland5
     #  - libpython2.7
       - libzstd1
+      - xkb-data
     after: [desktop-qt5]
 
   qaseprite:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,6 @@ apps:
     plugs:
       - desktop
       - desktop-legacy
-      - wayland
       - unity7
       - home
       - removable-media
@@ -27,7 +26,6 @@ apps:
     plugs: &basic-plugs
       - desktop
       - desktop-legacy
-      - wayland
       - unity7
       - home
       - removable-media
@@ -66,7 +64,6 @@ parts:
     stage-packages:
       - libqt5quick5
       - qt5-image-formats-plugins
-      - qtwayland5
     #  - libpython2.7
       - libzstd1
     after: [desktop-qt5]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ apps:
     plugs:
       - desktop
       - desktop-legacy
+      - wayland
       - unity7
       - home
       - removable-media
@@ -26,6 +27,7 @@ apps:
     plugs: &basic-plugs
       - desktop
       - desktop-legacy
+      - wayland
       - unity7
       - home
       - removable-media
@@ -64,6 +66,7 @@ parts:
     stage-packages:
       - libqt5quick5
       - qt5-image-formats-plugins
+      - qtwayland5
     #  - libpython2.7
       - libzstd1
     after: [desktop-qt5]


### PR DESCRIPTION
Such that the Tiled snap will hopefully start working again on Wayland based on XWayland.

Currently we're seeing this when trying to launch Tiled on Wayland:
```
$ snap run tiled
xkbcommon: ERROR: failed to add default include path /usr/share/X11/xkb
qt.qpa.wayland: failed to create xkb context
QSocketNotifier: Can only be used with threads started with QThread
Segmentation fault (core dumped)
```