### PR TITLE
Fixed error about existing member when adding new members

### DIFF
--- a/src/tiled/propertytypeseditor.cpp
+++ b/src/tiled/propertytypeseditor.cpp
@@ -572,7 +572,8 @@ void PropertyTypesEditor::openAddMemberDialog()
 
         connect(mAddValueProperty, &Property::addRequested, this, [this] (bool focus) {
             const auto &name = mAddValueProperty->name();
-            addMember(name, mAddValueProperty->value());
+            const bool reportExisting = focus;
+            addMember(name, mAddValueProperty->value(), reportExisting);
 
             if (auto property = mMembersProperty->property(name)) {
                 if (focus)
@@ -592,7 +593,7 @@ void PropertyTypesEditor::openAddMemberDialog()
     mMembersView->focusProperty(mAddValueProperty, PropertiesView::FocusLabel);
 }
 
-void PropertyTypesEditor::addMember(const QString &name, const QVariant &value)
+void PropertyTypesEditor::addMember(const QString &name, const QVariant &value, bool reportExisting)
 {
     if (name.isEmpty())
         return;
@@ -603,9 +604,11 @@ void PropertyTypesEditor::addMember(const QString &name, const QVariant &value)
 
     auto &classType = static_cast<ClassPropertyType&>(*propertyType);
     if (classType.members.contains(name)) {
-        QMessageBox::critical(this,
-                              tr("Error Adding Member"),
-                              tr("There is already a member named '%1'.").arg(name));
+        if (reportExisting) {
+            QMessageBox::critical(this,
+                                  tr("Error Adding Member"),
+                                  tr("There is already a member named '%1'.").arg(name));
+        }
         return;
     }
 

--- a/src/tiled/propertytypeseditor.h
+++ b/src/tiled/propertytypeseditor.h
@@ -116,7 +116,7 @@ private:
 
     void openClassOfPopup();
     void openAddMemberDialog();
-    void addMember(const QString &name, const QVariant &value = QVariant());
+    void addMember(const QString &name, const QVariant &value, bool reportExisting);
     void removeMember();
     void renameSelectedMember();
     void renameMember(const QString &name);


### PR DESCRIPTION
Resolved by only popping up the error dialog when explicitly trying to add a member. When it happens just because the focus on the add value widget is lost, we silently abort when there is an existing member with the same name.

This avoids the problem because in fact the "addRequested" signal is currently always emitted two times: once by the user pressing Enter or clicking somewhere, and then another time when the add value widget loses focus. A more proper fix might be to make sure we only emit this signal once.