### PR TITLE
Python plugin: Fixed tiledbinding.py for Python 3.14

### DIFF
--- a/src/plugins/python/qtbinding.py
+++ b/src/plugins/python/qtbinding.py
@@ -23,7 +23,7 @@ from pybindgen import *
 import pybindgen.typehandlers.base as typehandlers
 from pybindgen.typehandlers.base import ForwardWrapperBase, PointerParameter
 
-"""
+r"""
 class QFlagsTransformation(typehandlers.TypeTransformation):
   def __init__(self):
     self.rx = re.compile(r'(?:::)?QFlags<\s*(\w+)\s*>')

--- a/src/plugins/python/tiledbinding.py
+++ b/src/plugins/python/tiledbinding.py
@@ -258,7 +258,7 @@ cls_mapobject = tiled.add_class('MapObject', cls_object)
 cls_mapobject.add_constructor([])
 cls_mapobject.add_constructor([('QString','name'), ('QString','type'),
     ('QPointF','pos'), ('QSizeF','size') ])
-cls_mapobject.add_enum('Shape', ('Rectangle','Polygon','Polyline','Ellipse','Text','Point'))
+cls_mapobject.add_enum('Shape', ('Rectangle','Polygon','Polyline','Ellipse','Capsule','Text','Point'))
 cls_mapobject.add_method('setPosition', None, [('QPointF','pos')])
 cls_mapobject.add_method('x', 'double', [])
 cls_mapobject.add_method('setX', None, [('double','x')])


### PR DESCRIPTION
* Some `\s` in a regular expression that was part of a string was causing the compiler to complain about invalid escape character.

* Shape enum was missing `Capsule`.