### PR TITLE
feat(ci/cd): merge request on homebrew cask workflow

### DIFF
--- a/.github/workflows/merge-request-homebrew.yml
+++ b/.github/workflows/merge-request-homebrew.yml
@@ -22,4 +22,5 @@ jobs:
         with:
           token: ${{ secrets.HOMEBREW_BUMP_TOKEN }}
           cask: tiled
+          org: mapeditor
           tag: ${{ inputs.tag || github.ref }}


### PR DESCRIPTION
closes: #2849

A workflow for Merge Request on Homebrew Casks.

- Automatically triggers when a GitHub Release is published (released event)
- Also available as a manual trigger with an optional tag input
- Runs on macos-latest, guarded to only execute on mapeditor/tiled (not forks)
- Uses `eugenesvk/action-homebrew-bump-cask` pinned to SHA for supply-chain safety
- Opens a PR against `homebrew/homebrew-cask` to update the tiled cask version and SHA
