### PR TITLE
Rename AppVeyor Windows artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ environment:
       QTDIR: C:\Qt\6.10.2\msvc2022_64
       PYTHONHOME: C:\Python312-x64
       DEFAULT_PROFILE: MSVC2022-x64
+      FILE_SUFFIX: Windows-10+_msvc_x86_64
       PUSH_RELEASE: false
       ENABLE_ZSTD: false
     - QT_VERSION: 5.15.2
@@ -31,6 +32,7 @@ environment:
       MINGW: C:\Qt\Tools\mingw810_32
       MINGW_COMPONENT: tools_mingw
       MINGW_VARIANT: qt.tools.win32_mingw810
+      FILE_SUFFIX: Windows-7-8_x86
       PUSH_RELEASE: true
       ENABLE_ZSTD: true
       CC: i686-w64-mingw32-gcc.exe
@@ -43,6 +45,7 @@ environment:
       MINGW: C:\Qt\Tools\mingw1310_64
       MINGW_COMPONENT: tools_mingw1310
       MINGW_VARIANT: qt.tools.win64_mingw1310
+      FILE_SUFFIX: Windows-10+_x86_64
       PUSH_RELEASE: true
       ENABLE_ZSTD: true
       CC: x86_64-w64-mingw32-gcc.exe
@@ -96,7 +99,7 @@ build_script:
 after_build:
   - cd release
   - cd installer*
-  - move tiled-*.msi %APPVEYOR_BUILD_FOLDER%
+  - move tiled-*.msi %APPVEYOR_BUILD_FOLDER%\Tiled-%TILED_VERSION%_%FILE_SUFFIX%.msi
   - cd ..
   - cd archive*
   - move tiled-*.7z %APPVEYOR_BUILD_FOLDER%
@@ -104,7 +107,7 @@ after_build:
 
 artifacts:
   - name: Installer
-    path: 'tiled-*.msi'
+    path: 'Tiled-*.msi'
   - name: Archive
     path: 'tiled-*.7z'
 


### PR DESCRIPTION
For consistency with the GitHub builds, and so I can stop doing this renaming manually. :)