### PR TITLE
Fixed crash on macOS when JS code is JIT-compiled

### DIFF
--- a/src/tiledapp/app.entitlements
+++ b/src/tiledapp/app.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+  </dict>
+</plist>

--- a/src/tiledapp/main.cpp
+++ b/src/tiledapp/main.cpp
@@ -422,6 +422,13 @@ int main(int argc, char *argv[])
     }
 #endif
 
+    // Disable JIT compilation in the Qt Quick V4 engine on macOS, since it
+    // triggers a crash in code-signed releases. This is resolved by adding the
+    // com.apple.security.cs.allow-jit entitlement since Qt 6.8.2.
+#if defined(Q_OS_MAC) && !defined(QT_DEBUG) && QT_VERSION < QT_VERSION_CHECK(6, 8, 2)
+    qputenv("QV4_FORCE_INTERPRETER", "1");
+#endif
+
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
 
     // High-DPI scaling is always enabled in Qt 6

--- a/src/tiledapp/tiledapp.qbs
+++ b/src/tiledapp/tiledapp.qbs
@@ -10,6 +10,7 @@ TiledQtGuiApplication {
 
     Depends { name: "libtilededitor" }
     Depends { name: "ib"; condition: qbs.targetOS.contains("macos") }
+    Depends { name: "codesign"; condition: qbs.targetOS.contains("macos") }
     Depends { name: "Qt.gui-private"; condition: qbs.targetOS.contains("windows") && Qt.core.versionMajor >= 6 }
     Depends { name: "texttemplate"; condition: qbs.targetOS.contains("windows") }
 
@@ -43,6 +44,7 @@ TiledQtGuiApplication {
         condition: qbs.targetOS.contains("macos")
         cpp.frameworks: ["Foundation"]
         bundle.identifierPrefix: "org.mapeditor"
+        codesign.teamIdentifier: "QL3K47J68L"
         ib.appIconName: "tiled-icon-mac"
         targetName: "Tiled"
     }
@@ -72,10 +74,11 @@ TiledQtGuiApplication {
     }
 
     Group {
-        name: "macOS (Info.plist and icons)"
+        name: "macOS (Info.plist, icons and entitlements)"
         condition: qbs.targetOS.contains("macos")
         files: [
             "Info.plist",
+            "app.entitlements",
             "images/tiled.xcassets",
         ]
     }


### PR DESCRIPTION
The codesigned release did not have the right entitlement to be able to execute JIT-compiled code.

Also, the MAP_JIT memory flag is only set by Qt since 6.8.2, so when Tiled is compiled against earlier Qt versions, we now force the use of the JS interpreter to disable the JIT compiler.

TODO: This change relies on the Qbs codesign module (available since Qbs 1.19), which will likely need CI updates.

Closes #4218