### PR TITLE
tmxrasterizer: add --search-path option and stdout output support

### DIFF
--- a/src/libtiled/mapformat.cpp
+++ b/src/libtiled/mapformat.cpp
@@ -31,6 +31,8 @@
 #include "map.h"
 #include "mapreader.h"
 
+#include <QFile>
+
 namespace Tiled {
 
 std::unique_ptr<Map> readMap(const QString &fileName, QString *error)
@@ -55,6 +57,31 @@ std::unique_ptr<Map> readMap(const QString &fileName, QString *error)
     // Fall back to default reader (TMX format)
     MapReader reader;
     std::unique_ptr<Map> map(reader.readMap(fileName));
+
+    if (error) {
+        if (!map)
+            *error = reader.errorString();
+        else
+            *error = QString();
+    }
+
+    if (map)
+        map->fileName = fileName;
+
+    return map;
+}
+
+std::unique_ptr<Map> readMap(const QString &fileName, const QString &searchPath, QString *error)
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly)) {
+        if (error)
+            *error = file.errorString();
+        return nullptr;
+    }
+
+    MapReader reader;
+    std::unique_ptr<Map> map(reader.readMap(&file, searchPath));
 
     if (error) {
         if (!map)

--- a/src/libtiled/mapformat.cpp
+++ b/src/libtiled/mapformat.cpp
@@ -32,6 +32,7 @@
 #include "mapreader.h"
 
 #include <QFile>
+#include <QFileInfo>
 
 namespace Tiled {
 
@@ -73,6 +74,28 @@ std::unique_ptr<Map> readMap(const QString &fileName, QString *error)
 
 std::unique_ptr<Map> readMap(const QString &fileName, const QString &searchPath, QString *error)
 {
+    const QString resolvedPath = searchPath.isEmpty()
+            ? QFileInfo(fileName).absolutePath()
+            : searchPath;
+
+    // Try the first registered map format that claims to support the file
+    if (MapFormat *format = findSupportingMapFormat(fileName)) {
+        std::unique_ptr<Map> map(format->read(fileName, resolvedPath));
+
+        if (error) {
+            if (!map)
+                *error = format->errorString();
+            else
+                *error = QString();
+        }
+
+        if (map)
+            map->fileName = fileName;
+
+        return map;
+    }
+
+    // Fall back to default reader (TMX format)
     QFile file(fileName);
     if (!file.open(QIODevice::ReadOnly)) {
         if (error)
@@ -81,7 +104,7 @@ std::unique_ptr<Map> readMap(const QString &fileName, const QString &searchPath,
     }
 
     MapReader reader;
-    std::unique_ptr<Map> map(reader.readMap(&file, searchPath));
+    std::unique_ptr<Map> map(reader.readMap(&file, resolvedPath));
 
     if (error) {
         if (!map)

--- a/src/libtiled/mapformat.h
+++ b/src/libtiled/mapformat.h
@@ -73,6 +73,15 @@ public:
     virtual std::unique_ptr<Map> read(const QString &fileName) = 0;
 
     /**
+     * Overload that allows specifying a custom \a searchPath for resolving
+     * relative references to external tilesets and images. The default
+     * implementation ignores the search path and calls read(fileName).
+     */
+    virtual std::unique_ptr<Map> read(const QString &fileName,
+                                      const QString &searchPath)
+    { Q_UNUSED(searchPath); return read(fileName); }
+
+    /**
      * Writes the given \a map based on the suggested \a fileName.
      *
      * This function may write to a different file name or may even write to

--- a/src/libtiled/mapformat.h
+++ b/src/libtiled/mapformat.h
@@ -136,6 +136,14 @@ TILEDSHARED_EXPORT std::unique_ptr<Map> readMap(const QString &fileName,
                                                 QString *error = nullptr);
 
 /**
+ * Overload that allows specifying a custom \a searchPath for resolving
+ * relative references to external tilesets and images.
+ */
+TILEDSHARED_EXPORT std::unique_ptr<Map> readMap(const QString &fileName,
+                                                const QString &searchPath,
+                                                QString *error = nullptr);
+
+/**
  * Attempts to find a map format supporting the given file.
  */
 TILEDSHARED_EXPORT MapFormat *findSupportingMapFormat(const QString &fileName);

--- a/src/tmxrasterizer/main.cpp
+++ b/src/tmxrasterizer/main.cpp
@@ -105,6 +105,9 @@ int main(int argc, char *argv[])
                           { QStringLiteral("frame-duration"),
                             QCoreApplication::translate("main", "Duration of each frame in milliseconds, defaults to 100."),
                             QCoreApplication::translate("main", "number") },
+                          { QStringLiteral("search-path"),
+                            QCoreApplication::translate("main", "Override the search path used to resolve tileset and image references. Useful when the map file is in a temporary location (e.g. during git diff)."),
+                            QCoreApplication::translate("main", "path") },
                       });
     parser.addPositionalArgument(QStringLiteral("map|world"), QCoreApplication::translate("main", "Map or world file to render."));
     parser.addPositionalArgument(QStringLiteral("image"), QCoreApplication::translate("main", "Image file to output."));
@@ -185,6 +188,9 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
+
+    if (parser.isSet(QLatin1String("search-path")))
+        w.setSearchPath(parser.value(QLatin1String("search-path")));
 
     return w.render(fileToOpen, fileToSave);
 }

--- a/src/tmxrasterizer/main.cpp
+++ b/src/tmxrasterizer/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
                             QCoreApplication::translate("main", "Duration of each frame in milliseconds, defaults to 100."),
                             QCoreApplication::translate("main", "number") },
                           { QStringLiteral("search-path"),
-                            QCoreApplication::translate("main", "Override the search path used to resolve tileset and image references. Useful when the map file is in a temporary location (e.g. during git diff)."),
+                            QCoreApplication::translate("main", "Override the search path used to resolve tileset and image references."),
                             QCoreApplication::translate("main", "path") },
                       });
     parser.addPositionalArgument(QStringLiteral("map|world"), QCoreApplication::translate("main", "Map or world file to render."));

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -32,7 +32,6 @@
 #include "imagelayer.h"
 #include "map.h"
 #include "mapformat.h"
-#include "mapreader.h"
 #include "objectgroup.h"
 #include "tilelayer.h"
 #include "tilesetmanager.h"
@@ -176,8 +175,7 @@ int TmxRasterizer::render(const QString &fileName,
     // If we're not rendering a world, load the map once and create a renderer
     if (!fileName.endsWith(QLatin1String(".world"), Qt::CaseInsensitive)) {
         QString errorString;
-        map = mSearchPath.isEmpty() ? readMap(fileName, &errorString)
-                                    : readMap(fileName, mSearchPath, &errorString);
+        map = readMap(fileName, mSearchPath, &errorString);
         if (!map) {
             qWarning("Error while reading \"%s\":\n%s",
                      qUtf8Printable(fileName),
@@ -306,8 +304,7 @@ int TmxRasterizer::renderWorld(const QString &worldFileName,
     }
     QRect worldBoundingRect;
     for (const WorldMapEntry &mapEntry : maps) {
-        std::unique_ptr<Map> map { mSearchPath.isEmpty() ? readMap(mapEntry.fileName, &errorString)
-                                                         : readMap(mapEntry.fileName, mSearchPath, &errorString) };
+        std::unique_ptr<Map> map { readMap(mapEntry.fileName, mSearchPath, &errorString) };
         if (!map) {
             qWarning("Error while reading \"%s\":\n%s",
                      qUtf8Printable(mapEntry.fileName),
@@ -344,8 +341,7 @@ int TmxRasterizer::renderWorld(const QString &worldFileName,
     painter.translate(-worldBoundingRect.topLeft());
 
     for (const WorldMapEntry &mapEntry : maps) {
-        std::unique_ptr<Map> map { mSearchPath.isEmpty() ? readMap(mapEntry.fileName, &errorString)
-                                                         : readMap(mapEntry.fileName, mSearchPath, &errorString) };
+        std::unique_ptr<Map> map { readMap(mapEntry.fileName, mSearchPath, &errorString) };
         if (!map) {
             qWarning("Error while reading \"%s\":\n%s",
                     qUtf8Printable(mapEntry.fileName),

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -32,12 +32,14 @@
 #include "imagelayer.h"
 #include "map.h"
 #include "mapformat.h"
+#include "mapreader.h"
 #include "objectgroup.h"
 #include "tilelayer.h"
 #include "tilesetmanager.h"
 #include "world.h"
 
 #include <QDebug>
+#include <QFile>
 #include <QFileInfo>
 #include <QImageWriter>
 
@@ -174,7 +176,8 @@ int TmxRasterizer::render(const QString &fileName,
     // If we're not rendering a world, load the map once and create a renderer
     if (!fileName.endsWith(QLatin1String(".world"), Qt::CaseInsensitive)) {
         QString errorString;
-        map = readMap(fileName, &errorString);
+        map = mSearchPath.isEmpty() ? readMap(fileName, &errorString)
+                                    : readMap(fileName, mSearchPath, &errorString);
         if (!map) {
             qWarning("Error while reading \"%s\":\n%s",
                      qUtf8Printable(fileName),
@@ -253,6 +256,21 @@ int TmxRasterizer::renderMap(const MapRenderer &renderer,
 int TmxRasterizer::saveImage(const QString &imageFileName,
                              const QImage &image) const
 {
+    if (imageFileName == QLatin1String("-")) {
+        QFile stdoutFile;
+        if (!stdoutFile.open(stdout, QIODevice::WriteOnly)) {
+            qWarning("Error while opening stdout for writing");
+            return 1;
+        }
+        QImageWriter imageWriter(&stdoutFile, "png");
+        if (!imageWriter.write(image)) {
+            qWarning("Error while writing to stdout: %s",
+                     qUtf8Printable(imageWriter.errorString()));
+            return 1;
+        }
+        return 0;
+    }
+
     QImageWriter imageWriter(imageFileName);
 
     if (!imageWriter.canWrite())
@@ -288,7 +306,8 @@ int TmxRasterizer::renderWorld(const QString &worldFileName,
     }
     QRect worldBoundingRect;
     for (const WorldMapEntry &mapEntry : maps) {
-        std::unique_ptr<Map> map { readMap(mapEntry.fileName, &errorString) };
+        std::unique_ptr<Map> map { mSearchPath.isEmpty() ? readMap(mapEntry.fileName, &errorString)
+                                                         : readMap(mapEntry.fileName, mSearchPath, &errorString) };
         if (!map) {
             qWarning("Error while reading \"%s\":\n%s",
                      qUtf8Printable(mapEntry.fileName),
@@ -325,7 +344,8 @@ int TmxRasterizer::renderWorld(const QString &worldFileName,
     painter.translate(-worldBoundingRect.topLeft());
 
     for (const WorldMapEntry &mapEntry : maps) {
-        std::unique_ptr<Map> map { readMap(mapEntry.fileName, &errorString) };
+        std::unique_ptr<Map> map { mSearchPath.isEmpty() ? readMap(mapEntry.fileName, &errorString)
+                                                         : readMap(mapEntry.fileName, mSearchPath, &errorString) };
         if (!map) {
             qWarning("Error while reading \"%s\":\n%s",
                     qUtf8Printable(mapEntry.fileName),

--- a/src/tmxrasterizer/tmxrasterizer.h
+++ b/src/tmxrasterizer/tmxrasterizer.h
@@ -68,6 +68,8 @@ public:
     void setLayersToHide(QStringList layersToHide) { mLayersToHide = layersToHide; }
     void setLayersToShow(QStringList layersToShow) { mLayersToShow = layersToShow; }
 
+    void setSearchPath(const QString &searchPath) { mSearchPath = searchPath; }
+
     void setObjectsToHide(QStringList objectsToHide) { mObjectsToHide = objectsToHide; }
     void setObjectsToShow(QStringList objectsToShow) { mObjectsToShow = objectsToShow; }
 
@@ -90,6 +92,7 @@ private:
     QStringList mObjectsToHide;
     QStringList mObjectsToShow;
     int mLayerTypesToShow = Layer::AnyLayerType & ~Layer::GroupLayerType;
+    QString mSearchPath;
 
     void drawMapLayers(const MapRenderer &renderer, QPainter &painter, QPoint mapOffset = QPoint(0, 0)) const;
     int renderMap(const MapRenderer &renderer, const QString &imageFileName);


### PR DESCRIPTION
Fixes #3867                                                                                                             
                                                                                                                          
Adds two features to make tmxrasterizer more useful as a git diff tool:                                                 
                  
 --search-path <path>                                                                                                    
Overrides the directory used to resolve tileset and image references. Useful when rasterizing a temporary copy of a map
file (e.g. from git diff) where the file has been relocated away from its assets.                                       
                  
Stdout output                                                                                                           
Passing - as the output filename writes the PNG to stdout, enabling pipe-based workflows:
tmxrasterizer map.tmx - | compare - other.png diff.png                                                                  
                                                        
The search path support is implemented via a new readMap(fileName, searchPath, error) overload in mapformat.cpp, which  
passes the custom path to MapReader using its existing QIODevice-based API. The --search-path option also applies when  
rendering worlds. 