### PR TITLE
changed org.glassfish.jaxb dependency version

### DIFF
--- a/util/java/libtiled-java/pom.xml
+++ b/util/java/libtiled-java/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>
                 <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.14.0</version>
+                <version>0.15.3</version>
                 <configuration>
                     <args>
                         <arg>-Xannotate</arg>
@@ -210,7 +210,7 @@
                 <dependency>
                     <groupId>org.glassfish.jaxb</groupId>
                     <artifactId>jaxb-runtime</artifactId>
-                    <version>2.3.3</version>
+                    <version>2.3.6</version>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
dependency version updated from 2.3.3 -> 2.3.6

this change fixes the error that is thrown in java 21 when is called `new TMXMapReader()`
```
java.security.PrivilegedActionException: java.lang.NoSuchMethodException: sun.misc.Unsafe.defineClass(java.lang.String,[B,int,int,java.lang.ClassLoader,java.security.ProtectionDomain)
```

similar error occured in other projects
[https://github.com/highsource/jaxb-tools/issues/201#issuecomment-808009784](https://github.com/highsource/jaxb-tools/issues/201#issuecomment-808009784)

