### PR TITLE
Expand the status bar info for the Stamp Brush

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Added support for SVG 1.2 / CSS blending modes to layers (#3932)
 * Added button to toggle Terrain Brush to full tile mode (by Finlay Pearson, #3407)
 * Added square selection and expand-from-center to Rectangular Select tool (#4201)
+* Added status bar info for various Stamp Brush modes (#3092)
 * Added export plugin for Remixed Dungeon (by Mikhael Danilov, #4158)
 * Added "World > World Properties" menu action (with dogboydog, #4190)
 * Scripting: Added API for custom property types (with dogboydog, #3971)

--- a/src/tiled/stampbrush.h
+++ b/src/tiled/stampbrush.h
@@ -90,6 +90,8 @@ signals:
 protected:
     void tilePositionChanged(QPoint tilePos) override;
 
+    void updateStatusInfo() override;
+
     void mapDocumentChanged(MapDocument *oldDocument,
                             MapDocument *newDocument) override;
 


### PR DESCRIPTION
Now displays some additional information when capturing or drawing lines
or ellipses:

* When capturing a stamp: "Capture area (\<width> x \<height>)"
* When drawing an ellipse: "Draw ellipse (size: \<width> x \<height>)"
* When drawing a line: "Draw line (length: \<length>)"

Closes #3092
See also issue #4201