### PR TITLE
Fixed Object::resolvedProperties

### DIFF
--- a/src/libtiled/object.cpp
+++ b/src/libtiled/object.cpp
@@ -88,8 +88,8 @@ QVariant Object::resolvedProperty(const QString &name) const
 
 QVariantMap Object::resolvedProperties() const
 {
-    QVariantMap allProperties;
-    Tiled::mergeProperties(allProperties, inheritedProperties());
+    QVariantMap allProperties(inheritedProperties());
+    Tiled::mergeProperties(allProperties, properties());
     return allProperties;
 }
 


### PR DESCRIPTION
By accident it was only returning the inherited properties. This was a regression in c99a1e77de2b41bad638b67272562f08e8289118.