### PR TITLE
Fix scripts checkbox and icon overlapping issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,3 @@ gmon.out
 # Vim files
 *.swp
 *.swo
-.vs/

--- a/src/tiled/tiledproxystyle.cpp
+++ b/src/tiled/tiledproxystyle.cpp
@@ -706,25 +706,25 @@ void TiledProxyStyle::drawControl(ControlElement element,
             if (
                 qobject_cast<const QComboBox*>(widget) ||
                 (option->styleObject && option->styleObject->property("_q_isComboBoxPopupItem").toBool()))
-                ignoreCheckMark = true;
+                ignoreCheckMark = true; //ignore the checkmarks provided by the QComboMenuDelegate
 
-            if (!ignoreCheckMark) {
+            if (!ignoreCheckMark) { 
                 checkcol = qMax<int>(defaultCheckWidth, menuItem->maxIconWidth) + dualOffset;
 
                 const qreal boxMargin = dpiScaled(3.5, option);
                 const qreal boxWidth = defaultCheckWidth - 2 * boxMargin;
-                QRectF checkRectF(option->rect.left() + boxMargin + checkColHOffset, option->rect.center().y() - boxWidth / 2 + 1, boxWidth, boxWidth);
+                QRectF checkRectF(option->rect.left() + boxMargin + checkColHOffset, option->rect.center().y() - boxWidth/2 + 1, boxWidth, boxWidth);
                 QRect checkRect = checkRectF.toRect();
-                checkRect.setWidth(checkRect.height());
+                checkRect.setWidth(checkRect.height()); // avoid .toRect() round error results in non-perfect square
                 checkRect = visualRect(menuItem->direction, menuItem->rect, checkRect);
-
                 if (checkable) {
                     if (menuItem->checkType & QStyleOptionMenuItem::Exclusive) {
+                        // Radio button
                         if (checked || sunken) {
                             painter->setRenderHint(QPainter::Antialiasing);
                             painter->setPen(Qt::NoPen);
 
-                            QPalette::ColorRole textRole = !enabled ? QPalette::Text :
+                            QPalette::ColorRole textRole = !enabled ? QPalette::Text:
                                 selected ? QPalette::HighlightedText : QPalette::ButtonText;
                             painter->setBrush(option->palette.brush(option->palette.currentColorGroup(), textRole));
                             const int adjustment = checkRect.height() * 0.3;
@@ -741,13 +741,14 @@ void TiledProxyStyle::drawControl(ControlElement element,
                     }
                 }
             }
-            else {
+            else { //ignore checkmark
                 if (menuItem->icon.isNull())
                     checkcol = 0;
                 else
                     checkcol = menuItem->maxIconWidth;
             }
 
+            // Text and icon, ripped from windows style
             bool dis = !(menuItem->state & State_Enabled);
             bool act = menuItem->state & State_Selected;
             const QStyleOption* opt = option;
@@ -758,7 +759,7 @@ void TiledProxyStyle::drawControl(ControlElement element,
             // Shift the icon by the offset
             int iconOffsetX = checkColHOffset;
             int iconAreaWidth = checkcol;
-            if (!ignoreCheckMark /* && checkable */&& !menuItem->icon.isNull()) {
+            if (!ignoreCheckMark && !menuItem->icon.isNull()) {
                 iconOffsetX += dualOffset;
                 iconAreaWidth = menuItem->maxIconWidth;
             }
@@ -775,7 +776,7 @@ void TiledProxyStyle::drawControl(ControlElement element,
 
                 int smallIconSize = proxy()->pixelMetric(PM_SmallIconSize, option, widget);
                 QSize iconSize(smallIconSize, smallIconSize);
-                if (const QComboBox* combo = qobject_cast<const QComboBox*>(widget))
+                if (const QComboBox *combo = qobject_cast<const QComboBox*>(widget))
                     iconSize = combo->iconSize();
                 if (checked)
                     pixmap = menuItem->icon.pixmap(iconSize, mode, QIcon::On);


### PR DESCRIPTION
Fixes #3464

**The Issue:**
If an Action is checkable, its icon is displayed instead of the checkbox, with a button-like look to indicate whether the Action is checked.

**The Fix:**
Updated the UI engine to support side-by-side dual rendering of both the checkbox and the icon:
- Removed the `if (menuItem->icon.isNull())` restriction in `drawControl` (`CE_MenuItem`).
- Updated `sizeFromContents` (`CT_MenuItem`) to widen the menu item bounds when both elements are present to prevent text clipping.
- Decoupled the icon rendering rect (`vCheckRect`) from the checkbox rect, applying a `dualOffset` to shift the icons to the right.

**Testing:**
Tested locally on Windows 11 under the Tiled Fusion theme.

**Results**
<img width="365" height="369" alt="Screenshot 2026-03-20 212157" src="https://github.com/user-attachments/assets/15c02f82-da62-4b99-b9ef-b74656d60036" />
