### PR TITLE
Change Clipboard Mime-Type to Support Text

### DIFF
--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -33,6 +33,7 @@
 #include "tile.h"
 #include "tilelayer.h"
 #include "tmxmapformat.h"
+#include "preferences.h"
 
 #include <QApplication>
 #include <QClipboard>
@@ -47,7 +48,6 @@
 
 #include <algorithm>
 
-static const char * const TMX_MIMETYPE = "text/plain";
 
 using namespace Tiled;
 
@@ -59,6 +59,9 @@ ClipboardManager::ClipboardManager()
     connect(mClipboard, &QClipboard::dataChanged,
             this, &ClipboardManager::update,
             Qt::QueuedConnection);
+
+    connect(Preferences::instance(), &Preferences::enableTextPasteChanged,
+            this, &ClipboardManager::update);
 
     update();
 }
@@ -79,6 +82,12 @@ ClipboardManager *ClipboardManager::instance()
  */
 std::unique_ptr<Map> ClipboardManager::map() const
 {
+
+    const char* TMX_MIMETYPE =
+    Preferences::instance()->enableTextPaste()
+        ? "text/plain"
+        : "text/tmx";
+
     const auto mimeData = mClipboard->mimeData();
     const QByteArray data = mimeData->data(QLatin1String(TMX_MIMETYPE));
     if (data.isEmpty())
@@ -94,6 +103,11 @@ std::unique_ptr<Map> ClipboardManager::map() const
 void ClipboardManager::setMap(const Map &map)
 {
     TmxMapFormat format;
+
+    const char* TMX_MIMETYPE =
+    Preferences::instance()->enableTextPaste()
+        ? "text/plain"
+        : "text/tmx";
 
     auto mimeData = new QMimeData;
     mimeData->setData(QLatin1String(TMX_MIMETYPE), format.toByteArray(&map));
@@ -274,6 +288,12 @@ void ClipboardManager::update()
     bool hasListValues = false;
 
     if (const auto data = mClipboard->mimeData()) {
+        
+        const char* TMX_MIMETYPE =
+        Preferences::instance()->enableTextPaste()
+            ? "text/plain"
+            : "text/tmx";
+
         hasMap = data->hasFormat(QLatin1String(TMX_MIMETYPE));
         hasProperties = data->hasFormat(QLatin1String(PROPERTIES_MIMETYPE));
         hasListValues = data->hasFormat(QLatin1String(LIST_VALUES_MIMETYPE));

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -447,6 +447,17 @@ void Preferences::setSafeSavingEnabled(bool enabled)
     SaveFile::setSafeSavingEnabled(enabled);
 }
 
+bool Preferences::enableTextPaste() const
+{
+    return get("Storage/enableTextPaste", false);
+}
+
+void Preferences::setEnableTextPaste(bool enabled)
+{
+    setValue(QLatin1String("Storage/enableTextPaste"), enabled);
+    emit enableTextPasteChanged(enabled);
+}
+
 bool Preferences::exportOnSave() const
 {
     return get("Storage/ExportOnSave", false);

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -118,6 +118,9 @@ public:
     bool exportOnSave() const;
     void setExportOnSave(bool enabled);
 
+    bool enableTextPaste() const;
+    void setEnableTextPaste(bool enabled);
+
     enum ExportOption {
         EmbedTilesets                   = 0x1,
         DetachTemplateInstances         = 0x2,
@@ -259,6 +262,8 @@ signals:
 
     void checkForUpdatesChanged(bool on);
     void displayNewsChanged(bool on);
+
+    void enableTextPasteChanged(bool enabled);
 
     void aboutToSwitchSession();
 

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -93,6 +93,9 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             preferences, &Preferences::setSafeSavingEnabled);
     connect(mUi->exportOnSave, &QCheckBox::toggled,
             preferences, &Preferences::setExportOnSave);
+    connect(mUi->enableTextPaste, &QCheckBox::toggled,
+            preferences, &Preferences::setEnableTextPaste);
+
     connect(mUi->naturalSorting, &QCheckBox::toggled,
             preferences, &Preferences::setNaturalSorting);
 
@@ -220,6 +223,8 @@ void PreferencesDialog::fromPreferences()
     mUi->restoreSession->setChecked(prefs->restoreSessionOnStartup());
     mUi->safeSaving->setChecked(prefs->safeSavingEnabled());
     mUi->exportOnSave->setChecked(prefs->exportOnSave());
+    mUi->enableTextPaste->setChecked(prefs->enableTextPaste());
+
     mUi->naturalSorting->setChecked(prefs->naturalSorting());
 
     mUi->embedTilesets->setChecked(prefs->exportOption(Preferences::EmbedTilesets));

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -64,6 +64,16 @@
             </property>
            </widget>
           </item>
+           <item row="4" column="0">
+           <widget class="QCheckBox" name="enableTextPaste">
+            <property name="toolTip">
+             <string>Enable to copy TMX as text from other programs.</string>
+            </property>
+            <property name="text">
+             <string>Set clipboard to use plain text</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -687,6 +697,8 @@
   <tabstop>restoreSession</tabstop>
   <tabstop>safeSaving</tabstop>
   <tabstop>exportOnSave</tabstop>
+  <tabstop>enableTextPaste</tabstop>
+
   <tabstop>embedTilesets</tabstop>
   <tabstop>detachTemplateInstances</tabstop>
   <tabstop>resolveObjectTypesAndProperties</tabstop>


### PR DESCRIPTION
Proposal to update Clipboard mime-type to `text/plain` to allow for interoperability of copy/paste functions with external programs. Please see [Issue 4290](https://github.com/mapeditor/tiled/issues/4290) for details.