### PR TITLE
Add null guard for clipboard mime data in properties()

### DIFF
--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -104,6 +104,9 @@ void ClipboardManager::setMap(const Map &map)
 Properties ClipboardManager::properties() const
 {
     auto mimeData = mClipboard->mimeData();
+    if (!mimeData)
+        return {};
+
     const QByteArray data = mimeData->data(QLatin1String(PROPERTIES_MIMETYPE));
     const QJsonArray array = QCborValue::fromCbor(data).toArray().toJsonArray();
     return propertiesFromJson(array);


### PR DESCRIPTION
### Summary

Adds a defensive null check for the clipboard mime data in ClipboardManager::properties().

### Problem

The function assumes that mimeData() always returns a valid pointer. Although this is usually true, adding a guard prevents potential null dereference.

### Solution

A simple null check was added before accessing clipboard data.

### Benefit

Improves robustness and prevents potential crashes when clipboard data is unavailable.