### PR TITLE
docs: Fixed documentation for JSON Map Format - Chunk

### DIFF
--- a/docs/reference/json-map-format.rst
+++ b/docs/reference/json-map-format.rst
@@ -206,8 +206,8 @@ Chunks are used to store the tile layer data for
     :widths: 1, 1, 4
 
     data,             array or string,  "Array of ``unsigned int`` (GIDs) or base64-encoded data"
-    height,           int,              "Height in tiles"
-    width,            int,              "Width in tiles"
+    height,           int,              "Row count"
+    width,            int,              "Column count"
     x,                int,              "X coordinate in tiles"
     y,                int,              "Y coordinate in tiles"
 
@@ -217,11 +217,11 @@ Chunk Example
 .. code:: json
 
     {
-      "data":[1, 2, 1, 2, 3, 1, 3, 1, 2, 2, 3, 3, 4, 4, 4, 1, ],
-      "height":16,
-      "width":16,
+      "data":[1, 2, 1, 2, 3, 1, 3, 1, 2, 2, 3, 3, 4, 4, 4, 1],
+      "height":4,
+      "width":4,
       "x":0,
-      "y":-16,
+      "y":-16
     }
 
 .. _json-object:


### PR DESCRIPTION
The example was wrong since width 16 and height 16 implies 256 elements in data rather than 16

It also had trailing commas which made it invalid json

I also updated the description of width and height to be the same as for Layer.