### PR TITLE
AutoMapping: Don't match rules based on empty input indexes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Added support for SVG 1.2 / CSS blending modes to layers (#3932)
+* AutoMapping: Don't match rules based on empty input indexes
 * Raised minimum supported Qt version from 5.12 to 5.15
 
 ### Tiled 1.11.2 (28 Jan 2025)


### PR DESCRIPTION
If an input index is entirely empty for a given rule, then this index will no longer cause the rule to always match.

An always-matching rule can still be declared by using the special "Ignore" tile in its input.