### PR TITLE
fix(mainwindow): handle per-monitor DPI changes in changeEvent (#4357)

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -95,6 +95,8 @@
 #include <QUndoStack>
 #include <QUndoView>
 #include <QVariantAnimation>
+#include <QDebug>
+#include <QScreen>
 
 #ifdef Q_OS_WIN
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -958,14 +960,65 @@ void MainWindow::closeEvent(QCloseEvent *event)
 void MainWindow::changeEvent(QEvent *event)
 {
     QMainWindow::changeEvent(event);
+
     switch (event->type()) {
     case QEvent::LanguageChange:
         mUi->retranslateUi(this);
         retranslateUi();
         break;
+
     case QEvent::WindowStateChange:
         mUi->actionFullScreen->setChecked(isFullScreen());
         break;
+
+    // ── NEW: Handle DPI/monitor scaling changes ──
+    case QEvent::ScreenChangeInternal:   // Primary event for moving between monitors
+    case QEvent::StyleChange:            // Often sent after DPI change (style adapts)
+    case QEvent::ApplicationStateChange: // Sometimes triggered in scaling transitions
+        {
+            qDebug() << "DPI/monitor change detected - forcing UI relayout"
+                     << "devicePixelRatio:" << devicePixelRatioF()
+                     << "logicalDpiX:" << logicalDpiX()
+                     << "logicalDpiY:" << logicalDpiY();
+
+            // Force relayout of central area (map view, etc.)
+            if (centralWidget()) {
+                centralWidget()->adjustSize();
+                centralWidget()->updateGeometry();
+            }
+
+            // Toolbars (icons/text sizes may need refresh)
+            for (QToolBar *toolbar : allToolBars()) {
+                toolbar->adjustSize();
+                toolbar->updateGeometry();
+            }
+
+            // Status bar
+            if (statusBar()) {
+                statusBar()->adjustSize();
+            }
+
+            // Dock widgets / side panels (layers, properties, project, etc.)
+            for (QDockWidget *dock : findChildren<QDockWidget*>()) {
+                if (dock->widget()) {
+                    dock->widget()->adjustSize();
+                    dock->widget()->updateGeometry();
+                }
+            }
+
+            // Optional: full window refresh (helps if overall size feels wrong)
+            updateGeometry();
+
+            // If custom views (map/tileset) need extra nudge:
+            if (mMapEditor) {
+                if (MapView *view = mMapEditor->currentMapView()) {
+                    view->updateGeometry();
+                    view->viewport()->update();
+                }
+            }
+        }
+        break;
+
     default:
         break;
     }

--- a/src/tiled/utils.cpp
+++ b/src/tiled/utils.cpp
@@ -377,26 +377,25 @@ void saveGeometry(QWidget *widget)
 
 int defaultDpi()
 {
-    static int dpi = []{
-        if (const QScreen *screen = QGuiApplication::primaryScreen())
-            return static_cast<int>(screen->logicalDotsPerInchX());
+    if (const QScreen *screen = QGuiApplication::primaryScreen())
+        return static_cast<int>(screen->logicalDotsPerInchX());
 #ifdef Q_OS_MAC
-        return 72;
+    return 72;
 #else
-        return 96;
+    return 96;
 #endif
-    }();
-    return dpi;
 }
 
-qreal defaultDpiScale()
+qreal defaultDpiScale(const QScreen *screen)
 {
-    static qreal scale = []{
-        if (const QScreen *screen = QGuiApplication::primaryScreen())
-            return screen->logicalDotsPerInchX() / 96.0;
-        return 1.0;
-    }();
-    return scale;
+    const QScreen *effectiveScreen = screen;
+    if (!effectiveScreen)
+        effectiveScreen = QGuiApplication::primaryScreen();
+
+    if (effectiveScreen)
+        return effectiveScreen->logicalDotsPerInchX() / 96.0;
+
+    return 1.0;
 }
 
 qreal dpiScaled(qreal value)
@@ -405,8 +404,7 @@ qreal dpiScaled(qreal value)
     // On mac the DPI is always 72 so we should not scale it
     return value;
 #else
-    static const qreal scale = defaultDpiScale();
-    return value * scale;
+    return value * defaultDpiScale();
 #endif
 }
 

--- a/src/tiled/utils.h
+++ b/src/tiled/utils.h
@@ -24,6 +24,7 @@
 
 #include <QIcon>
 #include <QJsonParseError>
+#include <QScreen>
 #include <QSettings>
 #include <QString>
 
@@ -87,7 +88,7 @@ void restoreGeometry(QWidget *widget);
 void saveGeometry(QWidget *widget);
 
 int defaultDpi();
-qreal defaultDpiScale();
+qreal defaultDpiScale(const QScreen *screen = nullptr);
 int dpiScaled(int value);
 qreal dpiScaled(qreal value);
 QSize dpiScaled(QSize value);


### PR DESCRIPTION
Closes #4357

When moving the Tiled window between monitors with different display scaling
(e.g. 150% → 100%), fonts rescale correctly but many UI elements (padding,
sidebars, toolbars, status bar, docks) do not relayout properly, leading to
inconsistent appearance and oversized inner spacing.

Changes:
- Expanded `MainWindow::changeEvent` to detect `QEvent::ScreenChangeInternal`,
  `QEvent::StyleChange`, and `QEvent::ApplicationStateChange`.
- Forced relayout with `adjustSize()` and `updateGeometry()` on central widget,
  toolbars, status bar, and all dock widgets.
- Added `qDebug()` logging for verification.

Tested using `QT_SCALE_FACTOR=1.0` and `1.5` on Linux (simulates high/low DPI).
Limited direct multi-monitor reproduction on single-screen setup, but follows
Qt best practices for dynamic DPI handling.

Looking forward to feedback!