### PR TITLE
Fix status bar pixel coords being rounded instead of floored

### DIFF
--- a/src/tiled/abstractobjecttool.cpp
+++ b/src/tiled/abstractobjecttool.cpp
@@ -181,7 +181,7 @@ void AbstractObjectTool::mouseMoved(const QPointF &pos,
     if (Layer *layer = currentLayer())
         offsetPos -= mapScene()->absolutePositionForLayer(*layer);
 
-    const QPoint pixelPos = offsetPos.toPoint();
+    const QPoint pixelPos(qFloor(offsetPos.x()), qFloor(offsetPos.y()));
 
     const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos);
     const int x = qFloor(tilePosF.x());

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -112,7 +112,7 @@ void AbstractWorldTool::mouseMoved(const QPointF &pos,
     if (Layer *layer = currentLayer())
         offsetPos -= mapScene()->absolutePositionForLayer(*layer);
 
-    const QPoint pixelPos = offsetPos.toPoint();
+    const QPoint pixelPos(qFloor(offsetPos.x()), qFloor(offsetPos.y()));
     const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos);
     const int x = qFloor(tilePosF.x());
     const int y = qFloor(tilePosF.y());


### PR DESCRIPTION
I've mentioned what change might be needed in issue #3833 comment : [https://github.com/mapeditor/tiled/issues/3833#issuecomment-4049757604](https://github.com/mapeditor/tiled/issues/3833#issuecomment-4049757604)

As pointer is in top-left pixel, it's floored : 0, 0 (0, 0) and stopped flickering around when we move it in single pixel. 
<img width="1920" height="1080" alt="Screenshot (81)" src="https://github.com/user-attachments/assets/e123c38b-8b3e-4e4f-8544-77df8cf5fd09" />
