### PR TITLE
fix(java): Fix tmxviewer initialization error 

### DIFF
--- a/util/java/tmxviewer-java/pom.xml
+++ b/util/java/tmxviewer-java/pom.xml
@@ -58,6 +58,14 @@
                         </goals>
                         <configuration>
                             <minimizeJar>true</minimizeJar>
+                            <filters>
+                                <filter>
+                                    <artifact>org.glassfish.jaxb:*</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>TMXViewer</mainClass>


### PR DESCRIPTION
Fixes[ the error ](https://github.com/mapeditor/tiled/issues/3284#issuecomment-1047864956)when opening tmxviewer-1.4.4-SNAPSHOT.jar 

```
Exception in thread "main" java.lang.ExceptionInInitializerError
        at com.sun.xml.bind.v2.model.impl.RuntimeModelBuilder.<init>(RuntimeModelBuilder.java:62)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.getTypeInfoSet(JAXBContextImpl.java:434)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:282)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:109)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl$JAXBContextBuilder.build(JAXBContextImpl.java:1142)
        at com.sun.xml.bind.v2.ContextFactory.createContext(ContextFactory.java:144)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:297)
        at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:286)
        at javax.xml.bind.ContextFinder.find(ContextFinder.java:409)
        at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:721)
        at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:662)
        at org.mapeditor.io.TMXMapReader.<init>(TMXMapReader.java:118)
        at TMXViewer.main(TMXViewer.java:81)
Caused by: java.lang.IllegalStateException: Can't find ReflectionNavigator class
        at com.sun.xml.bind.v2.model.impl.Utils.<clinit>(Utils.java:63)
        ... 15 more
```


```
java -version
openjdk version "21.0.2" 2024-01-16
OpenJDK Runtime Environment (build 21.0.2+13-58)
OpenJDK 64-Bit Server VM (build 21.0.2+13-58, mixed mode, sharing)
```