### PR TITLE
Clamp scroll delta to viewport size to prevent panning overshoot

### DIFF
--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -604,20 +604,21 @@ void MapView::wheelEvent(QWheelEvent *event)
     // on that event.
     QPoint pixels = event->pixelDelta();
 
-    if (pixels.isNull()) {
+    const bool isNewGesture = event->phase() == Qt::ScrollBegin
+                              || !mScrollTimer.isValid()
+                              || mScrollTimer.elapsed() > 300;
+
+    if (pixels.isNull() || isNewGesture) {
         QPointF steps = event->angleDelta() / 8.0 / 15.0;
         int lines = QApplication::wheelScrollLines();
         pixels.setX(int(steps.x() * lines * hBar->singleStep()));
         pixels.setY(int(steps.y() * lines * vBar->singleStep()));
     } else {
         pixels = Utils::dpiScaled(pixels);
-
-        // Clamp to viewport size to prevent overshooting from accumulated
-        // deltas on the first touchpad scroll event.
-        const QSize maxDelta = viewport()->size();
-        pixels.setX(qBound(-maxDelta.width(), pixels.x(), maxDelta.width()));
-        pixels.setY(qBound(-maxDelta.height(), pixels.y(), maxDelta.height()));
     }
+
+    if (!event->pixelDelta().isNull())
+        mScrollTimer.restart();
 
     scrollBy(-pixels);
 }

--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -611,6 +611,12 @@ void MapView::wheelEvent(QWheelEvent *event)
         pixels.setY(int(steps.y() * lines * vBar->singleStep()));
     } else {
         pixels = Utils::dpiScaled(pixels);
+
+        // Clamp to viewport size to prevent overshooting from accumulated
+        // deltas on the first touchpad scroll event.
+        const QSize maxDelta = viewport()->size();
+        pixels.setX(qBound(-maxDelta.width(), pixels.x(), maxDelta.width()));
+        pixels.setY(qBound(-maxDelta.height(), pixels.y(), maxDelta.height()));
     }
 
     scrollBy(-pixels);

--- a/src/tiled/mapview.h
+++ b/src/tiled/mapview.h
@@ -22,6 +22,7 @@
 
 #include "preferences.h"
 
+#include <QElapsedTimer>
 #include <QGraphicsView>
 #include <QPinchGesture>
 
@@ -130,6 +131,7 @@ private:
     void setMapDocument(MapDocument *mapDocument);
 
     MapDocument *mMapDocument = nullptr;
+    QElapsedTimer mScrollTimer;
     QPoint mLastMousePos;
     QPoint mScrollStartPos;
     QPointF mLastMouseScenePos;


### PR DESCRIPTION
Fixes #4252

On Linux, touchpad drivers accumulate scroll events during gesture recognition and release them all at once as a large pixelDelta() on the first event. This caused the view to overshoot significantly on the first scroll input.

Clamping the pixelDelta to the viewport size in MapView::wheelEvent() ensures a single event cannot scroll more than one screen's worth. Normal smooth scrolling is unaffected since typical per-event deltas are only 10-30px.

Note: improvement may vary depending on touchpad driver. Testing from the original reporter would be appreciated.