### PR TITLE
karchive: Explicitly convert enum to int for QString::arg

### DIFF
--- a/src/karchive/src/kar.cpp
+++ b/src/karchive/src/kar.cpp
@@ -90,7 +90,7 @@ bool KAr::openArchive(QIODevice::OpenMode mode)
         return true;
     }
     if (mode != QIODevice::ReadOnly && mode != QIODevice::ReadWrite) {
-        setErrorString(tr("Unsupported mode %1").arg(mode));
+        setErrorString(tr("Unsupported mode %1").arg(static_cast<int>(mode)));
         return false;
     }
 

--- a/src/karchive/src/karchive.cpp
+++ b/src/karchive/src/karchive.cpp
@@ -152,7 +152,7 @@ bool KArchive::open(QIODevice::OpenMode mode)
     }
 
     if (!d->dev->isOpen() && !d->dev->open(mode)) {
-        setErrorString(tr("Could not set device mode to %1").arg(mode));
+        setErrorString(tr("Could not set device mode to %1").arg(static_cast<int>(mode)));
         return false;
     }
 
@@ -200,7 +200,7 @@ bool KArchive::createDevice(QIODevice::OpenMode mode)
         }
         break; // continued below
     default:
-        setErrorString(tr("Unsupported mode %1").arg(d->mode));
+        setErrorString(tr("Unsupported mode %1").arg(static_cast<int>(d->mode)));
         return false;
     }
     return true;

--- a/src/karchive/src/krcc.cpp
+++ b/src/karchive/src/krcc.cpp
@@ -110,7 +110,7 @@ bool KRcc::openArchive(QIODevice::OpenMode mode)
         return true;
     }
     if (mode != QIODevice::ReadOnly && mode != QIODevice::ReadWrite) {
-        setErrorString(tr("Unsupported mode %1").arg(mode));
+        setErrorString(tr("Unsupported mode %1").arg(static_cast<int>(mode)));
         return false;
     }
 


### PR DESCRIPTION
The current code doesn't compile after https://github.com/qt/qtbase/commit/0a1c69bba5b5dd26b937ac0a67ab0bdd1c32b221 (released in Qt 6.10.1).

Just the patch suggested in #4294, since due to the Qt version dependency update in #4296 we'll wait with that until after Tiled 1.12.

Closes #4294