### PR TITLE
CI: Perform Qt 5 builds on Ubuntu 22.04

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,6 +16,9 @@ on:
 
 env:
   QBS_VERSION: 2.4.1
+  CMAKE_VERSION: 3.31
+  QT5_VERSION: 5.15.2
+  QT6_VERSION: 6.8.2
   SENTRY_VERSION: 0.7.19
   SENTRY_ORG: mapeditor
   SENTRY_PROJECT: tiled
@@ -39,29 +42,12 @@ jobs:
         echo "release=${TILED_RELEASE}" >> $GITHUB_OUTPUT
 
   linux:
-    name: Linux (AppImage, Qt ${{ matrix.qt_version_major }})
-    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Linux (AppImage)
+    runs-on: ubuntu-22.04
     needs: version
-
-    strategy:
-      matrix:
-        include:
-        - ubuntu_version: 22.04
-          qt_version: 5.15.2
-          qt_version_major: 5
-          qt_arch: gcc_64
-          qt_modules: ""
-          qbs_default_profile: x86_64-linux-gnu-gcc-10
-        - ubuntu_version: 22.04
-          qt_version: 6.8.2
-          qt_version_major: 6
-          qt_arch: linux_gcc_64
-          qt_modules: "qtimageformats"
-          qbs_default_profile: x86_64-linux-gnu-gcc-11
 
     env:
       TILED_VERSION: ${{ needs.version.outputs.version }}
-      QT_VERSION: ${{ matrix.qt_version }}
 
     steps:
     - name: Checkout repository
@@ -91,9 +77,9 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: ${{ matrix.qt_version }}
-        arch: ${{ matrix.qt_arch }}
-        modules: ${{ matrix.qt_modules }}
+        version: ${{ env.QT6_VERSION }}
+        arch: linux_gcc_64
+        modules: "qtimageformats"
         tools: 'tools_qtcreator'
         setup-python: false
         cache: true
@@ -106,13 +92,13 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '3.31'
+        cmake-version: '{{ env.CMAKE_VERSION }}'
 
     - name: Setup Qbs
       run: |
         qbs --version
         qbs setup-toolchains --detect
-        qbs config defaultProfile ${{ matrix.qbs_default_profile }}
+        qbs config defaultProfile x86_64-linux-gnu-gcc-11
 
     - name: Build Sentry Native
       run: |
@@ -159,7 +145,7 @@ jobs:
         chmod +x linuxdeploy*.AppImage
         export EXTRA_QT_PLUGINS=svg
         export LD_LIBRARY_PATH=${QT_ROOT_DIR}/lib:$PWD/AppDir/usr/lib
-        export OUTPUT=Tiled-${{ needs.version.outputs.version }}_Linux_Qt-${{ matrix.qt_version_major }}_x86_64.AppImage
+        export OUTPUT=Tiled-${{ needs.version.outputs.version }}_Linux_x86_64.AppImage
         # Avoid shipping the debug information
         find AppDir -name \*.debug -delete
         ./linuxdeploy-x86_64.AppImage --appdir AppDir --custom-apprun=dist/linux/AppRun --exclude-library "*libpython3*" --plugin qt
@@ -170,8 +156,8 @@ jobs:
     - name: Upload Tiled.AppImage
       uses: actions/upload-artifact@v4
       with:
-        name: Tiled-${{ needs.version.outputs.version }}_Linux_Qt-${{ matrix.qt_version_major }}_x86_64.AppImage
-        path: Tiled-${{ needs.version.outputs.version }}_Linux_Qt-${{ matrix.qt_version_major }}_x86_64.AppImage
+        name: Tiled-${{ needs.version.outputs.version }}_Linux_x86_64.AppImage
+        path: Tiled-${{ needs.version.outputs.version }}_Linux_x86_64.AppImage
 
   snap:
     name: Linux (snap)
@@ -220,12 +206,12 @@ jobs:
     strategy:
       matrix:
         include:
-        - qt_version: 5.15.2
+        - qt_version: ${{ env.QT5_VERSION }}
           qt_modules: ""
           version_suffix: "10.13-10.15"
           architectures: x86_64
           cmake_architectures: x86_64
-        - qt_version: 6.8.2
+        - qt_version: ${{ env.QT6_VERSION }}
           qt_modules: "qtimageformats"
           version_suffix: "11+"
           architectures: x86_64,arm64
@@ -233,7 +219,6 @@ jobs:
 
     env:
       TILED_VERSION: ${{ needs.version.outputs.version }}
-      QT_VERSION: ${{ matrix.qt_version }}
 
     steps:
     - name: Checkout repository
@@ -257,7 +242,7 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '3.31'
+        cmake-version: '{{ env.CMAKE_VERSION }}'
 
     - name: Setup Qbs
       run: |
@@ -342,7 +327,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - qt_version: 5.15.2
+        - qt_version: ${{ env.QT5_VERSION }}
           qt_version_major: 5
           qt_arch: win32_mingw81
           qt_modules: ""
@@ -352,7 +337,7 @@ jobs:
           mingw_component: tools_mingw
           mingw_variant: qt.tools.win32_mingw810
           mingw_dir: mingw810_32
-        - qt_version: 6.8.2
+        - qt_version: ${{ env.QT6_VERSION }}
           qt_version_major: 6
           qt_arch: win64_mingw
           qt_modules: "qtimageformats"
@@ -395,11 +380,11 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '3.31'
+        cmake-version: '{{ env.CMAKE_VERSION }}'
 
     - name: Install Qbs
       run: |
-        choco install -y qbs --version ${QBS_VERSION}
+        choco install -y qbs --version ${{ env.QBS_VERSION }}
 
     - name: Setup Qbs
       run: |
@@ -471,8 +456,7 @@ jobs:
         files: |
           Tiled-${{ needs.version.outputs.version }}_Windows-10+_x86_64.msi/*.msi
           Tiled-${{ needs.version.outputs.version }}_Windows-7-8_x86.msi/*.msi
-          Tiled-${{ needs.version.outputs.version }}_Linux_Qt-5_x86_64.AppImage/*.AppImage
-          Tiled-${{ needs.version.outputs.version }}_Linux_Qt-6_x86_64.AppImage/*.AppImage
+          Tiled-${{ needs.version.outputs.version }}_Linux_x86_64.AppImage/*.AppImage
           Tiled-${{ needs.version.outputs.version }}_macOS-10.13-10.15.app/*.zip
           Tiled-${{ needs.version.outputs.version }}_macOS-11+.app/*.zip
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '{{ env.CMAKE_VERSION }}'
+        cmake-version: '${{ env.CMAKE_VERSION }}'
 
     - name: Setup Qbs
       run: |
@@ -240,7 +240,7 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '{{ env.CMAKE_VERSION }}'
+        cmake-version: '${{ env.CMAKE_VERSION }}'
 
     - name: Setup Qbs
       run: |
@@ -378,7 +378,7 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '{{ env.CMAKE_VERSION }}'
+        cmake-version: '${{ env.CMAKE_VERSION }}'
 
     - name: Install Qbs
       run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -17,8 +17,6 @@ on:
 env:
   QBS_VERSION: 2.4.1
   CMAKE_VERSION: 3.31
-  QT5_VERSION: 5.15.2
-  QT6_VERSION: 6.8.2
   SENTRY_VERSION: 0.7.19
   SENTRY_ORG: mapeditor
   SENTRY_PROJECT: tiled
@@ -77,7 +75,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: ${{ env.QT6_VERSION }}
+        version: 6.8.2
         arch: linux_gcc_64
         modules: "qtimageformats"
         tools: 'tools_qtcreator'
@@ -206,12 +204,12 @@ jobs:
     strategy:
       matrix:
         include:
-        - qt_version: ${{ env.QT5_VERSION }}
+        - qt_version: 5.15.2
           qt_modules: ""
           version_suffix: "10.13-10.15"
           architectures: x86_64
           cmake_architectures: x86_64
-        - qt_version: ${{ env.QT6_VERSION }}
+        - qt_version: 6.8.2
           qt_modules: "qtimageformats"
           version_suffix: "11+"
           architectures: x86_64,arm64
@@ -327,7 +325,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - qt_version: ${{ env.QT5_VERSION }}
+        - qt_version: 5.15.2
           qt_version_major: 5
           qt_arch: win32_mingw81
           qt_modules: ""
@@ -337,7 +335,7 @@ jobs:
           mingw_component: tools_mingw
           mingw_variant: qt.tools.win32_mingw810
           mingw_dir: mingw810_32
-        - qt_version: ${{ env.QT6_VERSION }}
+        - qt_version: 6.8.2
           qt_version_major: 6
           qt_arch: win64_mingw
           qt_modules: "qtimageformats"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - ubuntu_version: 20.04
+        - ubuntu_version: 22.04
           qt_version: 5.15.2
           qt_version_major: 5
           qt_arch: gcc_64

--- a/docs/manual/python.rst
+++ b/docs/manual/python.rst
@@ -48,9 +48,9 @@ There are several `example scripts`_ available in the repository.
     .. figure:: images/python-windows.png
 
     On Linux you will need to install the appropriate package. However,
-    currently Linux AppImage builds are done on Ubuntu 20.04 against Python
-    3.8, and you'd need to install the same version somehow (on Fedora you can
-    just install the ``python3.8`` package).
+    currently Linux AppImage builds are done on Ubuntu 22.04 against Python
+    3.10, and you'd need to install the same version (on Ubuntu likely
+    ``libpython3.10`` and on Fedora ``python3.10-libs``).
 
     The Python plugin is not available for macOS releases, nor in the Ubuntu
     snap.


### PR DESCRIPTION
Support for Ubuntu 20.04 runner images will be dropped by 2025-04-15.

This also increases the Python version required by the Qt 5 AppImage from 3.8 to 3.10.