### PR TITLE
Fixed possible crash in the Custom Types Editor

### DIFF
--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -2208,7 +2208,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     , mRemoveIcon(QIcon(QStringLiteral(":/images/16/remove.png")))
     , mAddIcon(QIcon(QStringLiteral(":/images/16/add.png")))
     , mRenameIcon(QIcon(QLatin1String(":/images/16/rename.png")))
-    , mRootProperty(new GroupProperty())
+    , mRootProperty(new GroupProperty(this))
     , mCustomProperties(new CustomProperties(mRootProperty))
     , mPropertiesView(new PropertiesView(this))
 {


### PR DESCRIPTION
Due to a missing parent on the `GroupProperty` used by the `PropertiesWidget`, the `GroupProperty` instance would not get deleted, which in turns causes the `CustomProperties` instance to not get deleted.

The leaked `CustomProperties` instance would later cause a crash when editing the custom types because it accesses a roaming Document pointer while it tries to update itself.