### PR TITLE
Fixed bugs about Japanese & Chinese input methods:

### DIFF
--- a/src/tiled/locatorwidget.cpp
+++ b/src/tiled/locatorwidget.cpp
@@ -36,6 +36,8 @@
 #include <QApplication>
 #include <QCollator>
 #include <QDir>
+#include <QGuiApplication>
+#include <QInputMethod>
 #include <QKeyEvent>
 #include <QPainter>
 #include <QScrollBar>
@@ -271,7 +273,10 @@ LocatorWidget::LocatorWidget(LocatorSource *locatorSource,
     , mResultsView(new ResultsView(this))
 {
     setAttribute(Qt::WA_DeleteOnClose);
+    setAttribute(Qt::WA_InputMethodEnabled);
     setFrameStyle(QFrame::StyledPanel | QFrame::Plain);
+    setAutoFillBackground(true);
+    setFocusPolicy(Qt::StrongFocus);
 
     mLocatorSource->setParent(this);        // take ownership of source
 
@@ -286,6 +291,7 @@ LocatorWidget::LocatorWidget(LocatorSource *locatorSource,
     mFilterEdit->setFilteredView(mResultsView);
     mFilterEdit->setClearTextOnEscape(false);
     mFilterEdit->setFont(scaledFont(mFilterEdit->font(), 1.5));
+    mFilterEdit->setAttribute(Qt::WA_InputMethodEnabled);
 
     setFocusProxy(mFilterEdit);
     mResultsView->setFocusProxy(mFilterEdit);
@@ -315,6 +321,12 @@ void LocatorWidget::setVisible(bool visible)
 
     if (visible) {
         setFocus();
+        activateWindow();
+
+        // Ensure the text field gets focus directly, so input methods can
+        // attach to it reliably.
+        mFilterEdit->setFocus(Qt::ShortcutFocusReason);
+        QGuiApplication::inputMethod()->update(Qt::ImEnabled);
 
         if (!mFilterEdit->text().isEmpty())
             mFilterEdit->clear();

--- a/src/tiled/locatorwidget.cpp
+++ b/src/tiled/locatorwidget.cpp
@@ -289,7 +289,6 @@ LocatorWidget::LocatorWidget(LocatorSource *locatorSource,
     mFilterEdit->setFilteredView(mResultsView);
     mFilterEdit->setClearTextOnEscape(false);
     mFilterEdit->setFont(scaledFont(mFilterEdit->font(), 1.5));
-    mFilterEdit->setAttribute(Qt::WA_InputMethodEnabled);
 
     setFocusProxy(mFilterEdit);
     mResultsView->setFocusProxy(mFilterEdit);

--- a/src/tiled/locatorwidget.cpp
+++ b/src/tiled/locatorwidget.cpp
@@ -321,6 +321,8 @@ void LocatorWidget::setVisible(bool visible)
         setFocus();
         activateWindow();
 
+        // just a fallback to make sure the input method will be enabled in some situation
+        // like changed the focus object when showing this widget
         QGuiApplication::inputMethod()->update(Qt::ImEnabled);
         if (!mFilterEdit->text().isEmpty())
             mFilterEdit->clear();

--- a/src/tiled/locatorwidget.cpp
+++ b/src/tiled/locatorwidget.cpp
@@ -273,9 +273,7 @@ LocatorWidget::LocatorWidget(LocatorSource *locatorSource,
     , mResultsView(new ResultsView(this))
 {
     setAttribute(Qt::WA_DeleteOnClose);
-    setAttribute(Qt::WA_InputMethodEnabled);
     setFrameStyle(QFrame::StyledPanel | QFrame::Plain);
-    setAutoFillBackground(true);
     setFocusPolicy(Qt::StrongFocus);
 
     mLocatorSource->setParent(this);        // take ownership of source
@@ -323,11 +321,7 @@ void LocatorWidget::setVisible(bool visible)
         setFocus();
         activateWindow();
 
-        // Ensure the text field gets focus directly, so input methods can
-        // attach to it reliably.
-        mFilterEdit->setFocus(Qt::ShortcutFocusReason);
         QGuiApplication::inputMethod()->update(Qt::ImEnabled);
-
         if (!mFilterEdit->text().isEmpty())
             mFilterEdit->clear();
         else


### PR DESCRIPTION
Fixed https://github.com/mapeditor/tiled/issues/3403

Add setAttribute(Qt::WA_InputMethodEnabled); to LocatorWidget, to avoid the problem of non-Latin input methods like Chinese or Japanese IME.

Relevant bugs of Qt: https://qt-project.atlassian.net/browse/QTBUG-83490