### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -26,7 +26,6 @@ env:
   SENTRY_PROJECT: tiled
   TILED_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
   TILED_SNAPSHOT: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-  SIGNING_ENABLED: ${{ secrets.SIGNING_ENABLED }}
 
 jobs:
   version:
@@ -34,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
-      release: ${{ steps.get-version.outputs.release }}
 
     steps:
     - name: Get version
@@ -42,7 +40,6 @@ jobs:
       run: |
         if [[ "$TILED_RELEASE" == 'true' ]]; then echo "version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT ; fi
         if [[ "$TILED_RELEASE" != 'true' ]]; then echo "version=$(date "+%Y.%m.%d")" >> $GITHUB_OUTPUT ; fi
-        echo "release=${TILED_RELEASE}" >> $GITHUB_OUTPUT
 
   linux:
     name: Linux (AppImage)
@@ -133,7 +130,7 @@ jobs:
 
     - name: Upload symbols and sources to Sentry
       if: github.repository == 'mapeditor/tiled' && github.event_name == 'push'
-      continue-on-error: ${{ needs.version.outputs.release == 'false' }}
+      continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       run: |
@@ -191,7 +188,7 @@ jobs:
 
     - name: Release snap (beta channel)
       uses: snapcore/action-publish@master
-      if: github.repository == 'mapeditor/tiled' && github.event_name == 'push' && (github.ref == 'refs/heads/snapshot' || needs.version.outputs.release == 'true')
+      if: github.repository == 'mapeditor/tiled' && github.event_name == 'push' && (github.ref == 'refs/heads/snapshot' || startsWith(github.ref, 'refs/tags/v'))
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
       with:
@@ -219,6 +216,7 @@ jobs:
 
     env:
       TILED_VERSION: ${{ needs.version.outputs.version }}
+      SIGNING_ENABLED: ${{ secrets.SIGNING_ENABLED }}
 
     steps:
     - name: Checkout repository
@@ -444,7 +442,7 @@ jobs:
     permissions:
       contents: write
 
-    if: github.repository == 'mapeditor/tiled' && github.event_name == 'push' && needs.version.outputs.release == 'true'
+    if: github.repository == 'mapeditor/tiled' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Download all artifacts
@@ -469,7 +467,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [version, linux, macos, windows]
 
-    if: github.repository == 'mapeditor/tiled' && github.event_name == 'push' && needs.version.outputs.release == 'true'
+    if: github.repository == 'mapeditor/tiled' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Releases were not working due to the following issue:

> Skip output 'release' since it may contain secret.

This was resolved by scoping the `SIGNING_ENABLED` secret more narrowly. Also, the 'release' output was removed.