### PR TITLE
tscnplugin: Export map custom properties as TileMap metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@
 * Workaround tileset view layout regression in Qt 6.9
 * Raised minimum supported Qt version from 5.12 to 5.15.2
 * AppImage: Updated to Sentry 0.12.8
+* Godot 4 plugin: Added support for exporting map properties as Godot's TileMap metadata (by Ximo Planells Lerma, #4301)
 
 ### Tiled 1.11.2 (28 Jan 2025)
 

--- a/docs/manual/export-tscn.rst
+++ b/docs/manual/export-tscn.rst
@@ -72,8 +72,8 @@ of the Godot TileSet resource.
 
 .. _godot4-map-properties:
 
-Map Properties
-~~~~~~~~~~~~~~
+Special Map Properties
+~~~~~~~~~~~~~~~~~~~~~~
 
 Maps support the following custom property:
 
@@ -94,6 +94,21 @@ overwritten every time the map is exported.
 .. raw:: html
 
    <div class="new">New in Tiled 1.11</div>
+
+Exported Map Properties
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Any custom properties defined on the map will be exported as metadata on the
+root TileMap node. Property names are sanitized by removing spaces and special
+characters. For example: a custom property named "My Property" becomes
+"MyProperty" when exported.
+
+Metadata is displayed in Godot in the Inspector and can be accessed in Godot
+at runtime using `get_meta()`.
+
+.. raw:: html
+
+   <div class="new">New in Tiled 1.12</div>
 
 Object Properties
 ~~~~~~~~~~~~~~~~~

--- a/src/plugins/tscn/tscnplugin.cpp
+++ b/src/plugins/tscn/tscnplugin.cpp
@@ -855,7 +855,7 @@ static void writeTileset(const Map *map, QFileDevice *device, bool isExternal, A
     device->write("\n");
 }
 
-static void writeTileMapMetadata(const Properties &mapProperties, AssetInfo &assetInfo, QFileDevice *device)
+static void writeMetadata(const Properties &mapProperties, AssetInfo &assetInfo, QFileDevice *device)
 {
     QSet<QString> sanitizedNames;
     sanitizedNames.reserve(mapProperties.size());
@@ -877,13 +877,13 @@ static void writeTileMapMetadata(const Properties &mapProperties, AssetInfo &ass
         const QString sanitizedName = sanitizeSpecialChars(name);
 
         if (sanitizedName.isEmpty()) {
-            Tiled::WARNING(TscnPlugin::tr("Unable to export map property '%1': sanitized name is empty").arg(name));
+            Tiled::WARNING(TscnPlugin::tr("Unable to export property '%1': sanitized name is empty").arg(name));
             continue;
         }
 
         // Check that we haven't already written a property with a sanitizedName that matches the one we are processing.
         if (sanitizedNames.contains(sanitizedName)) {
-            Tiled::WARNING(TscnPlugin::tr("Unable to export map property '%1': sanitized name collision '%2'").arg(name, sanitizedName));
+            Tiled::WARNING(TscnPlugin::tr("Unable to export property '%1': sanitized name collision '%2'").arg(name, sanitizedName));
             continue;
         }
         sanitizedNames.insert(sanitizedName);
@@ -977,9 +977,7 @@ bool TscnPlugin::write(const Map *map, const QString &fileName, Options options)
 
         // Write map custom properties as node metadata
         Properties mapProperties = map->properties();
-        if (!mapProperties.isEmpty()) {
-            writeTileMapMetadata(mapProperties, assetInfo, device);
-        }
+        writeMetadata(mapProperties, assetInfo, device);
 
         // Tile packing format:
         // DestLocation, SrcX, SrcY


### PR DESCRIPTION
This PR updates the Godot 4 exporter to write the map custom properties (if any) as TileMap node metadata when writing the .tscn file.

It loops over all the elements of `map->properties()` and if the property name can be sanitized as a Godot identifier and the type is supported by the exporter it write a new line to the .tscn:

```
metadata/$name = $value
```

Example:

Exporting a map with following Tile custom properties:

<img width="1243" height="776" alt="Screenshot from 2025-12-11 14-09-54" src="https://github.com/user-attachments/assets/e5bf7376-541d-48fb-b475-fbf16774c0a9" />

Will write to the .tscn files the following lines:

```
metadata/myboolprop = true
metadata/mycolorprop = Color(0.827451, 0.211765, 0.509804, 1)
metadata/myproperty = "my value"
```
That will show up in Godot editor as:

<img width="1556" height="972" alt="Screenshot from 2025-12-11 14-09-29" src="https://github.com/user-attachments/assets/5ede56ec-e02e-4002-9819-e8998220c4f0" />

