### PR TITLE
Avoid assertion on shutdown in debug builds

### DIFF
--- a/src/tiled/pannableviewhelper.cpp
+++ b/src/tiled/pannableviewhelper.cpp
@@ -64,7 +64,7 @@ private:
 
     bool eventFilter(QObject *watched, QEvent *event) override
     {
-        if (watched == MainWindow::instance()) {
+        if (watched == MainWindow::maybeInstance()) {
             if (event->type() == QEvent::WinIdChange)
                 installOnWindowHandle();
             return false;


### PR DESCRIPTION
When the MainWindow is destroyed, SpaceBarEventFilter gets called after MainWindow::mInstance has been set to nullptr.

Small mistake I made in b979729bab3edf06e29b63a092cf8defe6fb6186.