### PR TITLE
Fixed crash when closing last document with properties selected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
-* Fixed potential crash when handling file reloads
+* Fixed crash while handling file reloads without any files opened
+* Fixed crash when closing the last file with multiple custom properties selected
 
 ### Tiled 1.11.1 (11 Jan 2025)
 

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -161,7 +161,7 @@ void PropertiesWidget::updateActions()
     bool allCustomProperties = !items.isEmpty() && mPropertyBrowser->allCustomPropertyItems(items);
     bool editingTileset = mDocument && mDocument->type() == Document::TilesetDocumentType;
     bool isTileset = mPropertyBrowser->object() && mPropertyBrowser->object()->isPartOfTileset();
-    bool canModify = allCustomProperties && (!isTileset || editingTileset);
+    bool canModify = mDocument && allCustomProperties && (!isTileset || editingTileset);
 
     // Disable remove and rename actions when none of the selected objects
     // actually have the selected property (it may be inherited).


### PR DESCRIPTION
When there is more than one custom property selected when closing the last document, a crash would occur due to a null pointer dereference while updating the actions on the Properties view tool bar.

Thanks to crash reports sent to Sentry for exposing this one!