### PR TITLE
Removed no longer necessary static_casts in signal connections

### DIFF
--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -280,11 +280,8 @@ CommandProcess::CommandProcess(const Command &command, bool inTerminal, bool sho
 #endif
     }
 
-    connect(this, &QProcess::errorOccurred,
-            this, &CommandProcess::handleProcessError);
-
-    connect(this, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
-            this, &QObject::deleteLater);
+    connect(this, &QProcess::errorOccurred, this, &CommandProcess::handleProcessError);
+    connect(this, &QProcess::finished, this, &QObject::deleteLater);
 
     if (showOutput) {
         Tiled::INFO(tr("Executing: %1").arg(mFinalCommand));

--- a/src/tiled/newmapdialog.cpp
+++ b/src/tiled/newmapdialog.cpp
@@ -108,11 +108,11 @@ NewMapDialog::NewMapDialog(QWidget *parent) :
     font.setPointSizeF(size - 1);
     mUi->pixelSizeLabel->setFont(font);
 
-    connect(mUi->mapWidth, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &NewMapDialog::refreshPixelSize);
-    connect(mUi->mapHeight, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &NewMapDialog::refreshPixelSize);
-    connect(mUi->tileWidth, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &NewMapDialog::refreshPixelSize);
-    connect(mUi->tileHeight, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &NewMapDialog::refreshPixelSize);
-    connect(mUi->orientation, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &NewMapDialog::refreshPixelSize);
+    connect(mUi->mapWidth, &QSpinBox::valueChanged, this, &NewMapDialog::refreshPixelSize);
+    connect(mUi->mapHeight, &QSpinBox::valueChanged, this, &NewMapDialog::refreshPixelSize);
+    connect(mUi->tileWidth, &QSpinBox::valueChanged, this, &NewMapDialog::refreshPixelSize);
+    connect(mUi->tileHeight, &QSpinBox::valueChanged, this, &NewMapDialog::refreshPixelSize);
+    connect(mUi->orientation, &QComboBox::currentIndexChanged, this, &NewMapDialog::refreshPixelSize);
     connect(mUi->fixedSize, &QAbstractButton::toggled, this, &NewMapDialog::updateWidgets);
 
     if (session::fixedSize)

--- a/src/tiled/newtilesetdialog.cpp
+++ b/src/tiled/newtilesetdialog.cpp
@@ -86,7 +86,7 @@ NewTilesetDialog::NewTilesetDialog(QWidget *parent) :
     connect(mUi->image, &QLineEdit::textChanged, this, &NewTilesetDialog::updateOkButton);
     connect(mUi->image, &QLineEdit::textChanged, this, &NewTilesetDialog::updateColorPickerButton);
     connect(mUi->useTransparentColor, &QCheckBox::toggled, this, &NewTilesetDialog::updateColorPickerButton);
-    connect(mUi->tilesetType, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+    connect(mUi->tilesetType, &QComboBox::currentIndexChanged,
             this, &NewTilesetDialog::tilesetTypeChanged);
     connect(mUi->dropperButton, &QAbstractButton::clicked, this, &NewTilesetDialog::pickColorFromImage);
 

--- a/src/tiled/offsetmapdialog.cpp
+++ b/src/tiled/offsetmapdialog.cpp
@@ -44,7 +44,7 @@ OffsetMapDialog::OffsetMapDialog(MapDocument *mapDocument, QWidget *parent)
 
     boundsSelectionChanged();   // updates wrap checkboxes
 
-    connect(mUi->boundsSelection, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+    connect(mUi->boundsSelection, &QComboBox::currentIndexChanged,
             this, &OffsetMapDialog::boundsSelectionChanged);
 }
 

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -120,19 +120,19 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
     mUi->crashReportingLabel->setVisible(false);
 #endif
 
-    connect(mUi->languageCombo, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+    connect(mUi->languageCombo, &QComboBox::currentIndexChanged,
             this, &PreferencesDialog::languageSelected);
     connect(mUi->gridColor, &ColorButton::colorChanged,
             preferences, &Preferences::setGridColor);
     connect(mUi->backgroundFadeColor, &ColorButton::colorChanged,
             preferences, &Preferences::setBackgroundFadeColor);
-    connect(mUi->gridFine, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+    connect(mUi->gridFine, &QSpinBox::valueChanged,
             preferences, &Preferences::setGridFine);
-    connect(mUi->gridMajorX, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+    connect(mUi->gridMajorX, &QSpinBox::valueChanged,
             preferences, &Preferences::setGridMajorX);
-    connect(mUi->gridMajorY, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+    connect(mUi->gridMajorY, &QSpinBox::valueChanged,
             preferences, &Preferences::setGridMajorY);
-    connect(mUi->objectLineWidth, static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+    connect(mUi->objectLineWidth, &QDoubleSpinBox::valueChanged,
             preferences, &Preferences::setObjectLineWidth);
     connect(mUi->preciseTileObjectSelection, &QCheckBox::toggled,
             this, [] (bool checked) { MapObjectItem::preciseTileObjectSelection = checked; });
@@ -147,9 +147,9 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
     connect(mUi->duplicateAddsCopy, &QCheckBox::toggled,
             this, [] (bool checked) { Editor::duplicateAddsCopy = checked; });
 
-    connect(mUi->styleCombo, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+    connect(mUi->styleCombo, &QComboBox::currentIndexChanged,
             this, &PreferencesDialog::styleComboChanged);
-    connect(mUi->objectSelectionBehaviorCombo, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+    connect(mUi->objectSelectionBehaviorCombo, &QComboBox::currentIndexChanged,
             this, [] (int index) { AbstractObjectTool::ourSelectionBehavior = static_cast<AbstractObjectTool::SelectionBehavior>(index); });
     connect(mUi->baseColor, &ColorButton::colorChanged,
             preferences, &Preferences::setBaseColor);
@@ -160,8 +160,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             preferences, &Preferences::setUseCustomFont);
     connect(mUi->fontComboBox, &QFontComboBox::currentFontChanged,
             preferences, &Preferences::setCustomFont);
-    connect(mUi->fontSize, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged),
-            this, [=] (int size) {
+    connect(mUi->fontSize, &QSpinBox::valueChanged, this, [=](int size) {
         QFont font = mUi->fontComboBox->currentFont();
         font.setPointSize(size);
         mUi->fontComboBox->setCurrentFont(font);

--- a/src/tiled/tileanimationeditor.cpp
+++ b/src/tiled/tileanimationeditor.cpp
@@ -312,7 +312,7 @@ TileAnimationEditor::TileAnimationEditor(QWidget *parent)
     connect(mPreviewAnimationDriver, &TileAnimationDriver::update,
             this, &TileAnimationEditor::advancePreviewAnimation);
 
-    connect(mUi->frameTime, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+    connect(mUi->frameTime, &QSpinBox::valueChanged,
             this, &TileAnimationEditor::setDefaultFrameTime);
 
     connect(mUi->setFrameTimeButton, &QAbstractButton::clicked,

--- a/src/tiled/zoomable.cpp
+++ b/src/tiled/zoomable.cpp
@@ -187,8 +187,7 @@ void Zoomable::setComboBox(QComboBox *comboBox)
         for (qreal scale : std::as_const(mZoomFactors))
             mComboBox->addItem(scaleToString(scale), scale);
         syncComboBox();
-        connect(mComboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::activated),
-                this, &Zoomable::comboActivated);
+        connect(mComboBox, &QComboBox::activated, this, &Zoomable::comboActivated);
 
         mComboBox->setEditable(true);
         mComboBox->setInsertPolicy(QComboBox::NoInsert);


### PR DESCRIPTION
We're compiling without the deprecated alternative signatures for these signals.