### PR TITLE
Github Actions: Try using latest qaseprite

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         repository: mapeditor/qaseprite
         path: qaseprite
-        ref: '1.0'
+        ref: '1.0.1'
 
     - name: Install dependencies
       run: |
@@ -244,7 +244,7 @@ jobs:
       with:
         repository: mapeditor/qaseprite
         path: qaseprite
-        ref: '1.0'
+        ref: '1.0.1'
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
@@ -372,7 +372,7 @@ jobs:
       with:
         repository: mapeditor/qaseprite
         path: qaseprite
-        ref: '1.0'
+        ref: '1.0.1'
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ build_script:
   - if defined MINGW git clone --depth 1 -b release https://github.com/facebook/zstd.git
   - if defined MINGW cd zstd/lib & set CC=gcc & mingw32-make -j2 libzstd.a & cd ../../
   - echo Building qaseprite
-  - git clone --depth 1 --recurse-submodules --shallow-submodules --branch 1.0 https://github.com/mapeditor/qaseprite.git
+  - git clone --depth 1 --recurse-submodules --shallow-submodules --branch 1.0.1 https://github.com/mapeditor/qaseprite.git
   - cd qaseprite\aseprite\laf
   - patch -p1 < ..\..\laf-msvc-dynamic-runtime.patch
   - cd ..\..

--- a/dist/win/installer.qbs
+++ b/dist/win/installer.qbs
@@ -60,9 +60,7 @@ WindowsInstallerPackage {
             defs.push("RpMap");
 
         var imageFormatsPath = FileInfo.joinPaths(Qt.core.pluginPath, "imageformats")
-        if (File.exists(FileInfo.joinPaths(imageFormatsPath, "libqaseprite.dll")))
-            defs.push("AsepriteImageFormatPlugin=libqaseprite.dll");
-        else if (File.exists(FileInfo.joinPaths(imageFormatsPath, "qaseprite.dll")))
+        if (File.exists(FileInfo.joinPaths(imageFormatsPath, "qaseprite.dll")))
             defs.push("AsepriteImageFormatPlugin=qaseprite.dll");
 
         // Since Qt 6.2 we rely on the schannel backend.


### PR DESCRIPTION
Now qaseprite uses `qt_add_plugin`, which fixes the plugin's extension on macOS and unifies the file name to `qaseprite.dll` between MinGW and MSVC.