### PR TITLE
Fix point object bounding box in multi-object selections

### DIFF
--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -924,7 +924,8 @@ static QRectF objectBounds(const MapObject *object,
             return transform.map(screenPolygon).boundingRect();
         }
         case MapObject::Point: {
-            return transform.mapRect(renderer->shape(object).boundingRect());
+            const QPointF pos = renderer->pixelToScreenCoords(object->position());
+            return transform.mapRect(QRectF(pos, QSizeF(0, 0)));
         }
         case MapObject::Polygon:
         case MapObject::Polyline: {


### PR DESCRIPTION
Fixes #3784

The objectBounds() function was using renderer->shape(object) for Point objects, which returns the visual pin shape rather than the actual point position. This caused the selection bounding box to be larger than expected, affecting snapping and rotation behavior.

Fix by returning a zero-size rect at the point's screen position, consistent with how Point objects are treated geometrically.

Before:
<img width="286" height="223" alt="Screenshot 2026-03-06 221013" src="https://github.com/user-attachments/assets/7c519f89-8146-46d1-933e-3c775660edeb" />

After:
<img width="240" height="170" alt="Screenshot 2026-03-06 221340" src="https://github.com/user-attachments/assets/931eb671-e4f7-4e14-9f90-1db37e562508" />

