### PR TITLE
AutoMapping: Removed the "touched layers" optimization

### DIFF
--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -155,14 +155,9 @@ AutoMapper::AutoMapper(std::unique_ptr<Map> rulesMap)
 
 AutoMapper::~AutoMapper() = default;
 
-QString AutoMapper::rulesMapFileName() const
+const QString &AutoMapper::rulesMapFileName() const
 {
     return mRulesMap->fileName;
-}
-
-bool AutoMapper::ruleLayerNameUsed(const QString &ruleLayerName) const
-{
-    return mRuleMapSetup.mInputLayerNames.contains(ruleLayerName);
 }
 
 template<typename Type>
@@ -1365,9 +1360,6 @@ void AutoMapper::copyMapRegion(const Rule &rule, QPoint offset,
 
         if (!rule.options.ignoreLock && !toTileLayer->isUnlocked())
             continue;
-
-        if (!context.touchedTileLayers.isEmpty())
-            appendUnique<const TileLayer*>(context.touchedTileLayers, toTileLayer);
 
         for (const QRect &rect : rule.outputRegion) {
             copyTileRegion(tileOutput.tileLayer, rect, toTileLayer,

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -256,9 +256,6 @@ struct TILED_EDITOR_EXPORT AutoMappingContext
     // Clones of existing tile layers that might have been changed in AutoMapper::autoMap
     std::unordered_map<TileLayer*, std::unique_ptr<TileLayer>> originalToOutputLayerMapping;
 
-    // Used to keep track of touched tile layers (only when initially non-empty)
-    QVector<const TileLayer*> touchedTileLayers;
-
 private:
     friend class AutoMapper;
 
@@ -335,13 +332,7 @@ public:
     explicit AutoMapper(std::unique_ptr<Map> rulesMap);
     ~AutoMapper();
 
-    QString rulesMapFileName() const;
-
-    /**
-     * Checks if the passed \a ruleLayerName is used as input layer in this
-     * instance of AutoMapper.
-     */
-    bool ruleLayerNameUsed(const QString &ruleLayerName) const;
+    const QString &rulesMapFileName() const;
 
     /**
      * This needs to be called directly before the autoMap call.

--- a/src/tiled/automapperwrapper.cpp
+++ b/src/tiled/automapperwrapper.cpp
@@ -37,19 +37,13 @@ using namespace Tiled;
 
 AutoMapperWrapper::AutoMapperWrapper(MapDocument *mapDocument,
                                      const QVector<const AutoMapper *> &autoMappers,
-                                     const QRegion &where,
-                                     const TileLayer *touchedLayer)
+                                     const QRegion &where)
     : PaintTileLayer(mapDocument)
 {
     AutoMappingContext context(mapDocument);
 
     for (const auto autoMapper : autoMappers)
         autoMapper->prepareAutoMap(context);
-
-    // During "AutoMap while drawing", keep track of the touched layers, so we
-    // can skip any rule maps that doesn't have these layers as input entirely.
-    if (touchedLayer)
-        context.touchedTileLayers.append(touchedLayer);
 
     // use a copy of the region, so each AutoMapper can manipulate it and the
     // following AutoMappers do see the impact
@@ -63,13 +57,6 @@ AutoMapperWrapper::AutoMapperWrapper(MapDocument *mapDocument,
         // stop expanding region when it's already the entire fixed-size map
         if (appliedRegionPtr && (!map->infinite() && (mapRect - region).isEmpty()))
             appliedRegionPtr = nullptr;
-
-        if (touchedLayer) {
-            if (std::none_of(context.touchedTileLayers.cbegin(),
-                             context.touchedTileLayers.cend(),
-                             [&] (const TileLayer *tileLayer) { return autoMapper->ruleLayerNameUsed(tileLayer->name()); }))
-                continue;
-        }
 
         autoMapper->autoMap(region, appliedRegionPtr, context);
 

--- a/src/tiled/automapperwrapper.h
+++ b/src/tiled/automapperwrapper.h
@@ -41,8 +41,7 @@ class AutoMapperWrapper : public PaintTileLayer
 public:
     AutoMapperWrapper(MapDocument *mapDocument,
                       const QVector<const AutoMapper *> &autoMappers,
-                      const QRegion &where,
-                      const TileLayer *touchedLayer = nullptr);
+                      const QRegion &where);
 };
 
 } // namespace Tiled

--- a/src/tiled/automappingmanager.h
+++ b/src/tiled/automappingmanager.h
@@ -86,7 +86,7 @@ signals:
     void warningsOccurred(bool automatic);
 
 private:
-    void onRegionEdited(const QRegion &where, TileLayer *touchedLayer);
+    void onRegionEdited(const QRegion &where);
     void onMapFileNameChanged();
     void onFileChanged(const QString &path);
 
@@ -99,10 +99,10 @@ private:
     /**
      * Applies automapping to the region \a where.
      *
-     * If a \a touchedLayer is given, only those AutoMappers will be used which
-     * have a rule layer matching the \a touchedLayer.
+     * If \a whileDrawing is true, the changes made through AutoMapping will
+     * merge with the previous undo operation when possible.
      */
-    void autoMapInternal(const QRegion &where, const TileLayer *touchedLayer);
+    void autoMapInternal(const QRegion &where, bool whileDrawing);
 
     /**
      * deletes all its data structures


### PR DESCRIPTION
The "AutoMap While Drawing" had an optimization where it skipped entire rule maps when none of their input layers had been "touched". This was based on the assumption that its rules would not need to be re-evaluated anyway.

Unfortunately, we can't make this assumption in general. The effect of certain rules might be relevant even if none of their input or output layers have been touched.