### PR TITLE
Preserve tile selection when toggling dynamic wrapping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * Added export plugin for Remixed Dungeon (by Mikhael Danilov, #4158)
 * Added "World > World Properties" menu action (with dogboydog, #4190)
 * Added Delete shortcut to Remove Tiles action by default and avoid ambiguity (#4201)
+* Fixed selection to be preserved when toggling dynamic wrapping (by Mollah Hamza, #4385)
 * Fixed tileset tabs to fall back to filename in case of unnamed tilesets (by Sid, #4360)
 * Fixed alpha component of tint color not applying correctly to opaque images (by Roland Helmerichs, #4310)
 * Fixed panning with space bar not always working on first click (with Oval, #4338)

--- a/src/tiled/tilesetmodel.cpp
+++ b/src/tiled/tilesetmodel.cpp
@@ -237,10 +237,9 @@ void TilesetModel::setColumnCountOverride(int columnCount)
     if (mColumnCountOverride == columnCount)
         return;
 
-    const int oldColumnCount = TilesetModel::columnCount();
-
     emit layoutAboutToBeChanged();
 
+    const int oldColumnCount = TilesetModel::columnCount();
     const QModelIndexList oldIndexes = persistentIndexList();
 
     mColumnCountOverride = columnCount;


### PR DESCRIPTION
 Fixes #3949

## Problem
When toggling "Dynamically Wrap Tiles" in the Tilesets dock or Tileset Editor, the current tile selection was being cleared. Since wrapping is purely a visual/layout option, the selection should be preserved.

## Root Cause
`TilesetModel::setColumnCountOverride()` was using `beginResetModel()`/ `endResetModel()`, which causes Qt to unconditionally clear the selection model. This is the wrong mechanism here since only the column layout is changing, not the underlying tile data.

## Fix
Switch to `layoutAboutToBeChanged()`/`layoutChanged()` with persistent index remapping. Before the column count changes, persistent indexes are captured and remapped to their new positions after the change, so the selection model correctly tracks the same tiles through the reflow.