### PR TITLE
CI: Added 'brew update' to install latest Qbs

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -26,7 +26,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install qbs
+        brew update
+        brew install qbs qttools
 
     - name: Setup Qbs
       run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -241,6 +241,7 @@ jobs:
 
     - name: Setup Qbs
       run: |
+        brew update
         brew install qbs
         qbs setup-toolchains --detect
         qbs setup-qt --detect


### PR DESCRIPTION
Without this I'm still getting Qbs 3.0.3 but we need a fix in Qbs 3.1.