### PR TITLE
Fixed potential crash when handling file reloads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Fixed potential crash when handling file reloads
+
 ### Tiled 1.11.1 (11 Jan 2025)
 
 * Releases now ship with support for loading Aseprite images (#4109)

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -974,8 +974,10 @@ bool DocumentManager::reloadDocument(Document *document)
         break;
     }
 
-    if (!isDocumentChangedOnDisk(currentDocument()))
-        mFileChangedWarning->setVisible(false);
+    // We may need to hide the file changed warning
+    if (auto current = currentDocument())
+        if (!isDocumentChangedOnDisk(current))
+            mFileChangedWarning->setVisible(false);
 
     emit documentReloaded(document);
 
@@ -1172,8 +1174,10 @@ void DocumentManager::fileChanged(const QString &fileName)
 
     document->setChangedOnDisk(true);
 
-    if (isDocumentChangedOnDisk(currentDocument()))
-        mFileChangedWarning->setVisible(true);
+    // We may need to show the file changed warning
+    if (auto current = currentDocument())
+        if (isDocumentChangedOnDisk(current))
+            mFileChangedWarning->setVisible(true);
 }
 
 void DocumentManager::hideChangedWarning()


### PR DESCRIPTION
A crash could occur if a file (usually a map, tileset or world) got reloaded while no editor was currently open.

Thanks to crash reports sent to Sentry for exposing this one!