### PR TITLE
Fix issue with opening Tile Animation Editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Scripting: Added TileMap.chunkSize and TileMap.compressionLevel properties
 * AutoMapping: Don't match rules based on empty input indexes
 * AutoMapping: Optimized reloading of rule maps and load rule maps on-demand
+* Windows: Fixed issue with opening Tile Animation Editor (#4223)
 * Workaround tileset view layout regression in Qt 6.9
 * Raised minimum supported Qt version from 5.12 to 5.15.2
 

--- a/src/tiled/tileseteditor.h
+++ b/src/tiled/tileseteditor.h
@@ -150,6 +150,7 @@ private:
     void setWangColorImage(Tile *tile, int index);
     void setWangColorColor(WangColor *wangColor, const QColor &color);
 
+    void setAnimationEditorVisible(bool visible);
     void onAnimationEditorClosed();
 
     void setCurrentTile(Tile *tile);
@@ -175,7 +176,7 @@ private:
     WangDock *mWangDock;
     QComboBox *mZoomComboBox;
     QLabel *mStatusInfoLabel;
-    TileAnimationEditor *mTileAnimationEditor;
+    TileAnimationEditor *mTileAnimationEditor = nullptr;
 
     QHash<TilesetDocument*, TilesetView*> mViewForTileset;
     TilesetDocument *mCurrentTilesetDocument = nullptr;


### PR DESCRIPTION
On Windows, with Tiled compiled against Qt 6, the Tile Animation Editor would fail to become visible when it had been left in a maximized state before closing Tiled.

Somehow the dialog in a maximized state was receiving WM_DESTROY when its parent QMainWindow was added to the layout in
DocumentManager::setEditor:

> External WM_DESTROY received for QWidgetWindow(0x20d997eba40, name="TileAnimationEditorWindow") , parent: QWindow(0x0) , transient parent: QWindow(0x0)

I'm not entirely sure what causes this behavior, but I've found that lazily creating the TileAnimationEditor on the first time it is opened provided a workaround.

Closes #4223