### PR TITLE
Fix Tile Stamps with external tilesets not loading on startup

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -1040,13 +1040,13 @@ void MainWindow::initializeSession()
     // adding the project's extension path.
     ScriptManager::instance().ensureInitialized();
 
-    // Load tile stamps (delayed so that potential custom types and file
-    // formats can be supported by stamps - which isn't perfect since there
-    // will still be issues when the project isn't open on startup)
-    TileStampManager::instance()->loadStamps();
-
     if (projectLoaded || Preferences::instance()->restoreSessionOnStartup())
         restoreSession();
+
+    // Load tile stamps after restoring the session, so that any files opened
+    // on startup (including external tilesets) are available when resolving
+    // references inside stamps.
+    TileStampManager::instance()->loadStamps();
 }
 
 bool MainWindow::openFile(const QString &fileName, FileFormat *fileFormat)


### PR DESCRIPTION
### Description
This PR fixes an issue where Tile Stamps referencing external tilesets would fail to load when a project was opened directly or when a session was restored.

**Linked Issue**: https://github.com/mapeditor/tiled/issues/3808

### Root Cause
The `TileStampManager::loadStamps()` function was being called before [restoreSession()](cci:1://file:///home/aayushmaan/TiledGSOC/tiled/src/tiled/mainwindow.cpp:1505:0-1523:1) in `MainWindow::initializeSession()`. Because external tilesets are loaded and initialized as part of the session restoration, the stamps were attempting to resolve tileset references before they were available in the [TilesetManager](cci:1://file:///home/aayushmaan/TiledGSOC/tiled/src/libtiled/tilesetmanager.cpp:43:0-57:1).

### Solution
Ensured [restoreSession()](cci:1://file:///home/aayushmaan/TiledGSOC/tiled/src/tiled/mainwindow.cpp:1505:0-1523:1) is called before [loadStamps()](cci:1://file:///home/aayushmaan/TiledGSOC/tiled/src/tiled/tilestampmanager.cpp:197:0-232:1) in `MainWindow::initializeSession()`. This ensures that the project context and all external tilesets are fully operational before the tile stamps are processed.

### Technical Details
- Modified [tiled/src/tiled/mainwindow.cpp](cci:7://file:///home/aayushmaan/TiledGSOC/tiled/src/tiled/mainwindow.cpp:0:0-0:0) to swap the initialization order.
- This resolves the race condition without side effects, as labels and UI components in the stamps dock are correctly updated once the model loads.

### Verification Results
- **Reproduction**: Confirmed the bug by opening a project with stamps referencing `.tsx`/`.tsj` files.
- **Fix Confirmation**: Verified that stamps now consistently appear in the Tile Stamps dock on startup.
- **Build Check**: Successfully built using [qbs](cci:7://file:///home/aayushmaan/TiledGSOC/tiled/tests/tests.qbs:0:0-0:0).

Fixes #3808
