### PR TITLE
Qbs: Restrict debug DLL handling to MSVC toolchain on Windows

### DIFF
--- a/dist/distribute.qbs
+++ b/dist/distribute.qbs
@@ -105,7 +105,7 @@ Product {
 
     property var pluginFiles: {
         if (qbs.targetOS.contains("windows")) {
-            if (qbs.debugInformation)
+            if (qbs.debugInformation && qbs.toolchain.contains("msvc"))
                 return ["*d.dll"];
             else
                 return ["*.dll"];
@@ -117,7 +117,7 @@ Product {
 
     property var pluginExcludeFiles: {
         var files = ["*.pdb"];
-        if (!(qbs.targetOS.contains("windows") && qbs.debugInformation)) {
+        if (!(qbs.toolchain.contains("msvc") && qbs.debugInformation)) {
             // Exclude debug DLLs.
             //
             // This also excludes the qdirect2d.dll platform plugin, but I'm
@@ -189,7 +189,7 @@ Product {
         prefix: FileInfo.joinPaths(Qt.core.pluginPath, "/tls/")
         files: {
             if (qbs.targetOS.contains("windows")) {
-                if (qbs.debugInformation)
+                if (qbs.debugInformation && qbs.toolchain.contains("msvc"))
                     return ["qschannelbackendd.dll"];
                 else
                     return ["qschannelbackend.dll"];


### PR DESCRIPTION
Avoids warnings when using MinGW, since the Qt MinGW builds are no longer shipping debug DLLs since Qt 5.14.

Closes #4233