### PR TITLE
Add preference for default object color 

### DIFF
--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -41,6 +41,18 @@
 
 namespace Tiled {
 
+static QColor sDefaultObjectColor = Qt::gray;
+
+QColor MapObject::defaultColor()
+{
+    return sDefaultObjectColor;
+}
+
+void MapObject::setDefaultColor(const QColor &color)
+{
+    sDefaultObjectColor = color;
+}
+
 TextData::TextData()
     : font(QStringLiteral("sans-serif"))
 {
@@ -289,7 +301,7 @@ MapObjectColors MapObject::effectiveColors() const
     } else if (mObjectGroup && mObjectGroup->color().isValid()) {
         colors.main = mObjectGroup->color();
     } else {
-        colors.main = Qt::gray;
+        colors.main = sDefaultObjectColor;
     }
 
     if (drawFill) {

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -213,6 +213,9 @@ public:
     QColor effectiveColor() const;
     MapObjectColors effectiveColors() const;
 
+    static QColor defaultColor();
+    static void setDefaultColor(const QColor &color);
+
     QVariant mapObjectProperty(Property property) const;
     void setMapObjectProperty(Property property, const QVariant &value);
 

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -148,10 +148,16 @@ MapItem::MapItem(const MapDocumentPtr &mapDocument, DisplayMode displayMode,
     renderer->setObjectLineWidth(prefs->objectLineWidth());
     renderer->setFlag(ShowTileObjectOutlines, prefs->showTileObjectOutlines());
 
+    MapObject::setDefaultColor(prefs->defaultObjectColor());
+
     connect(prefs, &Preferences::objectLineWidthChanged, this, &MapItem::setObjectLineWidth);
     connect(prefs, &Preferences::showTileObjectOutlinesChanged, this, &MapItem::setShowTileObjectOutlines);
     connect(prefs, &Preferences::highlightCurrentLayerChanged, this, &MapItem::updateSelectedLayersHighlight);
     connect(prefs, &Preferences::propertyTypesChanged, this, &MapItem::syncAllObjectItems);
+    connect(prefs, &Preferences::defaultObjectColorChanged, this, [this] (QColor color) {
+        MapObject::setDefaultColor(color);
+        syncAllObjectItems();
+    });
     connect(prefs, &Preferences::backgroundFadeColorChanged, this, [this] (QColor color) { mDarkRectangle->setBrush(color); });
 
     connect(mapDocument.data(), &Document::changed, this, &MapItem::documentChanged);

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -191,6 +191,11 @@ QColor Preferences::backgroundFadeColor() const
     return get<QColor>("Interface/BackgroundFadeColor", Qt::black);
 }
 
+QColor Preferences::defaultObjectColor() const
+{
+    return get<QColor>("Interface/DefaultObjectColor", QColor(128, 128, 128));
+}
+
 int Preferences::gridFine() const
 {
     return get<int>("Interface/GridFine", 4);
@@ -373,6 +378,12 @@ void Preferences::setBackgroundFadeColor(QColor backgroundFadeColor)
 {
     setValue(QLatin1String("Interface/BackgroundFadeColor"), backgroundFadeColor.name());
     emit backgroundFadeColorChanged(backgroundFadeColor);
+}
+
+void Preferences::setDefaultObjectColor(QColor color)
+{
+    setValue(QLatin1String("Interface/DefaultObjectColor"), color.name());
+    emit defaultObjectColorChanged(color);
 }
 
 void Preferences::setGridFine(int gridFine)

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -193,7 +193,8 @@ QColor Preferences::backgroundFadeColor() const
 
 QColor Preferences::defaultObjectColor() const
 {
-    return get<QColor>("Interface/DefaultObjectColor", QColor(128, 128, 128));
+    const QColor color = get<QColor>("Interface/DefaultObjectColor", QColor(128, 128, 128));
+    return color.isValid() ? color : QColor(128, 128, 128);
 }
 
 int Preferences::gridFine() const

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -66,6 +66,7 @@ public:
     bool snapToPixels() const;
     QColor gridColor() const;
     QColor backgroundFadeColor() const;
+    QColor defaultObjectColor() const;
     int gridFine() const;
     QSize gridMajor() const;
     qreal objectLineWidth() const;
@@ -202,6 +203,7 @@ public slots:
     void setSnapToPixels(bool snapToPixels);
     void setGridColor(QColor gridColor);
     void setBackgroundFadeColor(QColor backgroundFadeColor);
+    void setDefaultObjectColor(QColor color);
     void setGridFine(int gridFine);
     void setGridMajor(QSize gridMajor);
     void setGridMajorX(int gridMajorX);
@@ -229,6 +231,7 @@ signals:
     void snapToPixelsChanged(bool snapToPixels);
     void gridColorChanged(QColor gridColor);
     void backgroundFadeColorChanged(QColor backgroundFadeColor);
+    void defaultObjectColorChanged(QColor color);
     void gridFineChanged(int gridFine);
     void gridMajorChanged(QSize gridMajor);
     void objectLineWidthChanged(qreal lineWidth);

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -126,6 +126,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             preferences, &Preferences::setGridColor);
     connect(mUi->backgroundFadeColor, &ColorButton::colorChanged,
             preferences, &Preferences::setBackgroundFadeColor);
+    connect(mUi->defaultObjectColor, &ColorButton::colorChanged,
+            preferences, &Preferences::setDefaultObjectColor);
     connect(mUi->gridFine, &QSpinBox::valueChanged,
             preferences, &Preferences::setGridFine);
     connect(mUi->gridMajorX, &QSpinBox::valueChanged,
@@ -251,6 +253,7 @@ void PreferencesDialog::fromPreferences()
     mUi->languageCombo->setCurrentIndex(languageIndex);
     mUi->gridColor->setColor(prefs->gridColor());
     mUi->backgroundFadeColor->setColor(prefs->backgroundFadeColor());
+    mUi->defaultObjectColor->setColor(prefs->defaultObjectColor());
     mUi->gridFine->setValue(prefs->gridFine());
     mUi->gridMajorX->setValue(prefs->gridMajor().width());
     mUi->gridMajorY->setValue(prefs->gridMajor().height());

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -193,7 +193,7 @@
           <string>Interface</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="4" column="3">
+          <item row="5" column="3">
            <spacer name="horizontalSpacer_5">
             <property name="orientation">
              <enum>Qt::Orientation::Horizontal</enum>
@@ -219,7 +219,7 @@
             </property>
            </spacer>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="label_7">
             <property name="text">
              <string>Major grid:</string>
@@ -256,14 +256,14 @@
           <item row="1" column="1">
            <widget class="Tiled::ColorButton" name="gridColor"/>
           </item>
-          <item row="6" column="0" colspan="2">
+          <item row="7" column="0" colspan="2">
            <widget class="QCheckBox" name="openGL">
             <property name="text">
              <string>Hardware &amp;accelerated drawing (OpenGL)</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0" colspan="2">
+          <item row="8" column="0" colspan="2">
            <widget class="QCheckBox" name="naturalSorting">
             <property name="toolTip">
              <string>Sort files numerically (d3, d20) instead of alphabetically (d20, d3)</string>
@@ -273,7 +273,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1" colspan="2">
+          <item row="5" column="1" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
              <widget class="Tiled::ExpressionSpinBox" name="gridMajorX">
@@ -307,7 +307,7 @@
           <item row="2" column="1">
            <widget class="Tiled::ColorButton" name="backgroundFadeColor"/>
           </item>
-          <item row="8" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="label_defaultObjectColor">
             <property name="text">
              <string>Default object color:</string>
@@ -317,10 +317,10 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="1">
+          <item row="3" column="1">
            <widget class="Tiled::ColorButton" name="defaultObjectColor"/>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="label">
             <property name="text">
              <string>Object line width:</string>
@@ -330,7 +330,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
              <string>Fine grid divisions:</string>
@@ -343,7 +343,7 @@
           <item row="0" column="1">
            <widget class="QComboBox" name="languageCombo"/>
           </item>
-          <item row="5" column="1" colspan="2">
+          <item row="6" column="1" colspan="2">
            <widget class="Tiled::ExpressionDoubleSpinBox" name="objectLineWidth">
             <property name="suffix">
              <string> pixels</string>
@@ -359,7 +359,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1" colspan="2">
+          <item row="4" column="1" colspan="2">
            <widget class="Tiled::ExpressionSpinBox" name="gridFine">
             <property name="minimum">
              <number>1</number>

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -307,6 +307,19 @@
           <item row="2" column="1">
            <widget class="Tiled::ColorButton" name="backgroundFadeColor"/>
           </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_defaultObjectColor">
+            <property name="text">
+             <string>Default object color:</string>
+            </property>
+            <property name="buddy">
+             <cstring>defaultObjectColor</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="Tiled::ColorButton" name="defaultObjectColor"/>
+          </item>
           <item row="5" column="0">
            <widget class="QLabel" name="label">
             <property name="text">


### PR DESCRIPTION
 Fixes #3861                                                                                                             
                                                                                                                          
Adds a "Default object color" setting to Preferences → Interface, placed alongside the other color settings (Grid color, Background fade color). The color defaults to gray, matching the previous hardcoded behavior, and updates all map objects live when changed.                                                                                              
                  
The default color is stored as a static in libtiled and set from Preferences on startup and on change, keeping libtiled independent of the preferences system.