### PR TITLE
Fix Erase Terrain button not activating Terrain brush

### DIFF
--- a/src/tiled/wangdock.cpp
+++ b/src/tiled/wangdock.cpp
@@ -429,11 +429,10 @@ void WangDock::refreshCurrentWangColor()
 void WangDock::wangColorIndexPressed(const QModelIndex &index)
 {
     const int color = index.data(WangColorModel::WangColorIndexRole).toInt();
-    if (!color)
-        return;
-
-    WangColor *currentWangColor = mCurrentWangSet->colorAt(color).data();
-    mDocument->setCurrentObject(currentWangColor, mWangColorModel->tilesetDocument());
+    if (color) {
+        WangColor *currentWangColor = mCurrentWangSet->colorAt(color).data();
+        mDocument->setCurrentObject(currentWangColor, mWangColorModel->tilesetDocument());
+    }
 
     emit selectWangBrush();
 }


### PR DESCRIPTION
Closes #4177 

### Description:
A bug was reported where clicking Erase Terrain in the Terrain Sets dock cleared the current terrain selection but did not switch the active tool to the Terrain Brush. This left users painting with whatever tool was previously selected (Stamp Brush) and broke the expected workflow.

### Before:
In the video , you can see when `Erase Terrain` button was pressed , the current tool remained `Stamp Brush` instead of swtiching to `Terrain Brush`.


https://github.com/user-attachments/assets/cd797b69-4797-44d6-95ca-d8c480bbf0f5


### After:
After the change, clicking `Erase Terrain` always activates the `Terrain Brush` , restoring the intended behaviour.



https://github.com/user-attachments/assets/377e8190-ccd5-491c-a4bc-baeefc9a7726

