### PR TITLE
Shortcut for current tool now switches to previous tool

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Added status info for various Stamp Brush, Terrain Brush and Eraser modes (#3092, #4201)
 * Added Escape to clear tile selection when any tile related tool is selected (#4243)
 * Added Escape to cancel tile selection and shape drawing operations
+* Made the shortcut for current tool switch to previous tool (#4280)
 * Allow canceling Select Same Tile, Magic Wand and Bucket Fill operations with right-click and Escape
 * Allow dragging over multiple tiles with Select Same Tile, Magic Wand and Bucket Fill tools (#4276)
 * Don't switch to Edit Polygons tool on double-click with Alt pressed

--- a/src/tiled/toolmanager.h
+++ b/src/tiled/toolmanager.h
@@ -106,6 +106,7 @@ private:
 
     QActionGroup *mActionGroup;
     AbstractTool *mSelectedTool = nullptr;
+    AbstractTool *mPreviousSelectedTool = nullptr;
     QHash<Layer::TypeFlag, AbstractTool *> mSelectedToolForLayerType;
     MapDocument *mMapDocument = nullptr;
     Tile *mTile = nullptr;


### PR DESCRIPTION
This allows for quickly toggling between the current and any other tool by pressing the shortcut repeatedly.

Hopefully it won't trip off too many people who expect the shortcut for the current tool to just keep the current tool selected, so that we don't need to make this behavior optional.

The idea came from Collin van Ginkel's brain.