### PR TITLE
Fixed ability to change image and object layer properties

### DIFF
--- a/src/tiled/changeimagelayerproperty.h
+++ b/src/tiled/changeimagelayerproperty.h
@@ -39,6 +39,8 @@ public:
                                      QList<ImageLayer *> imageLayers,
                                      const QColor &newColor);
 
+    int id() const override { return Cmd_ChangeImageLayerTransparentColor; }
+
 private:
     QColor getValue(const ImageLayer *imageLayer) const override;
     void setValue(ImageLayer *imageLayer, const QColor &value) const override;
@@ -50,6 +52,8 @@ public:
     ChangeImageLayerImageSource(Document *document,
                                 QList<ImageLayer *> imageLayers,
                                 const QUrl &imageSource);
+
+    int id() const override { return Cmd_ChangeImageLayerImageSource; }
 
 private:
     QUrl getValue(const ImageLayer *imageLayer) const override;

--- a/src/tiled/changeobjectgroupproperties.h
+++ b/src/tiled/changeobjectgroupproperties.h
@@ -42,6 +42,8 @@ public:
                            QList<ObjectGroup *> objectGroups,
                            const QColor &newColor);
 
+    int id() const override { return Cmd_ChangeObjectGroupColor; }
+
 private:
     QColor getValue(const ObjectGroup *objectGroup) const override;
     void setValue(ObjectGroup *objectGroup, const QColor &value) const override;
@@ -60,6 +62,8 @@ public:
     ChangeObjectGroupDrawOrder(Document *document,
                                QList<ObjectGroup *> objectGroups,
                                ObjectGroup::DrawOrder newDrawOrder);
+
+    int id() const override { return Cmd_ChangeObjectGroupDrawOrder; }
 
 private:
     ObjectGroup::DrawOrder getValue(const ObjectGroup *objectGroup) const override;

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -1125,7 +1125,7 @@ protected:
     template <class T>
     QList<T*> selectedLayersOfType(Layer::TypeFlag typeFlag)
     {
-        if (mDocument)
+        if (!mDocument)
             return {};
 
         QList<T*> result;
@@ -1212,9 +1212,8 @@ private:
             emit mImageProperty->valueChanged();
         if (layerChange.properties & ImageLayerChangeEvent::TransparentColorProperty)
             emit mTransparentColorProperty->valueChanged();
-        if (layerChange.properties & ImageLayerChangeEvent::RepeatProperty) {
+        if (layerChange.properties & ImageLayerChangeEvent::RepeatProperty)
             emit mRepeatProperty->valueChanged();
-        }
     }
 
     ImageLayer *imageLayer() const

--- a/src/tiled/undocommands.h
+++ b/src/tiled/undocommands.h
@@ -30,8 +30,10 @@ namespace Tiled {
  */
 enum UndoCommands {
     Cmd_ChangeClassName,
+    Cmd_ChangeImageLayerImageSource,
     Cmd_ChangeImageLayerRepeatX,
     Cmd_ChangeImageLayerRepeatY,
+    Cmd_ChangeImageLayerTransparentColor,
     Cmd_ChangeLayerBlendMode,
     Cmd_ChangeLayerLocked,
     Cmd_ChangeLayerName,
@@ -54,6 +56,8 @@ enum UndoCommands {
     Cmd_ChangeMapStaggerAxis,
     Cmd_ChangeMapStaggerIndex,
     Cmd_ChangeMapTileSize,
+    Cmd_ChangeObjectGroupColor,
+    Cmd_ChangeObjectGroupDrawOrder,
     Cmd_ChangeSelectedArea,
     Cmd_ChangeTileImageRect,
     Cmd_ChangeTileProbability,


### PR DESCRIPTION
Due to an inverted condition introduced in 629b53cea8dbc4ae46c9447a, it was not actually possible to change properties specific to image layers and object layers.

Also fixed the undo entry merging for these properties, which was broken because their undo commands did not have an ID.