### PR TITLE
Add plain text fallback when reading clipboard map data

### DIFF
--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -80,14 +80,23 @@ ClipboardManager *ClipboardManager::instance()
 std::unique_ptr<Map> ClipboardManager::map() const
 {
     const auto mimeData = mClipboard->mimeData();
-    const QByteArray data = mimeData->data(QLatin1String(TMX_MIMETYPE));
-    if (data.isEmpty())
+    if (!mimeData)
         return nullptr;
+
+    QByteArray data = mimeData->data(QLatin1String(TMX_MIMETYPE));
+
+    // Fallback to plain text if custom TMX MIME type is unavailable
+    if (data.isEmpty() && mimeData->hasText()) {
+        data = mimeData->text().toUtf8();
+    }
+
+    if (data.isEmpty()) {
+        return nullptr;
+    }
 
     TmxMapFormat format;
     return format.fromByteArray(data);
 }
-
 /**
  * Sets the given map on the clipboard.
  */


### PR DESCRIPTION
### Summary

Add a plain text fallback when reading clipboard map data.

### Problem

`ClipboardManager::update()` enables the Paste option when plain text exists in the clipboard. However, `ClipboardManager::map()` previously only attempted to read the custom text/tmx MIME type, which could lead to Paste being enabled while no data is actually read.

### Solution

If text/tmx data is unavailable, the code now falls back to reading plain text from the clipboard and attempts to parse it as TMX data.

### Result

This keeps clipboard behavior consistent and allows valid TMX XML copied as plain text (for example from external tools or browsers) to be parsed correctly.