### PR TITLE
CI: Limit push builds to 'master' and tags

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -2,6 +2,10 @@ name: Compile on latest macOS (Homebrew)
 
 on:
   push:
+    branches:
+      - master
+    tags:
+      - '*'
     paths-ignore:
     - 'docs/**'
     - '**.md'

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -2,6 +2,10 @@ name: Build Packages
 
 on:
   push:
+    branches:
+      - master
+    tags:
+      - '*'
     paths-ignore:
     - 'docs/**'
     - '**.md'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,6 +2,10 @@ name: Compile on Ubuntu
 
 on:
   push:
+    branches:
+      - master
+    tags:
+      - '*'
     paths-ignore:
     - 'docs/**'
     - '**.md'


### PR DESCRIPTION
Most other branches are only created to open a pull request, and then we only want the pull request related builds to trigger.