### PR TITLE
Fixed qaseprite compile on Windows

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         repository: mapeditor/qaseprite
         path: qaseprite
-        submodules: 'recursive'
+        ref: '1.0'
 
     - name: Install dependencies
       run: |
@@ -128,8 +128,10 @@ jobs:
     - name: Install qaseprite plugin
       working-directory: qaseprite
       run: |
+        ./update-submodules.sh --minimal
         cmake -B build -DCMAKE_BUILD_TYPE=Release \
           -DUSE_SHARED_ZLIB=on \
+          -DUSE_SHARED_LIBPNG=on \
           -DUSE_SHARED_PIXMAN=on \
           -DUSE_SHARED_FREETYPE=on \
           -DUSE_SHARED_HARFBUZZ=on
@@ -242,7 +244,7 @@ jobs:
       with:
         repository: mapeditor/qaseprite
         path: qaseprite
-        submodules: 'recursive'
+        ref: '1.0'
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
@@ -268,6 +270,7 @@ jobs:
     - name: Install qaseprite plugin
       working-directory: qaseprite 
       run: |
+        ./update-submodules.sh --no-zlib
         cmake -B build -DCMAKE_BUILD_TYPE=Release \
           -DUSE_SHARED_ZLIB=on \
           -DCMAKE_OSX_ARCHITECTURES='${{ matrix.cmake_architectures }}'
@@ -369,7 +372,7 @@ jobs:
       with:
         repository: mapeditor/qaseprite
         path: qaseprite
-        submodules: 'recursive'
+        ref: '1.0'
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
@@ -406,9 +409,7 @@ jobs:
     - name: Install qaseprite plugin
       working-directory: qaseprite 
       run: |
-        pushd aseprite
-        patch -p1 < ../aseprite-msvc-dynamic-runtime.patch
-        popd
+        ./update-submodules.sh
         pushd aseprite/laf
         patch -p1 < ../../laf-msvc-dynamic-runtime.patch
         popd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,11 +51,8 @@ build_script:
   - if defined MINGW git clone --depth 1 -b release https://github.com/facebook/zstd.git
   - if defined MINGW cd zstd/lib & set CC=gcc & mingw32-make -j2 libzstd.a & cd ../../
   - echo Building qaseprite
-  - git clone --depth 1 --recurse-submodules https://github.com/mapeditor/qaseprite.git
-  - cd qaseprite
-  - cd aseprite
-  - patch -p1 < ..\aseprite-msvc-dynamic-runtime.patch
-  - cd laf
+  - git clone --depth 1 --recurse-submodules --shallow-submodules --branch 1.0 https://github.com/mapeditor/qaseprite.git
+  - cd qaseprite\aseprite\laf
   - patch -p1 < ..\..\laf-msvc-dynamic-runtime.patch
   - cd ..\..
   - if defined MINGW cmake -B build -DCMAKE_BUILD_TYPE=Release -G "MinGW Makefiles"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,11 +73,12 @@ parts:
     after: [desktop-qt5]
 
   qaseprite:
-    source: https://github.com/mapeditor/qaseprite.git
+    source: https://github.com/mapeditor/qaseprite/releases/download/1.0/qaseprite-1.0-source.tar.gz
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
       - -DUSE_SHARED_ZLIB=on
+      - -DUSE_SHARED_LIBPNG=on
       - -DUSE_SHARED_PIXMAN=on
       - -DUSE_SHARED_FREETYPE=on
       - -DUSE_SHARED_HARFBUZZ=on


### PR DESCRIPTION
The `aseprite-msvc-dynamic-runtime.patch` is gone after its target `CMakeLists.txt` was merged into the qaseprite one in https://github.com/mapeditor/qaseprite/commit/180451b8ae1bc2d06abae22e099955ddf7b9ead6.

Check out the 1.0 tag to avoid future breakage in case changes are made to the plugin. Also use the new `update-submodules.sh` script to check out only the required submodules.

The snap has been updated as well to use the 1.0 source archive.