### PR TITLE
Added additional description to Stagger Axis property

### DIFF
--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -99,8 +99,8 @@ template<> EnumData enumData<Map::Orientation>()
 template<> EnumData enumData<Map::StaggerAxis>()
 {
     return {{
-        QCoreApplication::translate("StaggerAxis", "X"),
-        QCoreApplication::translate("StaggerAxis", "Y")
+        QCoreApplication::translate("StaggerAxis", "X (Flat-top)"),
+        QCoreApplication::translate("StaggerAxis", "Y (Pointy-top)")
     }};
 }
 


### PR DESCRIPTION
A staggered X axis leads to flat-top hexes whereas a staggered Y axis leads to pointy-top hexes.

<img width="1034" height="468" alt="image" src="https://github.com/user-attachments/assets/a4730e0c-6d13-47be-948d-4ee5144b5e56" />

This setting also applies to maps using Isometric (Staggered) orientation, in which case this distinction does not exist, so I'm not entirely sure whether this is a good idea. Should we have the property only use the additional labels when the map is using Hexagonal orientation?
