### PR TITLE
Fixed potential crash if property creation fails for whatever reason

### DIFF
--- a/src/tiled/variantmapproperty.cpp
+++ b/src/tiled/variantmapproperty.cpp
@@ -190,6 +190,7 @@ bool VariantMapProperty::createOrUpdateProperty(int index,
         } else {
             qWarning() << "Failed to create property for" << name
                        << "with type" << newValue.typeName();
+            return false;
         }
     }
 


### PR DESCRIPTION
Failing to return false here would lead to invalid index in caller.

Split off from #4002 since this crash fix is relevant when switching between that branch and master.