### PR TITLE
Add native copy/paste layers feature

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -486,6 +486,11 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     mUi->menuEdit->insertAction(mUi->actionPreferences,
                                 mActionHandler->actionSelectNone());
     mUi->menuEdit->insertSeparator(mUi->actionPreferences);
+    mUi->menuEdit->insertAction(mUi->actionPreferences,
+                                mActionHandler->actionCopyLayers());
+    mUi->menuEdit->insertAction(mUi->actionPreferences,
+                                mActionHandler->actionPasteLayers());
+    mUi->menuEdit->insertSeparator(mUi->actionPreferences);
 
     mUi->menuMap->insertAction(mUi->actionOffsetMap,
                                mActionHandler->actionCropToSelection());

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -98,6 +98,12 @@ MapDocumentActionHandler::MapDocumentActionHandler(QObject *parent)
     mActionGroupLayers = new QAction(this);
     mActionUngroupLayers = new QAction(this);
 
+    mActionCopyLayers = new QAction(this);
+    mActionCopyLayers->setShortcut((Qt::CTRL | Qt::ALT) + Qt::Key_C);
+
+    mActionPasteLayers = new QAction(this);
+    mActionPasteLayers->setShortcut((Qt::CTRL | Qt::ALT) + Qt::Key_V);
+
     mActionDuplicateLayers = new QAction(this);
     mActionDuplicateLayers->setShortcut((Qt::CTRL | Qt::SHIFT) + Qt::Key_D);
     mActionDuplicateLayers->setIcon(
@@ -185,6 +191,8 @@ MapDocumentActionHandler::MapDocumentActionHandler(QObject *parent)
     connect(mActionGroupLayers, &QAction::triggered, this, &MapDocumentActionHandler::groupLayers);
     connect(mActionUngroupLayers, &QAction::triggered, this, &MapDocumentActionHandler::ungroupLayers);
 
+    connect(mActionCopyLayers, &QAction::triggered, this, &MapDocumentActionHandler::copyLayers);
+    connect(mActionPasteLayers, &QAction::triggered, this, &MapDocumentActionHandler::pasteLayers);
     connect(mActionDuplicateLayers, &QAction::triggered, this, &MapDocumentActionHandler::duplicateLayers);
     connect(mActionMergeLayersDown, &QAction::triggered, this, &MapDocumentActionHandler::mergeLayersDown);
     connect(mActionSelectPreviousLayer, &QAction::triggered, this, &MapDocumentActionHandler::selectPreviousLayer);
@@ -216,6 +224,8 @@ MapDocumentActionHandler::MapDocumentActionHandler(QObject *parent)
     ActionManager::registerAction(mActionGroupLayers, "GroupLayers");
     ActionManager::registerAction(mActionUngroupLayers, "UngroupLayers");
 
+    ActionManager::registerAction(mActionCopyLayers, "CopyLayers");
+    ActionManager::registerAction(mActionPasteLayers, "PasteLayers");
     ActionManager::registerAction(mActionDuplicateLayers, "DuplicateLayers");
     ActionManager::registerAction(mActionMergeLayersDown, "MergeLayersDown");
     ActionManager::registerAction(mActionSelectPreviousLayer, "SelectPreviousLayer");
@@ -259,6 +269,8 @@ void MapDocumentActionHandler::retranslateUi()
     mActionGroupLayers->setText(tr("&Group Layers"));
     mActionUngroupLayers->setText(tr("&Ungroup Layers"));
 
+    mActionCopyLayers->setText(tr("&Copy Layers"));
+    mActionPasteLayers->setText(tr("&Paste Layers"));
     mActionDuplicateLayers->setText(tr("&Duplicate Layers"));
     mActionMergeLayersDown->setText(tr("&Merge Layer Down"));   // todo: make plural after string-freeze
     mActionRemoveLayers->setText(tr("&Remove Layers"));
@@ -729,6 +741,104 @@ void MapDocumentActionHandler::ungroupLayers()
         mMapDocument->ungroupLayers(mMapDocument->selectedLayers());
 }
 
+void MapDocumentActionHandler::copyLayers()
+{
+    if (!mMapDocument)
+        return;
+
+    const QList<Layer *> selectedLayers = mMapDocument->selectedLayersOrdered();
+    if (selectedLayers.isEmpty())
+        return;
+
+    // Create a temporary map to store the copied layers
+    Map *map = mMapDocument->map();
+    Map::Parameters mapParameters = map->parameters();
+    mapParameters.infinite = false;
+    Map copyMap(mapParameters);
+
+    QList<Layer *> layersToCopy;
+
+    // Copy layers in the right order (groups before their children)
+    LayerIterator iterator(map);
+    iterator.toBack();
+    while (Layer *layer = iterator.previous())
+        if (selectedLayers.contains(layer))
+            layersToCopy.append(layer);
+
+    ObjectReferencesHelper objectRefs(map);
+
+    // Clone the layers, reassigning any layer and object IDs
+    while (!layersToCopy.isEmpty()) {
+        Layer *original = layersToCopy.takeFirst();
+        Layer *clone = original->clone();
+
+        // If a group layer gets copied, make sure any children are removed
+        // from the remaining list of layers to copy
+        if (original->isGroupLayer()) {
+            layersToCopy.erase(std::remove_if(layersToCopy.begin(),
+                                             layersToCopy.end(),
+                                             [&] (Layer *layer) {
+                                  return layer->isParentOrSelf(original);
+                              }), layersToCopy.end());
+        }
+
+        objectRefs.reassignIds(clone);
+        copyMap.addLayer(clone);
+    }
+
+    objectRefs.rewire();
+
+    // Resolve the set of tilesets used by the copied layers
+    copyMap.addTilesets(copyMap.usedTilesets());
+
+    ClipboardManager::instance()->setMap(copyMap);
+}
+
+void MapDocumentActionHandler::pasteLayers()
+{
+    if (!mMapDocument)
+        return;
+
+    std::unique_ptr<Map> clipboardMap = ClipboardManager::instance()->map();
+    if (!clipboardMap || clipboardMap->layerCount() == 0)
+        return;
+
+    Map *map = mMapDocument->map();
+    const QList<Layer *> selectedLayers = mMapDocument->selectedLayers();
+
+    // Find the top-most selected layer to determine where to paste
+    Layer *topLayer = selectedLayers.isEmpty() ? nullptr : selectedLayers.last();
+    GroupLayer *targetParent = topLayer ? topLayer->parentLayer() : nullptr;
+
+    int targetIndex;
+    if (topLayer)
+        targetIndex = topLayer->siblingIndex() + 1;
+    else
+        targetIndex = map->layerCount();
+
+    mMapDocument->undoStack()->beginMacro(tr("Paste Layers"));
+
+    ObjectReferencesHelper objectRefs(map);
+    QList<Layer *> newLayers;
+
+    // Clone each layer from the clipboard and add it to the map
+    for (int i = 0; i < clipboardMap->layerCount(); ++i) {
+        Layer *clipboardLayer = clipboardMap->layerAt(i);
+        Layer *clone = clipboardLayer->clone();
+
+        objectRefs.reassignIds(clone);
+        newLayers.append(clone);
+
+        mMapDocument->undoStack()->push(new AddLayer(mMapDocument, targetIndex, clone, targetParent));
+        targetIndex++;
+    }
+
+    objectRefs.rewire();
+
+    mMapDocument->undoStack()->endMacro();
+    mMapDocument->switchSelectedLayers(newLayers);
+}
+
 void MapDocumentActionHandler::duplicateLayers()
 {
     if (mMapDocument)
@@ -883,6 +993,9 @@ void MapDocumentActionHandler::updateActions()
     mActionGroupLayers->setEnabled(!selectedLayers.isEmpty());
     mActionUngroupLayers->setEnabled(std::any_of(selectedLayers.begin(), selectedLayers.end(),
                                                  [] (Layer *layer) { return layer->isGroupLayer() || layer->parentLayer(); }));
+
+    mActionCopyLayers->setEnabled(!selectedLayers.isEmpty());
+    mActionPasteLayers->setEnabled(ClipboardManager::instance()->hasMap());
 
     const bool hasPreviousLayer = LayerIterator(currentLayer).previous();
     const bool hasNextLayer = LayerIterator(currentLayer).next();

--- a/src/tiled/mapdocumentactionhandler.h
+++ b/src/tiled/mapdocumentactionhandler.h
@@ -73,6 +73,8 @@ public:
     QAction *actionGroupLayers() const { return mActionGroupLayers; }
     QAction *actionUngroupLayers() const { return mActionUngroupLayers; }
 
+    QAction *actionCopyLayers() const { return mActionCopyLayers; }
+    QAction *actionPasteLayers() const { return mActionPasteLayers; }
     QAction *actionDuplicateLayers() const { return mActionDuplicateLayers; }
     QAction *actionMergeLayersDown() const { return mActionMergeLayersDown; }
     QAction *actionRemoveLayers() const { return mActionRemoveLayers; }
@@ -119,6 +121,8 @@ public slots:
     void groupLayers();
     void ungroupLayers();
 
+    void copyLayers();
+    void pasteLayers();
     void duplicateLayers();
     void mergeLayersDown();
     void selectPreviousLayer();
@@ -159,6 +163,8 @@ private:
     QAction *mActionGroupLayers;
     QAction *mActionUngroupLayers;
 
+    QAction *mActionCopyLayers;
+    QAction *mActionPasteLayers;
     QAction *mActionDuplicateLayers;
     QAction *mActionMergeLayersDown;
     QAction *mActionRemoveLayers;


### PR DESCRIPTION
Closes #1154.

## What does this do?

Users can now copy selected layers and paste them as new layers, similar to how the [existing script](https://github.com/eishiya/tiled-scripts/blob/main/CopyPasteLayers.js) works, but built directly into the editor.

## How to use

1. Select one or more layers in the Layers panel
2. Edit → Copy Layers
3. Edit → Paste Layers
Pasted layers appear above the currently selected layer, or at the top if nothing is selected.

## What's supported

- All layer types (tile, object, image, group)
- Multiple layer selection
- Group layers with children (recursive)
- All layer properties (opacity, tint, offset, parallax, etc.)
- Object properties and references
- Cross-document paste
- Undo/redo integration

## Implementation details

The implementation follows the existing `duplicateLayers()` pattern but uses the system clipboard via `ClipboardManager`. Layers are serialized as a temporary Map object in TMX format, allowing paste operations across different map documents.

Key changes:
- Added `copyLayers()` and `pasteLayers()` methods to `MapDocumentActionHandler`
- Uses `ObjectReferencesHelper` for proper ID reassignment
- Integrates with existing undo/redo system via macro commands
- Menu items enable/disable based on selection and clipboard state

One thing to be noted:
Keyboard shortcuts use Ctrl+Alt+C/V to avoid conflicts with existing copy/paste actions for tile/object content.
