### PR TITLE
Removed no longer necessary qOverload usages

### DIFF
--- a/src/tiled/propertiesview.cpp
+++ b/src/tiled/propertiesview.cpp
@@ -284,8 +284,7 @@ QWidget *IntProperty::createEditor(QWidget *parent)
         const QSignalBlocker blocker(spinBox);
         spinBox->setValue(value());
     });
-    connect(spinBox, qOverload<int>(&SpinBox::valueChanged),
-            this, &IntProperty::setValue);
+    connect(spinBox, &SpinBox::valueChanged, this, &IntProperty::setValue);
 
     return widget;
 }
@@ -304,7 +303,7 @@ QWidget *FloatProperty::createEditor(QWidget *parent)
     syncEditor();
 
     connect(this, &Property::valueChanged, editor, syncEditor);
-    connect(editor, qOverload<double>(&DoubleSpinBox::valueChanged),
+    connect(editor, &DoubleSpinBox::valueChanged,
             this, &FloatProperty::setValue);
 
     return editor;
@@ -575,7 +574,7 @@ QWidget *FontProperty::createEditor(QWidget *parent)
 
     connect(this, &Property::valueChanged, fontComboBox, syncEditor);
     connect(fontComboBox, &QFontComboBox::currentFontChanged, this, syncProperty);
-    connect(sizeSpinBox, qOverload<int>(&QSpinBox::valueChanged), this, syncProperty);
+    connect(sizeSpinBox, &QSpinBox::valueChanged, this, syncProperty);
     connect(bold, &QAbstractButton::toggled, this, syncProperty);
     connect(italic, &QAbstractButton::toggled, this, syncProperty);
     connect(underline, &QAbstractButton::toggled, this, syncProperty);
@@ -629,8 +628,8 @@ QWidget *QtAlignmentProperty::createEditor(QWidget *parent)
     syncEditor();
 
     connect(this, &Property::valueChanged, editor, syncEditor);
-    connect(horizontalComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, syncProperty);
-    connect(verticalComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, syncProperty);
+    connect(horizontalComboBox, &QComboBox::currentIndexChanged, this, syncProperty);
+    connect(verticalComboBox, &QComboBox::currentIndexChanged, this, syncProperty);
 
     return editor;
 }
@@ -653,7 +652,7 @@ QWidget *BaseEnumProperty::createEnumEditor(QWidget *parent)
     syncEditor();
 
     QObject::connect(this, &Property::valueChanged, editor, syncEditor);
-    QObject::connect(editor, qOverload<int>(&QComboBox::currentIndexChanged), this,
+    QObject::connect(editor, &QComboBox::currentIndexChanged, this,
                      [editor, this] {
         setValue(editor->currentData().toInt());
     });

--- a/src/tiled/propertyeditorwidgets.cpp
+++ b/src/tiled/propertyeditorwidgets.cpp
@@ -412,8 +412,8 @@ SizeEdit::SizeEdit(QWidget *parent)
                                    { m_heightLabel, m_heightSpinBox },
                                }, this);
 
-    connect(m_widthSpinBox, qOverload<int>(&QSpinBox::valueChanged), this, &SizeEdit::valueChanged);
-    connect(m_heightSpinBox, qOverload<int>(&QSpinBox::valueChanged), this, &SizeEdit::valueChanged);
+    connect(m_widthSpinBox, &QSpinBox::valueChanged, this, &SizeEdit::valueChanged);
+    connect(m_heightSpinBox, &QSpinBox::valueChanged, this, &SizeEdit::valueChanged);
 }
 
 void SizeEdit::setValue(const QSize &size)
@@ -453,8 +453,8 @@ SizeFEdit::SizeFEdit(QWidget *parent)
                                    { m_heightLabel, m_heightSpinBox },
                                }, this);
 
-    connect(m_widthSpinBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SizeFEdit::valueChanged);
-    connect(m_heightSpinBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &SizeFEdit::valueChanged);
+    connect(m_widthSpinBox, &QDoubleSpinBox::valueChanged, this, &SizeFEdit::valueChanged);
+    connect(m_heightSpinBox, &QDoubleSpinBox::valueChanged, this, &SizeFEdit::valueChanged);
 }
 
 void SizeFEdit::setValue(const QSizeF &size)
@@ -482,8 +482,8 @@ PointEdit::PointEdit(QWidget *parent)
                                    { m_yLabel, m_ySpinBox },
                                }, this);
 
-    connect(m_xSpinBox, qOverload<int>(&QSpinBox::valueChanged), this, &PointEdit::valueChanged);
-    connect(m_ySpinBox, qOverload<int>(&QSpinBox::valueChanged), this, &PointEdit::valueChanged);
+    connect(m_xSpinBox, &QSpinBox::valueChanged, this, &PointEdit::valueChanged);
+    connect(m_ySpinBox, &QSpinBox::valueChanged, this, &PointEdit::valueChanged);
 }
 
 void PointEdit::setValue(const QPoint &point)
@@ -517,8 +517,8 @@ PointFEdit::PointFEdit(QWidget *parent)
                                    { m_yLabel, m_ySpinBox },
                                }, this);
 
-    connect(m_xSpinBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &PointFEdit::valueChanged);
-    connect(m_ySpinBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &PointFEdit::valueChanged);
+    connect(m_xSpinBox, &QDoubleSpinBox::valueChanged, this, &PointFEdit::valueChanged);
+    connect(m_ySpinBox, &QDoubleSpinBox::valueChanged, this, &PointFEdit::valueChanged);
 }
 
 void PointFEdit::setValue(const QPointF &point)
@@ -561,10 +561,10 @@ RectEdit::RectEdit(QWidget *parent)
     m_widthSpinBox->setMinimum(0);
     m_heightSpinBox->setMinimum(0);
 
-    connect(m_xSpinBox, qOverload<int>(&QSpinBox::valueChanged), this, &RectEdit::valueChanged);
-    connect(m_ySpinBox, qOverload<int>(&QSpinBox::valueChanged), this, &RectEdit::valueChanged);
-    connect(m_widthSpinBox, qOverload<int>(&QSpinBox::valueChanged), this, &RectEdit::valueChanged);
-    connect(m_heightSpinBox, qOverload<int>(&QSpinBox::valueChanged), this, &RectEdit::valueChanged);
+    connect(m_xSpinBox, &QSpinBox::valueChanged, this, &RectEdit::valueChanged);
+    connect(m_ySpinBox, &QSpinBox::valueChanged, this, &RectEdit::valueChanged);
+    connect(m_widthSpinBox, &QSpinBox::valueChanged, this, &RectEdit::valueChanged);
+    connect(m_heightSpinBox, &QSpinBox::valueChanged, this, &RectEdit::valueChanged);
 }
 
 void RectEdit::setValue(const QRect &rect)
@@ -619,10 +619,10 @@ RectFEdit::RectFEdit(QWidget *parent)
                                    { m_heightLabel, m_heightSpinBox },
                                }, this);
 
-    connect(m_xSpinBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &RectFEdit::valueChanged);
-    connect(m_ySpinBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &RectFEdit::valueChanged);
-    connect(m_widthSpinBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &RectFEdit::valueChanged);
-    connect(m_heightSpinBox, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &RectFEdit::valueChanged);
+    connect(m_xSpinBox, &QDoubleSpinBox::valueChanged, this, &RectFEdit::valueChanged);
+    connect(m_ySpinBox, &QDoubleSpinBox::valueChanged, this, &RectFEdit::valueChanged);
+    connect(m_widthSpinBox, &QDoubleSpinBox::valueChanged, this, &RectFEdit::valueChanged);
+    connect(m_heightSpinBox, &QDoubleSpinBox::valueChanged, this, &RectFEdit::valueChanged);
 }
 
 void RectFEdit::setValue(const QRectF &rect)

--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -998,7 +998,7 @@ void PropertyTypesEditor::addEnumProperties()
     mStorageTypeComboBox = new QComboBox(mUi->groupBox);
     mStorageTypeComboBox->addItems({ tr("String"), tr("Number") });
 
-    connect(mStorageTypeComboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+    connect(mStorageTypeComboBox, &QComboBox::currentIndexChanged,
             this, [this] (int index) { if (index != -1) setStorageType(static_cast<EnumPropertyType::StorageType>(index)); });
 
     mValuesAsFlagsCheckBox = new QCheckBox(tr("Allow multiple values (flags)"), mUi->groupBox);

--- a/src/tiled/variantmapproperty.cpp
+++ b/src/tiled/variantmapproperty.cpp
@@ -553,7 +553,7 @@ QWidget *AddValueProperty::createEditor(QWidget *parent)
 
     m_value = typeBox->currentData();
 
-    connect(typeBox, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int index) {
+    connect(typeBox, &QComboBox::currentIndexChanged, this, [=](int index) {
         m_value = typeBox->itemData(index);
         session::propertyType = typeBox->currentText();
     });


### PR DESCRIPTION
Since we require at least Qt 5.15 and set `QT_DISABLE_DEPRECATED_BEFORE`, we don't need to use `qOverload` for selecting the right signal anymore.