### PR TITLE
Allow Delete to remove tiles by default and avoid ambiguity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Added status bar info for various Stamp and Terrain Brush modes (#3092, #4201)
 * Added export plugin for Remixed Dungeon (by Mikhael Danilov, #4158)
 * Added "World > World Properties" menu action (with dogboydog, #4190)
+* Added Delete shortcut to Remove Tiles action by default and avoid ambiguity (#4201)
 * Scripting: Added API for custom property types (with dogboydog, #3971)
 * Scripting: Added TileMap.chunkSize and TileMap.compressionLevel properties
 * AutoMapping: Don't match rules based on empty input indexes

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -166,6 +166,8 @@ TilesetEditor::TilesetEditor(QObject *parent)
 
     mAddTiles->setIcon(QIcon(QLatin1String(":images/16/add.png")));
     mRemoveTiles->setIcon(QIcon(QLatin1String(":images/16/remove.png")));
+    mRemoveTiles->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    mRemoveTiles->setShortcuts(QKeySequence::Delete);
     mRelocateTiles->setIcon(QIcon(QLatin1String(":images/22/stock-tool-move-22.png")));
     mRelocateTiles->setCheckable(true);
     mRelocateTiles->setIconVisibleInMenu(false);
@@ -178,6 +180,10 @@ TilesetEditor::TilesetEditor(QObject *parent)
     editWang->setIconVisibleInMenu(false);
     mDynamicWrappingToggle->setCheckable(true);
     mDynamicWrappingToggle->setIcon(QIcon(QLatin1String("://images/scalable/wrap.svg")));
+
+    // The shortcut set on the 'Remove Tiles' action should only be active
+    // while the tileset view is focused, to avoid ambiguities.
+    mWidgetStack->addAction(mRemoveTiles);
 
     Utils::setThemeIcon(mAddTiles, "add");
     Utils::setThemeIcon(mRemoveTiles, "remove");
@@ -318,7 +324,7 @@ void TilesetEditor::addDocument(Document *document)
 
 void TilesetEditor::removeDocument(Document *document)
 {
-    TilesetDocument *tilesetDocument = qobject_cast<TilesetDocument*>(document);
+    auto tilesetDocument = qobject_cast<TilesetDocument*>(document);
     Q_ASSERT(tilesetDocument);
     Q_ASSERT(mViewForTileset.contains(tilesetDocument));
 

--- a/src/tiled/tileseteditor.h
+++ b/src/tiled/tileseteditor.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "clipboardmanager.h"
 #include "editor.h"
 #include "wangset.h"
 


### PR DESCRIPTION
* Set 'Delete' as shortcut on the 'Remove Tiles' action by default, rather than leaving it empty.

* Set the shortcut to have widget context, so that it only works when the tileset view is focused (and also recieves precedence of any global 'Delete' shortcut then).

Part of issue #4201