### PR TITLE
libtiled-java: Prepare for 1.4.3 release

### DIFF
--- a/util/java/CHANGELOG.md
+++ b/util/java/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [1.4.3] - 2025-06-02
+
+### Fixed
+- Updated dependencies to fix a bug when running under Java 21.
+
+### Changed
+- Updated `maven-jaxb2-plugin` to version 0.15.3.
+- Updated `jaxb-runtime` to version 2.3.6.
+
+---
+
+Previous releases are not listed here. Future changes will be documented in this file.

--- a/util/java/libtiled-java/pom.xml
+++ b/util/java/libtiled-java/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.mapeditor</groupId>
         <artifactId>tiled-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>libtiled</artifactId>
@@ -214,13 +214,13 @@
         <profile>
             <id>java-11-profile</id>
             <activation>
-                <jdk>[1.9,)</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <dependencies>
                 <dependency>
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
-                    <version>2.4.0-b180830.0359</version>
+                    <version>2.3.1</version>
                 </dependency>
                 <dependency>
                     <groupId>javax.annotation</groupId>
@@ -230,7 +230,7 @@
                 <dependency>
                     <groupId>org.glassfish.jaxb</groupId>
                     <artifactId>jaxb-runtime</artifactId>
-                    <version>4.0.5</version>
+                    <version>2.3.9</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/util/java/pom.xml
+++ b/util/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.mapeditor</groupId>
     <artifactId>tiled-parent</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.3</version>
     <packaging>pom</packaging>
 
     <name>Tiled</name>

--- a/util/java/tmxviewer-java/pom.xml
+++ b/util/java/tmxviewer-java/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.mapeditor</groupId>
         <artifactId>tiled-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>tmxviewer</artifactId>


### PR DESCRIPTION
`jaxb-api` and `jaxb-runtime` are reverted to 2.3 for compatibility. Updating further would require switching from `javax.xml.bind` to `jakarta.xml.bind`.