### PR TITLE
Add warning log when clipboard TMX parsing fails

### DIFF
--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -95,13 +95,6 @@ std::unique_ptr<Map> ClipboardManager::map() const
 
     return map;
 }
-
-    if (!map) {
-        qWarning() << "Failed to parse TMX data from clipboard";
-    }
-
-    return map;
-}
 /**
  * Sets the given map on the clipboard.
  */


### PR DESCRIPTION
Adds a warning log when parsing TMX data from the clipboard fails.

This helps with debugging situations where clipboard data cannot be converted into a Map instance.