### PR TITLE
Adjust world map position when resizing a map with offset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Allow canceling Select Same Tile, Magic Wand and Bucket Fill operations with right-click and Escape
 * Allow dragging over multiple tiles with Select Same Tile, Magic Wand and Bucket Fill tools (#4276)
 * Don't switch to Edit Polygons tool on double-click with Alt pressed
+* Adjust world map position when resizing a map with offset (#4270)
 * Added export plugin for Remixed Dungeon (by Mikhael Danilov, #4158)
 * Added "World > World Properties" menu action (with dogboydog, #4190)
 * Added Delete shortcut to Remove Tiles action by default and avoid ambiguity (#4201)

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -31,6 +31,7 @@
 #include "changemapobjectsorder.h"
 #include "changeproperties.h"
 #include "changeselectedarea.h"
+#include "changeworld.h"
 #include "containerhelpers.h"
 #include "editablemap.h"
 #include "editor.h"
@@ -60,6 +61,9 @@
 #include "tilelayer.h"
 #include "tilesetdocument.h"
 #include "transformmapobjects.h"
+#include "world.h"
+#include "worlddocument.h"
+#include "worldmanager.h"
 
 #include <QFileInfo>
 #include <QRect>
@@ -395,7 +399,7 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
     const QPointF pixelOffset = origin - newOrigin;
 
     // Resize the map and each layer
-    QUndoCommand *command = new QUndoCommand(tr("Resize Map"));
+    auto command = new QUndoCommand(tr("Resize Map"));
 
     QList<MapObject *> objectsToRemove;
     QList<MapObject *> objectsToMove;
@@ -404,12 +408,12 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
     while (Layer *layer = iterator.next()) {
         switch (layer->layerType()) {
         case Layer::TileLayerType: {
-            TileLayer *tileLayer = static_cast<TileLayer*>(layer);
+            auto tileLayer = static_cast<TileLayer*>(layer);
             new ResizeTileLayer(this, tileLayer, size, offset, command);
             break;
         }
         case Layer::ObjectGroupType: {
-            ObjectGroup *objectGroup = static_cast<ObjectGroup*>(layer);
+            auto objectGroup = static_cast<ObjectGroup*>(layer);
 
             for (MapObject *o : objectGroup->objects()) {
                 // Remove objects that will fall outside of the map
@@ -450,6 +454,23 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
     new ResizeMap(this, size, command);
     new ChangeSelectedArea(this, movedSelection, command);
 
+    // Adjust world position if this map is part of any loaded worlds
+    if (!pixelOffset.isNull()) {
+        const QString &mapName = fileName();
+        const QPoint offsetPixels = pixelOffset.toPoint();
+
+        for (const auto &worldDocument : WorldManager::instance().worlds()) {
+            auto world = worldDocument->world();
+            const int mapIdx = world->mapIndex(mapName);
+            if (mapIdx < 0)
+                continue; // also skips maps matched via pattern
+
+            const QPoint prevPos = world->mapRect(mapName).topLeft();
+            const QPoint newPos = prevPos - offsetPixels;
+            new SetMapPosInLoadedWorld(worldDocument->fileName(), mapName, prevPos, newPos, command);
+        }
+    }
+
     undoStack()->push(command);
 
     // TODO: Handle layers that don't match the map size correctly
@@ -460,8 +481,7 @@ void MapDocument::autocropMap()
     if (!mCurrentLayer || !mCurrentLayer->isTileLayer())
         return;
 
-    TileLayer *tileLayer = static_cast<TileLayer*>(mCurrentLayer);
-
+    auto tileLayer = static_cast<TileLayer*>(mCurrentLayer);
     const QRect bounds = tileLayer->region().boundingRect();
     if (bounds.isNull())
         return;
@@ -1072,12 +1092,12 @@ void MapDocument::paintTileLayers(const Map &map, bool mergeable,
         if (!mMap->infinite() && !target->rect().intersects(source->bounds()))
             continue;
 
-        PaintTileLayer *paintCommand = new PaintTileLayer(this,
-                                                          target,
-                                                          source->x(),
-                                                          source->y(),
-                                                          source,
-                                                          paintRegion);
+        auto paintCommand = new PaintTileLayer(this,
+                                               target,
+                                               source->x(),
+                                               source->y(),
+                                               source,
+                                               paintRegion);
 
         if (missingTilesets && !missingTilesets->isEmpty()) {
             for (const SharedTileset &tileset : std::as_const(*missingTilesets)) {
@@ -1615,7 +1635,7 @@ void MapDocument::checkIssues()
 
     LayerIterator it(map());
     for (Layer *layer : map()->objectGroups()) {
-        ObjectGroup *objectGroup = static_cast<ObjectGroup*>(layer->asObjectGroup());
+        auto objectGroup = static_cast<ObjectGroup*>(layer->asObjectGroup());
         for (MapObject *mapObject : *objectGroup) {
             if (const ObjectTemplate *objectTemplate = mapObject->objectTemplate())
                 if (!objectTemplate->object())

--- a/src/tiled/undocommands.h
+++ b/src/tiled/undocommands.h
@@ -68,6 +68,7 @@ enum UndoCommands {
     Cmd_ChangeWangSetName,
     Cmd_EraseTiles,
     Cmd_PaintTileLayer,
+    Cmd_SetMapRect,
     Cmd_SetProperty,
 };
 

--- a/src/tiled/worlddocument.h
+++ b/src/tiled/worlddocument.h
@@ -24,8 +24,6 @@
 #include "document.h"
 #include "editableasset.h"
 
-class WorldManager;
-
 namespace Tiled {
 
 class World;


### PR DESCRIPTION
When an offset is applied while resizing a map, this offset will now affect the maps position in any loaded worlds the map is in. This affects both manual resizing as well as the "crop to selection" and "autocrop" actions.

Implemented using a `SetMapPosInLoadedWorld` command which has a weak reference (file name) to a loaded world, to avoid issues when a world is later unloaded. It in turn uses `SetMapRectCommand` to apply the change to the world, which was adjusted to set itself as obsolete when applicable in order to disappear when the resize operation is undone.

Closes #4270