### PR TITLE
GitHub Actions / Qbs: Adjusted Qt version and don't install tests

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -249,8 +249,8 @@ jobs:
         brew install qbs
         qbs setup-toolchains --detect
         qbs setup-qt --detect
-        qbs config profiles.qt-6-9-2.baseProfile xcode
-        qbs config defaultProfile qt-6-9-2
+        qbs config profiles.qt-6-9-3.baseProfile xcode
+        qbs config defaultProfile qt-6-9-3
 
     - name: Build Zstandard
       run: |

--- a/qbs/imports/TiledTest.qbs
+++ b/qbs/imports/TiledTest.qbs
@@ -2,6 +2,7 @@ import qbs.FileInfo
 
 CppApplication {
     type: base.concat("autotest")
+    install: false
 
     Depends { name: "libtiled" }
     Depends { name: "Qt.testlib" }


### PR DESCRIPTION
When updating the Qt version to 6.9.3, I forgot to update the default profile selected for the macOS build.

Also, since Qbs 3.1, the convenience items are installing by default, so we need to explicitly disable that for the autotests (came up in #4282).