### PR TITLE
Fix the placeholder tiles selection bug

### DIFF
--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -582,12 +582,7 @@ void TilesetEditor::currentChanged(const QModelIndex &index)
 {
     if (index.isValid()) {
         auto model = static_cast<const TilesetModel*>(index.model());
-        auto newTile = model->tileAt(index);
-        if (newTile && newTile->imageShape().isEmpty()) {
-            setCurrentTile(nullptr);
-        } else {
-            setCurrentTile(newTile);
-        }
+        setCurrentTile(model->tileAt(index));
     } else {
         setCurrentTile(nullptr);
     }
@@ -596,13 +591,14 @@ void TilesetEditor::currentChanged(const QModelIndex &index)
 void TilesetEditor::indexPressed(const QModelIndex &index)
 {
     TilesetView *view = currentTilesetView();
-    Tile *tile = view->tilesetModel()->tileAt(index);
-    if (tile && tile->imageShape().isEmpty()){
+	Tile *tile = view->tilesetModel()->tileAt(index);
+
+	// fixed https://github.com/mapeditor/tiled/issues/3498
+	if (!tile){
         mCurrentTilesetDocument->setSelectedTiles({});
-        mCurrentTilesetDocument->setCurrentObject(nullptr);
-    }else{
-        mCurrentTilesetDocument->setCurrentObject(tile);
-    }
+	}
+
+    mCurrentTilesetDocument->setCurrentObject(tile);
 }
 
 void TilesetEditor::saveDocumentState(TilesetDocument *tilesetDocument) const

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -582,7 +582,12 @@ void TilesetEditor::currentChanged(const QModelIndex &index)
 {
     if (index.isValid()) {
         auto model = static_cast<const TilesetModel*>(index.model());
-        setCurrentTile(model->tileAt(index));
+        auto newTile = model->tileAt(index);
+        if (newTile && newTile->imageShape().isEmpty()) {
+            setCurrentTile(nullptr);
+        } else {
+            setCurrentTile(newTile);
+        }
     } else {
         setCurrentTile(nullptr);
     }
@@ -591,8 +596,13 @@ void TilesetEditor::currentChanged(const QModelIndex &index)
 void TilesetEditor::indexPressed(const QModelIndex &index)
 {
     TilesetView *view = currentTilesetView();
-    if (Tile *tile = view->tilesetModel()->tileAt(index))
+    Tile *tile = view->tilesetModel()->tileAt(index);
+    if (tile && tile->imageShape().isEmpty()){
+        mCurrentTilesetDocument->setSelectedTiles({});
+        mCurrentTilesetDocument->setCurrentObject(nullptr);
+    }else{
         mCurrentTilesetDocument->setCurrentObject(tile);
+    }
 }
 
 void TilesetEditor::saveDocumentState(TilesetDocument *tilesetDocument) const


### PR DESCRIPTION
Fixed https://github.com/mapeditor/tiled/issues/3498
Now when users click a placeholder cell, the current selected cell will be deselected, instead of staying the selection on the placeholder cell.
![GIF 2026-3-5 14-57-28](https://github.com/user-attachments/assets/aabf08c2-ab75-4299-a5d5-a7fbb12e515a)
![GIF 2026-3-5 14-56-38](https://github.com/user-attachments/assets/477eef8c-7b6e-42ac-9abd-aac42c28545a)
