### PR TITLE
Added Expand/Collapse API to GroupLayer- Contd

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 * Fixed suggesting filename with trailing dot when export filter is unset (by Sid, #4368)
 * Fixed snapping mode sync across instances (by Sid, #4364)
 * Fixed missing error message when 'Export as Image' fails (by kunal649, #4397)
+* Scripting: Added isExpanded/setExpanded API to LayersView and ObjectsView (#3997)
 * Scripting: Added API for custom property types (with dogboydog, #3971)
 * Scripting: Added `TileMap.chunkSize` and `TileMap.compressionLevel` properties
 * Scripting: Added optional defaultValue and toolTip params to `Dialog` add widget methods (by Oval, #4358)

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -2817,6 +2817,20 @@ interface MapEditor {
    * @since 1.12
    */
   tool(shortName: string): Tool | null;
+
+  /**
+   * Access the Layers view.
+   *
+   * @since 2.0
+   */
+  readonly layersView: LayersView;
+
+  /**
+   * Access the Objects view.
+   *
+   * @since 2.0
+   */
+  readonly objectsView: ObjectsView;
 }
 
 /**
@@ -2844,6 +2858,42 @@ interface TilesetsView {
    * usually more useful than the list of selected tiles.
    */
   selectedTiles: Tile[];
+}
+
+/**
+ * The Layers view, accessible through {@link MapEditor.layersView}.
+ *
+ * @since 2.0
+ */
+interface LayersView {
+  /**
+   * Returns whether the given group layer is expanded in the Layers view.
+   * Returns false for non-group layers.
+   */
+  isExpanded(layer: Layer): boolean;
+
+  /**
+   * Sets the expanded state of the given group layer in the Layers view.
+   * Has no effect for non-group layers.
+   */
+  setExpanded(layer: Layer, expanded: boolean): void;
+}
+
+/**
+ * The Objects view, accessible through {@link MapEditor.objectsView}.
+ *
+ * @since 2.0
+ */
+interface ObjectsView {
+  /**
+   * Returns whether the given object group is expanded in the Objects view.
+   */
+  isExpanded(layer: ObjectGroup): boolean;
+
+  /**
+   * Sets the expanded state of the given object group in the Objects view.
+   */
+  setExpanded(layer: ObjectGroup, expanded: boolean): void;
 }
 
 /**

--- a/src/tiled/changelayer.cpp
+++ b/src/tiled/changelayer.cpp
@@ -23,7 +23,6 @@
 #include "changeevents.h"
 #include "document.h"
 #include "layer.h"
-#include "map.h"
 
 #include <QCoreApplication>
 

--- a/src/tiled/layerdock.cpp
+++ b/src/tiled/layerdock.cpp
@@ -24,17 +24,18 @@
 #include "layerdock.h"
 
 #include "actionmanager.h"
-#include "scriptmanager.h"
+#include "changeevents.h"
+#include "editablelayer.h"
+#include "grouplayer.h"
+#include "iconcheckdelegate.h"
 #include "layer.h"
 #include "layermodel.h"
 #include "map.h"
 #include "mapdocument.h"
 #include "mapdocumentactionhandler.h"
 #include "reversingproxymodel.h"
+#include "scriptmanager.h"
 #include "utils.h"
-#include "iconcheckdelegate.h"
-#include "changeevents.h"
-#include "grouplayer.h"
 
 #include <QApplication>
 #include <QBoxLayout>
@@ -125,34 +126,25 @@ void LayerDock::setMapDocument(MapDocument *mapDocument)
     }
 }
 
-bool LayerDock::isExpanded(EditableGroupLayer *layer) const
+bool LayerDock::isExpanded(EditableLayer *layer) const
 {
     if (!layer) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid argument"));
         return false;
     }
-    return isExpanded(static_cast<GroupLayer*>(layer->layer()));
+    if (auto *groupLayer = layer->layer()->asGroupLayer())
+        return mLayerView->isExpanded(groupLayer);
+    return false;
 }
 
-void LayerDock::setExpanded(EditableGroupLayer *layer, bool expanded)
+void LayerDock::setExpanded(EditableLayer *layer, bool expanded)
 {
     if (!layer) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid argument"));
         return;
     }
-    setExpanded(static_cast<GroupLayer*>(layer->layer()), expanded);
-}
-
-bool LayerDock::isExpanded(GroupLayer *layer) const {
-    auto sourceIndex = mMapDocument->layerModel()->index(layer);
-    auto index = mLayerView->proxyModel()->mapFromSource(sourceIndex);
-    return mLayerView->isExpanded(index);
-}
-
-void LayerDock::setExpanded(GroupLayer *layer, bool expanded) {
-    auto sourceIndex = mMapDocument->layerModel()->index(layer);
-    auto index = mLayerView->proxyModel()->mapFromSource(sourceIndex);
-    mLayerView->setExpanded(index, expanded);
+    if (auto *groupLayer = layer->layer()->asGroupLayer())
+        mLayerView->setExpanded(groupLayer, expanded);
 }
 
 void LayerDock::changeEvent(QEvent *e)
@@ -281,6 +273,24 @@ void LayerView::setMapDocument(MapDocument *mapDocument)
 void LayerView::editLayerModelIndex(const QModelIndex &layerModelIndex)
 {
     edit(mProxyModel->mapFromSource(layerModelIndex));
+}
+
+bool LayerView::isExpanded(GroupLayer *layer) const
+{
+    if (!mMapDocument)
+        return false;
+    auto sourceIndex = mMapDocument->layerModel()->index(layer);
+    auto index = mProxyModel->mapFromSource(sourceIndex);
+    return QTreeView::isExpanded(index);
+}
+
+void LayerView::setExpanded(GroupLayer *layer, bool expanded)
+{
+    if (!mMapDocument)
+        return;
+    auto sourceIndex = mMapDocument->layerModel()->index(layer);
+    auto index = mProxyModel->mapFromSource(sourceIndex);
+    QTreeView::setExpanded(index, expanded);
 }
 
 void LayerView::onExpanded(const QModelIndex &proxyIndex)

--- a/src/tiled/layerdock.h
+++ b/src/tiled/layerdock.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
+#include "editablelayer.h"
 #include "mapdocument.h"
-#include "editablegrouplayer.h"
 
 #include <QDockWidget>
 #include <QTreeView>
@@ -33,6 +33,7 @@ class QModelIndex;
 
 namespace Tiled {
 
+class GroupLayer;
 class LayerView;
 
 /**
@@ -53,10 +54,8 @@ public:
      */
     void setMapDocument(MapDocument *mapDocument);
 
-    Q_INVOKABLE bool isExpanded(EditableGroupLayer *layer) const;
-    Q_INVOKABLE void setExpanded(EditableGroupLayer *layer, bool expanded);
-    bool isExpanded(GroupLayer *layer) const;
-    void setExpanded(GroupLayer *layer, bool expanded);
+    Q_INVOKABLE bool isExpanded(EditableLayer *layer) const;
+    Q_INVOKABLE void setExpanded(EditableLayer *layer, bool expanded);
 
 protected:
     void changeEvent(QEvent *e) override;
@@ -86,6 +85,9 @@ public:
     void setMapDocument(MapDocument *mapDocument);
 
     void editLayerModelIndex(const QModelIndex &layerModelIndex);
+
+    bool isExpanded(GroupLayer *layer) const;
+    void setExpanded(GroupLayer *layer, bool expanded);
 
     QAbstractProxyModel *proxyModel() { return mProxyModel; }
 

--- a/src/tiled/objectsdock.cpp
+++ b/src/tiled/objectsdock.cpp
@@ -34,6 +34,7 @@
 #include "utils.h"
 
 #include <QBoxLayout>
+#include <QCoreApplication>
 #include <QEvent>
 #include <QLabel>
 #include <QMenu>
@@ -158,7 +159,7 @@ bool ObjectsDock::isExpanded(EditableObjectGroup *layer) const
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid argument"));
         return false;
     }
-    return isExpanded(layer->objectGroup());
+    return mObjectsView->isExpanded(layer->objectGroup());
 }
 
 void ObjectsDock::setExpanded(EditableObjectGroup *layer, bool expanded)
@@ -167,15 +168,7 @@ void ObjectsDock::setExpanded(EditableObjectGroup *layer, bool expanded)
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid argument"));
         return;
     }
-    setExpanded(layer->objectGroup(), expanded);
-}
-
-bool ObjectsDock::isExpanded(ObjectGroup *layer) const {
-    return mObjectsView->isExpanded(mObjectsView->layerViewIndex(layer));
-}
-
-void ObjectsDock::setExpanded(ObjectGroup *layer, bool expanded) {
-    mObjectsView->setExpanded(mObjectsView->layerViewIndex(layer), expanded);
+    mObjectsView->setExpanded(layer->objectGroup(), expanded);
 }
 
 void ObjectsDock::changeEvent(QEvent *e)

--- a/src/tiled/objectsdock.h
+++ b/src/tiled/objectsdock.h
@@ -45,8 +45,6 @@ public:
 
     Q_INVOKABLE bool isExpanded(EditableObjectGroup *layer) const;
     Q_INVOKABLE void setExpanded(EditableObjectGroup *layer, bool expanded);
-    bool isExpanded(ObjectGroup *layer) const;
-    void setExpanded(ObjectGroup *layer, bool expanded);
 
 protected:
     void changeEvent(QEvent *e) override;

--- a/src/tiled/objectsview.cpp
+++ b/src/tiled/objectsview.cpp
@@ -24,6 +24,7 @@
 #include "iconcheckdelegate.h"
 #include "mapdocument.h"
 #include "mapobjectmodel.h"
+#include "objectgroup.h"
 #include "preferences.h"
 #include "reversingproxymodel.h"
 #include "utils.h"
@@ -123,6 +124,16 @@ QModelIndex ObjectsView::layerViewIndex(Layer *layer) const
     }
 
     return QModelIndex();
+}
+
+bool ObjectsView::isExpanded(ObjectGroup *layer) const
+{
+    return QTreeView::isExpanded(layerViewIndex(layer));
+}
+
+void ObjectsView::setExpanded(ObjectGroup *layer, bool expanded)
+{
+    QTreeView::setExpanded(layerViewIndex(layer), expanded);
 }
 
 void ObjectsView::ensureVisible(MapObject *mapObject)

--- a/src/tiled/objectsview.h
+++ b/src/tiled/objectsview.h
@@ -27,6 +27,7 @@ namespace Tiled {
 
 class Layer;
 class MapObject;
+class ObjectGroup;
 
 class MapDocument;
 class MapObjectModel;
@@ -46,6 +47,9 @@ public:
     MapObjectModel *mapObjectModel() const;
 
     QModelIndex layerViewIndex(Layer *layer) const;
+
+    bool isExpanded(ObjectGroup *layer) const;
+    void setExpanded(ObjectGroup *layer, bool expanded);
 
     void ensureVisible(MapObject *mapObject);
 


### PR DESCRIPTION
Resolves : #3997 
Continuation of PR : #4009 

Addressed all the review comments : 

Reverted grouplayer.h changess.

Reverted editablegrouplayer.h/cpp and editableobjectgroup.h/cpp , Removed the isExpanded/setExpanded properties and methods that were added directly to the layer object

Moved Q_INVOKABLE isExpanded/setExpanded out of the header files , In `layerdock.h` and `objectsdock.h`, the methods were defined inline. Moved the implementations to layerdock.cpp and objectsdock.cpp respectively.

Added null checks , The moved implementations now check for a null layer argument and call ScriptManager::instance().throwError(...) with a proper translated error message, matching the pattern used rest of pplaces.