### PR TITLE
AutoMapping: Optimized reloading of rule maps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added support for SVG 1.2 / CSS blending modes to layers (#3932)
 * AutoMapping: Don't match rules based on empty input indexes
+* AutoMapping: Optimized reloading of rule maps and load rule maps on-demand
 * Raised minimum supported Qt version from 5.12 to 5.15
 
 ### Tiled 1.11.2 (28 Jan 2025)

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -143,10 +143,9 @@ AutoMappingContext::AutoMappingContext(MapDocument *mapDocument)
 }
 
 
-AutoMapper::AutoMapper(std::unique_ptr<Map> rulesMap, const QRegularExpression &mapNameFilter)
+AutoMapper::AutoMapper(std::unique_ptr<Map> rulesMap)
     : mRulesMap(std::move(rulesMap))
     , mRulesMapRenderer(MapRenderer::create(mRulesMap.get()))
-    , mMapNameFilter(mapNameFilter)
 {
     setupRuleMapProperties();
 

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -674,7 +674,7 @@ void AutoMapper::setupRules()
 #endif
 }
 
-void AutoMapper::prepareAutoMap(AutoMappingContext &context)
+void AutoMapper::prepareAutoMap(AutoMappingContext &context) const
 {
     setupWorkMapLayers(context);
 

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -31,7 +31,6 @@
 #include <QList>
 #include <QMap>
 #include <QRegion>
-#include <QRegularExpression>
 #include <QSet>
 #include <QString>
 #include <QVector>
@@ -333,11 +332,10 @@ public:
      * @param rulesMap The map containing the AutoMapping rules. The
      *                 AutoMapper takes ownership of this map.
      */
-    AutoMapper(std::unique_ptr<Map> rulesMap, const QRegularExpression &mapNameFilter = {});
+    explicit AutoMapper(std::unique_ptr<Map> rulesMap);
     ~AutoMapper();
 
     QString rulesMapFileName() const;
-    const QRegularExpression &mapNameFilter() const;
 
     /**
      * Checks if the passed \a ruleLayerName is used as input layer in this
@@ -467,7 +465,6 @@ private:
      */
     const std::unique_ptr<Map> mRulesMap;
     const std::unique_ptr<MapRenderer> mRulesMapRenderer;
-    const QRegularExpression mMapNameFilter;
 
     RuleMapSetup mRuleMapSetup;
 
@@ -489,10 +486,5 @@ private:
 
     const TileLayer dummy;  // used in case input layers are missing
 };
-
-inline const QRegularExpression &AutoMapper::mapNameFilter() const
-{
-    return mMapNameFilter;
-}
 
 } // namespace Tiled

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -351,7 +351,7 @@ public:
      * painful to keep these data structures up to date all time. (indices of
      * layers of the working map)
      */
-    void prepareAutoMap(AutoMappingContext &context);
+    void prepareAutoMap(AutoMappingContext &context) const;
 
     /**
      * Here is done all the AutoMapping.

--- a/src/tiled/automapperwrapper.cpp
+++ b/src/tiled/automapperwrapper.cpp
@@ -36,7 +36,7 @@
 using namespace Tiled;
 
 AutoMapperWrapper::AutoMapperWrapper(MapDocument *mapDocument,
-                                     const QVector<AutoMapper *> &autoMappers,
+                                     const QVector<const AutoMapper *> &autoMappers,
                                      const QRegion &where,
                                      const TileLayer *touchedLayer)
     : PaintTileLayer(mapDocument)

--- a/src/tiled/automapperwrapper.h
+++ b/src/tiled/automapperwrapper.h
@@ -40,7 +40,7 @@ class AutoMapperWrapper : public PaintTileLayer
 {
 public:
     AutoMapperWrapper(MapDocument *mapDocument,
-                      const QVector<AutoMapper*> &autoMappers,
+                      const QVector<const AutoMapper *> &autoMappers,
                       const QRegion &where,
                       const TileLayer *touchedLayer = nullptr);
 };

--- a/src/tiled/automappingmanager.cpp
+++ b/src/tiled/automappingmanager.cpp
@@ -109,21 +109,6 @@ void AutomappingManager::autoMapInternal(const QRegion &where,
 
     const bool automatic = touchedLayer != nullptr;
 
-    if (!mLoaded) {
-        if (mRulesFile.isEmpty()) {
-            mError = tr("No AutoMapping rules provided. Save the map or refer to a rule file in the project properties.");
-            emit errorsOccurred(automatic);
-            return;
-        }
-
-        if (loadFile(mRulesFile)) {
-            mLoaded = true;
-        } else {
-            emit errorsOccurred(automatic);
-            return;
-        }
-    }
-
     // Even if no AutoMapper instance will be executed, we still want to report
     // any warnings or errors that might have been reported while interpreting
     // the rule maps.
@@ -135,14 +120,29 @@ void AutomappingManager::autoMapInternal(const QRegion &where,
             emit errorsOccurred(automatic);
     });
 
+    if (!mLoaded) {
+        if (mRulesFile.isEmpty()) {
+            mError = tr("No AutoMapping rules provided. Save the map or refer to a rule file in the project properties.");
+            return;
+        }
+
+        if (!loadFile(mRulesFile))
+            return;
+
+        mLoaded = true;
+    }
+
     // Determine the list of AutoMappers that is relevant for this map
     const QString mapFileName = QFileInfo(mMapDocument->fileName()).fileName();
+
     QVector<const AutoMapper*> autoMappers;
-    autoMappers.reserve(mActiveAutoMappers.size());
-    for (auto autoMapper : mActiveAutoMappers) {
-        const auto &mapNameFilter = autoMapper->mapNameFilter();
+    autoMappers.reserve(mRuleMapReferences.size());
+
+    for (auto &ruleMap : std::as_const(mRuleMapReferences)) {
+        const auto &mapNameFilter = ruleMap.mapNameFilter;
         if (!mapNameFilter.isValid() || mapNameFilter.match(mapFileName).hasMatch())
-            autoMappers.append(autoMapper);
+            if (const AutoMapper *autoMapper = findAutoMapper(ruleMap.filePath))
+                autoMappers.append(autoMapper);
     }
 
     if (autoMappers.isEmpty())
@@ -165,6 +165,24 @@ void AutomappingManager::autoMapInternal(const QRegion &where,
 }
 
 /**
+ * Returns the AutoMapper instance for the given rules file, loading it if
+ * necessary. Returns nullptr if the file could not be loaded.
+ */
+const AutoMapper *AutomappingManager::findAutoMapper(const QString &filePath)
+{
+    auto it = mLoadedAutoMappers.find(filePath);
+    if (it != mLoadedAutoMappers.end())
+        return it->second.get();
+
+    auto autoMapper = loadRuleMap(filePath);
+    if (!autoMapper)
+        return nullptr;
+
+    auto result = mLoadedAutoMappers.emplace(filePath, std::move(autoMapper));
+    return result.first->second.get();
+}
+
+/**
  * This function parses a rules file or loads a rules map file.
  *
  * While parsing a rules file, any listed files with extension "txt" will also
@@ -183,7 +201,8 @@ bool AutomappingManager::loadFile(const QString &filePath)
         return loadRulesFile(filePath);
     }
 
-    return loadRuleMap(filePath);
+    mRuleMapReferences.append(RuleMapReference { filePath, mMapNameFilter });
+    return true;
 }
 
 bool AutomappingManager::loadRulesFile(const QString &filePath)
@@ -251,41 +270,30 @@ bool AutomappingManager::loadRulesFile(const QString &filePath)
     return ret;
 }
 
-bool AutomappingManager::loadRuleMap(const QString &filePath)
+std::unique_ptr<AutoMapper> AutomappingManager::loadRuleMap(const QString &filePath)
 {
-    auto it = mLoadedAutoMappers.find(filePath);
-    if (it != mLoadedAutoMappers.end()) {
-        mActiveAutoMappers.push_back(it->second.get());
-        return true;
-    }
-
     QString errorString;
-    std::unique_ptr<Map> rules { readMap(filePath, &errorString) };
-
-    if (!rules) {
+    auto rulesMap = readMap(filePath, &errorString);
+    if (!rulesMap) {
         QString error = tr("Opening rules map '%1' failed: %2")
                 .arg(filePath, errorString);
         ERROR(error);
 
         mError += error;
         mError += QLatin1Char('\n');
-        return false;
+        return {};
     }
 
-    std::unique_ptr<AutoMapper> autoMapper { new AutoMapper(std::move(rules), mMapNameFilter) };
+    mWatcher.addPath(filePath);
+
+    auto autoMapper = std::make_unique<AutoMapper>(std::move(rulesMap));
 
     mWarning += autoMapper->warningString();
     const QString error = autoMapper->errorString();
-    if (error.isEmpty()) {
-        auto autoMapperPtr = autoMapper.get();
-        mLoadedAutoMappers.insert(std::make_pair(filePath, std::move(autoMapper)));
-        mActiveAutoMappers.push_back(autoMapperPtr);
-        mWatcher.addPath(filePath);
-    } else {
+    if (!error.isEmpty())
         mError += error;
-    }
 
-    return true;
+    return autoMapper;
 }
 
 /**
@@ -346,7 +354,7 @@ void AutomappingManager::refreshRulesFile(const QString &ruleFileOverride)
 
 void AutomappingManager::cleanUp()
 {
-    mActiveAutoMappers.clear();
+    mRuleMapReferences.clear();
     mLoaded = false;
 }
 
@@ -358,7 +366,9 @@ void AutomappingManager::onFileChanged(const QString &path)
     // File will be re-added when it is still relevant
     mWatcher.removePath(path);
 
-    cleanUp();
+    // Re-parse the rules file(s) when any of them changed
+    if (path.endsWith(QLatin1String(".txt"), Qt::CaseInsensitive))
+        cleanUp();
 }
 
 #include "moc_automappingmanager.cpp"

--- a/src/tiled/automappingmanager.h
+++ b/src/tiled/automappingmanager.h
@@ -30,7 +30,7 @@
 #include <QString>
 
 #include <memory>
-#include <vector>
+#include <unordered_map>
 
 namespace Tiled {
 
@@ -38,6 +38,12 @@ class TileLayer;
 
 class AutoMapper;
 class MapDocument;
+
+struct RuleMapReference
+{
+    QString filePath;
+    QRegularExpression mapNameFilter;
+};
 
 /**
  * This class is a superior class to the AutoMapper and AutoMapperWrapper class.
@@ -84,9 +90,11 @@ private:
     void onMapFileNameChanged();
     void onFileChanged(const QString &path);
 
+    const AutoMapper *findAutoMapper(const QString &filePath);
+
     bool loadFile(const QString &filePath);
     bool loadRulesFile(const QString &filePath);
-    bool loadRuleMap(const QString &filePath);
+    std::unique_ptr<AutoMapper> loadRuleMap(const QString &filePath);
 
     /**
      * Applies automapping to the region \a where.
@@ -113,13 +121,13 @@ private:
     std::unordered_map<QString, std::unique_ptr<AutoMapper>> mLoadedAutoMappers;
 
     /**
-     * The active list of AutoMapper instances, in the order they were
+     * The active list of rule map references, in the order they were
      * encountered in the rules file.
      *
      * Some loaded rule maps might not be active, and some might be active
      * multiple times.
      */
-    std::vector<const AutoMapper*> mActiveAutoMappers;
+    QVector<RuleMapReference> mRuleMapReferences;
 
     /**
      * This tells you if the rules for the current map document were already

--- a/src/tiled/automappingmanager.h
+++ b/src/tiled/automappingmanager.h
@@ -82,7 +82,7 @@ signals:
 private:
     void onRegionEdited(const QRegion &where, TileLayer *touchedLayer);
     void onMapFileNameChanged();
-    void onFileChanged();
+    void onFileChanged(const QString &path);
 
     bool loadFile(const QString &filePath);
     bool loadRulesFile(const QString &filePath);
@@ -107,10 +107,19 @@ private:
     MapDocument *mMapDocument = nullptr;
 
     /**
-     * For each new file of rules a new AutoMapper is setup. In this vector we
-     * can store all of the AutoMappers in order.
+     * For each rule map referenced by the rules file a new AutoMapper is
+     * setup. In this map we store all loaded AutoMappers instances.
      */
-    std::vector<std::unique_ptr<AutoMapper>> mAutoMappers;
+    std::unordered_map<QString, std::unique_ptr<AutoMapper>> mLoadedAutoMappers;
+
+    /**
+     * The active list of AutoMapper instances, in the order they were
+     * encountered in the rules file.
+     *
+     * Some loaded rule maps might not be active, and some might be active
+     * multiple times.
+     */
+    std::vector<const AutoMapper*> mActiveAutoMappers;
 
     /**
      * This tells you if the rules for the current map document were already


### PR DESCRIPTION
By only deleting the `AutoMapper` instances for changed rule map files, the reloading becomes much faster since it can just reuse the still loaded instances.

Additionally, on-demand loading of rule maps avoids loading rule maps which do not apply to the current map based on file name filters.
    
Finally, re-parsing of the `rules.txt` file(s) now only happens when any of such files were changed, not when rule maps have changed.
