### PR TITLE
Windows installer: Enable WiX short-name generation

### DIFF
--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -35,7 +35,7 @@
     <Package Id='*' Keywords='Installer' Description="[ProductName] Installer"
              Comments='Windows Installer Package' Manufacturer='[Manufacturer]'
              Languages='1033' Compressed='yes' SummaryCodepage='1252'
-             InstallScope='perMachine' />
+             InstallScope='perMachine' ShortNames='yes' />
 
     <MajorUpgrade AllowDowngrades="yes" />
 


### PR DESCRIPTION
Enable ShortNames on the MSI Package so WiX emits short-name metadata for long file and directory names. This prevents installs from failing in environments that enforce short filename handling (for example with `SHORTFILENAMES=1`).

Closes #4362