### PR TITLE
Workaround tileset view layout regression in Qt 6.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Workaround tileset view layout regression in Qt 6.9
+
 ### Tiled 1.11.2 (28 Jan 2025)
 
 * YY plugin: Fixed compatibility with GameMaker 2024 (#4132)

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -95,7 +95,8 @@ public:
                    const QModelIndex &index) const override;
 
 private:
-    void drawFilmStrip(QPainter *painter, QRect targetRect) const;
+    static void drawFilmStrip(QPainter *painter, QRect targetRect);
+
     void drawWangOverlay(QPainter *painter,
                          const Tile *tile,
                          QRect targetRect,
@@ -210,7 +211,7 @@ QSize TileDelegate::sizeHint(const QStyleOptionViewItem & /* option */,
     return QSize(extra, extra);
 }
 
-void TileDelegate::drawFilmStrip(QPainter *painter, QRect targetRect) const
+void TileDelegate::drawFilmStrip(QPainter *painter, QRect targetRect)
 {
     painter->save();
 
@@ -300,6 +301,15 @@ TilesetView::TilesetView(QWidget *parent)
     vHeader->setSectionResizeMode(QHeaderView::ResizeToContents);
     hHeader->setMinimumSectionSize(1);
     vHeader->setMinimumSectionSize(1);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    // Since Qt 6.9 we force header mode to "FlexibleWithSectionMemoryUsage",
+    // to avoid what appears to be a bug in that implementation regarding
+    // resizing of sections (https://github.com/mapeditor/tiled/issues/4191).
+    hHeader->setStretchLastSection(true);
+    vHeader->setStretchLastSection(true);
+    hHeader->setStretchLastSection(false);
+    vHeader->setStretchLastSection(false);
+#endif
 
     // Hardcode this view on 'left to right' since it doesn't work properly
     // for 'right to left' languages.


### PR DESCRIPTION
It appears to be due to a bug in a recent memory usage optimization made to `QHeaderView` meant for very large models. This workaround effectively disables that optimization, but the tileset model generally isn't huge anyway.

Reported as [QTBUG-136453](https://bugreports.qt.io/browse/QTBUG-136453).

Closes #4191