### PR TITLE
Add Erase Empty Tiles mode to Stamp Brush

### DIFF
--- a/src/tiled/abstracttilefilltool.cpp
+++ b/src/tiled/abstracttilefilltool.cpp
@@ -47,6 +47,8 @@ AbstractTileFillTool::AbstractTileFillTool(Id id,
 
     connect(mStampActions->random(), &QAction::toggled, this, &AbstractTileFillTool::randomChanged);
     connect(mStampActions->wangFill(), &QAction::toggled, this, &AbstractTileFillTool::wangFillChanged);
+    connect(mStampActions->eraseMode(), &QAction::toggled, this, &AbstractTileFillTool::setEraseMode);
+    connect(this, &AbstractTileFillTool::eraseModeChanged, mStampActions->eraseMode(), &QAction::setChecked);
 
     connect(mStampActions->flipHorizontal(), &QAction::triggered, this,
             [this] { emit stampChanged(mStamp.flipped(FlipHorizontally)); });
@@ -118,7 +120,8 @@ void AbstractTileFillTool::populateToolBar(QToolBar *toolBar)
 {
     mStampActions->populateToolBar(toolBar,
                                    mFillMethod == RandomFill,
-                                   mFillMethod == WangFill);
+                                   mFillMethod == WangFill,
+                                   mEraseMode);
 }
 
 void AbstractTileFillTool::setFillMethod(FillMethod fillMethod)
@@ -146,6 +149,21 @@ void AbstractTileFillTool::setWangSet(WangSet *wangSet)
     mWangSet = wangSet;
 
     invalidateRandomAndMissingCache();
+}
+
+void AbstractTileFillTool::setEraseMode(bool value)
+{
+    if (mEraseMode == value)
+        return;
+
+    mEraseMode = value;
+    emit eraseModeChanged(value);
+
+    // Don't need to recalculate fill region if there was no preview
+    if (!mPreviewMap)
+        return;
+
+    tilePositionChanged(tilePosition());
 }
 
 void AbstractTileFillTool::mapDocumentChanged(MapDocument *oldDocument,
@@ -227,6 +245,17 @@ void AbstractTileFillTool::updatePreview(const QRegion &fillRegion)
     }
     }
 
+    if (mEraseMode) {
+        if (preview->layerCount() == 0) {
+            for (Layer *layer : targetLayers()) {
+                if (TileLayer *tileLayer = layer->asTileLayer()) {
+                    preview->addLayer(new TileLayer(tileLayer->name(), mFillBounds.topLeft(), mFillBounds.size()));
+                }
+            }
+        }
+        erasePreview(*preview, fillRegion);
+    }
+
     preview->addTilesets(preview->usedTilesets());
 
     brushItem()->setMap(preview);
@@ -241,7 +270,15 @@ bool AbstractTileFillTool::applyPreview(const QString &text)
 
     auto undoStack = mapDocument()->undoStack();
     undoStack->beginMacro(text);
-    mapDocument()->paintTileLayers(*preview, false, &mMissingTilesets);
+
+    if (mEraseMode) {
+        const QRegion eraseRegion = preview->modifiedTileRegion();
+        if (!eraseRegion.isEmpty())
+            mapDocument()->eraseTileLayers(eraseRegion, false, false);
+    } else {
+        mapDocument()->paintTileLayers(*preview, false, &mMissingTilesets);
+    }
+
     undoStack->endMacro();
     return true;
 }

--- a/src/tiled/abstracttilefilltool.h
+++ b/src/tiled/abstracttilefilltool.h
@@ -74,6 +74,7 @@ public:
 
 public slots:
     void setFillMethod(FillMethod fillMethod);
+    void setEraseMode(bool value);
     void setWangSet(WangSet *wangSet);
 
 signals:
@@ -81,6 +82,7 @@ signals:
 
     void randomChanged(bool value);
     void wangFillChanged(bool value);
+    void eraseModeChanged(bool value);
 
 protected:
     void mapDocumentChanged(MapDocument *oldDocument,
@@ -102,6 +104,7 @@ protected:
     QVector<SharedTileset> mMissingTilesets;
 
     FillMethod mFillMethod;
+    bool mEraseMode = false;
     QRect mFillBounds;
 
     StampActions *mStampActions;

--- a/src/tiled/abstracttiletool.cpp
+++ b/src/tiled/abstracttiletool.cpp
@@ -289,6 +289,39 @@ QList<Layer *> AbstractTileTool::targetLayersForStamp(const TileStamp &stamp) co
     return layers;
 }
 
+void AbstractTileTool::erasePreview(TileLayer &tileLayer)
+{
+    erasePreview(tileLayer, tileLayer.modifiedRegion());
+}
+
+void AbstractTileTool::erasePreview(Map &preview)
+{
+    for (Layer *layer : preview.layers())
+        if (TileLayer *tileLayer = layer->asTileLayer())
+            erasePreview(*tileLayer);
+}
+
+void AbstractTileTool::erasePreview(TileLayer &tileLayer, const QRegion &region)
+{
+    for (const QRect &rect : region.translated(-tileLayer.position())) {
+        for (int y = rect.top(); y <= rect.bottom(); ++y) {
+            for (int x = rect.left(); x <= rect.right(); ++x) {
+                Cell cell = tileLayer.cellAt(x, y);
+                cell.setTile(nullptr);
+                cell.setChecked(true);
+                tileLayer.setCell(x, y, cell);
+            }
+        }
+    }
+}
+
+void AbstractTileTool::erasePreview(Map &preview, const QRegion &region)
+{
+    for (Layer *layer : preview.layers())
+        if (TileLayer *tileLayer = layer->asTileLayer())
+            erasePreview(*tileLayer, region);
+}
+
 void AbstractTileTool::setBrushVisible(bool visible)
 {
     if (mBrushVisible == visible)

--- a/src/tiled/abstracttiletool.h
+++ b/src/tiled/abstracttiletool.h
@@ -125,6 +125,11 @@ protected:
 
     QList<Layer *> targetLayersForStamp(const TileStamp &stamp) const;
 
+    static void erasePreview(TileLayer &tileLayer);
+    static void erasePreview(Map &preview);
+    static void erasePreview(TileLayer &tileLayer, const QRegion &region);
+    static void erasePreview(Map &preview, const QRegion &region);
+
 private:
     void setBrushVisible(bool visible);
 

--- a/src/tiled/bucketfilltool.cpp
+++ b/src/tiled/bucketfilltool.cpp
@@ -55,7 +55,7 @@ void BucketFillTool::tilePositionChanged(QPoint tilePos)
         return;
 
     // Skip filling if the stamp is empty and not in wangFill mode
-    if (mStamp.isEmpty() && mFillMethod != WangFill)
+    if (mStamp.isEmpty() && mFillMethod != WangFill && !mEraseMode)
         return;
 
     // Make sure that a tile layer is selected
@@ -87,12 +87,14 @@ void BucketFillTool::tilePositionChanged(QPoint tilePos)
             // If not holding shift, a region is computed from the current pos
             bool computeRegion = true;
 
-            if (!mMouseDown)
-                mMatchCells.clear();
+            if (!mEraseMode) {
+                if (!mMouseDown)
+                    mMatchCells.clear();
 
-            const auto matchCell = regionComputer.cellAt(tilePos);
-            if (!mMatchCells.contains(matchCell))
-                mMatchCells.append(matchCell);
+                const auto matchCell = regionComputer.cellAt(tilePos);
+                if (!mMatchCells.contains(matchCell))
+                    mMatchCells.append(matchCell);
+            }
 
             // If the stamp is a single layer with a single tile, ignore that tile when making the region
             if (mFillMethod != WangFill && mStamp.variations().size() == 1 && mMatchCells.size() == 1) {
@@ -107,6 +109,8 @@ void BucketFillTool::tilePositionChanged(QPoint tilePos)
 
             if (computeRegion) {
                 const auto condition = [&](const Cell &cell) {
+                    if (mEraseMode)
+                        return !cell.isEmpty();
                     return mMatchCells.contains(cell);
                 };
                 mFillRegion = regionComputer.computePaintableFillRegion(tilePos, condition);

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -266,6 +266,9 @@ MapEditor::MapEditor(QObject *parent)
     connect(mStampBrush, &StampBrush::wangFillChanged, this, &MapEditor::setWangFill);
     connect(mBucketFillTool, &BucketFillTool::wangFillChanged, this, &MapEditor::setWangFill);
     connect(mShapeFillTool, &ShapeFillTool::wangFillChanged, this, &MapEditor::setWangFill);
+    connect(mStampBrush, &StampBrush::eraseModeChanged, this, &MapEditor::setEraseMode);
+    connect(mBucketFillTool, &BucketFillTool::eraseModeChanged, this, &MapEditor::setEraseMode);
+    connect(mShapeFillTool, &ShapeFillTool::eraseModeChanged, this, &MapEditor::setEraseMode);
 
     connect(mWangDock, &WangDock::currentWangSetChanged,
             mBucketFillTool, &BucketFillTool::setWangSet);
@@ -765,6 +768,13 @@ void MapEditor::setWangFill(bool value)
 
     mBucketFillTool->setFillMethod(fillMethod);
     mShapeFillTool->setFillMethod(fillMethod);
+}
+
+void MapEditor::setEraseMode(bool value)
+{
+    mStampBrush->setEraseMode(value);
+    mBucketFillTool->setEraseMode(value);
+    mShapeFillTool->setEraseMode(value);
 }
 
 /**

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -146,6 +146,7 @@ private:
 
     void setRandom(bool value);
     void setWangFill(bool value);
+    void setEraseMode(bool value);
 
     void setStamp(const TileStamp &stamp);
 

--- a/src/tiled/stampactions.cpp
+++ b/src/tiled/stampactions.cpp
@@ -31,6 +31,7 @@ StampActions::StampActions(QObject *parent) : QObject(parent)
 {
     QIcon diceIcon(QLatin1String(":images/24/dice.png"));
     QIcon wangIcon(QLatin1String(":images/24/terrain.png"));
+    QIcon eraseEmptyIcon(QLatin1String(":images/22/stock-tool-eraser.png"));
     QIcon flipHorizontalIcon(QLatin1String(":images/24/flip-horizontal.png"));
     QIcon flipVerticalIcon(QLatin1String(":images/24/flip-vertical.png"));
     QIcon rotateLeftIcon(QLatin1String(":images/24/rotate-left.png"));
@@ -51,6 +52,10 @@ StampActions::StampActions(QObject *parent) : QObject(parent)
     mWangFill->setIcon(wangIcon);
     mWangFill->setCheckable(true);
 
+    mEraseEmpty = new QAction(this);
+    mEraseEmpty->setIcon(eraseEmptyIcon);
+    mEraseEmpty->setCheckable(true);
+
     mFlipHorizontal = new QAction(this);
     mFlipHorizontal->setIcon(flipHorizontalIcon);
     mFlipHorizontal->setShortcut(Qt::Key_X);
@@ -69,6 +74,7 @@ StampActions::StampActions(QObject *parent) : QObject(parent)
 
     ActionManager::registerAction(mRandom, "RandomMode");
     ActionManager::registerAction(mWangFill, "WangFillMode");
+    ActionManager::registerAction(mEraseEmpty, "EraseEmptyMode");
     ActionManager::registerAction(mFlipHorizontal, "FlipHorizontal");
     ActionManager::registerAction(mFlipVertical, "FlipVertical");
     ActionManager::registerAction(mRotateLeft, "RotateLeft");
@@ -82,6 +88,7 @@ void StampActions::setEnabled(bool enabled)
 {
     mRandom->setEnabled(enabled);
     mWangFill->setEnabled(enabled);
+    mEraseEmpty->setEnabled(enabled);
     mFlipHorizontal->setEnabled(enabled);
     mFlipVertical->setEnabled(enabled);
     mRotateLeft->setEnabled(enabled);
@@ -92,18 +99,21 @@ void StampActions::languageChanged()
 {
     mRandom->setText(tr("Random Mode"));
     mWangFill->setText(tr("Terrain Fill Mode"));
+    mEraseEmpty->setText(tr("Erase Empty Tiles"));
     mFlipHorizontal->setText(tr("Flip Horizontally"));
     mFlipVertical->setText(tr("Flip Vertically"));
     mRotateLeft->setText(tr("Rotate Left"));
     mRotateRight->setText(tr("Rotate Right"));
 }
 
-void StampActions::populateToolBar(QToolBar *toolBar, bool isRandom, bool isWangFill)
+void StampActions::populateToolBar(QToolBar *toolBar, bool isRandom, bool isWangFill, bool isErasing)
 {
     mRandom->setChecked(isRandom);
     mWangFill->setChecked(isWangFill);
+    mEraseEmpty->setChecked(isErasing);
     toolBar->addAction(mRandom);
     toolBar->addAction(mWangFill);
+    toolBar->addAction(mEraseEmpty);
     toolBar->addSeparator();
     toolBar->addAction(mFlipHorizontal);
     toolBar->addAction(mFlipVertical);

--- a/src/tiled/stampactions.cpp
+++ b/src/tiled/stampactions.cpp
@@ -31,7 +31,7 @@ StampActions::StampActions(QObject *parent) : QObject(parent)
 {
     QIcon diceIcon(QLatin1String(":images/24/dice.png"));
     QIcon wangIcon(QLatin1String(":images/24/terrain.png"));
-    QIcon eraseEmptyIcon(QLatin1String(":images/22/stock-tool-eraser.png"));
+    QIcon eraseModeIcon(QLatin1String(":images/22/stock-tool-eraser.png"));
     QIcon flipHorizontalIcon(QLatin1String(":images/24/flip-horizontal.png"));
     QIcon flipVerticalIcon(QLatin1String(":images/24/flip-vertical.png"));
     QIcon rotateLeftIcon(QLatin1String(":images/24/rotate-left.png"));
@@ -52,9 +52,9 @@ StampActions::StampActions(QObject *parent) : QObject(parent)
     mWangFill->setIcon(wangIcon);
     mWangFill->setCheckable(true);
 
-    mEraseEmpty = new QAction(this);
-    mEraseEmpty->setIcon(eraseEmptyIcon);
-    mEraseEmpty->setCheckable(true);
+    mEraseMode = new QAction(this);
+    mEraseMode->setIcon(eraseModeIcon);
+    mEraseMode->setCheckable(true);
 
     mFlipHorizontal = new QAction(this);
     mFlipHorizontal->setIcon(flipHorizontalIcon);
@@ -74,7 +74,7 @@ StampActions::StampActions(QObject *parent) : QObject(parent)
 
     ActionManager::registerAction(mRandom, "RandomMode");
     ActionManager::registerAction(mWangFill, "WangFillMode");
-    ActionManager::registerAction(mEraseEmpty, "EraseEmptyMode");
+    ActionManager::registerAction(mEraseMode, "EraseMode");
     ActionManager::registerAction(mFlipHorizontal, "FlipHorizontal");
     ActionManager::registerAction(mFlipVertical, "FlipVertical");
     ActionManager::registerAction(mRotateLeft, "RotateLeft");
@@ -88,7 +88,7 @@ void StampActions::setEnabled(bool enabled)
 {
     mRandom->setEnabled(enabled);
     mWangFill->setEnabled(enabled);
-    mEraseEmpty->setEnabled(enabled);
+    mEraseMode->setEnabled(enabled);
     mFlipHorizontal->setEnabled(enabled);
     mFlipVertical->setEnabled(enabled);
     mRotateLeft->setEnabled(enabled);
@@ -99,7 +99,7 @@ void StampActions::languageChanged()
 {
     mRandom->setText(tr("Random Mode"));
     mWangFill->setText(tr("Terrain Fill Mode"));
-    mEraseEmpty->setText(tr("Erase Empty Tiles"));
+    mEraseMode->setText(tr("Erase Mode"));
     mFlipHorizontal->setText(tr("Flip Horizontally"));
     mFlipVertical->setText(tr("Flip Vertically"));
     mRotateLeft->setText(tr("Rotate Left"));
@@ -110,10 +110,10 @@ void StampActions::populateToolBar(QToolBar *toolBar, bool isRandom, bool isWang
 {
     mRandom->setChecked(isRandom);
     mWangFill->setChecked(isWangFill);
-    mEraseEmpty->setChecked(isErasing);
+    mEraseMode->setChecked(isErasing);
     toolBar->addAction(mRandom);
     toolBar->addAction(mWangFill);
-    toolBar->addAction(mEraseEmpty);
+    toolBar->addAction(mEraseMode);
     toolBar->addSeparator();
     toolBar->addAction(mFlipHorizontal);
     toolBar->addAction(mFlipVertical);

--- a/src/tiled/stampactions.h
+++ b/src/tiled/stampactions.h
@@ -38,10 +38,11 @@ public:
 
     void languageChanged();
 
-    void populateToolBar(QToolBar *toolBar, bool isRandom, bool isWangFill);
+    void populateToolBar(QToolBar *toolBar, bool isRandom, bool isWangFill, bool isErasing = false);
 
     QAction *random() const { return mRandom; }
     QAction *wangFill() const { return mWangFill; }
+    QAction *eraseEmpty() const { return mEraseEmpty; }
     QAction *flipHorizontal() const { return mFlipHorizontal; }
     QAction *flipVertical() const { return mFlipVertical; }
     QAction *rotateLeft() const { return mRotateLeft; }
@@ -50,6 +51,7 @@ public:
 private:
     QAction *mRandom;
     QAction *mWangFill;
+    QAction *mEraseEmpty;
     QAction *mFlipHorizontal;
     QAction *mFlipVertical;
     QAction *mRotateLeft;

--- a/src/tiled/stampactions.h
+++ b/src/tiled/stampactions.h
@@ -42,7 +42,7 @@ public:
 
     QAction *random() const { return mRandom; }
     QAction *wangFill() const { return mWangFill; }
-    QAction *eraseEmpty() const { return mEraseEmpty; }
+    QAction *eraseMode() const { return mEraseMode; }
     QAction *flipHorizontal() const { return mFlipHorizontal; }
     QAction *flipVertical() const { return mFlipVertical; }
     QAction *rotateLeft() const { return mRotateLeft; }
@@ -51,7 +51,7 @@ public:
 private:
     QAction *mRandom;
     QAction *mWangFill;
-    QAction *mEraseEmpty;
+    QAction *mEraseMode;
     QAction *mFlipHorizontal;
     QAction *mFlipVertical;
     QAction *mRotateLeft;

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -54,6 +54,8 @@ StampBrush::StampBrush(QObject *parent)
 
     connect(mStampActions->random(), &QAction::toggled, this, &StampBrush::randomChanged);
     connect(mStampActions->wangFill(), &QAction::toggled, this, &StampBrush::wangFillChanged);
+    connect(mStampActions->eraseEmpty(), &QAction::toggled, this, &StampBrush::setEraseEmpty);
+    connect(this, &StampBrush::eraseEmptyChanged, mStampActions->eraseEmpty(), &QAction::setChecked);
 
     connect(mStampActions->flipHorizontal(), &QAction::triggered, this,
             [this] { emit stampChanged(mStamp.flipped(FlipHorizontally)); });
@@ -323,7 +325,7 @@ void StampBrush::setStamp(const TileStamp &stamp)
 
 void StampBrush::populateToolBar(QToolBar *toolBar)
 {
-    mStampActions->populateToolBar(toolBar, mIsRandom, mIsWangFill);
+    mStampActions->populateToolBar(toolBar, mIsRandom, mIsWangFill, mIsEraseEmpty);
 }
 
 void StampBrush::setWangSet(WangSet *wangSet)
@@ -392,6 +394,25 @@ void StampBrush::doPaint(int flags, QHash<TileLayer*, QRegion> *paintedRegions)
     SharedMap preview = mPreviewMap;
     if (!preview)
         return;
+    /** 
+    * when erasing empty tiles, mark all empty cells in the preview as
+    *
+    * checked so that modifiedTileRegion() includes them in the paint
+    *
+    * region, causing them to overwrite existing tiles on the target layer.
+    */
+    if (mIsEraseEmpty) {
+        for (auto layer : preview->tileLayers()) {
+            auto tileLayer = static_cast<TileLayer*>(layer);
+            for (auto it = tileLayer->begin(); it != tileLayer->end(); ++it) {
+                if (it.value().isEmpty()) {
+                    Cell cell = it.value();
+                    cell.setChecked(true);
+                    tileLayer->setCell(it.key().x(), it.key().y(), cell);
+                }
+            }
+        }
+    }
 
     mapDocument()->paintTileLayers(*preview,
                                    (flags & Mergeable) == Mergeable,
@@ -560,7 +581,15 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
             if (regionCache.contains(map)) {
                 stampRegion = regionCache.value(map);
             } else {
-                stampRegion = map->modifiedTileRegion();
+                /** 
+                * When erasing empty tiles, the full stamp bounds is the
+                *
+                * region, not just the non-empty tile positions.
+                */
+                if (mIsEraseEmpty)
+                    stampRegion = map->tileBoundingRect();
+                else
+                    stampRegion = map->modifiedTileRegion();
                 regionCache.insert(map, stampRegion);
             }
 
@@ -668,8 +697,17 @@ void StampBrush::updatePreview(QPoint tilePos)
             break;
         }
 
-        if (mPreviewMap)
-            tileRegion = mPreviewMap->modifiedTileRegion();
+        if (mPreviewMap) {
+            /** 
+            * When erasing empty tiles, show the full stamp bounds so the
+            *
+            * user can see where empty cells will erase.
+            */
+            if (mIsEraseEmpty)
+                tileRegion = mPreviewMap->tileBoundingRect();
+            else
+                tileRegion = mPreviewMap->modifiedTileRegion();
+        }
 
         if (tileRegion.isEmpty())
             tileRegion = QRect(tilePos, tilePos);
@@ -705,6 +743,17 @@ void StampBrush::setWangFill(bool value)
         mIsRandom = false;
         mStampActions->random()->setChecked(false);
     }
+
+    updatePreview();
+}
+
+void StampBrush::setEraseEmpty(bool value)
+{
+    if (mIsEraseEmpty == value)
+        return;
+
+    mIsEraseEmpty = value;
+    emit eraseEmptyChanged(value);
 
     updatePreview();
 }

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -54,8 +54,8 @@ StampBrush::StampBrush(QObject *parent)
 
     connect(mStampActions->random(), &QAction::toggled, this, &StampBrush::randomChanged);
     connect(mStampActions->wangFill(), &QAction::toggled, this, &StampBrush::wangFillChanged);
-    connect(mStampActions->eraseEmpty(), &QAction::toggled, this, &StampBrush::setEraseEmpty);
-    connect(this, &StampBrush::eraseEmptyChanged, mStampActions->eraseEmpty(), &QAction::setChecked);
+    connect(mStampActions->eraseMode(), &QAction::toggled, this, &StampBrush::setEraseMode);
+    connect(this, &StampBrush::eraseModeChanged, mStampActions->eraseMode(), &QAction::setChecked);
 
     connect(mStampActions->flipHorizontal(), &QAction::triggered, this,
             [this] { emit stampChanged(mStamp.flipped(FlipHorizontally)); });
@@ -325,7 +325,7 @@ void StampBrush::setStamp(const TileStamp &stamp)
 
 void StampBrush::populateToolBar(QToolBar *toolBar)
 {
-    mStampActions->populateToolBar(toolBar, mIsRandom, mIsWangFill, mIsEraseEmpty);
+    mStampActions->populateToolBar(toolBar, mIsRandom, mIsWangFill, mEraseMode);
 }
 
 void StampBrush::setWangSet(WangSet *wangSet)
@@ -395,7 +395,7 @@ void StampBrush::doPaint(int flags, QHash<TileLayer*, QRegion> *paintedRegions)
     if (!preview)
         return;
 
-    if (mIsEraseEmpty) {
+    if (mEraseMode) {
         const QRegion eraseRegion = preview->modifiedTileRegion();
         if (!eraseRegion.isEmpty())
             mapDocument()->eraseTileLayers(eraseRegion,
@@ -442,7 +442,7 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
 {
     mPreviewMap.clear();
 
-    if (mStamp.isEmpty() && !mIsWangFill)
+    if (mStamp.isEmpty() && !mIsWangFill && !mEraseMode)
         return;
 
     if (mIsRandom) {
@@ -477,6 +477,10 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
 
         preview->addLayer(std::move(previewLayer));
         preview->addTilesets(preview->usedTilesets());
+
+        if (mEraseMode)
+            erasePreview(*preview, bounds);
+
         mPreviewMap = preview;
     } else if (mIsWangFill) {
         if (!mWangSet)
@@ -507,6 +511,9 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
         wangFiller.setRegion(paintedRegion);
         wangFiller.apply(*previewLayer);
 
+        if (mEraseMode)
+            erasePreview(*previewLayer, paintedRegion);
+
         preview->addLayer(std::move(previewLayer));
         preview->addTileset(mWangSet->tileset()->sharedFromThis());
         mPreviewMap = preview;
@@ -515,82 +522,88 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
         QVector<PaintOperation> operations;
         QHash<const Map *, QRegion> regionCache;
         QHash<const Map *, Map *> shiftedCopies;
-        const auto randomVariations = mStamp.randomVariations();
-        const Map::StaggerAxis mapStaggerAxis = mapDocument()->map()->staggerAxis();
-        const Map::StaggerIndex mapStaggerIndex = mapDocument()->map()->staggerIndex();
 
-        mMissingTilesets.clear();
+        if (mStamp.isEmpty()) {
+            for (const QPoint &p : points)
+                paintedRegion += QRect(p, p);
+        } else {
+            const auto randomVariations = mStamp.randomVariations();
+            const Map::StaggerAxis mapStaggerAxis = mapDocument()->map()->staggerAxis();
+            const Map::StaggerIndex mapStaggerIndex = mapDocument()->map()->staggerIndex();
 
-        // Pick a random variation for the first position
-        Map *variation = randomVariations.pick();
-        mapDocument()->unifyTilesets(*variation, mMissingTilesets);
+            mMissingTilesets.clear();
 
-        for (const QPoint &p : points) {
-            Map *map = variation;
+            // Pick a random variation for the first position
+            Map *variation = randomVariations.pick();
+            mapDocument()->unifyTilesets(*variation, mMissingTilesets);
 
-            // if staggered map, makes sure stamp stays the same
-            if (mapDocument()->map()->isStaggered()
-                    && ((mapStaggerAxis == Map::StaggerY) ? map->height() > 1 : map->width() > 1)) {
+            for (const QPoint &p : points) {
+                Map *map = variation;
 
-                const Map::StaggerIndex stampStaggerIndex = map->staggerIndex();
+                // if staggered map, makes sure stamp stays the same
+                if (mapDocument()->map()->isStaggered()
+                        && ((mapStaggerAxis == Map::StaggerY) ? map->height() > 1 : map->width() > 1)) {
 
-                if (mapStaggerAxis == Map::StaggerY) {
-                    bool topIsOdd = (p.y() - map->height() / 2) & 1;
+                    const Map::StaggerIndex stampStaggerIndex = map->staggerIndex();
 
-                    if ((stampStaggerIndex == mapStaggerIndex) == topIsOdd) {
-                        Map *shiftedMap = shiftedCopies.value(map);
-                        if (!shiftedMap) {
-                            shiftedMap = map->clone().release();
-                            shiftedCopies.insert(map, shiftedMap);
+                    if (mapStaggerAxis == Map::StaggerY) {
+                        bool topIsOdd = (p.y() - map->height() / 2) & 1;
 
-                            LayerIterator it(shiftedMap, Layer::TileLayerType);
-                            while (auto tileLayer = static_cast<TileLayer*>(it.next()))
-                                shiftRows(tileLayer, stampStaggerIndex);
+                        if ((stampStaggerIndex == mapStaggerIndex) == topIsOdd) {
+                            Map *shiftedMap = shiftedCopies.value(map);
+                            if (!shiftedMap) {
+                                shiftedMap = map->clone().release();
+                                shiftedCopies.insert(map, shiftedMap);
+
+                                LayerIterator it(shiftedMap, Layer::TileLayerType);
+                                while (auto tileLayer = static_cast<TileLayer*>(it.next()))
+                                    shiftRows(tileLayer, stampStaggerIndex);
+                            }
+                            map = shiftedMap;
                         }
-                        map = shiftedMap;
-                    }
-                } else {
-                    bool leftIsOdd = (p.x() - map->width() / 2) & 1;
+                    } else {
+                        bool leftIsOdd = (p.x() - map->width() / 2) & 1;
 
-                    if ((stampStaggerIndex == mapStaggerIndex) == leftIsOdd) {
-                        Map *shiftedMap = shiftedCopies.value(map);
-                        if (!shiftedMap) {
-                            shiftedMap = map->clone().release();
-                            shiftedCopies.insert(map, shiftedMap);
+                        if ((stampStaggerIndex == mapStaggerIndex) == leftIsOdd) {
+                            Map *shiftedMap = shiftedCopies.value(map);
+                            if (!shiftedMap) {
+                                shiftedMap = map->clone().release();
+                                shiftedCopies.insert(map, shiftedMap);
 
-                            LayerIterator it(shiftedMap, Layer::TileLayerType);
-                            while (auto tileLayer = static_cast<TileLayer*>(it.next()))
-                                shiftColumns(tileLayer, stampStaggerIndex);
+                                LayerIterator it(shiftedMap, Layer::TileLayerType);
+                                while (auto tileLayer = static_cast<TileLayer*>(it.next()))
+                                    shiftColumns(tileLayer, stampStaggerIndex);
+                            }
+                            map = shiftedMap;
                         }
-                        map = shiftedMap;
                     }
                 }
-            }
 
-            QRegion stampRegion;
-            if (regionCache.contains(map)) {
-                stampRegion = regionCache.value(map);
-            } else {
-                stampRegion = map->modifiedTileRegion();
-                regionCache.insert(map, stampRegion);
-            }
+                QRegion stampRegion;
+                if (regionCache.contains(map)) {
+                    stampRegion = regionCache.value(map);
+                } else {
+                    stampRegion = map->modifiedTileRegion();
+                    regionCache.insert(map, stampRegion);
+                }
 
-            QPoint centered(p.x() - map->width() / 2,
-                            p.y() - map->height() / 2);
+                QPoint centered(p.x() - map->width() / 2,
+                                p.y() - map->height() / 2);
 
-            const QRegion region = stampRegion.translated(centered.x(),
-                                                          centered.y());
-            if (!paintedRegion.intersects(region)) {
-                paintedRegion += region;
+                const QRegion region = stampRegion.translated(centered.x(),
+                                                              centered.y());
+                if (!paintedRegion.intersects(region)) {
+                    paintedRegion += region;
 
-                PaintOperation op = { centered, map };
-                operations.append(op);
+                    PaintOperation op = { centered, map };
+                    operations.append(op);
 
-                // Pick a potentially new random variation for the next position
-                Map *newVariation = randomVariations.pick();
-                if (variation != newVariation) {
-                    variation = newVariation;
-                    mapDocument()->unifyTilesets(*variation, mMissingTilesets);
+                    // Pick a potentially new random variation for the next position
+                    Map *newVariation = randomVariations.pick();
+                    if (variation != newVariation) {
+                        variation = newVariation;
+                        mapDocument()->unifyTilesets(*variation, mMissingTilesets);
+                    }
                 }
             }
         }
@@ -602,6 +615,11 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
         mapParameters.height = bounds.height();
         mapParameters.infinite = false;
         SharedMap preview = SharedMap::create(mapParameters);
+
+        if (mEraseMode && operations.isEmpty()) {
+            if (TileLayer *tileLayer = currentTileLayer())
+                preview->addLayer(new TileLayer(tileLayer->name(), bounds.topLeft(), bounds.size()));
+        }
 
         QHash<QString, QList<TileLayer*>> targetLayersByName;
 
@@ -629,6 +647,9 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &points)
         }
 
         qDeleteAll(shiftedCopies);
+
+        if (mEraseMode)
+            erasePreview(*preview, paintedRegion);
 
         preview->addTilesets(preview->usedTilesets());
         mPreviewMap = preview;
@@ -720,13 +741,13 @@ void StampBrush::setWangFill(bool value)
     updatePreview();
 }
 
-void StampBrush::setEraseEmpty(bool value)
+void StampBrush::setEraseMode(bool value)
 {
-    if (mIsEraseEmpty == value)
+    if (mEraseMode == value)
         return;
 
-    mIsEraseEmpty = value;
-    emit eraseEmptyChanged(value);
+    mEraseMode = value;
+    emit eraseModeChanged(value);
 
     updatePreview();
 }

--- a/src/tiled/stampbrush.h
+++ b/src/tiled/stampbrush.h
@@ -73,6 +73,7 @@ public:
 public slots:
     void setRandom(bool value);
     void setWangFill(bool value);
+    void setEraseEmpty(bool value);
     void setWangSet(WangSet *wangSet);
 
 signals:
@@ -86,6 +87,8 @@ signals:
     void randomChanged(bool value);
 
     void wangFillChanged(bool value);
+
+    void eraseEmptyChanged(bool value);
 
 protected:
     void tilePositionChanged(QPoint tilePos) override;
@@ -160,6 +163,8 @@ private:
 
     bool mIsWangFill = false;
     WangSet *mWangSet = nullptr;
+
+    bool mIsEraseEmpty = false;
 
     bool mRandomCacheValid = true;
     void updateRandomList();

--- a/src/tiled/stampbrush.h
+++ b/src/tiled/stampbrush.h
@@ -73,7 +73,7 @@ public:
 public slots:
     void setRandom(bool value);
     void setWangFill(bool value);
-    void setEraseEmpty(bool value);
+    void setEraseMode(bool value);
     void setWangSet(WangSet *wangSet);
 
 signals:
@@ -88,7 +88,7 @@ signals:
 
     void wangFillChanged(bool value);
 
-    void eraseEmptyChanged(bool value);
+    void eraseModeChanged(bool value);
 
 protected:
     void tilePositionChanged(QPoint tilePos) override;
@@ -164,7 +164,7 @@ private:
     bool mIsWangFill = false;
     WangSet *mWangSet = nullptr;
 
-    bool mIsEraseEmpty = false;
+    bool mEraseMode = false;
 
     bool mRandomCacheValid = true;
     void updateRandomList();


### PR DESCRIPTION
Ref https://github.com/mapeditor/tiled/issues/3643#issuecomment-3938748431

This PR adds an optional Erase Empty Tiles mode to the Stamp Brush.