### PR TITLE
TiledQuick: Add border and grid over mapitem.

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -79,7 +79,7 @@ jobs:
       with:
         version: 6.10.2
         arch: linux_gcc_64
-        modules: "qtimageformats"
+        modules: "qtimageformats qtshadertools"
         tools: 'tools_qtcreator'
         setup-python: false
         cache: true
@@ -200,7 +200,7 @@ jobs:
           architectures: x86_64
           cmake_architectures: x86_64
         - qt_version: 6.10.2
-          qt_modules: "qtimageformats"
+          qt_modules: "qtimageformats qtshadertools"
           version_suffix: "13+"
           architectures: x86_64,arm64
           cmake_architectures: x86_64;arm64
@@ -333,7 +333,7 @@ jobs:
         - qt_version: 6.10.2
           qt_version_major: 6
           qt_arch: win64_mingw
-          qt_modules: "qtimageformats"
+          qt_modules: "qtimageformats qtshadertools"
           arch: 64
           openssl_arch: x64
           filename_suffix: 'Windows-10+_x86_64'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 clone_depth: 200
-version: "1.12.{build}"
+version: '1.12.{build}'
 image:
   - Visual Studio 2022
 
@@ -107,9 +107,9 @@ after_build:
 
 artifacts:
   - name: Installer
-    path: "Tiled-*.msi"
+    path: 'Tiled-*.msi'
   - name: Archive
-    path: "tiled-*.7z"
+    path: 'tiled-*.7z'
 
 deploy:
   - provider: FTP
@@ -121,30 +121,30 @@ deploy:
     folder: update.mapeditor.org/snapshots-win
     artifact: /.*\.(msi|7z)/
     on:
-      branch: snapshot
-      push_release: true
+        branch: snapshot
+        push_release: true
 
   - provider: Webhook
     url: https://app.signpath.io/API/v1/670574d6-49bf-4a0c-824a-3ae977077079/Integrations/AppVeyor?ProjectKey=tiled&SigningPolicyKey=test-signing
     authorization:
-      secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
+        secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
     on:
-      appveyor_repo_tag: false
-      branch: master
-      push_release: true
+        appveyor_repo_tag: false
+        branch: master
+        push_release: true
 
   - provider: Webhook
     url: https://app.signpath.io/API/v1/670574d6-49bf-4a0c-824a-3ae977077079/Integrations/AppVeyor?ProjectKey=tiled&SigningPolicyKey=release-signing
     authorization:
-      secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
+        secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
     on:
-      branch: snapshot
-      push_release: true
+        branch: snapshot
+        push_release: true
 
   - provider: Webhook
     url: https://app.signpath.io/API/v1/670574d6-49bf-4a0c-824a-3ae977077079/Integrations/AppVeyor?ProjectKey=tiled&SigningPolicyKey=release-signing
     authorization:
-      secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
+        secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
     on:
-      appveyor_repo_tag: true
-      push_release: true
+        appveyor_repo_tag: true
+        push_release: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 clone_depth: 200
-version: '1.12.{build}'
+version: "1.12.{build}"
 image:
   - Visual Studio 2022
 
@@ -17,7 +17,7 @@ environment:
   matrix:
     - QT_VERSION: 6.10.2
       QT_ARCH: win64_msvc2022_64
-      QT_MODULES: qtimageformats
+      QT_MODULES: qtimageformats qtshadertools
       QTDIR: C:\Qt\6.10.2\msvc2022_64
       PYTHONHOME: C:\Python312-x64
       DEFAULT_PROFILE: MSVC2022-x64
@@ -39,7 +39,7 @@ environment:
       CXX: i686-w64-mingw32-g++.exe
     - QT_VERSION: 6.10.2
       QT_ARCH: win64_mingw
-      QT_MODULES: qtimageformats
+      QT_MODULES: qtimageformats qtshadertools
       QTDIR: C:\Qt\6.10.2\mingw_64
       PYTHONHOME: C:\Python312-x64
       MINGW: C:\Qt\Tools\mingw1310_64
@@ -107,9 +107,9 @@ after_build:
 
 artifacts:
   - name: Installer
-    path: 'Tiled-*.msi'
+    path: "Tiled-*.msi"
   - name: Archive
-    path: 'tiled-*.7z'
+    path: "tiled-*.7z"
 
 deploy:
   - provider: FTP
@@ -121,30 +121,30 @@ deploy:
     folder: update.mapeditor.org/snapshots-win
     artifact: /.*\.(msi|7z)/
     on:
-        branch: snapshot
-        push_release: true
+      branch: snapshot
+      push_release: true
 
   - provider: Webhook
     url: https://app.signpath.io/API/v1/670574d6-49bf-4a0c-824a-3ae977077079/Integrations/AppVeyor?ProjectKey=tiled&SigningPolicyKey=test-signing
     authorization:
-        secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
+      secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
     on:
-        appveyor_repo_tag: false
-        branch: master
-        push_release: true
+      appveyor_repo_tag: false
+      branch: master
+      push_release: true
 
   - provider: Webhook
     url: https://app.signpath.io/API/v1/670574d6-49bf-4a0c-824a-3ae977077079/Integrations/AppVeyor?ProjectKey=tiled&SigningPolicyKey=release-signing
     authorization:
-        secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
+      secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
     on:
-        branch: snapshot
-        push_release: true
+      branch: snapshot
+      push_release: true
 
   - provider: Webhook
     url: https://app.signpath.io/API/v1/670574d6-49bf-4a0c-824a-3ae977077079/Integrations/AppVeyor?ProjectKey=tiled&SigningPolicyKey=release-signing
     authorization:
-        secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
+      secure: 4E7IuM1Ftvdkx43gsqI3tUWb6tcvrfKB22sa6DsWaBzT+zv3DqceDCk0qc/JqTO+Er5UQNYwolmWBzMdys6fVA==
     on:
-        appveyor_repo_tag: true
-        push_release: true
+      appveyor_repo_tag: true
+      push_release: true

--- a/src/libtiledquick/grid.frag
+++ b/src/libtiledquick/grid.frag
@@ -16,18 +16,16 @@ layout(std140, binding = 0) uniform buf {
 
 void main()
 {
-    vec2 pixelPos = vTexCoord * vec2(ubuf.pixelWidth, ubuf.pixelHeight) * ubuf.scale;
-
     float thickness = 1;
-    float dashLength = 2;
-    float spaceLength = 2;
+    float dashLength = thickness * 2;
+    float spaceLength = dashLength;
 
-    if (pixelPos.x >= thickness && // Hides the leftmost grid lines
-       (mod(pixelPos.x, ubuf.tileWidth * ubuf.scale) < thickness &&
-        mod(pixelPos.y, dashLength + spaceLength) < dashLength) ||
-       (pixelPos.y >= thickness && // Hides the topmost grid lines
-        mod(pixelPos.y, ubuf.tileHeight * ubuf.scale) < thickness &&
-        mod(pixelPos.x, dashLength + spaceLength) < dashLength))
+    vec2 pixelPos = vTexCoord * vec2(ubuf.pixelWidth, ubuf.pixelHeight) * ubuf.scale + thickness * 0.5;
+
+    if ((mod(pixelPos.x, ubuf.tileWidth * ubuf.scale) < thickness &&
+         mod(pixelPos.y, dashLength + spaceLength) < dashLength) ||
+        (mod(pixelPos.y, ubuf.tileHeight * ubuf.scale) < thickness &&
+         mod(pixelPos.x, dashLength + spaceLength) < dashLength))
     {
         fragColor = ubuf.color * ubuf.qt_Opacity;
     } else {

--- a/src/libtiledquick/grid.frag
+++ b/src/libtiledquick/grid.frag
@@ -1,0 +1,36 @@
+#version 440
+
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 fragColor;
+
+layout(std140, binding = 0) uniform buf {
+    mat4 qt_Matrix;
+    float qt_Opacity;
+    float scale;
+    float pixelWidth;
+    float pixelHeight;
+    float tileWidth;
+    float tileHeight;
+    vec4 color;
+} ubuf;
+
+void main()
+{
+    vec2 pixelPos = vTexCoord * vec2(ubuf.pixelWidth, ubuf.pixelHeight) * ubuf.scale;
+
+    float thickness = 1;
+    float dashLength = 2;
+    float spaceLength = 2;
+
+    if (pixelPos.x >= thickness && // Hides the leftmost grid lines
+       (mod(pixelPos.x, ubuf.tileWidth * ubuf.scale) < thickness &&
+        mod(pixelPos.y, dashLength + spaceLength) < dashLength) ||
+       (pixelPos.y >= thickness && // Hides the topmost grid lines
+        mod(pixelPos.y, ubuf.tileHeight * ubuf.scale) < thickness &&
+        mod(pixelPos.x, dashLength + spaceLength) < dashLength))
+    {
+        fragColor = ubuf.color * ubuf.qt_Opacity;
+    } else {
+        discard;
+    }
+}

--- a/src/libtiledquick/grid.vert
+++ b/src/libtiledquick/grid.vert
@@ -1,0 +1,23 @@
+#version 440
+
+layout(location = 0) in vec4 qt_Vertex;
+layout(location = 1) in vec2 qt_MultiTexCoord0;
+
+layout(location = 0) out vec2 vTexCoord;
+
+layout(std140, binding = 0) uniform buf {
+    mat4 qt_Matrix;
+    float qt_Opacity;
+    float scale;
+    float pixelWidth;
+    float pixelHeight;
+    float tileWidth;
+    float tileHeight;
+    vec4 color;
+} ubuf;
+
+void main()
+{
+    vTexCoord = qt_MultiTexCoord0;
+    gl_Position = ubuf.qt_Matrix * qt_Vertex;
+}

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -7,7 +7,7 @@ DynamicLibrary {
 
     Depends { name: "libtiled" }
     Depends { name: "cpp" }
-    Depends { name: "Qt"; submodules: ["quick"]; versionAtLeast: "6.5" }
+    Depends { name: "Qt"; submodules: ["quick","shadertools"]; versionAtLeast: "6.5" }
 
     cpp.cxxLanguageVersion: "c++17"
     cpp.cxxFlags: {
@@ -38,6 +38,8 @@ DynamicLibrary {
     files: [
         "mapgriditem.cpp",
         "mapgriditem.h",
+        "mapgridmaterial.cpp",
+        "mapgridmaterial.h",
         "mapitem.h",
         "mapitem.cpp",
         "maploader.h",
@@ -57,6 +59,17 @@ DynamicLibrary {
         qbs.install: true
         qbs.installDir: "include/tiledquick"
         fileTagsFilter: "hpp"
+    }
+
+    Group {
+        name: "Shaders"
+        files: [
+            "grid.vert",
+            "grid.frag",
+        ]
+        fileTags: ["qt.shadertools.qsb"]
+
+        overrideTags: false
     }
 
     Export {

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -3,7 +3,7 @@ import qbs.Utilities
 DynamicLibrary {
     targetName: "tiledquick"
     builtByDefault: false
-    condition: Utilities.versionCompare(Qt.core.version, "6.5") >= 0
+    condition: Qt.core && Utilities.versionCompare(Qt.core.version, "6.5") >= 0
 
     Depends { name: "libtiled" }
     Depends { name: "cpp" }

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -67,8 +67,6 @@ DynamicLibrary {
         cpp.includePaths: exportingProduct.sourceDirectory
     }
 
-    Depends { name: "Qt.quick" }
-
     install: !qbs.targetOS.contains("darwin")
     installDir: {
         if (qbs.targetOS.contains("windows"))

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -36,6 +36,8 @@ DynamicLibrary {
     }
 
     files: [
+        "mapgriditem.cpp",
+        "mapgriditem.h",
         "mapitem.h",
         "mapitem.cpp",
         "maploader.h",
@@ -47,7 +49,7 @@ DynamicLibrary {
         "tilesnode.h",
         "tilesnode.cpp",
         "mapborderitem.h",
-        "mapborderitem.cpp"
+        "mapborderitem.cpp",
     ]
 
     Group {
@@ -66,6 +68,8 @@ DynamicLibrary {
 
         cpp.includePaths: exportingProduct.sourceDirectory
     }
+
+    Depends { name: "Qt.quick" }
 
     install: !qbs.targetOS.contains("darwin")
     installDir: {

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -45,7 +45,9 @@ DynamicLibrary {
         "tilelayeritem.cpp",
         "tiledquick_global.h",
         "tilesnode.h",
-        "tilesnode.cpp"
+        "tilesnode.cpp",
+        "mapborderitem.h",
+        "mapborderitem.cpp"
     ]
 
     Group {
@@ -64,6 +66,8 @@ DynamicLibrary {
 
         cpp.includePaths: exportingProduct.sourceDirectory
     }
+
+    Depends { name: "Qt.quick" }
 
     install: !qbs.targetOS.contains("darwin")
     installDir: {

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -36,22 +36,22 @@ DynamicLibrary {
     }
 
     files: [
+        "mapborderitem.cpp",
+        "mapborderitem.h",
         "mapgriditem.cpp",
         "mapgriditem.h",
         "mapgridmaterial.cpp",
         "mapgridmaterial.h",
-        "mapitem.h",
         "mapitem.cpp",
-        "maploader.h",
+        "mapitem.h",
         "maploader.cpp",
+        "maploader.h",
         "mapref.h",
-        "tilelayeritem.h",
-        "tilelayeritem.cpp",
         "tiledquick_global.h",
-        "tilesnode.h",
+        "tilelayeritem.cpp",
+        "tilelayeritem.h",
         "tilesnode.cpp",
-        "mapborderitem.h",
-        "mapborderitem.cpp",
+        "tilesnode.h",
     ]
 
     Group {
@@ -67,9 +67,6 @@ DynamicLibrary {
             "grid.vert",
             "grid.frag",
         ]
-        fileTags: ["qt.shadertools.qsb"]
-
-        overrideTags: false
     }
 
     Export {

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -82,8 +82,6 @@ DynamicLibrary {
         cpp.includePaths: exportingProduct.sourceDirectory
     }
 
-    Depends { name: "Qt.quick" }
-
     install: !qbs.targetOS.contains("darwin")
     installDir: {
         if (qbs.targetOS.contains("windows"))

--- a/src/libtiledquick/mapborderitem.cpp
+++ b/src/libtiledquick/mapborderitem.cpp
@@ -1,6 +1,5 @@
 #include "mapborderitem.h"
 
-#include <QQuickWindow>
 #include <QSGFlatColorMaterial>
 
 using namespace TiledQuick;
@@ -45,10 +44,10 @@ QSGNode *MapBorderItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNo
     return borderNode;
 }
 
-void MapBorderItem::setColor(const QColor &c)
+void MapBorderItem::setColor(const QColor &color)
 {
-    if (mColor != c) {
-        mColor = c;
+    if (mColor != color) {
+        mColor = color;
         emit colorChanged();
         update();
     }

--- a/src/libtiledquick/mapborderitem.cpp
+++ b/src/libtiledquick/mapborderitem.cpp
@@ -34,7 +34,7 @@ QSGNode *MapBorderItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNo
         vertex[4].set(0, 0);
 
         auto *material = new QSGFlatColorMaterial;
-        material->setColor(Qt::black);
+        material->setColor(mColor);
 
         borderNode->setMaterial(material);
         borderNode->setFlag(QSGNode::OwnsMaterial);

--- a/src/libtiledquick/mapborderitem.cpp
+++ b/src/libtiledquick/mapborderitem.cpp
@@ -1,0 +1,60 @@
+#include "mapborderitem.h"
+
+#include <QQuickWindow>
+#include <QSGFlatColorMaterial>
+
+using namespace TiledQuick;
+
+MapBorderItem::MapBorderItem(QQuickItem *parent)
+    : QQuickItem(parent)
+{
+    setFlag(ItemHasContents);
+}
+
+MapBorderItem::~MapBorderItem() = default;
+
+QSGNode *MapBorderItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *)
+{
+    QSGGeometryNode *borderNode = static_cast<QSGGeometryNode *>(node);
+
+    if (!borderNode) {
+        borderNode = new QSGGeometryNode;
+
+        auto *geometry = new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), 5);
+        geometry->setDrawingMode(QSGGeometry::DrawLineStrip);
+
+        borderNode->setGeometry(geometry);
+        borderNode->setFlag(QSGNode::OwnsGeometry);
+
+        auto *vertex = geometry->vertexDataAsPoint2D();
+        vertex[0].set(0, 0);
+        vertex[1].set(width(), 0);
+        vertex[2].set(width(), height());
+        vertex[3].set(0, height());
+        vertex[4].set(0, 0);
+
+        auto *material = new QSGFlatColorMaterial;
+        material->setColor(Qt::black);
+
+        borderNode->setMaterial(material);
+        borderNode->setFlag(QSGNode::OwnsMaterial);
+
+        borderNode->markDirty(QSGNode::DirtyGeometry);
+    }
+
+    return borderNode;
+}
+
+void MapBorderItem::setColor(const QColor &c)
+{
+    if (mColor != c) {
+        mColor = c;
+        emit colorChanged();
+        update();
+    }
+}
+
+QColor MapBorderItem::color() const
+{
+    return mColor;
+}

--- a/src/libtiledquick/mapborderitem.cpp
+++ b/src/libtiledquick/mapborderitem.cpp
@@ -26,21 +26,21 @@ QSGNode *MapBorderItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNo
         borderNode->setGeometry(geometry);
         borderNode->setFlag(QSGNode::OwnsGeometry);
 
-        auto *vertex = geometry->vertexDataAsPoint2D();
-        vertex[0].set(0, 0);
-        vertex[1].set(width(), 0);
-        vertex[2].set(width(), height());
-        vertex[3].set(0, height());
-        vertex[4].set(0, 0);
-
         auto *material = new QSGFlatColorMaterial;
-        material->setColor(mColor);
-
         borderNode->setMaterial(material);
         borderNode->setFlag(QSGNode::OwnsMaterial);
-
-        borderNode->markDirty(QSGNode::DirtyGeometry);
     }
+
+    auto *geometry = borderNode->geometry();
+    auto *vertex = geometry->vertexDataAsPoint2D();
+    vertex[0].set(0, 0);
+    vertex[1].set(width(), 0);
+    vertex[2].set(width(), height());
+    vertex[3].set(0, height());
+    vertex[4].set(0, 0);
+    borderNode->markDirty(QSGNode::DirtyGeometry);
+
+    static_cast<QSGFlatColorMaterial *>(borderNode->material())->setColor(mColor);
 
     return borderNode;
 }

--- a/src/libtiledquick/mapborderitem.cpp
+++ b/src/libtiledquick/mapborderitem.cpp
@@ -1,3 +1,23 @@
+/*
+ * mapborderitem.cpp
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "mapborderitem.h"
 
 #include <QSGFlatColorMaterial>
@@ -14,20 +34,18 @@ MapBorderItem::~MapBorderItem() = default;
 
 QSGNode *MapBorderItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *)
 {
-    QSGGeometryNode *borderNode = static_cast<QSGGeometryNode *>(node);
+    auto borderNode = static_cast<QSGGeometryNode *>(node);
 
     if (!borderNode) {
         borderNode = new QSGGeometryNode;
 
         auto *geometry = new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), 5);
         geometry->setDrawingMode(QSGGeometry::DrawLineStrip);
-
         borderNode->setGeometry(geometry);
-        borderNode->setFlag(QSGNode::OwnsGeometry);
 
-        auto *material = new QSGFlatColorMaterial;
-        borderNode->setMaterial(material);
-        borderNode->setFlag(QSGNode::OwnsMaterial);
+        borderNode->setMaterial(new QSGFlatColorMaterial);
+
+        borderNode->setFlags(QSGNode::OwnsGeometry | QSGNode::OwnsMaterial);
     }
 
     auto *geometry = borderNode->geometry();

--- a/src/libtiledquick/mapborderitem.cpp
+++ b/src/libtiledquick/mapborderitem.cpp
@@ -57,7 +57,11 @@ QSGNode *MapBorderItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNo
     vertex[4].set(0, 0);
     borderNode->markDirty(QSGNode::DirtyGeometry);
 
-    static_cast<QSGFlatColorMaterial *>(borderNode->material())->setColor(mColor);
+    auto material = static_cast<QSGFlatColorMaterial *>(borderNode->material());
+    if (material->color() != mColor) {
+        material->setColor(mColor);
+        borderNode->markDirty(QSGNode::DirtyMaterial);
+    }
 
     return borderNode;
 }

--- a/src/libtiledquick/mapborderitem.h
+++ b/src/libtiledquick/mapborderitem.h
@@ -1,13 +1,8 @@
 #pragma once
 
 #include <QQuickItem>
-#include <QColor>
 
 #include "tiledquick_global.h"
-
-namespace Tiled {
-class MapRenderer;
-}
 
 namespace TiledQuick {
 
@@ -24,7 +19,7 @@ public:
     QSGNode *updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *) override;
 
     QColor color() const;
-    void setColor(const QColor &c);
+    void setColor(const QColor &color);
 
 signals:
     void colorChanged();

--- a/src/libtiledquick/mapborderitem.h
+++ b/src/libtiledquick/mapborderitem.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QQuickItem>
+#include <QColor>
+
+#include "tiledquick_global.h"
+
+namespace Tiled {
+class MapRenderer;
+}
+
+namespace TiledQuick {
+
+class TILEDQUICK_SHARED_EXPORT MapBorderItem : public QQuickItem
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
+
+public:
+    explicit MapBorderItem(QQuickItem *parent = nullptr);
+    ~MapBorderItem() override;
+
+    QSGNode *updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *) override;
+
+    QColor color() const;
+    void setColor(const QColor &c);
+
+signals:
+    void colorChanged();
+
+private:
+    QColor mColor = Qt::black;
+};
+
+} // namespace TiledQuick

--- a/src/libtiledquick/mapborderitem.h
+++ b/src/libtiledquick/mapborderitem.h
@@ -1,3 +1,23 @@
+/*
+ * mapborderitem.h
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <QQuickItem>

--- a/src/libtiledquick/mapgriditem.cpp
+++ b/src/libtiledquick/mapgriditem.cpp
@@ -66,8 +66,7 @@ QPointF MapGridItem::gridSize() const
 
 void MapGridItem::setScale(const qreal &scale)
 {
-    if (mScale != scale)
-    {
+    if (mScale != scale) {
         mScale = scale;
         emit gridSizeChanged();
         update();
@@ -81,8 +80,7 @@ qreal MapGridItem::scale() const
 
 void MapGridItem::setColor(const QColor &color)
 {
-    if(mColor != color)
-    {
+    if(mColor != color) {
         mColor = color;
         emit colorChanged();
         update();

--- a/src/libtiledquick/mapgriditem.cpp
+++ b/src/libtiledquick/mapgriditem.cpp
@@ -1,0 +1,19 @@
+#include "mapgriditem.h"
+
+#include <QQuickWindow>
+#include <QSGFlatColorMaterial>
+
+using namespace TiledQuick;
+
+MapGridItem::MapGridItem(QQuickItem *parent)
+    : QQuickItem(parent)
+{
+    setFlag(ItemHasContents);
+}
+
+MapGridItem::~MapGridItem() = default;
+
+QSGNode *MapGridItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *)
+{
+    return node;
+}

--- a/src/libtiledquick/mapgriditem.cpp
+++ b/src/libtiledquick/mapgriditem.cpp
@@ -15,5 +15,102 @@ MapGridItem::~MapGridItem() = default;
 
 QSGNode *MapGridItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *)
 {
-    return node;
+    int gridWidth = mGridSize.x();
+    int gridHeight = mGridSize.y();
+    int tileWidth = width() / gridWidth;
+    int tileHeight = height() / gridHeight;
+    float segmentDrawLength = static_cast<float>(mSegmentLength / mScale);
+    qDebug() << segmentDrawLength;
+
+    // Currently only top line
+    int wVertexCountPerTile = 2 * ceil(0.5 * tileWidth * mScale / mSegmentLength);
+    int hVertexCountPerTile = 2 * ceil(0.5 * tileHeight * mScale / mSegmentLength);
+
+    int newVertexCount = (gridWidth * gridHeight) *
+                         (wVertexCountPerTile + hVertexCountPerTile);
+
+    qDebug() << gridWidth << "x" << gridHeight << ":" << tileWidth << "x" << tileHeight << mScale << "v:" << wVertexCountPerTile << "x" << hVertexCountPerTile << "x" << gridWidth << "x" << gridHeight;
+
+    QSGGeometryNode *gridNode = static_cast<QSGGeometryNode *>(node);
+
+    if (!gridNode) {
+        gridNode = new QSGGeometryNode;
+
+        auto *geometry = new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), newVertexCount);
+        geometry->setDrawingMode(QSGGeometry::DrawLines);
+
+        gridNode->setGeometry(geometry);
+        gridNode->setFlag(QSGNode::OwnsGeometry);
+
+        auto *material = new QSGFlatColorMaterial;
+        gridNode->setMaterial(material);
+        gridNode->setFlag(QSGNode::OwnsMaterial);
+    }
+
+    auto *geometry = gridNode->geometry();
+
+    if (geometry->vertexCount() != newVertexCount) {
+        geometry->allocate(newVertexCount);
+    }
+
+    auto *vertex = geometry->vertexDataAsPoint2D();
+    int currentVertex = 0;
+
+    for (int gridX = 0; gridX < gridWidth; gridX++) {
+        for (int gridY = 0; gridY < gridHeight; gridY++) {
+            for (int i = 0; i < wVertexCountPerTile/2; i++) {
+                float startX = i * segmentDrawLength * 2 + gridX * tileWidth;
+                float endX = startX + segmentDrawLength;
+
+                vertex[currentVertex++].set(startX, gridY * tileHeight);
+                vertex[currentVertex++].set(endX, gridY * tileHeight);
+            }
+
+            for (int i = 0; i < hVertexCountPerTile/2; i++) {
+                float startY = i * segmentDrawLength * 2 + gridY * tileHeight;
+                float endY = startY + segmentDrawLength;
+
+                vertex[currentVertex++].set(gridX * tileWidth, startY);
+                vertex[currentVertex++].set(gridX * tileWidth, endY);
+            }
+        }
+    }
+
+
+    qDebug() << currentVertex;
+
+
+    gridNode->markDirty(QSGNode::DirtyGeometry);
+
+    static_cast<QSGFlatColorMaterial *>(gridNode->material())->setColor(mColor);
+
+    return gridNode;
+}
+
+void MapGridItem::setGridSize(const QPointF &gridSize)
+{
+    if (mGridSize != gridSize) {
+        mGridSize = gridSize;
+        emit gridSizeChanged();
+        update();
+    }
+}
+
+QPointF MapGridItem::gridSize() const
+{
+    return mGridSize;
+}
+
+void MapGridItem::setScale(const qreal &scale)
+{
+    if (mScale != scale) {
+        mScale = scale;
+        emit gridSizeChanged();
+        update();
+    }
+}
+
+qreal MapGridItem::scale() const
+{
+    return mScale;
 }

--- a/src/libtiledquick/mapgriditem.cpp
+++ b/src/libtiledquick/mapgriditem.cpp
@@ -1,7 +1,5 @@
 #include "mapgriditem.h"
-
-#include <QQuickWindow>
-#include <QSGFlatColorMaterial>
+#include "mapgridmaterial.h"
 
 using namespace TiledQuick;
 
@@ -15,74 +13,39 @@ MapGridItem::~MapGridItem() = default;
 
 QSGNode *MapGridItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *)
 {
-    int gridWidth = mGridSize.x();
-    int gridHeight = mGridSize.y();
-    int tileWidth = width() / gridWidth;
-    int tileHeight = height() / gridHeight;
-    float segmentDrawLength = static_cast<float>(mSegmentLength / mScale);
-    qDebug() << segmentDrawLength;
-
-    // Currently only top line
-    int wVertexCountPerTile = 2 * ceil(0.5 * tileWidth * mScale / mSegmentLength);
-    int hVertexCountPerTile = 2 * ceil(0.5 * tileHeight * mScale / mSegmentLength);
-
-    int newVertexCount = (gridWidth * gridHeight) *
-                         (wVertexCountPerTile + hVertexCountPerTile);
-
-    qDebug() << gridWidth << "x" << gridHeight << ":" << tileWidth << "x" << tileHeight << mScale << "v:" << wVertexCountPerTile << "x" << hVertexCountPerTile << "x" << gridWidth << "x" << gridHeight;
-
     QSGGeometryNode *gridNode = static_cast<QSGGeometryNode *>(node);
 
     if (!gridNode) {
         gridNode = new QSGGeometryNode;
 
-        auto *geometry = new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), newVertexCount);
-        geometry->setDrawingMode(QSGGeometry::DrawLines);
+        auto *geometry = new QSGGeometry(QSGGeometry::defaultAttributes_TexturedPoint2D(), 4);
+        geometry->setDrawingMode(QSGGeometry::DrawTriangleStrip);
 
         gridNode->setGeometry(geometry);
         gridNode->setFlag(QSGNode::OwnsGeometry);
 
-        auto *material = new QSGFlatColorMaterial;
+        auto *material = new MapGridMaterial;
         gridNode->setMaterial(material);
         gridNode->setFlag(QSGNode::OwnsMaterial);
     }
 
-    auto *geometry = gridNode->geometry();
+    auto *vertices = gridNode->geometry()->vertexDataAsTexturedPoint2D();
 
-    if (geometry->vertexCount() != newVertexCount) {
-        geometry->allocate(newVertexCount);
-    }
-
-    auto *vertex = geometry->vertexDataAsPoint2D();
-    int currentVertex = 0;
-
-    for (int gridX = 0; gridX < gridWidth; gridX++) {
-        for (int gridY = 0; gridY < gridHeight; gridY++) {
-            for (int i = 0; i < wVertexCountPerTile/2; i++) {
-                float startX = i * segmentDrawLength * 2 + gridX * tileWidth;
-                float endX = startX + segmentDrawLength;
-
-                vertex[currentVertex++].set(startX, gridY * tileHeight);
-                vertex[currentVertex++].set(endX, gridY * tileHeight);
-            }
-
-            for (int i = 0; i < hVertexCountPerTile/2; i++) {
-                float startY = i * segmentDrawLength * 2 + gridY * tileHeight;
-                float endY = startY + segmentDrawLength;
-
-                vertex[currentVertex++].set(gridX * tileWidth, startY);
-                vertex[currentVertex++].set(gridX * tileWidth, endY);
-            }
-        }
-    }
-
-
-    qDebug() << currentVertex;
-
-
+    vertices[0].set(0, 0, 0, 0);
+    vertices[1].set(width(), 0, 1, 0);
+    vertices[2].set(0, height(), 0, 1);
+    vertices[3].set(width(), height(), 1, 1);
     gridNode->markDirty(QSGNode::DirtyGeometry);
 
-    static_cast<QSGFlatColorMaterial *>(gridNode->material())->setColor(mColor);
+    auto *material = static_cast<MapGridMaterial *>(gridNode->material());
+    material->mColor = mColor;
+    material->mScale = mScale;
+    material->mPixelWidth = width();
+    material->mPixelHeight = height();
+    material->mTileWidth = width() / mGridSize.x();
+    material->mTileHeight = height() / mGridSize.y();
+
+    gridNode->markDirty(QSGNode::DirtyGeometry);
 
     return gridNode;
 }
@@ -103,7 +66,8 @@ QPointF MapGridItem::gridSize() const
 
 void MapGridItem::setScale(const qreal &scale)
 {
-    if (mScale != scale) {
+    if (mScale != scale)
+    {
         mScale = scale;
         emit gridSizeChanged();
         update();
@@ -113,4 +77,19 @@ void MapGridItem::setScale(const qreal &scale)
 qreal MapGridItem::scale() const
 {
     return mScale;
+}
+
+void MapGridItem::setColor(const QColor &color)
+{
+    if(mColor != color)
+    {
+        mColor = color;
+        emit colorChanged();
+        update();
+    }
+}
+
+QColor MapGridItem::color() const
+{
+    return mColor;
 }

--- a/src/libtiledquick/mapgriditem.cpp
+++ b/src/libtiledquick/mapgriditem.cpp
@@ -58,26 +58,26 @@ QSGNode *MapGridItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNode
     material->mScale = mScale;
     material->mPixelWidth = width();
     material->mPixelHeight = height();
-    material->mTileWidth = width() / mGridSize.x();
-    material->mTileHeight = height() / mGridSize.y();
+    material->mTileWidth = mTileSize.x();
+    material->mTileHeight = mTileSize.y();
 
     gridNode->markDirty(QSGNode::DirtyGeometry | QSGNode::DirtyMaterial);
 
     return gridNode;
 }
 
-void MapGridItem::setGridSize(const QPointF &gridSize)
+void MapGridItem::setTileSize(const QPointF &tileSize)
 {
-    if (mGridSize != gridSize) {
-        mGridSize = gridSize;
-        emit gridSizeChanged();
+    if (mTileSize != tileSize) {
+        mTileSize = tileSize;
+        emit tileSizeChanged();
         update();
     }
 }
 
-QPointF MapGridItem::gridSize() const
+QPointF MapGridItem::tileSize() const
 {
-    return mGridSize;
+    return mTileSize;
 }
 
 void MapGridItem::setScale(const qreal &scale)

--- a/src/libtiledquick/mapgriditem.cpp
+++ b/src/libtiledquick/mapgriditem.cpp
@@ -1,3 +1,23 @@
+/*
+ * mapgriditem.cpp
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "mapgriditem.h"
 #include "mapgridmaterial.h"
 
@@ -13,29 +33,25 @@ MapGridItem::~MapGridItem() = default;
 
 QSGNode *MapGridItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *)
 {
-    QSGGeometryNode *gridNode = static_cast<QSGGeometryNode *>(node);
+    auto gridNode = static_cast<QSGGeometryNode *>(node);
 
     if (!gridNode) {
         gridNode = new QSGGeometryNode;
 
         auto *geometry = new QSGGeometry(QSGGeometry::defaultAttributes_TexturedPoint2D(), 4);
         geometry->setDrawingMode(QSGGeometry::DrawTriangleStrip);
-
         gridNode->setGeometry(geometry);
-        gridNode->setFlag(QSGNode::OwnsGeometry);
 
-        auto *material = new MapGridMaterial;
-        gridNode->setMaterial(material);
-        gridNode->setFlag(QSGNode::OwnsMaterial);
+        gridNode->setMaterial(new MapGridMaterial);
+
+        gridNode->setFlags(QSGNode::OwnsGeometry | QSGNode::OwnsMaterial);
     }
 
     auto *vertices = gridNode->geometry()->vertexDataAsTexturedPoint2D();
-
     vertices[0].set(0, 0, 0, 0);
     vertices[1].set(width(), 0, 1, 0);
     vertices[2].set(0, height(), 0, 1);
     vertices[3].set(width(), height(), 1, 1);
-    gridNode->markDirty(QSGNode::DirtyGeometry);
 
     auto *material = static_cast<MapGridMaterial *>(gridNode->material());
     material->mColor = mColor;
@@ -45,7 +61,7 @@ QSGNode *MapGridItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNode
     material->mTileWidth = width() / mGridSize.x();
     material->mTileHeight = height() / mGridSize.y();
 
-    gridNode->markDirty(QSGNode::DirtyGeometry);
+    gridNode->markDirty(QSGNode::DirtyGeometry | QSGNode::DirtyMaterial);
 
     return gridNode;
 }
@@ -68,7 +84,7 @@ void MapGridItem::setScale(const qreal &scale)
 {
     if (mScale != scale) {
         mScale = scale;
-        emit gridSizeChanged();
+        emit scaleChanged();
         update();
     }
 }

--- a/src/libtiledquick/mapgriditem.h
+++ b/src/libtiledquick/mapgriditem.h
@@ -14,18 +14,32 @@ class TILEDQUICK_SHARED_EXPORT MapGridItem : public QQuickItem
 {
     Q_OBJECT
 
+    Q_PROPERTY(QPointF gridSize READ gridSize WRITE setGridSize NOTIFY gridSizeChanged)
+    Q_PROPERTY(qreal scale READ scale WRITE setScale NOTIFY scaleChanged)
+
 public:
     explicit MapGridItem(QQuickItem *parent = nullptr);
     ~MapGridItem() override;
 
     QSGNode *updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *) override;
 
+    QPointF gridSize() const;
+    void setGridSize(const QPointF &gridSize);
+
+    qreal scale() const;
+    void setScale(const qreal &scale);
+
 signals:
+    void gridSizeChanged();
+    void scaleChanged();
 
 private:
-    QColor mColor = Qt::black;
-    int lineLength = 2;
-    int spaceLength = 2;
+    QPointF mGridSize = {0,0};
+    qreal mScale = 0;
+
+private:
+    QColor mColor = Qt::red;
+    int mSegmentLength = 2;
 };
 
 } // namespace TiledQuick

--- a/src/libtiledquick/mapgriditem.h
+++ b/src/libtiledquick/mapgriditem.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QQuickItem>
+
+#include "tiledquick_global.h"
+
+namespace Tiled {
+class MapRenderer;
+}
+
+namespace TiledQuick {
+
+class TILEDQUICK_SHARED_EXPORT MapGridItem : public QQuickItem
+{
+    Q_OBJECT
+
+public:
+    explicit MapGridItem(QQuickItem *parent = nullptr);
+    ~MapGridItem() override;
+
+    QSGNode *updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *) override;
+
+signals:
+
+private:
+    QColor mColor = Qt::black;
+    int lineLength = 2;
+    int spaceLength = 2;
+};
+
+} // namespace TiledQuick

--- a/src/libtiledquick/mapgriditem.h
+++ b/src/libtiledquick/mapgriditem.h
@@ -4,10 +4,6 @@
 
 #include "tiledquick_global.h"
 
-namespace Tiled {
-class MapRenderer;
-}
-
 namespace TiledQuick {
 
 class TILEDQUICK_SHARED_EXPORT MapGridItem : public QQuickItem
@@ -16,6 +12,7 @@ class TILEDQUICK_SHARED_EXPORT MapGridItem : public QQuickItem
 
     Q_PROPERTY(QPointF gridSize READ gridSize WRITE setGridSize NOTIFY gridSizeChanged)
     Q_PROPERTY(qreal scale READ scale WRITE setScale NOTIFY scaleChanged)
+    Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
 
 public:
     explicit MapGridItem(QQuickItem *parent = nullptr);
@@ -29,17 +26,18 @@ public:
     qreal scale() const;
     void setScale(const qreal &scale);
 
+    QColor color() const;
+    void setColor(const QColor &color);
+
 signals:
     void gridSizeChanged();
     void scaleChanged();
+    void colorChanged();
 
 private:
     QPointF mGridSize = {0,0};
     qreal mScale = 0;
-
-private:
-    QColor mColor = Qt::red;
-    int mSegmentLength = 2;
+    QColor mColor = Qt::black;
 };
 
 } // namespace TiledQuick

--- a/src/libtiledquick/mapgriditem.h
+++ b/src/libtiledquick/mapgriditem.h
@@ -1,3 +1,23 @@
+/*
+ * mapgriditem.h
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <QQuickItem>

--- a/src/libtiledquick/mapgriditem.h
+++ b/src/libtiledquick/mapgriditem.h
@@ -30,7 +30,7 @@ class TILEDQUICK_SHARED_EXPORT MapGridItem : public QQuickItem
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF gridSize READ gridSize WRITE setGridSize NOTIFY gridSizeChanged)
+    Q_PROPERTY(QPointF tileSize READ tileSize WRITE setTileSize NOTIFY tileSizeChanged)
     Q_PROPERTY(qreal scale READ scale WRITE setScale NOTIFY scaleChanged)
     Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
 
@@ -40,8 +40,8 @@ public:
 
     QSGNode *updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *) override;
 
-    QPointF gridSize() const;
-    void setGridSize(const QPointF &gridSize);
+    QPointF tileSize() const;
+    void setTileSize(const QPointF &tileSize);
 
     qreal scale() const;
     void setScale(const qreal &scale);
@@ -50,12 +50,12 @@ public:
     void setColor(const QColor &color);
 
 signals:
-    void gridSizeChanged();
+    void tileSizeChanged();
     void scaleChanged();
     void colorChanged();
 
 private:
-    QPointF mGridSize = {0,0};
+    QPointF mTileSize = {0,0};
     qreal mScale = 0;
     QColor mColor = Qt::black;
 };

--- a/src/libtiledquick/mapgridmaterial.cpp
+++ b/src/libtiledquick/mapgridmaterial.cpp
@@ -1,0 +1,76 @@
+#include "mapgridmaterial.h"
+
+using namespace TiledQuick;
+
+struct GridUniformBuffer
+{
+    float qt_Matrix[16];
+
+    float qt_Opacity;
+    float scale;
+    float pixelWidth;
+    float pixelHeight;
+
+    float tileWidth;
+    float tileHeight;
+    // Needed to fill the remaining 8 bytes in this 16-byte "block".
+    float _padding[2];
+
+    float color[4];
+};
+
+class MapGridShader : public QSGMaterialShader
+{
+public:
+    MapGridShader()
+    {
+        setShaderFileName(VertexStage, QStringLiteral(":/grid.vert.qsb"));
+        setShaderFileName(FragmentStage, QStringLiteral(":/grid.frag.qsb"));
+    }
+
+    bool updateUniformData(RenderState &state, QSGMaterial *newMaterial, QSGMaterial *) override
+    {
+        QByteArray *buffer = state.uniformData();
+        auto *u = reinterpret_cast<GridUniformBuffer *>(buffer->data());
+        auto *material = static_cast<MapGridMaterial *>(newMaterial);
+
+        memcpy(u->qt_Matrix, state.combinedMatrix().constData(), 64);
+        u->qt_Opacity = state.opacity();
+
+        u->scale = material->mScale;
+
+        u->pixelWidth = material->mPixelWidth;
+        u->pixelHeight = material->mPixelHeight;
+
+        u->tileWidth = material->mTileWidth;
+        u->tileHeight = material->mTileHeight;
+
+        u->color[0] = material->mColor.redF();
+        u->color[1] = material->mColor.greenF();
+        u->color[2] = material->mColor.blueF();
+        u->color[3] = material->mColor.alphaF();
+
+        return true;
+    }
+};
+
+MapGridMaterial::MapGridMaterial()
+{
+    setFlag(RequiresFullMatrix);
+    setFlag(QSGMaterial::Blending);
+}
+
+MapGridMaterial::~MapGridMaterial() = default;
+
+QSGMaterialShader *MapGridMaterial::createShader(QSGRendererInterface::RenderMode) const
+{
+    return new MapGridShader();
+}
+
+int MapGridMaterial::compare(const QSGMaterial *other) const
+{
+    auto *m = static_cast<const MapGridMaterial *>(other);
+    return (mColor == m->mColor &&
+            qFuzzyCompare(mScale, m->mScale) &&
+            qFuzzyCompare(mPixelWidth, m->mPixelWidth) ? 0 : 1);
+}

--- a/src/libtiledquick/mapgridmaterial.cpp
+++ b/src/libtiledquick/mapgridmaterial.cpp
@@ -1,3 +1,23 @@
+/*
+ * mapgridmaterial.cpp
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "mapgridmaterial.h"
 
 using namespace TiledQuick;
@@ -34,21 +54,20 @@ public:
         auto *u = reinterpret_cast<GridUniformBuffer *>(buffer->data());
         auto *material = static_cast<MapGridMaterial *>(newMaterial);
 
-        memcpy(u->qt_Matrix, state.combinedMatrix().constData(), 64);
+        if (state.isMatrixDirty())
+            memcpy(u->qt_Matrix, state.combinedMatrix().constData(), 64);
+
         u->qt_Opacity = state.opacity();
-
-        u->scale = material->mScale;
-
-        u->pixelWidth = material->mPixelWidth;
-        u->pixelHeight = material->mPixelHeight;
-
-        u->tileWidth = material->mTileWidth;
-        u->tileHeight = material->mTileHeight;
 
         u->color[0] = material->mColor.redF();
         u->color[1] = material->mColor.greenF();
         u->color[2] = material->mColor.blueF();
         u->color[3] = material->mColor.alphaF();
+        u->scale = material->mScale;
+        u->pixelWidth = material->mPixelWidth;
+        u->pixelHeight = material->mPixelHeight;
+        u->tileWidth = material->mTileWidth;
+        u->tileHeight = material->mTileHeight;
 
         return true;
     }
@@ -63,7 +82,7 @@ MapGridMaterial::~MapGridMaterial() = default;
 
 QSGMaterialShader *MapGridMaterial::createShader(QSGRendererInterface::RenderMode) const
 {
-    return new MapGridShader();
+    return new MapGridShader;
 }
 
 int MapGridMaterial::compare(const QSGMaterial *other) const

--- a/src/libtiledquick/mapgridmaterial.cpp
+++ b/src/libtiledquick/mapgridmaterial.cpp
@@ -69,7 +69,13 @@ QSGMaterialShader *MapGridMaterial::createShader(QSGRendererInterface::RenderMod
 int MapGridMaterial::compare(const QSGMaterial *other) const
 {
     auto *m = static_cast<const MapGridMaterial *>(other);
-    return (mColor == m->mColor &&
-            qFuzzyCompare(mScale, m->mScale) &&
-            qFuzzyCompare(mPixelWidth, m->mPixelWidth) ? 0 : 1);
+    return ((
+                mColor == m->mColor &&
+                qFuzzyCompare(mScale, m->mScale) &&
+                qFuzzyCompare(mPixelWidth, m->mPixelWidth) &&
+                qFuzzyCompare(mPixelHeight, m->mPixelHeight) &&
+                qFuzzyCompare(mTileWidth, m->mTileWidth) &&
+                qFuzzyCompare(mTileHeight, m->mTileHeight)
+                )? 0 : 1
+            );
 }

--- a/src/libtiledquick/mapgridmaterial.cpp
+++ b/src/libtiledquick/mapgridmaterial.cpp
@@ -56,8 +56,7 @@ public:
 
 MapGridMaterial::MapGridMaterial()
 {
-    setFlag(RequiresFullMatrix);
-    setFlag(QSGMaterial::Blending);
+    setFlag(RequiresFullMatrix | Blending);
 }
 
 MapGridMaterial::~MapGridMaterial() = default;

--- a/src/libtiledquick/mapgridmaterial.h
+++ b/src/libtiledquick/mapgridmaterial.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QSGMaterial>
+
+#include "tiledquick_global.h"
+
+namespace TiledQuick {
+
+class TILEDQUICK_SHARED_EXPORT MapGridMaterial : public QSGMaterial
+{
+public:
+    MapGridMaterial();
+    ~MapGridMaterial() override;
+
+    QSGMaterialShader *createShader(QSGRendererInterface::RenderMode) const override;
+
+    QSGMaterialType *type() const override { static QSGMaterialType t; return &t; }
+
+    int compare(const QSGMaterial *other) const override;
+
+    QColor mColor = Qt::black;
+    float mScale = 1;
+    float mPixelWidth = 0;
+    float mPixelHeight = 0;
+    float mTileWidth = 0;
+    float mTileHeight = 0;
+};
+
+}

--- a/src/libtiledquick/mapgridmaterial.h
+++ b/src/libtiledquick/mapgridmaterial.h
@@ -26,4 +26,4 @@ public:
     float mTileHeight = 0;
 };
 
-}
+} // namespace TiledQuick

--- a/src/libtiledquick/mapgridmaterial.h
+++ b/src/libtiledquick/mapgridmaterial.h
@@ -1,3 +1,23 @@
+/*
+ * mapgridmaterial.cpp
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <QSGMaterial>

--- a/src/libtiledquick/mapitem.cpp
+++ b/src/libtiledquick/mapitem.cpp
@@ -62,6 +62,14 @@ QRectF MapItem::boundingRect() const
     return mRenderer->mapBoundingRect();
 }
 
+QSize MapItem::tileSize() const
+{
+    if (!mMap)
+        return {0,0};
+
+    return mMap->tileSize();
+}
+
 QPointF MapItem::screenToTileCoords(qreal x, qreal y) const
 {
     if (!mRenderer)

--- a/src/libtiledquick/mapitem.cpp
+++ b/src/libtiledquick/mapitem.cpp
@@ -26,8 +26,6 @@
 #include "maprenderer.h"
 #include "tilelayer.h"
 
-#include <cmath>
-
 using namespace TiledQuick;
 
 MapItem::MapItem(QQuickItem *parent)

--- a/src/libtiledquick/mapitem.h
+++ b/src/libtiledquick/mapitem.h
@@ -69,6 +69,7 @@ public:
     Q_INVOKABLE QPointF pixelToScreenCoords(const QPointF &position) const;
     Q_INVOKABLE QPointF pixelToTileCoords(qreal x, qreal y) const;
     Q_INVOKABLE QPointF pixelToTileCoords(const QPointF &position) const;
+    Q_INVOKABLE QSize tileSize() const;
 
     void componentComplete() override;
 

--- a/src/tiledquick/qml/main.qml
+++ b/src/tiledquick/qml/main.qml
@@ -233,7 +233,7 @@ ApplicationWindow {
                     } else {
                         var mapRelativeCoords = singleFingerPanArea.mapToItem(mapItem, singleFingerPanArea.mouseX, singleFingerPanArea.mouseY)
                         var tileCoords = mapItem.screenToTileCoords(mapRelativeCoords.x, mapRelativeCoords.y)
-                        Math.floor(tileCoords.x) + ", " + Math.floor(tileCoords.y) + ", " + mapContainer.scale;
+                        Math.floor(tileCoords.x) + ", " + Math.floor(tileCoords.y);
                     }
                 }
             }

--- a/src/tiledquick/qml/main.qml
+++ b/src/tiledquick/qml/main.qml
@@ -166,11 +166,14 @@ ApplicationWindow {
                 anchors.fill: mapItem
 
                 color: "black"
+            }
 
-                Tiled.MapGridItem {
-                    id: mapGriditem
-                    anchors.fill: parent
-                }
+            Tiled.MapGridItem {
+                id: mapGriditem
+                anchors.fill: mapItem
+
+                gridSize: mapItem.pixelToTileCoords(width, height);
+                scale: mapContainer.scale;
             }
         }
     }
@@ -228,7 +231,7 @@ ApplicationWindow {
                     } else {
                         var mapRelativeCoords = singleFingerPanArea.mapToItem(mapItem, singleFingerPanArea.mouseX, singleFingerPanArea.mouseY)
                         var tileCoords = mapItem.screenToTileCoords(mapRelativeCoords.x, mapRelativeCoords.y)
-                        Math.floor(tileCoords.x) + ", " + Math.floor(tileCoords.y)
+                        Math.floor(tileCoords.x) + ", " + Math.floor(tileCoords.y) + ", " + mapContainer.scale;
                     }
                 }
             }

--- a/src/tiledquick/qml/main.qml
+++ b/src/tiledquick/qml/main.qml
@@ -165,7 +165,7 @@ ApplicationWindow {
                 id: mapBorderItem
                 anchors.fill: mapItem
 
-                color: "red"
+                color: "black"
             }
         }
     }

--- a/src/tiledquick/qml/main.qml
+++ b/src/tiledquick/qml/main.qml
@@ -174,6 +174,8 @@ ApplicationWindow {
 
                 gridSize: mapItem.pixelToTileCoords(width, height);
                 scale: mapContainer.scale;
+
+                color: "black"
             }
         }
     }

--- a/src/tiledquick/qml/main.qml
+++ b/src/tiledquick/qml/main.qml
@@ -172,7 +172,7 @@ ApplicationWindow {
                 id: mapGriditem
                 anchors.fill: mapItem
 
-                gridSize: mapItem.pixelToTileCoords(width, height);
+                gridSize: Qt.point(width / mapItem.tileSize().width, height / mapItem.tileSize().height);
                 scale: mapContainer.scale;
 
                 color: "black"

--- a/src/tiledquick/qml/main.qml
+++ b/src/tiledquick/qml/main.qml
@@ -166,6 +166,11 @@ ApplicationWindow {
                 anchors.fill: mapItem
 
                 color: "black"
+
+                Tiled.MapGridItem {
+                    id: mapGriditem
+                    anchors.fill: parent
+                }
             }
         }
     }

--- a/src/tiledquick/qml/main.qml
+++ b/src/tiledquick/qml/main.qml
@@ -160,6 +160,13 @@ ApplicationWindow {
                             mapView.height / scale);
                 }
             }
+
+            Tiled.MapBorderItem {
+                id: mapBorderItem
+                anchors.fill: mapItem
+
+                color: "red"
+            }
         }
     }
 

--- a/src/tiledquick/qml/main.qml
+++ b/src/tiledquick/qml/main.qml
@@ -172,7 +172,7 @@ ApplicationWindow {
                 id: mapGriditem
                 anchors.fill: mapItem
 
-                gridSize: Qt.point(width / mapItem.tileSize().width, height / mapItem.tileSize().height);
+                tileSize: Qt.point(mapItem.tileSize().width, mapItem.tileSize().height);
                 scale: mapContainer.scale;
 
                 color: "black"
@@ -233,7 +233,7 @@ ApplicationWindow {
                     } else {
                         var mapRelativeCoords = singleFingerPanArea.mapToItem(mapItem, singleFingerPanArea.mouseX, singleFingerPanArea.mouseY)
                         var tileCoords = mapItem.screenToTileCoords(mapRelativeCoords.x, mapRelativeCoords.y)
-                        Math.floor(tileCoords.x) + ", " + Math.floor(tileCoords.y);
+                        Math.floor(tileCoords.x) + ", " + Math.floor(tileCoords.y)
                     }
                 }
             }

--- a/src/tiledquickplugin/tiledquickplugin.cpp
+++ b/src/tiledquickplugin/tiledquickplugin.cpp
@@ -22,6 +22,7 @@
 
 #include "mapitem.h"
 #include "maploader.h"
+#include "mapborderitem.h"
 #include "tiled.h"
 
 #include <qqml.h>
@@ -36,6 +37,7 @@ void TiledQuickPlugin::registerTypes(const char *uri)
 
     qmlRegisterType<MapLoader>(uri, 1, 0, "MapLoader");
     qmlRegisterType<MapItem>(uri, 1, 0, "MapItem");
+    qmlRegisterType<MapBorderItem>(uri, 1, 0, "MapBorderItem");
 
     Tiled::increaseImageAllocationLimit();
 }

--- a/src/tiledquickplugin/tiledquickplugin.cpp
+++ b/src/tiledquickplugin/tiledquickplugin.cpp
@@ -23,6 +23,7 @@
 #include "mapitem.h"
 #include "maploader.h"
 #include "mapborderitem.h"
+#include "mapgriditem.h"
 #include "tiled.h"
 
 #include <qqml.h>
@@ -38,6 +39,7 @@ void TiledQuickPlugin::registerTypes(const char *uri)
     qmlRegisterType<MapLoader>(uri, 1, 0, "MapLoader");
     qmlRegisterType<MapItem>(uri, 1, 0, "MapItem");
     qmlRegisterType<MapBorderItem>(uri, 1, 0, "MapBorderItem");
+    qmlRegisterType<MapGridItem>(uri, 1, 0, "MapGridItem");
 
     Tiled::increaseImageAllocationLimit();
 }


### PR DESCRIPTION
Draws a simple 1px-width border around `MapItem` using the Qt Scene Graph. The border is drawn on top of the map, and the color is changeable within `tiledquick/qml/main.qml`.

Draws a grid across the map. The color is changeable within `tiledquick/qml/main.qml`. The grid's dash length, space length after dash, and thickness are changeable within `libtiledquick/grid.frag`.

This is my first pull request, so I chose a small feature and wanted to practice mirroring the existing style and standards. This problem has also helped me gain some experience with QtQuick, and I plan on implementing the mouse-following grid-snapping object found in the default Tiled next.

As part of my attempt to imitate the existing style, I have kept my in-code comments to a minimum. Please let me know if including more comments is the better practice, and I can go back and add them.

Any and all feedback is appreciated!