### PR TITLE
Objects dock: set text for Move Objects to Layer action

### DIFF
--- a/src/tiled/objectsdock.cpp
+++ b/src/tiled/objectsdock.cpp
@@ -173,6 +173,7 @@ void ObjectsDock::retranslateUi()
     mActionObjectProperties->setText(tr("Object Properties"));
     mActionMoveUp->setText(tr("Move Objects Up"));
     mActionMoveDown->setText(tr("Move Objects Down"));
+    mActionMoveToGroup->setText(tr("Move Objects to Layer"));
 
     updateActions();
 }


### PR DESCRIPTION
Resolve #4336 
The mActionMoveToGroup action was missing a setText() call in retranslateUi(), unlike all other toolbar actions in the same dock. This left the action with no visible name in the keyboard shortcuts dialog and no label for accessibility tools.

@bjorn kindly review and have a look.
Thanks