### PR TITLE
AppImage: Updated to Sentry 0.9.0

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -17,7 +17,7 @@ on:
 env:
   QBS_VERSION: 2.4.1
   CMAKE_VERSION: 3.31
-  SENTRY_VERSION: 0.7.19
+  SENTRY_VERSION: 0.9.0
   SENTRY_ORG: mapeditor
   SENTRY_PROJECT: tiled
   TILED_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * AutoMapping: Optimized reloading of rule maps and load rule maps on-demand
 * Workaround tileset view layout regression in Qt 6.9
 * Raised minimum supported Qt version from 5.12 to 5.15.2
+* AppImage: Updated to Sentry 0.9.0
 
 ### Tiled 1.11.2 (28 Jan 2025)
 


### PR DESCRIPTION
Doesn't look like it should have any relevant breaking changes.