### PR TITLE
Docs: "Manual" draw order -> "Index Order"

### DIFF
--- a/docs/manual/keyboard-shortcuts.rst
+++ b/docs/manual/keyboard-shortcuts.rst
@@ -104,13 +104,13 @@ When an object layer is selected
 
 -  ``S`` - Activate :ref:`select-objects-tool`
 
-   -  ``PgUp`` - Raise selected objects (with Manual object drawing
+   -  ``PgUp`` - Raise selected objects (with Index Order object drawing
       order)
-   -  ``PgDown`` - Lower selected objects (with Manual object drawing
+   -  ``PgDown`` - Lower selected objects (with Index Order object drawing
       order)
-   -  ``Home`` - Move selected objects to Top (with Manual object
+   -  ``Home`` - Move selected objects to Top (with Index Order object
       drawing order)
-   -  ``End`` - Move selected objects to Bottom (with Manual object
+   -  ``End`` - Move selected objects to Bottom (with Index Order object
       drawing order)
 
 -  ``O`` - Activate :ref:`edit-polygons-tool`

--- a/docs/manual/objects.rst
+++ b/docs/manual/objects.rst
@@ -267,7 +267,7 @@ Changing Stacking Order
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 If the active :ref:`Object Layer <object-layer-introduction>` has its Drawing
-Order property set to Manual (the default is Top Down), you can control
+Order property set to Index Order (the default is Top Down), you can control
 the stacking order of the selected objects within their object layer
 using the following keys:
 


### PR DESCRIPTION
At some point, the Manual object draw order was renamed to Index Order, but the docs were not updated.

This PR updates the Working with Objects and Keyboard Shortcuts manual pages. I'm not sure why the Keyboard Shortcuts page even mentions the draw order, as the shortcuts work to reorder Objects regardless of draw order, the order just doesn't impact rendering in Top Down mode.

I **did not** update the mention of the manual draw order in the scripting docs, as there it is unclear whether "manual" refers to the name of the mode or its function. Perhaps that should be updated too though.