### PR TITLE
GitHub Actions: Fixed macos-latest build

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -31,9 +31,11 @@ jobs:
       run: |
         brew update
         brew install qbs qttools
+        echo "$(brew --prefix qbs)/bin" >> "$GITHUB_PATH"
 
     - name: Setup Qbs
       run: |
+        qbs --version
         qbs setup-toolchains --detect
         qbs config defaultProfile xcode
 


### PR DESCRIPTION
Add Homebrew Qbs path for macOS-latest so that Qbs doesn't run through its symlink. Follow-up to 400e62395319ab1b0bd9dc260854e95eeb7710a5.