### PR TITLE
Object Selection: toggle objects when using rectangle with Ctrl/Shift

### DIFF
--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -1197,8 +1197,17 @@ void ObjectSelectionTool::updateSelection(const QPointF &pos,
     QList<MapObject*> selectedObjects = objectsAboutToBeSelected(pos, modifiers);
 
     if (modifiers & (Qt::ControlModifier | Qt::ShiftModifier)) {
-        for (MapObject *object : mapDocument()->selectedObjects())
-            if (!selectedObjects.contains(object))
+        const QList<MapObject*> rectObjects = selectedObjects;
+        const QList<MapObject*> currentSelection = mapDocument()->selectedObjects();
+
+        selectedObjects.clear();
+
+        for (MapObject *object : currentSelection)
+            if (!rectObjects.contains(object))
+                selectedObjects.append(object);
+
+        for (MapObject *object : rectObjects)
+            if (!currentSelection.contains(object))
                 selectedObjects.append(object);
     } else {
         setMode(Resize);    // new selection resets edit mode


### PR DESCRIPTION
 Fixes #3718 
                                                                                            
Ctrl/Shift + click already toggles individual objects in/out of the selection. This makes Ctrl/Shift + rectangle drag behave consistently by computing the symmetric difference: objects in the rectangle that are already selected get removed, and objects not yet selected get added.