### PR TITLE
Added compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ default/
 
 # clangd cache
 .cache/
+compile_commands.json
 
 # Mac stuff
 *.DS_Store


### PR DESCRIPTION
I added a local symlink here to the `compile_commands.json` file generated at `defaults/compile_commands.json`, which helps `clangd` understand the code. The linked file can be generated using:

    qbs generate -g clangdb