### PR TITLE
Fix custom AppRun for Qt 6 AppImage

### DIFF
--- a/dist/linux/AppRun
+++ b/dist/linux/AppRun
@@ -7,11 +7,6 @@ set -e
 this_dir="$(readlink -f "$(dirname "$0")")"
 bin_dir="/usr/bin"
 
-# this hook only exists for the Qt 5 AppImage
-if [ -f "$this_dir"/apprun-hooks/"linuxdeploy-plugin-qt-hook.sh" ]; then
-    source "$this_dir"/apprun-hooks/"linuxdeploy-plugin-qt-hook.sh"
-fi
-
 my_help() {
     echo "Usage (Meta):"
     echo


### PR DESCRIPTION
The `linuxdeploy-plugin-qt-hook.sh` no longer exists in the Qt 6 AppImage due to a change in `linuxdeploy-plugin-qt`.

Closes #4319