### PR TITLE
Add texture filtering preference (#3801)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Added texture filtering preference: Auto, Nearest Neighbor, Smooth (#3801)
 * Added 'Collapse All' action and 'Only Expand to Current' mode to Project view (with rhythmcache, #4346)
 
 ### Tiled 1.12.0 (13 March 2026)

--- a/src/tiled/exportasimagedialog.cpp
+++ b/src/tiled/exportasimagedialog.cpp
@@ -109,7 +109,7 @@ ExportAsImageDialog::~ExportAsImageDialog()
 
 static bool smoothTransform(qreal scale)
 {
-    return scale != qreal(1) && scale < qreal(2);
+    return Preferences::instance()->smoothTransform(scale != qreal(1) && scale < qreal(2));
 }
 
 void ExportAsImageDialog::accept()
@@ -170,7 +170,9 @@ void ExportAsImageDialog::accept()
         renderFlags |= MiniMapRenderer::DrawGrid;
     if (session::includeBackgroundColor)
         renderFlags |= MiniMapRenderer::DrawBackground;
-    if (session::useCurrentScale && smoothTransform(mCurrentScale))
+
+    if (Preferences::instance()->smoothTransform(session::useCurrentScale
+                                                  && smoothTransform(mCurrentScale)))
         renderFlags |= MiniMapRenderer::SmoothPixmapTransform;
 
     MapRenderer *renderer = mMapDocument->renderer();

--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -101,6 +101,14 @@ MapView::MapView(QWidget *parent)
     connect(verticalScrollBar(), &QAbstractSlider::rangeChanged, this, &MapView::updateViewRect);
 
     connect(mZoomable, &Zoomable::scaleChanged, this, &MapView::adjustScale);
+    setRenderHint(QPainter::SmoothPixmapTransform, mZoomable->smoothTransform());
+
+    connect(Preferences::instance(), &Preferences::textureFilteringChanged,
+            this, [this] {
+        setRenderHint(QPainter::SmoothPixmapTransform,
+                      mZoomable->smoothTransform());
+        viewport()->update();
+    });
 
     connect(mPanningDriver, &TileAnimationDriver::update, this, &MapView::updatePanning);
 

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -259,6 +259,30 @@ void Preferences::setObjectLabelVisibility(ObjectLabelVisiblity visibility)
     emit objectLabelVisibilityChanged(visibility);
 }
 
+Preferences::TextureFiltering Preferences::textureFiltering() const
+{
+    return static_cast<TextureFiltering>(get<int>("Interface/TextureFiltering", TextureFilteringAuto));
+}
+
+void Preferences::setTextureFiltering(TextureFiltering filtering)
+{
+    setValue(QLatin1String("Interface/TextureFiltering"), filtering);
+    emit textureFilteringChanged(filtering);
+}
+
+bool Preferences::smoothTransform(bool scaleIsSmooth) const
+{
+    switch (textureFiltering()) {
+    case TextureFilteringNearest:
+        return false;
+    case TextureFilteringSmooth:
+        return true;
+    case TextureFilteringAuto:
+    default:
+        return scaleIsSmooth;
+    }
+}
+
 bool Preferences::labelForHoveredObject() const
 {
     return get("Interface/LabelForHoveredObject", false);

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -85,8 +85,17 @@ public:
         AllObjectLabels
     };
 
+    enum TextureFiltering {
+        TextureFilteringAuto,
+        TextureFilteringNearest,
+        TextureFilteringSmooth
+    };
+
     ObjectLabelVisiblity objectLabelVisibility() const;
     void setObjectLabelVisibility(ObjectLabelVisiblity visibility);
+    TextureFiltering textureFiltering() const;
+    void setTextureFiltering(TextureFiltering filtering);
+    bool smoothTransform(bool scaleIsSmooth) const;
 
     bool labelForHoveredObject() const;
     void setLabelForHoveredObject(bool enabled);
@@ -237,6 +246,7 @@ signals:
     void highlightHoveredObjectChanged(bool highlight);
     void showTilesetGridChanged(bool showTilesetGrid);
     void objectLabelVisibilityChanged(ObjectLabelVisiblity);
+    void textureFilteringChanged(TextureFiltering);
     void labelForHoveredObjectChanged(bool enabled);
 
     void applicationStyleChanged(ApplicationStyle);

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -71,6 +71,9 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
     mUi->objectSelectionBehaviorCombo->addItems({ tr("Select From Any Layer"),
                                                   tr("Prefer Selected Layers"),
                                                   tr("Selected Layers Only") });
+    mUi->textureFilteringCombo->addItems({ tr("Auto"),
+                                           tr("Nearest Neighbor"),
+                                           tr("Smooth") });
 
     auto *pluginListModel = new PluginListModel(this);
     auto *pluginProxyModel = new QSortFilterProxyModel(this);
@@ -95,6 +98,10 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             preferences, &Preferences::setExportOnSave);
     connect(mUi->naturalSorting, &QCheckBox::toggled,
             preferences, &Preferences::setNaturalSorting);
+    connect(mUi->textureFilteringCombo, &QComboBox::currentIndexChanged,
+            this, [] (int index) {
+        Preferences::instance()->setTextureFiltering(static_cast<Preferences::TextureFiltering>(index));
+    });
 
     connect(mUi->embedTilesets, &QCheckBox::toggled, preferences, [preferences] (bool value) {
         preferences->setExportOption(Preferences::EmbedTilesets, value);
@@ -238,6 +245,7 @@ void PreferencesDialog::fromPreferences()
     mUi->autoScrolling->setChecked(MapView::ourAutoScrollingEnabled);
     mUi->smoothScrolling->setChecked(MapView::ourSmoothScrollingEnabled);
     mUi->duplicateAddsCopy->setChecked(Editor::duplicateAddsCopy);
+    mUi->textureFilteringCombo->setCurrentIndex(prefs->textureFiltering());
 
     const QFont customFont = prefs->customFont();
     mUi->fontGroupBox->setChecked(prefs->useCustomFont());
@@ -286,6 +294,9 @@ void PreferencesDialog::retranslateUi()
     mUi->objectSelectionBehaviorCombo->setItemText(0, tr("Select From Any Layer"));
     mUi->objectSelectionBehaviorCombo->setItemText(1, tr("Prefer Selected Layers"));
     mUi->objectSelectionBehaviorCombo->setItemText(3, tr("Selected Layers Only"));
+    mUi->textureFilteringCombo->setItemText(0, tr("Auto"));
+    mUi->textureFilteringCombo->setItemText(1, tr("Nearest Neighbor"));
+    mUi->textureFilteringCombo->setItemText(2, tr("Smooth"));
 }
 
 void PreferencesDialog::styleComboChanged()

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -273,6 +273,19 @@
             </property>
            </widget>
           </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="textureFilteringLabel">
+            <property name="text">
+             <string>Texture filtering:</string>
+            </property>
+            <property name="buddy">
+             <cstring>textureFilteringCombo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1" colspan="2">
+           <widget class="QComboBox" name="textureFilteringCombo"/>
+          </item>
           <item row="4" column="1" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
@@ -703,6 +716,7 @@
   <tabstop>objectLineWidth</tabstop>
   <tabstop>openGL</tabstop>
   <tabstop>naturalSorting</tabstop>
+  <tabstop>textureFilteringCombo</tabstop>
   <tabstop>objectSelectionBehaviorCombo</tabstop>
   <tabstop>preciseTileObjectSelection</tabstop>
   <tabstop>wheelZoomsByDefault</tabstop>

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -322,6 +322,8 @@ TilesetView::TilesetView(QWidget *parent)
 
     connect(prefs, &Preferences::showTilesetGridChanged,
             this, &TilesetView::setDrawGrid);
+    connect(prefs, &Preferences::textureFilteringChanged,
+            this, [this] { viewport()->update(); });
 
     connect(StyleHelper::instance(), &StyleHelper::styleApplied,
             this, &TilesetView::updateBackgroundColor);

--- a/src/tiled/wangcolorview.cpp
+++ b/src/tiled/wangcolorview.cpp
@@ -20,6 +20,7 @@
 
 #include "wangcolorview.h"
 
+#include "preferences.h"
 #include "utils.h"
 #include "wangcolormodel.h"
 
@@ -64,7 +65,8 @@ void WangColorDelegate::initStyleOption(QStyleOptionViewItem *option, const QMod
         const qreal scale = std::max(scaleX, scaleY);
         const QSizeF targetSize = size * scale;
 
-        painter.setRenderHint(QPainter::SmoothPixmapTransform, scale < 1.0);
+        painter.setRenderHint(QPainter::SmoothPixmapTransform,
+                              Preferences::instance()->smoothTransform(scale < 1.0));
         painter.drawPixmap(QRectF(decorationSize.width() - targetSize.width(),
                                   decorationSize.height() - targetSize.height(),
                                   targetSize.width(),
@@ -103,6 +105,9 @@ WangColorView::WangColorView(QWidget *parent)
     setIndentation(0);
     setUniformRowHeights(true);
     setItemDelegate(new WangColorDelegate(this));
+
+    connect(Preferences::instance(), &Preferences::textureFilteringChanged,
+            this, [this] { viewport()->update(); });
 }
 
 WangColorView::~WangColorView()

--- a/src/tiled/zoomable.cpp
+++ b/src/tiled/zoomable.cpp
@@ -20,6 +20,8 @@
 
 #include "zoomable.h"
 
+#include "preferences.h"
+
 #include <QComboBox>
 #include <QLineEdit>
 #include <QPinchGesture>
@@ -139,6 +141,11 @@ void Zoomable::handlePinchGesture(QPinchGesture *pinch)
     case Qt::GestureCanceled:
         break;
     }
+}
+
+bool Zoomable::smoothTransform() const
+{
+    return Preferences::instance()->smoothTransform(mScale != qreal(1) && mScale < qreal(2));
 }
 
 void Zoomable::zoomIn()

--- a/src/tiled/zoomable.h
+++ b/src/tiled/zoomable.h
@@ -65,12 +65,9 @@ public:
     void handlePinchGesture(QPinchGesture *pinch);
 
     /**
-     * Returns whether images should be smoothly transformed when drawn at the
-     * current scale. This is the case when the scale is not 1 and smaller than
-     * 2.
+     * Returns whether images should be smoothly transformed when drawn at the current scale.
      */
-    bool smoothTransform() const
-    { return mScale != qreal(1) && mScale < qreal(2); }
+    bool smoothTransform() const;
 
     void setZoomFactors(const QVector<qreal>& factors);
     void setComboBox(QComboBox *comboBox);


### PR DESCRIPTION
Fixes #3801

This adds a Texture filtering preference under Edit --> Preferences --> Interface with three options:

* Auto - current behavior (smooth only at fractional zoom levels)
* Nearest Neighbor - always sharp/pixelated
* Smooth - always interpolated
The main motivation is that rotated or resized tile objects look jagged at native zoom levels (100%, 200%) because Auto forces nearest-neighbor there. With the Smooth option, users can get clean rendering regardless of zoom.

The preference applies to the map view, tileset view, wang color view, and export-as-image. Preview/thumbnail contexts (minimap, stamp model) are left always-smooth intentionally.



https://github.com/user-attachments/assets/2bf46f3c-6a51-41d7-ba6d-ac926a4ff44d


