### PR TITLE
Fixes issue #2974

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * Added export plugin for Remixed Dungeon (by Mikhael Danilov, #4158)
 * Added "World > World Properties" menu action (with dogboydog, #4190)
 * Added Delete shortcut to Remove Tiles action by default and avoid ambiguity (#4201)
+* Fixed alpha component of tint color not applying correctly to opaque images (by Roland Helmerichs, #4310)
 * Scripting: Added API for custom property types (with dogboydog, #3971)
 * Scripting: Added TileMap.chunkSize and TileMap.compressionLevel properties
 * AutoMapping: Don't match rules based on empty input indexes

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -119,8 +119,8 @@ static QPixmap tinted(const QPixmap &pixmap, const QRect &rect, const QColor &co
 
     QColor fullOpacity = color;
     fullOpacity.setAlpha(255);
-    // tint the final color (this will will mess up the alpha which we will fix
-    // in the next lines)
+    // tint the final color (this will mess up the alpha which we will fix in
+    // the next lines)
     painter.setCompositionMode(QPainter::CompositionMode_Multiply);
     painter.fillRect(resultImage.rect(), fullOpacity);
 


### PR DESCRIPTION
If pngs used for tilesets don't have an alpha channel tinting a tile layer with an alpha below 255 produces wrong results.
This is a small demo for that issue [issue-demo.zip](https://github.com/user-attachments/files/24408582/issue-demo.zip)

That's how it looks currently
<img width="1882" height="1124" alt="before" src="https://github.com/user-attachments/assets/1f2794dd-a2a0-418f-b0a1-56e92e908c83" />

Result with my proposed fix:
<img width="1882" height="1124" alt="after_fix" src="https://github.com/user-attachments/assets/12c7faeb-f87b-496a-923e-f1fca8e15a3e" />

