### PR TITLE
Appstream screenshot captions

### DIFF
--- a/org.mapeditor.Tiled.appdata.xml
+++ b/org.mapeditor.Tiled.appdata.xml
@@ -379,10 +379,12 @@
   <!-- GPL 2 by TMW -->
   <screenshot type="default" width="800" height="600">
     <image>https://www.mapeditor.org/img/appdata/screenshot_objects.png</image>
+    <caption>Editing map objects</caption>
   </screenshot>
   <!-- CC BY SA 3.0 By Clint Bellanger -->
   <screenshot width="800" height="600">
     <image>https://www.mapeditor.org/img/appdata/screenshot_terrain.png</image>
+    <caption>Using the terrain brush</caption>
   </screenshot>
  </screenshots>
  <kudos>

--- a/org.mapeditor.Tiled.appdata.xml
+++ b/org.mapeditor.Tiled.appdata.xml
@@ -379,12 +379,12 @@
   <!-- GPL 2 by TMW -->
   <screenshot type="default" width="800" height="600">
     <image>https://www.mapeditor.org/img/appdata/screenshot_objects.png</image>
-    <caption>Editing map objects</caption>
+    <caption>Annotate your map with objects</caption>
   </screenshot>
   <!-- CC BY SA 3.0 By Clint Bellanger -->
   <screenshot width="800" height="600">
     <image>https://www.mapeditor.org/img/appdata/screenshot_terrain.png</image>
-    <caption>Using the terrain brush</caption>
+    <caption>Automate placement of terrain transitions</caption>
   </screenshot>
  </screenshots>
  <kudos>


### PR DESCRIPTION
Fixes #3938 
Adds missing AppStream screenshot captions in ```org.mapeditor.Tiled.appdata.xml```to address the appstream-screenshot-missing-caption warning during Flatpak build validation.
