### PR TITLE
Scripting: Avoid triggering disabled actions in tiled.trigger

### DIFF
--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -584,9 +584,9 @@ QByteArray ScriptModule::decompress(const QByteArray &data, CompressionMethod me
 
 void ScriptModule::trigger(const QByteArray &actionName) const
 {
-    if (QAction *action = ActionManager::findAction(actionName))
+    if (QAction *action = ActionManager::findEnabledAction(actionName))
         action->trigger();
-    else
+    else if (!ActionManager::findAction(actionName))
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Unknown action"));
 }
 


### PR DESCRIPTION
Trying to trigger a disabled action is now ignored. Maybe more importantly, if there are multiple actions registered with the same name, the first enabled action will be triggered.

TODO: Document behavior