### PR TITLE
Add named properties on focus lost

### DIFF
--- a/src/tiled/propertiesview.cpp
+++ b/src/tiled/propertiesview.cpp
@@ -1354,7 +1354,8 @@ PropertiesView::PropertyWidgets PropertiesView::createPropertyWidgets(Property *
     widgets.addButton->setFocusPolicy(Qt::StrongFocus); // needed for AddValueProperty
     Utils::setThemeIcon(widgets.addButton, "add");
     editorLayout->addWidget(widgets.addButton, 0, Qt::AlignTop);
-    connect(widgets.addButton, &QAbstractButton::clicked, property, &Property::addRequested);
+    connect(widgets.addButton, &QAbstractButton::clicked,
+            property, [property] { emit property->addRequested(); });
 
     if (auto groupProperty = qobject_cast<GroupProperty *>(property)) {
         auto containerWidget = new QWidget(parent);

--- a/src/tiled/propertiesview.h
+++ b/src/tiled/propertiesview.h
@@ -115,7 +115,7 @@ signals:
 
     void resetRequested();
     void removeRequested();
-    void addRequested();
+    void addRequested(bool focus = true);
 
     void contextMenuRequested(const QPoint &globalPos);
 

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -2317,10 +2317,11 @@ GroupProperty *PropertiesWidget::customPropertiesGroup() const
     return mCustomProperties;
 }
 
-void PropertiesWidget::selectCustomProperty(const QString &name)
+void PropertiesWidget::selectCustomProperty(const QString &name, bool focus)
 {
     if (auto property = mCustomProperties->property(name)) {
-        mPropertiesView->focusProperty(property);
+        if (focus)
+            mPropertiesView->focusProperty(property);
         mPropertiesView->setSelectedProperties({ property });
     }
 }
@@ -2667,8 +2668,10 @@ void PropertiesWidget::showAddValueProperty()
     if (!mAddValueProperty) {
         mAddValueProperty = new AddValueProperty(mCustomProperties);
 
-        connect(mAddValueProperty, &Property::addRequested, this, [this] {
-            addProperty(mAddValueProperty->name(), mAddValueProperty->value());
+        connect(mAddValueProperty, &Property::addRequested, this, [this] (bool focus) {
+            const auto &name = mAddValueProperty->name();
+            addProperty(name, mAddValueProperty->value());
+            selectCustomProperty(name, focus);
             mCustomProperties->deleteProperty(mAddValueProperty);
         });
         connect(mAddValueProperty, &Property::removeRequested, this, [this] {
@@ -2695,8 +2698,6 @@ void PropertiesWidget::addProperty(const QString &name, const QVariant &value)
                                         mDocument->currentObjects(),
                                         name, value));
     }
-
-    selectCustomProperty(name);
 }
 
 void PropertiesWidget::removeProperties()
@@ -2790,7 +2791,9 @@ void PropertiesWidget::showContextMenu(const QPoint &pos)
 
             if (actions.testFlag(Property::Action::Add)) {
                 QAction *add = contextMenu.addAction(mAddIcon, tr("Add"),
-                                                     focusedProperty, &Property::addRequested);
+                                                     focusedProperty, [focusedProperty] {
+                    emit focusedProperty->addRequested();
+                });
                 add->setEnabled(!actions.testFlag(Property::Action::AddDisabled));
                 Utils::setThemeIcon(add, "add");
             }

--- a/src/tiled/propertieswidget.h
+++ b/src/tiled/propertieswidget.h
@@ -63,7 +63,7 @@ signals:
     void bringToFront();
 
 public slots:
-    void selectCustomProperty(const QString &name);
+    void selectCustomProperty(const QString &name, bool focus = true);
 
 protected:
     bool event(QEvent *event) override;

--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -572,8 +572,16 @@ void PropertyTypesEditor::openAddMemberDialog()
         mAddValueProperty->setPlaceholderText(tr("Member name"));
         mAddValueProperty->setParentClassType(static_cast<const ClassPropertyType*>(propertyType));
 
-        connect(mAddValueProperty, &Property::addRequested, this, [this] {
-            addMember(mAddValueProperty->name(), mAddValueProperty->value());
+        connect(mAddValueProperty, &Property::addRequested, this, [this] (bool focus) {
+            const auto &name = mAddValueProperty->name();
+            addMember(name, mAddValueProperty->value());
+
+            if (auto property = mMembersProperty->property(name)) {
+                if (focus)
+                    mMembersView->focusProperty(property);
+                mMembersView->setSelectedProperties({ property });
+            }
+
             mMembersProperty->deleteProperty(mAddValueProperty);
         });
         connect(mAddValueProperty, &Property::removeRequested, this, [this] {
@@ -605,11 +613,6 @@ void PropertyTypesEditor::addMember(const QString &name, const QVariant &value)
 
     applyMemberToSelectedType(name, value);
     updateDetails();
-
-    if (auto property = mMembersProperty->property(name)) {
-        mMembersView->focusProperty(property);
-        mMembersView->setSelectedProperties({ property });
-    }
 }
 
 void PropertyTypesEditor::removeMember()

--- a/src/tiled/variantmapproperty.cpp
+++ b/src/tiled/variantmapproperty.cpp
@@ -510,9 +510,13 @@ QWidget *AddValueProperty::createLabel(int level, QWidget *parent)
         if (!focusWidget || focusWidget->window() != parent->window())
             return;
 
-        // Request removal if focus moved elsewhere
-        if (!parent->isAncestorOf(focusWidget))
-            emit removeRequested();
+        // Request add or removal if focus moved elsewhere
+        if (!parent->isAncestorOf(focusWidget)) {
+            if (!name().isEmpty())
+                emit addRequested(false);   // add without focusing, in response to focus out
+            else
+                emit removeRequested();
+        }
     });
 
     return nameEdit;


### PR DESCRIPTION
When adding a new property or class member, losing the focus of the "add value widget" always aborted the addition. Now, it instead adds the property when a name had been entered.

In this case, the value edit for the new property is not explicitly focused, to avoid disrupting the user's focus change.

A few direct signal-to-signal connections were exchanged for lambdas to avoid the "focus" parameter getting set based on a "checked" parameter in the original signals.