### PR TITLE
Add initial support for QML-based extensions with QAction integration

### DIFF
--- a/src/plugins/tbin/tidemapformat.cpp
+++ b/src/plugins/tbin/tidemapformat.cpp
@@ -69,7 +69,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
             while ( xml.readNextStartElement() )
             {
-                if ( xml.name() == "Property" )
+                if (xml.name() == QStringLiteral("Property"))
                 {
                     const QXmlStreamAttributes attrs = xml.attributes();
 
@@ -111,11 +111,11 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
         {
             if ( xml.name() == QLatin1String( "Description" ) )
                 tmap.desc = xml.readElementText().toStdString();
-            else if ( xml.name() == "TileSheets" )
+            else if ( xml.name() == QLatin1String("TileSheets") )
             {
                 while ( xml.readNextStartElement() )
                 {
-                    if ( xml.name() != "TileSheet" )
+                    if ( xml.name() != QLatin1String("TileSheet") )
                     {
                         xml.skipCurrentElement();
                         continue;
@@ -130,9 +130,9 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                     {
                         if ( xml.name() == QLatin1String( "Description" ) )
                             ts.desc = xml.readElementText().toStdString();
-                        else if ( xml.name() == "ImageSource" )
+                        else if ( xml.name() == QLatin1String("ImageSource") )
                             ts.image = xml.readElementText().toStdString();
-                        else if ( xml.name() == "Alignment" )
+                        else if ( xml.name() == QLatin1String("Alignment" ))
                         {
                             const QXmlStreamAttributes alignAttrs = xml.attributes();
 
@@ -153,7 +153,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
                             xml.skipCurrentElement();
                         }
-                        else if (xml.name() == "Properties")
+                        else if (xml.name() == QStringLiteral("Property"))
                             ts.props = readProps();
                         else xml.skipCurrentElement();
                     }
@@ -161,11 +161,11 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                     tmap.tilesheets.push_back( ts );
                 }
             }
-            else if ( xml.name() == "Layers" )
+            else if ( xml.name() == QLatin1String("Layers") )
             {
                 while ( xml.readNextStartElement() )
                 {
-                    if ( xml.name() != "Layer" )
+                    if ( xml.name() != QLatin1String("Layer") )
                     {
                         xml.skipCurrentElement();
                         continue;
@@ -181,7 +181,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                     {
                         if ( xml.name() == QLatin1String( "Description" ) )
                             layer.desc = xml.readElementText().toStdString();
-                        else if ( xml.name() == "Dimensions" )
+                        else if ( xml.name() == QLatin1String("Dimensions") )
                         {
                             const QXmlStreamAttributes alignAttrs = xml.attributes();
 
@@ -196,7 +196,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
                             xml.skipCurrentElement();
                         }
-                        else if ( xml.name() == "TileArray" )
+                        else if ( xml.name() == QLatin1String( "TileArray" ))
                         {
                             tbin::Tile nullTile;
                             nullTile.staticData.tileIndex = -1;
@@ -218,7 +218,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                                 // for compatibility with xTile code.
                                 while ( xml.readNextStartElement() )
                                 {
-                                    if (xml.name() == "Properties")
+                                    if (xml.name() == QStringLiteral("Property"))
                                         tile.props = readProps();
                                     else xml.skipCurrentElement();
                                 }
@@ -230,7 +230,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                             tbin::Vector2i tilePos;
                             while ( xml.readNextStartElement() )
                             {
-                                if (xml.name() != "Row" )
+                                if (xml.name() != QLatin1String("Row") )
                                 {
                                     xml.skipCurrentElement();
                                     continue;
@@ -238,18 +238,18 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
                                 while ( xml.readNextStartElement() )
                                 {
-                                    if ( xml.name() == "TileSheet" )
+                                    if ( xml.name() == QLatin1String( "TileSheet") )
                                     {
                                         const QXmlStreamAttributes tsAttrs = xml.attributes();
                                         lastTilesheet = tsAttrs.value( "Ref" ).toString().toStdString();
                                         xml.skipCurrentElement();
                                     }
-                                    else if ( xml.name() == "Static" )
+                                    else if ( xml.name() == QLatin1String("Static") )
                                     {
                                         layer.tiles[ tilePos.x + tilePos.y * layer.layerSize.x ] = readStaticTile( lastTilesheet );
                                         tilePos.x += 1;
                                     }
-                                    else if ( xml.name() == "Animated" )
+                                    else if ( xml.name() == QLatin1String("Animated" ))
                                     {
                                         const QXmlStreamAttributes tileAttrs = xml.attributes();
 
@@ -258,23 +258,23 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
                                         while ( xml.readNextStartElement() )
                                         {
-                                            if (xml.name() == "Frames" )
+                                            if (xml.name() == QLatin1String("Frames") )
                                             {
                                                 std::string lastTilesheet; // Shadowing the previous declaration intentionally, because we explicitly do not want to use/affect it
                                                 while ( xml.readNextStartElement() )
                                                 {
-                                                    if ( xml.name() == "TileSheet" )
+                                                    if ( xml.name() == QLatin1String("TileSheet") )
                                                     {
                                                         const QXmlStreamAttributes tsAttrs = xml.attributes();
                                                         lastTilesheet = tsAttrs.value( "Ref" ).toString().toStdString();
                                                         xml.skipCurrentElement();
                                                     }
-                                                    else if (xml.name() == "Static")
+                                                    else if (xml.name() == QLatin1String( "Static"))
                                                         tile.animatedData.frames.push_back( readStaticTile( lastTilesheet ) );
                                                     else xml.skipCurrentElement();
                                                 }
                                             }
-                                            else if (xml.name() == "Properties")
+                                            else if (xml.name() == QStringLiteral("Property"))
                                                 tile.props = readProps();
                                             else xml.skipCurrentElement();
                                         }
@@ -282,7 +282,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                                         layer.tiles[ tilePos.x + tilePos.y * layer.layerSize.x ] = tile;
                                         tilePos.x += 1;
                                     }
-                                    else if ( xml.name() == "Null" )
+                                    else if ( xml.name() == QLatin1String("Null" ))
                                     {
                                         const QXmlStreamAttributes tileAttrs = xml.attributes();
                                         tilePos.x += tileAttrs.value( "Count" ).toString().toInt();
@@ -295,7 +295,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                                 tilePos.y += 1;
                             }
                         }
-                        else if (xml.name() == "Properties")
+                        else if (xml.name() == QStringLiteral("Property"))
                             layer.props = readProps();
                         else xml.skipCurrentElement();
                     }
@@ -303,7 +303,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                     tmap.layers.push_back( layer );
                 }
             }
-            else if (xml.name() == "Properties")
+            else if (xml.name() == QStringLiteral("Property"))
                 tmap.props = readProps();
             else xml.skipCurrentElement();
         }

--- a/src/plugins/tbin/tidemapformat.cpp
+++ b/src/plugins/tbin/tidemapformat.cpp
@@ -69,7 +69,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
             while ( xml.readNextStartElement() )
             {
-                if (xml.name() == QStringLiteral("Property"))
+                if (xml.name() == QLatin1String("Properties"))
                 {
                     const QXmlStreamAttributes attrs = xml.attributes();
 
@@ -153,7 +153,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
                             xml.skipCurrentElement();
                         }
-                        else if (xml.name() == QStringLiteral("Property"))
+                        else if (xml.name() == QLatin1String("Properties"))
                             ts.props = readProps();
                         else xml.skipCurrentElement();
                     }
@@ -218,7 +218,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                                 // for compatibility with xTile code.
                                 while ( xml.readNextStartElement() )
                                 {
-                                    if (xml.name() == QStringLiteral("Property"))
+                                    if (xml.name() == QLatin1String("Properties"))
                                         tile.props = readProps();
                                     else xml.skipCurrentElement();
                                 }
@@ -274,7 +274,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                                                     else xml.skipCurrentElement();
                                                 }
                                             }
-                                            else if (xml.name() == QStringLiteral("Property"))
+                                            else if (xml.name() == QLatin1String("Properties"))
                                                 tile.props = readProps();
                                             else xml.skipCurrentElement();
                                         }
@@ -295,7 +295,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                                 tilePos.y += 1;
                             }
                         }
-                        else if (xml.name() == QStringLiteral("Property"))
+                        else if (xml.name() == QLatin1String("Properties"))
                             layer.props = readProps();
                         else xml.skipCurrentElement();
                     }
@@ -303,7 +303,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                     tmap.layers.push_back( layer );
                 }
             }
-            else if (xml.name() == QStringLiteral("Property"))
+            else if (xml.name() == QLatin1String("Properties"))
                 tmap.props = readProps();
             else xml.skipCurrentElement();
         }

--- a/src/tiled/abstracttool.cpp
+++ b/src/tiled/abstracttool.cpp
@@ -198,4 +198,4 @@ Layer *AbstractTool::currentLayer() const
 
 } // namespace Tiled
 
-#include "moc_abstracttool.cpp"
+// #include "moc_abstracttool.cpp"

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -506,6 +506,8 @@ DynamicLibrary {
         "tilecollisiondock.h",
         "tiledapplication.cpp",
         "tiledapplication.h",
+        "tiledaction.h",
+        "tiledaction.cpp",
         "tilededitor_global.h",
         "tiledproxystyle.cpp",
         "tiledproxystyle.h",

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -414,6 +414,8 @@ DynamicLibrary {
         "propertytypeseditor.ui",
         "propertytypesmodel.cpp",
         "propertytypesmodel.h",
+        "qmltool.cpp",
+        "qmltool.h",
         "raiselowerhelper.cpp",
         "raiselowerhelper.h",
         "randompicker.h",
@@ -623,8 +625,10 @@ DynamicLibrary {
     Export {
         Depends { name: "cpp" }
         Depends { name: "libtiled" }
+        // Depends { name: "tiled"}
         Depends { name: "qtsingleapplication" }
         Depends { name: "Qt"; submodules: ["qml"] }
+
         cpp.includePaths: exportingProduct.sourceDirectory
     }
 

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -232,9 +232,14 @@ MapEditor::MapEditor(QObject *parent)
 
     auto qmlTools =ScriptManager::instance().qmlTools();
 
-
     for (QmlTool * tool : qmlTools){
         mToolManager->registerTool(tool);
+        QAction* action = new QAction(tool->icon(),tool->name(),this);
+        action->setCheckable(true);
+        mToolsToolBar->addAction(action);
+        connect(action,&QAction::triggered, this ,[this,tool](){
+            setSelectedTool(tool);
+        });
     }
 
     mToolManager->createShortcuts(mMainWindow);

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -77,6 +77,8 @@
 #include "zoomable.h"
 #include "worldmanager.h"
 #include "worldmovemaptool.h"
+#include "qmltool.h"
+
 
 #include <QComboBox>
 #include <QDialogButtonBox>
@@ -226,6 +228,14 @@ MapEditor::MapEditor(QObject *parent)
             mToolManager->unregisterTool(tool);
         }
     });
+
+
+    auto qmlTools =ScriptManager::instance().qmlTools();
+
+
+    for (QmlTool * tool : qmlTools){
+        mToolManager->registerTool(tool);
+    }
 
     mToolManager->createShortcuts(mMainWindow);
 

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -132,6 +132,7 @@ public:
 
     AbstractTool *selectedTool() const;
     void setSelectedTool(AbstractTool *tool);
+    ToolManager *toolManager () const{ return mToolManager;}
 
     Q_INVOKABLE AbstractTool *tool(const QByteArray &id) const;
 

--- a/src/tiled/qmltool.cpp
+++ b/src/tiled/qmltool.cpp
@@ -1,8 +1,11 @@
 #include "qmltool.h"
+
 #include <QGraphicsSceneMouseEvent>
-#include "mapscene.h"
 #include <QIcon>
 #include <QKeySequence>
+#include <QCursor>
+
+#include "mapscene.h"
 #include "id.h"
 
 namespace Tiled {
@@ -25,8 +28,31 @@ void QmlTool::setIconSource(const QString &source)
 {
     mIconSource = source;
 
-    // load icon from theme (same way Tiled tools do)
-    setIcon(QIcon::fromTheme(source));
+    if (source.startsWith(QStringLiteral(":/")) || source.startsWith(QStringLiteral("file")) )
+        setIcon(QIcon(source));
+    else
+        setIcon(QIcon::fromTheme(source));
+}
+
+int QmlTool::cursorShape() const
+{
+    return mCursorShape;
+}
+
+void QmlTool::setCursorShape(int shape)
+{
+    mCursorShape = shape;
+    setCursor(QCursor((Qt::CursorShape)shape));
+}
+
+QObject* QmlTool::options() const
+{
+    return mOptions;
+}
+
+void QmlTool::setOptions(QObject *opt)
+{
+    mOptions = opt;
 }
 
 void QmlTool::mouseEntered()
@@ -55,6 +81,11 @@ void QmlTool::mouseReleased(QGraphicsSceneMouseEvent *event)
 {
     emit qmlMouseReleased(event->scenePos().x(),
                           event->scenePos().y());
+}
+
+void QmlTool::drawOverlay(QPainter *painter, const QRectF &)
+{
+    emit qmlDrawOverlay(painter);
 }
 
 void QmlTool::languageChanged()

--- a/src/tiled/qmltool.cpp
+++ b/src/tiled/qmltool.cpp
@@ -1,0 +1,64 @@
+#include "qmltool.h"
+#include <QGraphicsSceneMouseEvent>
+#include "mapscene.h"
+#include <QIcon>
+#include <QKeySequence>
+#include "id.h"
+
+namespace Tiled {
+
+QmlTool::QmlTool(QObject *parent)
+    : AbstractTool(Id("qmltool"),
+                   QStringLiteral("QML Tool"),
+                   QIcon(),
+                   QKeySequence(),
+                   parent)
+{
+}
+
+QString QmlTool::iconSource() const
+{
+    return mIconSource;
+}
+
+void QmlTool::setIconSource(const QString &source)
+{
+    mIconSource = source;
+
+    // load icon from theme (same way Tiled tools do)
+    setIcon(QIcon::fromTheme(source));
+}
+
+void QmlTool::mouseEntered()
+{
+    emit qmlMouseEntered();
+}
+
+void QmlTool::mouseLeft()
+{
+    emit qmlMouseLeft();
+}
+
+void QmlTool::mouseMoved(const QPointF &pos,
+                         Qt::KeyboardModifiers)
+{
+    emit qmlMouseMoved(pos.x(), pos.y());
+}
+
+void QmlTool::mousePressed(QGraphicsSceneMouseEvent *event)
+{
+    emit qmlMousePressed(event->scenePos().x(),
+                         event->scenePos().y());
+}
+
+void QmlTool::mouseReleased(QGraphicsSceneMouseEvent *event)
+{
+    emit qmlMouseReleased(event->scenePos().x(),
+                          event->scenePos().y());
+}
+
+void QmlTool::languageChanged()
+{
+}
+
+}

--- a/src/tiled/qmltool.h
+++ b/src/tiled/qmltool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "abstracttool.h"
+#include <QPainter>
 
 namespace Tiled {
 
@@ -9,12 +10,20 @@ class QmlTool : public AbstractTool
     Q_OBJECT
 
     Q_PROPERTY(QString iconSource READ iconSource WRITE setIconSource)
+    Q_PROPERTY(int cursorShape READ cursorShape WRITE setCursorShape)
+    Q_PROPERTY(QObject* options READ options WRITE setOptions)
 
 public:
     explicit QmlTool(QObject *parent = nullptr);
 
     QString iconSource() const;
     void setIconSource(const QString &source);
+
+    int cursorShape() const;
+    void setCursorShape(int shape);
+
+    QObject* options() const;
+    void setOptions(QObject *opt);
 
     void mouseEntered() override;
     void mouseLeft() override;
@@ -27,6 +36,8 @@ public:
 
     void languageChanged() override;
 
+    void drawOverlay(QPainter *painter, const QRectF &exposed) ;
+
 signals:
 
     void qmlMouseEntered();
@@ -36,8 +47,14 @@ signals:
     void qmlMousePressed(int x, int y);
     void qmlMouseReleased(int x, int y);
 
+    void qmlDrawOverlay(QPainter *painter);
+
 private:
+
     QString mIconSource;
+    int mCursorShape = Qt::ArrowCursor;
+    QObject *mOptions = nullptr;
 };
 
 }
+

--- a/src/tiled/qmltool.h
+++ b/src/tiled/qmltool.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "abstracttool.h"
+
+namespace Tiled {
+
+class QmlTool : public AbstractTool
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString iconSource READ iconSource WRITE setIconSource)
+
+public:
+    explicit QmlTool(QObject *parent = nullptr);
+
+    QString iconSource() const;
+    void setIconSource(const QString &source);
+
+    void mouseEntered() override;
+    void mouseLeft() override;
+
+    void mouseMoved(const QPointF &pos,
+                    Qt::KeyboardModifiers modifiers) override;
+
+    void mousePressed(QGraphicsSceneMouseEvent *event) override;
+    void mouseReleased(QGraphicsSceneMouseEvent *event) override;
+
+    void languageChanged() override;
+
+signals:
+
+    void qmlMouseEntered();
+    void qmlMouseLeft();
+
+    void qmlMouseMoved(int x, int y);
+    void qmlMousePressed(int x, int y);
+    void qmlMouseReleased(int x, int y);
+
+private:
+    QString mIconSource;
+};
+
+}

--- a/src/tiled/scriptedaction.cpp
+++ b/src/tiled/scriptedaction.cpp
@@ -23,6 +23,7 @@
 #include "scriptmanager.h"
 
 #include <QJSEngine>
+#include <QQmlEngine>
 
 namespace Tiled {
 

--- a/src/tiled/scriptedfileformat.h
+++ b/src/tiled/scriptedfileformat.h
@@ -24,6 +24,7 @@
 #include "tilesetformat.h"
 
 #include <QJSValue>
+#include <QQmlEngine>
 
 namespace Tiled {
 

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -56,6 +56,15 @@
 #include "tilelayerwangedit.h"
 #include "tilesetdock.h"
 #include "tileseteditor.h"
+#include "documentmanager.h"
+#include "mapdocument.h"
+#include "qmltool.h"
+#include "toolmanager.h"
+#include "mainwindow.h"
+#include "mapeditor.h"
+#include "toolmanager.h"
+#include "editor.h"
+
 
 #include <QCoreApplication>
 #include <QQmlComponent>
@@ -150,6 +159,7 @@ ScriptManager::ScriptManager(QObject *parent)
     qRegisterMetaType<ScriptImage*>();
     qRegisterMetaType<WangIndex::Value>("WangIndex");
     qmlRegisterType<Tiled::QmlAction>("Tiled", 1, 0, "QmlAction");
+    qmlRegisterType<Tiled::QmlTool>("Tiled", 1, 0, "QmlTool");
 
     connect(&mWatcher, &FileSystemWatcher::pathsChanged,
             this, &ScriptManager::scriptFilesChanged);
@@ -333,81 +343,117 @@ void ScriptManager::loadQmlExtension(const QString &filePath)
         return;
     }
 
-    QObject *object = component.create();
+    QObject *root = component.create();
 
-    if (!object) {
-        qWarning() << "Failed to create QML object";
+    if (!root) {
+        qWarning() << "Failed to create QML extension";
         return;
     }
 
-    // keep extension alive
-    object->setParent(this);
-    mExtensions.append(object);
+    root->setParent(this);
+    mExtensions.append(root);
 
-    // we only care about QmlAction objects
-    QmlAction *action = qobject_cast<QmlAction *>(object);
+    registerQmlExtension(root);
+
+    qDebug() << "QML extension loaded:" << filePath;
+}
+
+
+void ScriptManager::registerQmlExtension(QObject *root)
+{
+    // Load actions
+    QList<QmlAction*> actions = root->findChildren<QmlAction*>();
+
+    for (QmlAction *action : actions) {
+        registerAction(action);
+    }
+
+    // Load tools
+    QList<QmlTool*> tools = root->findChildren<QmlTool*>();
+
+    for (QmlTool *tool : tools) {
+        registerTool(tool);
+    }
+    for (QObject *child : root->children()) {
+
+        if (auto action = qobject_cast<QmlAction*>(child)) {
+            registerAction(action);
+        }
+
+        if (auto tool = qobject_cast<QmlTool*>(child)) {
+            registerTool(tool);
+        }
+    }
+}
+
+void ScriptManager::registerAction(QmlAction *action)
+{
     if (!action)
         return;
 
-    // register with ActionManager
     if (!action->objectName().isEmpty()) {
-        Tiled::ActionManager::registerAction(
+        ActionManager::registerAction(
             action,
-            Tiled::Id(action->objectName().toUtf8()));
+            Id(action->objectName().toUtf8()));
     }
 
-    // find MainWindow
-    Tiled::MainWindow *mainWindow = nullptr;
+    addActionToMenu(action);
+
+    qDebug() << "Registered QML action:" << action->text();
+}
+
+void ScriptManager::addActionToMenu(QmlAction *action)
+{
+    MainWindow *mainWindow = nullptr;
 
     for (QWidget *w : QApplication::topLevelWidgets()) {
-        mainWindow = qobject_cast<Tiled::MainWindow *>(w);
+        mainWindow = qobject_cast<MainWindow *>(w);
         if (mainWindow)
             break;
     }
 
-    if (!mainWindow) {
-        qWarning() << "MainWindow not found";
+    if (!mainWindow)
         return;
-    }
 
     QMenuBar *menuBar = mainWindow->menuBar();
 
-    QString targetMenuName = action->menu();
-    if (targetMenuName.isEmpty())
-        targetMenuName = QStringLiteral("Extensions");
+    QString menuName = action->menu();
+    if (menuName.isEmpty())
+        menuName = QStringLiteral("Extensions");
 
     QMenu *targetMenu = nullptr;
 
-    // search existing menu
     for (QAction *act : menuBar->actions()) {
 
         if (!act->menu())
             continue;
 
-        QString menuText = act->text();
-        menuText.remove(QRegularExpression(QStringLiteral("&")));          // remove Qt shortcut markers
-        menuText = menuText.trimmed();
+        QString text = act->text();
+        text.replace(QStringLiteral("&"), QString());
+        text = text.trimmed();
 
-        if (menuText.compare(targetMenuName, Qt::CaseInsensitive) == 0) {
+        if (text.compare(menuName, Qt::CaseInsensitive) == 0) {
             targetMenu = act->menu();
             break;
         }
     }
 
-    // create menu if it doesn't exist
-    if (!targetMenu) {
-        targetMenu = menuBar->addMenu(targetMenuName);
-    }
+    if (!targetMenu)
+        targetMenu = menuBar->addMenu(menuName);
 
-    // prevent duplicate insertion
-    if (!targetMenu->actions().contains(action)) {
+    if (!targetMenu->actions().contains(action))
         targetMenu->addAction(action);
-    }
-
-    qDebug() << "QML extension loaded:" << action->text()
-             << "→ menu:" << targetMenuName;
 }
 
+void ScriptManager::registerTool(QmlTool *tool)
+{
+    if (!tool)
+        return;
+
+    mQmlTools.append(tool);
+
+    qDebug() << "Registered QML tool:" << tool->name();
+}
 bool ScriptManager::checkError(QJSValue value, const QString &program)
 {
     if (!value.isError())
@@ -441,6 +487,10 @@ bool ScriptManager::checkError(QJSValue value, const QString &program)
     return true;
 }
 
+QList <QmlTool*>ScriptManager::qmlTools() const{
+    return mQmlTools;
+}
+
 void ScriptManager::throwError(const QString &message)
 {
     mEngine->throwError(message);
@@ -467,7 +517,12 @@ void ScriptManager::reset()
 
     delete mEngine;
     delete mModule;
-    qDeleteAll(mExtensions);
+    for (QObject *ext : std::as_const(mExtensions))
+    {
+        if (ext)
+            ext->deleteLater();
+    }
+
     mExtensions.clear();
 
     mEngine = nullptr;

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -447,6 +447,8 @@ void ScriptManager::reset()
 
     delete mEngine;
     delete mModule;
+    qDeleteAll(mExtensions);
+    mExtensions.clear();
 
     mEngine = nullptr;
     mModule = nullptr;

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -321,71 +321,91 @@ void ScriptManager::loadExtension(const QString &path)
 
 void ScriptManager::loadQmlExtension(const QString &filePath)
 {
-    if (!mEngine)
-    {
+    if (!mEngine) {
         qWarning() << "QML engine not initialized";
         return;
     }
 
     QQmlComponent component(mEngine, QUrl::fromLocalFile(filePath));
 
-    if (component.isError())
-    {
+    if (component.isError()) {
         qWarning() << component.errors();
         return;
     }
 
     QObject *object = component.create();
 
-    if (!object)
-    {
+    if (!object) {
         qWarning() << "Failed to create QML object";
         return;
     }
 
+    // keep extension alive
     object->setParent(this);
     mExtensions.append(object);
 
-    QAction *action = qobject_cast<QAction *>(object);
+    // we only care about QmlAction objects
+    QmlAction *action = qobject_cast<QmlAction *>(object);
     if (!action)
         return;
-    if (!action->objectName().isEmpty())
-    {
+
+    // register with ActionManager
+    if (!action->objectName().isEmpty()) {
         Tiled::ActionManager::registerAction(
             action,
             Tiled::Id(action->objectName().toUtf8()));
     }
+
+    // find MainWindow
     Tiled::MainWindow *mainWindow = nullptr;
 
-    for (QWidget *w : QApplication::topLevelWidgets())
-    {
+    for (QWidget *w : QApplication::topLevelWidgets()) {
         mainWindow = qobject_cast<Tiled::MainWindow *>(w);
         if (mainWindow)
             break;
     }
 
-    if (!mainWindow)
+    if (!mainWindow) {
+        qWarning() << "MainWindow not found";
         return;
+    }
 
     QMenuBar *menuBar = mainWindow->menuBar();
-    QMenu *extensionsMenu = nullptr;
 
-    for (QAction *act : menuBar->actions())
-    {
-        if (act->menu() &&
-            act->text().compare(QStringLiteral("Extensions"),
-                                Qt::CaseInsensitive) == 0)
-        {
-            extensionsMenu = act->menu();
+    QString targetMenuName = action->menu();
+    if (targetMenuName.isEmpty())
+        targetMenuName = QStringLiteral("Extensions");
+
+    QMenu *targetMenu = nullptr;
+
+    // search existing menu
+    for (QAction *act : menuBar->actions()) {
+
+        if (!act->menu())
+            continue;
+
+        QString menuText = act->text();
+        menuText.remove(QRegularExpression(QStringLiteral("&")));          // remove Qt shortcut markers
+        menuText = menuText.trimmed();
+
+        if (menuText.compare(targetMenuName, Qt::CaseInsensitive) == 0) {
+            targetMenu = act->menu();
             break;
         }
     }
 
-    if (!extensionsMenu)
-        extensionsMenu = menuBar->addMenu(QStringLiteral("Extensions"));
+    // create menu if it doesn't exist
+    if (!targetMenu) {
+        targetMenu = menuBar->addMenu(targetMenuName);
+    }
 
-    if (!extensionsMenu->actions().contains(action))
-        extensionsMenu->addAction(action);
+    // prevent duplicate insertion
+    if (!targetMenu->actions().contains(action)) {
+        targetMenu->addAction(action);
+    }
+
+    qDebug() << "QML extension loaded:" << action->text()
+             << "→ menu:" << targetMenuName;
 }
 
 bool ScriptManager::checkError(QJSValue value, const QString &program)

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -58,6 +58,7 @@
 #include "tileseteditor.h"
 
 #include <QCoreApplication>
+#include <QQmlComponent>
 #include <QDesktopServices>
 #include <QDir>
 #include <QFile>
@@ -69,6 +70,18 @@
 #include <QStringDecoder>
 #endif
 #include <QtDebug>
+#include <QFileInfo>
+#include <QDebug>
+#include <QQmlContext>
+#include "tiledaction.h"
+#include "mainwindow.h"
+#include <QMenuBar>
+#include "actionmanager.h"
+#include "id.h"
+#include <QApplication>
+#include <QWidget>
+#include <QJSEngine>
+#include <QJSValue>
 
 namespace Tiled {
 
@@ -136,6 +149,7 @@ ScriptManager::ScriptManager(QObject *parent)
     qRegisterMetaType<ScriptTilesetFormatWrapper*>();
     qRegisterMetaType<ScriptImage*>();
     qRegisterMetaType<WangIndex::Value>("WangIndex");
+    qmlRegisterType<Tiled::QmlAction>("Tiled", 1, 0, "QmlAction");
 
     connect(&mWatcher, &FileSystemWatcher::pathsChanged,
             this, &ScriptManager::scriptFilesChanged);
@@ -284,17 +298,94 @@ void ScriptManager::loadExtension(const QString &path)
 
     const QStringList nameFilters = {
         QLatin1String("*.js"),
-        QLatin1String("*.mjs")
+        QLatin1String("*.mjs"),
+        QLatin1String("*.qml")
     };
     const QDir dir(path);
-    const QStringList jsFiles = dir.entryList(nameFilters,
+    const QStringList files = dir.entryList(nameFilters,
                                               QDir::Files | QDir::Readable);
 
-    for (const QString &jsFile : jsFiles) {
-        const QString absolutePath = dir.filePath(jsFile);
+    for (const QString &file : files) {
+        const QString absolutePath = dir.filePath(file);
+        if (absolutePath.endsWith(QStringLiteral(".qml"),
+                                  Qt::CaseInsensitive))
+        {
+            loadQmlExtension(absolutePath);
+        }
+        else{
         evaluateFileOrLoadModule(absolutePath);
+        }
         mWatcher.addPath(absolutePath);
     }
+}
+
+void ScriptManager::loadQmlExtension(const QString &filePath)
+{
+    if (!mEngine)
+    {
+        qWarning() << "QML engine not initialized";
+        return;
+    }
+
+    QQmlComponent component(mEngine, QUrl::fromLocalFile(filePath));
+
+    if (component.isError())
+    {
+        qWarning() << component.errors();
+        return;
+    }
+
+    QObject *object = component.create();
+
+    if (!object)
+    {
+        qWarning() << "Failed to create QML object";
+        return;
+    }
+
+    object->setParent(this);
+    mExtensions.append(object);
+
+    QAction *action = qobject_cast<QAction *>(object);
+    if (!action)
+        return;
+    if (!action->objectName().isEmpty())
+    {
+        Tiled::ActionManager::registerAction(
+            action,
+            Tiled::Id(action->objectName().toUtf8()));
+    }
+    Tiled::MainWindow *mainWindow = nullptr;
+
+    for (QWidget *w : QApplication::topLevelWidgets())
+    {
+        mainWindow = qobject_cast<Tiled::MainWindow *>(w);
+        if (mainWindow)
+            break;
+    }
+
+    if (!mainWindow)
+        return;
+
+    QMenuBar *menuBar = mainWindow->menuBar();
+    QMenu *extensionsMenu = nullptr;
+
+    for (QAction *act : menuBar->actions())
+    {
+        if (act->menu() &&
+            act->text().compare(QStringLiteral("Extensions"),
+                                Qt::CaseInsensitive) == 0)
+        {
+            extensionsMenu = act->menu();
+            break;
+        }
+    }
+
+    if (!extensionsMenu)
+        extensionsMenu = menuBar->addMenu(QStringLiteral("Extensions"));
+
+    if (!extensionsMenu->actions().contains(action))
+        extensionsMenu->addAction(action);
 }
 
 bool ScriptManager::checkError(QJSValue value, const QString &program)
@@ -332,7 +423,7 @@ bool ScriptManager::checkError(QJSValue value, const QString &program)
 
 void ScriptManager::throwError(const QString &message)
 {
-    engine()->throwError(message);
+    mEngine->throwError(message);
 }
 
 void ScriptManager::throwNullArgError(int argNumber)
@@ -367,13 +458,14 @@ void ScriptManager::reset()
 void ScriptManager::initialize()
 {
     auto engine = new QQmlEngine(this);
+    mModule=new ScriptModule(this);
 
     // We'll report errors in the Console view instead
     engine->setOutputWarningsToStandardError(false);
     connect(engine, &QQmlEngine::warnings, this, &ScriptManager::onScriptWarnings);
 
     mEngine = engine;
-    mModule = new ScriptModule(this);
+    // mModule = new ScriptModule(this);
 
     QJSValue globalObject = engine->globalObject();
 

--- a/src/tiled/scriptmanager.h
+++ b/src/tiled/scriptmanager.h
@@ -28,8 +28,10 @@
 #include <QQmlError>
 #include <QScopedValueRollback>
 #include <QStringList>
+#include <QTimer>
 
 class QJSEngine;
+class QQmlEngine;
 
 namespace Tiled {
 
@@ -68,7 +70,7 @@ public:
     const QString &extensionsPath() const;
 
     ScriptModule *module() const;
-    QJSEngine *engine() const;
+    QQmlEngine *engine() const;
 
     QJSValue evaluate(const QString &program,
                       const QString &fileName = QString(), int lineNumber = 1);
@@ -106,10 +108,11 @@ private:
 
     void loadExtensions();
     void loadExtension(const QString &path);
+    void loadQmlExtension(const QString &filePath);
 
     QJSValue evaluateFile(const QString &fileName);
 
-    QJSEngine *mEngine = nullptr;
+    // QJSEngine *mEngine = nullptr;
     ScriptModule *mModule = nullptr;
     FileSystemWatcher mWatcher;
     QString mExtensionsPath;
@@ -120,6 +123,8 @@ private:
     friend struct ResetBlocker;
     bool mResetBlocked = false;
     QTimer mResetTimer;
+    QQmlEngine * mEngine =nullptr;
+    QList<QObject*> mExtensions;
 
     static ScriptManager *mInstance;
 };
@@ -135,7 +140,7 @@ inline ScriptModule *ScriptManager::module() const
     return mModule;
 }
 
-inline QJSEngine *ScriptManager::engine() const
+inline QQmlEngine *ScriptManager::engine() const
 {
     return mEngine;
 }

--- a/src/tiled/scriptmanager.h
+++ b/src/tiled/scriptmanager.h
@@ -22,6 +22,8 @@
 
 #include "filesystemwatcher.h"
 #include "tilededitor_global.h"
+#include "tiledaction.h"
+#include  "qmltool.h"
 
 #include <QJSValue>
 #include <QObject>
@@ -91,6 +93,7 @@ public:
 
     bool projectExtensionsSuppressed() const;
     void enableProjectExtensions();
+    QList<QmlTool*> qmlTools () const;
 
 signals:
     void projectExtensionsSuppressedChanged(bool);
@@ -110,6 +113,15 @@ private:
     void loadExtension(const QString &path);
     void loadQmlExtension(const QString &filePath);
 
+    void registerQmlExtension(QObject *root);
+
+    void registerAction(QmlAction *action);
+
+    void registerTool(QmlTool *tool);
+    void  addTool(AbstractTool *tool);
+
+    void addActionToMenu(QmlAction *action);
+
     QJSValue evaluateFile(const QString &fileName);
 
     // QJSEngine *mEngine = nullptr;
@@ -125,7 +137,8 @@ private:
     QTimer mResetTimer;
     QQmlEngine * mEngine =nullptr;
     QList<QObject*> mExtensions;
-
+    QList<QmlTool*> mTools;
+    QList<QmlTool*> mQmlTools;
     static ScriptManager *mInstance;
 };
 

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -42,6 +42,8 @@
 #include "tileseteditor.h"
 #include "worlddocument.h"
 #include "worldmanager.h"
+#include "editabletilelayer.h"
+#include "editablemap.h"
 
 #include <QAction>
 #include <QCoreApplication>

--- a/src/tiled/tiledaction.cpp
+++ b/src/tiled/tiledaction.cpp
@@ -1,4 +1,5 @@
 #include "tiledaction.h"
+
 #include <QIcon>
 #include <QKeySequence>
 
@@ -43,8 +44,26 @@ void QmlAction::setShortcut(const QString &shortcutStr)
     QAction::setShortcut(QKeySequence(shortcutStr));
 }
 
+QString QmlAction::menu() const
+{
+    return mMenu;
+}
+
+void QmlAction::setMenu(const QString &menu)
+{
+    mMenu = menu;
+}
+
+QString QmlAction::context() const
+{
+    return mContext;
+}
+
+void QmlAction::setContext(const QString &context)
+{
+    mContext = context;
+}
+
 }
 
 #include "moc_tiledaction.cpp"
-
-

--- a/src/tiled/tiledaction.cpp
+++ b/src/tiled/tiledaction.cpp
@@ -38,9 +38,9 @@ QString QmlAction::shortcut() const
     return QAction::shortcut().toString();
 }
 
-void QmlAction::setShortcutString(const QString &shortcutStr)
+void QmlAction::setShortcut(const QString &shortcutStr)
 {
-    setShortcut(QKeySequence(shortcutStr));
+    QAction::setShortcut(QKeySequence(shortcutStr));
 }
 
 }

--- a/src/tiled/tiledaction.cpp
+++ b/src/tiled/tiledaction.cpp
@@ -1,0 +1,50 @@
+#include "tiledaction.h"
+#include <QIcon>
+#include <QKeySequence>
+
+namespace Tiled {
+
+QmlAction::QmlAction(QObject *parent)
+    : QAction(parent)
+{
+    connect(this, &QAction::triggered,
+            this, &QmlAction::triggeredFromQml);
+}
+
+QString QmlAction::id() const
+{
+    return mId;
+}
+
+void QmlAction::setId(const QString &id)
+{
+    mId = id;
+    setObjectName(id);
+}
+
+QString QmlAction::iconSource() const
+{
+    return mIconSource;
+}
+
+void QmlAction::setIconSource(const QString &path)
+{
+    mIconSource = path;
+    setIcon(QIcon(path));
+}
+
+QString QmlAction::shortcut() const
+{
+    return QAction::shortcut().toString();
+}
+
+void QmlAction::setShortcutString(const QString &shortcutStr)
+{
+    setShortcut(QKeySequence(shortcutStr));
+}
+
+}
+
+#include "moc_tiledaction.cpp"
+
+

--- a/src/tiled/tiledaction.h
+++ b/src/tiled/tiledaction.h
@@ -12,7 +12,7 @@ class QmlAction : public QAction
     Q_PROPERTY(QString id READ id WRITE setId)
     Q_PROPERTY(QString text READ text WRITE setText)
     Q_PROPERTY(QString iconSource READ iconSource WRITE setIconSource)
-    Q_PROPERTY(QString shortcut READ shortcut WRITE setShortcutString)
+    Q_PROPERTY(QString shortcut READ shortcut WRITE setShortcut)
 
 public:
     explicit QmlAction(QObject *parent = nullptr);
@@ -24,7 +24,7 @@ public:
     void setIconSource(const QString &path);
 
     QString shortcut() const;
-    void setShortcutString(const QString &shortcut);
+    void setShortcut(const QString &shortcut);
 
 signals:
     void triggeredFromQml();   // forwarded to QML

--- a/src/tiled/tiledaction.h
+++ b/src/tiled/tiledaction.h
@@ -13,6 +13,8 @@ class QmlAction : public QAction
     Q_PROPERTY(QString text READ text WRITE setText)
     Q_PROPERTY(QString iconSource READ iconSource WRITE setIconSource)
     Q_PROPERTY(QString shortcut READ shortcut WRITE setShortcut)
+    Q_PROPERTY(QString menu READ menu WRITE setMenu)
+    Q_PROPERTY(QString context READ context WRITE setContext)
 
 public:
     explicit QmlAction(QObject *parent = nullptr);
@@ -26,15 +28,20 @@ public:
     QString shortcut() const;
     void setShortcut(const QString &shortcut);
 
+    QString menu() const;
+    void setMenu(const QString &menu);
+
+    QString context() const;
+    void setContext(const QString &context);
+
 signals:
-    void triggeredFromQml();   // forwarded to QML
+    void triggeredFromQml();
 
 private:
     QString mId;
     QString mIconSource;
+    QString mMenu = QStringLiteral("Extensions");  // default menu
+    QString mContext;               // optional context
 };
 
 }
-
-
-

--- a/src/tiled/tiledaction.h
+++ b/src/tiled/tiledaction.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QAction>
+#include <QString>
+
+namespace Tiled {
+
+class QmlAction : public QAction
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString id READ id WRITE setId)
+    Q_PROPERTY(QString text READ text WRITE setText)
+    Q_PROPERTY(QString iconSource READ iconSource WRITE setIconSource)
+    Q_PROPERTY(QString shortcut READ shortcut WRITE setShortcutString)
+
+public:
+    explicit QmlAction(QObject *parent = nullptr);
+
+    QString id() const;
+    void setId(const QString &id);
+
+    QString iconSource() const;
+    void setIconSource(const QString &path);
+
+    QString shortcut() const;
+    void setShortcutString(const QString &shortcut);
+
+signals:
+    void triggeredFromQml();   // forwarded to QML
+
+private:
+    QString mId;
+    QString mIconSource;
+};
+
+}
+
+
+

--- a/src/tiledapp/tiledapp.qbs
+++ b/src/tiledapp/tiledapp.qbs
@@ -34,8 +34,6 @@ TiledQtGuiApplication {
     }
 
     files: [
-        "../tiled/tiledaction.cpp",
-        "../tiled/tiledaction.h",
         "commandlineparser.cpp",
         "commandlineparser.h",
         "main.cpp",

--- a/src/tiledapp/tiledapp.qbs
+++ b/src/tiledapp/tiledapp.qbs
@@ -34,6 +34,8 @@ TiledQtGuiApplication {
     }
 
     files: [
+        "../tiled/tiledaction.cpp",
+        "../tiled/tiledaction.h",
         "commandlineparser.cpp",
         "commandlineparser.h",
         "main.cpp",


### PR DESCRIPTION
this PR introduces initial support for loading QML-based extensions in Tiled.
The goal is to allow extension developers to define actions and behaviors using QML instead of only JavaScript, while still integrating with the existing scripting infrastructure.

Key Features
Adds a QML extension loader to ScriptManager
Introduces a QML-compatible action class (QmlAction)
Allows QML extensions to create menu actions
Integrates QML actions with the existing ActionManager
Ensures loaded QML extensions remain alive during runtime
Supports loading .qml files alongside .js extensions


After this change, Tiled can load QML extensions that define actions, allowing extension developers to create menu commands and interact with the Tiled API directly from QML.

example-
import QtQuick 2.15
import Tiled 1.0

QmlAction {
    objectName: "AddLayer"
    text: "Add Tile Layer"

    onTriggered: {
        var map = tiled.activeAsset
        var layer = new TileLayer("Layer100", map.width, map.height)
        map.addLayer(layer)
    }
}