### PR TITLE
Fixed wheel behavior on spin boxes in Properties view

### DIFF
--- a/src/tiled/propertiesview.cpp
+++ b/src/tiled/propertiesview.cpp
@@ -283,7 +283,7 @@ QWidget *IntProperty::createEditor(QWidget *parent)
         connect(slider, &QSlider::valueChanged, this, &IntProperty::setValue);
     }
 
-    auto spinBox = new ExpressionSpinBox(parent);
+    auto spinBox = new SpinBox(parent);
     spinBox->setRange(m_minimum, m_maximum);
     spinBox->setSingleStep(m_singleStep);
     spinBox->setSuffix(m_suffix);
@@ -516,7 +516,7 @@ QWidget *FontProperty::createEditor(QWidget *parent)
     auto editor = new QWidget(parent);
     auto fontComboBox = new QFontComboBox(editor);
 
-    auto sizeSpinBox = new ExpressionSpinBox(editor);
+    auto sizeSpinBox = new SpinBox(editor);
     sizeSpinBox->setRange(1, 999);
     sizeSpinBox->setSuffix(tr(" px"));
     sizeSpinBox->setKeyboardTracking(false);


### PR DESCRIPTION
Small regression in b081934a7fa12c2df0fc0213d59de3200d030896 caused the mouse wheel to affect the value of unfocused spin boxes again.