### PR TITLE
Add square selection and expand-from-center to Rectangular Select tool

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Allow changing the values of number inputs using expressions (with dogboydog, #4234)
 * Added support for SVG 1.2 / CSS blending modes to layers (#3932)
 * Added button to toggle Terrain Brush to full tile mode (by Finlay Pearson, #3407)
+* Added square selection and expand-from-center to Rectangular Select tool (#4201)
 * Added export plugin for Remixed Dungeon (by Mikhael Danilov, #4158)
 * Added "World > World Properties" menu action (with dogboydog, #4190)
 * Scripting: Added API for custom property types (with dogboydog, #3971)

--- a/docs/manual/editing-tile-layers.rst
+++ b/docs/manual/editing-tile-layers.rst
@@ -156,16 +156,26 @@ There are various tile selection tools that all work in similar fashion:
 -  |stock-tool-by-color-select| **Select Same Tile** allows selection of
    same-tiles across the entire layer (shortcut: ``S``)
 
-By default, each of these tools replaces the currently selected area.
-The following modifiers can be used to change this behavior:
+By default, each of these tools replaces the currently selected area. The
+following modifiers can be used to change the selection mode before starting
+the selection:
 
--  Holding ``Shift`` expands the current selection with the new area
--  Holding ``Ctrl`` subtracts the new area from the current selection
--  Holding ``Ctrl`` and ``Shift`` selects the intersection of the new
+-  Hold ``Shift`` to expand the current selection with the new area
+-  Hold ``Ctrl`` to subtract the new area from the current selection
+-  Hold ``Ctrl`` and ``Shift`` to select the intersection of the new
    area with the current selection
 
 You can also lock into one of these modes (Add, Subtract or Intersect)
 by clicking on one of the tool buttons in the Tool Options toolbar.
+
+.. raw:: html
+
+   <div class="new">Since Tiled 1.12</div>
+
+While selecting an area, the following modifiers can be used:
+
+- Hold ``Shift`` to constrain the selection to a square.
+- Hold ``Ctrl`` to expand the selection from the starting location.
 
 Managing Tile Stamps
 --------------------

--- a/src/tiled/tileselectiontool.h
+++ b/src/tiled/tileselectiontool.h
@@ -35,6 +35,8 @@ public:
     void mousePressed(QGraphicsSceneMouseEvent *event) override;
     void mouseReleased(QGraphicsSceneMouseEvent *event) override;
 
+    void modifiersChanged(Qt::KeyboardModifiers modifiers) override;
+
     void languageChanged() override;
 
 protected:
@@ -49,8 +51,11 @@ private:
 
     QPoint mMouseScreenStart;
     QPoint mSelectionStart;
-    bool mMouseDown;
-    bool mSelecting;
+    bool mMouseDown = false;
+    bool mSelecting = false;
+    bool mForceSquare = false;
+    bool mExpandFromCenter = false;
+    Qt::KeyboardModifiers mLastModifiers = Qt::NoModifier;
 };
 
 } // namespace Tiled


### PR DESCRIPTION
Now while selecting with the Rectangular Select tool, holding Shift will constrain the selection to a square shape, and holding Ctrl (Cmd on macOS) will expand the selection from its center.

Part of issue #4201