### PR TITLE
Qbs: Use exportingProduct.sourceDirectory

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -263,7 +263,9 @@ jobs:
       run: |
         brew install qbs
         qbs setup-toolchains --detect
-        qbs config defaultProfile xcode
+        qbs setup-qt --detect
+        qbs config profiles.qt-6-8-2.baseProfile xcode
+        qbs config defaultProfile qt-6-8-2
 
     - name: Build Zstandard
       run: |

--- a/src/karchive/karchive.qbs
+++ b/src/karchive/karchive.qbs
@@ -1,3 +1,5 @@
+import qbs.FileInfo
+
 StaticLibrary {
     condition: !qbs.toolchain.contains("msvc")
 
@@ -54,7 +56,7 @@ StaticLibrary {
 
     Export {
         Depends { name: "cpp" }
-        cpp.includePaths: "src"
+        cpp.includePaths: FileInfo.joinPaths(exportingProduct.sourceDirectory, "src")
         cpp.defines: [
             "KARCHIVE_NO_DEPRECATED",
             "KARCHIVE_STATIC_DEFINE",

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -199,7 +199,7 @@ DynamicLibrary {
             submodules: ["gui"]
         }
 
-        cpp.includePaths: "."
+        cpp.includePaths: exportingProduct.sourceDirectory
     }
 
     install: !qbs.targetOS.contains("darwin")

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -16,10 +16,15 @@ DynamicLibrary {
     cpp.cxxLanguageVersion: "c++17"
     cpp.cxxFlags: {
         var flags = base;
+
         if (qbs.toolchain.contains("msvc")) {
             if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
                 flags.push("/permissive-");
         }
+
+        if (pkgConfigZstd.found)
+            flags = flags.concat(pkgConfigZstd.cflags);
+
         return flags;
     }
     cpp.visibility: "minimal"
@@ -69,9 +74,8 @@ DynamicLibrary {
 
     Properties {
         condition: pkgConfigZstd.found
-        cpp.cxxFlags: outer.concat(pkgConfigZstd.cflags)
-        cpp.libraryPaths: outer.concat(pkgConfigZstd.libraryPaths)
-        cpp.linkerFlags: outer.concat(pkgConfigZstd.linkerFlags)
+        cpp.libraryPaths: pkgConfigZstd.libraryPaths
+        cpp.linkerFlags: pkgConfigZstd.linkerFlags
     }
 
     // When libzstd was not found but staticZstd is enabled, assume that zstd
@@ -79,8 +83,8 @@ DynamicLibrary {
     // done by the autobuilds for Windows and macOS).
     Properties {
         condition: !pkgConfigZstd.found && project.staticZstd
-        cpp.libraryPaths: outer.concat(["../../zstd/lib"])
-        cpp.includePaths: outer.concat(["../../zstd/lib"])
+        cpp.libraryPaths: "../../zstd/lib"
+        cpp.includePaths: "../../zstd/lib"
     }
 
     Properties {

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -62,7 +62,7 @@ DynamicLibrary {
             submodules: ["quick"]
         }
 
-        cpp.includePaths: "."
+        cpp.includePaths: exportingProduct.sourceDirectory
     }
 
     install: !qbs.targetOS.contains("darwin")

--- a/src/plugins/python/python.qbs
+++ b/src/plugins/python/python.qbs
@@ -15,8 +15,13 @@ TiledPlugin {
 
     cpp.cxxFlags: {
         var flags = base
+
         if (qbs.toolchain.contains("gcc") && !qbs.toolchain.contains("clang"))
             flags.push("-Wno-cast-function-type")
+
+        if (pkgConfigPython3.found)
+            flags = flags.concat(pkgConfigPython3.compilerFlags);
+
         return flags
     }
 
@@ -34,7 +39,6 @@ TiledPlugin {
 
     Properties {
         condition: pkgConfigPython3.found
-        cpp.cxxFlags: outer.concat(pkgConfigPython3.compilerFlags)
         cpp.defines: pkgConfigPython3.defines
         cpp.dynamicLibraries: pkgConfigPython3.libraries
         cpp.includePaths: pkgConfigPython3.includePaths

--- a/src/qtsingleapplication/qtsingleapplication.qbs
+++ b/src/qtsingleapplication/qtsingleapplication.qbs
@@ -1,3 +1,5 @@
+import qbs.FileInfo
+
 StaticLibrary {
     name: "qtsingleapplication"
 
@@ -26,6 +28,6 @@ StaticLibrary {
     Export {
         Depends { name: "cpp" }
         Depends { name: "Qt.widgets" }
-        cpp.includePaths: "src"
+        cpp.includePaths: FileInfo.joinPaths(exportingProduct.sourceDirectory, "src")
     }
 }

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -609,7 +609,7 @@ DynamicLibrary {
         Depends { name: "libtiled" }
         Depends { name: "qtsingleapplication" }
         Depends { name: "Qt"; submodules: ["qml"] }
-        cpp.includePaths: "."
+        cpp.includePaths: exportingProduct.sourceDirectory
     }
 
     install: !qbs.targetOS.contains("darwin")

--- a/tiled.qbs
+++ b/tiled.qbs
@@ -4,7 +4,7 @@ Project {
     name: "Tiled"
 
     qbsSearchPaths: "qbs"
-    minimumQbsVersion: "1.13"
+    minimumQbsVersion: "1.18"
 
     property string version: Environment.getEnv("TILED_VERSION") || "1.11.2";
     property bool snapshot: Environment.getEnv("TILED_SNAPSHOT") == "true"


### PR DESCRIPTION
This fixes the following warning when using Qbs 2.6: "Resolving path properties relative to the exporting product's location is deprecated."

Raises the minimum version of Qbs to 1.18 (dropping support for compiling on Ubuntu 20.04 out of the box, which shipped with Qbs 1.13).