### PR TITLE
Add preference for world object label visibility

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -463,6 +463,26 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     connect(objectLabelVisibilityGroup, &QActionGroup::triggered,
             this, &MainWindow::labelVisibilityActionTriggered);
 
+    QActionGroup *worldObjectLabelVisibilityGroup = new QActionGroup(this);
+    mUi->actionWorldObjectLabelsActiveOnly->setActionGroup(worldObjectLabelVisibilityGroup);
+    mUi->actionWorldObjectLabelsNearest->setActionGroup(worldObjectLabelVisibilityGroup);
+    mUi->actionWorldObjectLabelsAll->setActionGroup(worldObjectLabelVisibilityGroup);
+
+    switch (preferences->worldObjectLabelVisibility()) {
+    case Preferences::WorldLabelsActiveOnly:
+        mUi->actionWorldObjectLabelsActiveOnly->setChecked(true);
+        break;
+    case Preferences::WorldLabelsNearest:
+        mUi->actionWorldObjectLabelsNearest->setChecked(true);
+        break;
+    case Preferences::WorldLabelsAll:
+        mUi->actionWorldObjectLabelsAll->setChecked(true);
+        break;
+    }
+
+    connect(worldObjectLabelVisibilityGroup, &QActionGroup::triggered,
+            this, &MainWindow::worldObjectLabelVisibilityActionTriggered);
+
     mUi->actionLabelForHoveredObject->setChecked(preferences->labelForHoveredObject());
     connect(mUi->actionLabelForHoveredObject, &QAction::triggered,
             preferences, &Preferences::setLabelForHoveredObject);
@@ -1700,6 +1720,18 @@ void MainWindow::labelVisibilityActionTriggered(QAction *action)
         visibility = Preferences::AllObjectLabels;
 
     Preferences::instance()->setObjectLabelVisibility(visibility);
+}
+
+void MainWindow::worldObjectLabelVisibilityActionTriggered(QAction *action)
+{
+    Preferences::WorldObjectLabelVisibility visibility = Preferences::WorldLabelsActiveOnly;
+
+    if (action == mUi->actionWorldObjectLabelsNearest)
+        visibility = Preferences::WorldLabelsNearest;
+    else if (action == mUi->actionWorldObjectLabelsAll)
+        visibility = Preferences::WorldLabelsAll;
+
+    Preferences::instance()->setWorldObjectLabelVisibility(visibility);
 }
 
 void MainWindow::zoomIn()

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -150,6 +150,7 @@ private:
     void updatePopupGeometry(QSize size);
 
     void labelVisibilityActionTriggered(QAction *action);
+    void worldObjectLabelVisibilityActionTriggered(QAction *action);
     void zoomIn();
     void zoomOut();
     void zoomNormal();

--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -157,6 +157,14 @@
      <addaction name="separator"/>
      <addaction name="actionLabelForHoveredObject"/>
     </widget>
+    <widget class="QMenu" name="menuWorldObjectLabels">
+     <property name="title">
+      <string>Show &amp;World Object Names</string>
+     </property>
+     <addaction name="actionWorldObjectLabelsActiveOnly"/>
+     <addaction name="actionWorldObjectLabelsNearest"/>
+     <addaction name="actionWorldObjectLabelsAll"/>
+    </widget>
     <widget class="QMenu" name="menuSnapping">
      <property name="title">
       <string>Snapping</string>
@@ -171,6 +179,7 @@
     <addaction name="actionShowTileObjectOutlines"/>
     <addaction name="actionShowObjectReferences"/>
     <addaction name="menuShowObjectNames"/>
+    <addaction name="menuWorldObjectLabels"/>
     <addaction name="actionShowTileAnimations"/>
     <addaction name="actionShowTileCollisionShapes"/>
     <addaction name="actionEnableWorlds"/>
@@ -571,6 +580,33 @@
    </property>
    <property name="text">
     <string>For &amp;All Objects</string>
+   </property>
+  </action>
+  <action name="actionWorldObjectLabelsActiveOnly">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Active Map &amp;Only</string>
+   </property>
+  </action>
+  <action name="actionWorldObjectLabelsNearest">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Nearest Maps</string>
+   </property>
+  </action>
+  <action name="actionWorldObjectLabelsAll">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;All Maps</string>
    </property>
   </action>
   <action name="actionAutoMapWhileDrawing">

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -223,27 +223,15 @@ void MapItem::setDisplayMode(DisplayMode displayMode)
         setZValue(-1);
 
         mBorderRectangle->setBrush(QColor(0, 0, 0, 64));
-
-        mTileSelectionItem.reset();
-        mTileGridItem.reset();
-        mObjectSelectionItem.reset();
     } else {
         unsetCursor();
 
         setZValue(0);
 
         mBorderRectangle->setBrush(Qt::NoBrush);
-
-        mTileSelectionItem = std::make_unique<TileSelectionItem>(mapDocument(), this);
-        mTileSelectionItem->setZValue(10000 - 3);
-
-        mTileGridItem = std::make_unique<TileGridItem>(mapDocument(), this);
-        mTileGridItem->setZValue(10000 - 2);
-
-        mObjectSelectionItem = std::make_unique<ObjectSelectionItem>(mapDocument(), this);
-        mObjectSelectionItem->setZValue(10000 - 1);
     }
 
+    updateOverlayState();
     updateSelectedLayersHighlight();
 }
 
@@ -259,6 +247,14 @@ void MapItem::setShowTileCollisionShapes(bool enabled)
     for (LayerItem *item : std::as_const(mLayerItems))
         if (item->layer()->isTileLayer())
             item->update();
+}
+
+void MapItem::setShowWorldLabels(bool show)
+{
+    if (mShowWorldLabels == show)
+        return;
+    mShowWorldLabels = show;
+    updateOverlayState();
 }
 
 void MapItem::updateLayerPositions()
@@ -921,6 +917,40 @@ void MapItem::updateSelectedLayersHighlight()
             qreal multiplier = (foundSelected && !isSelected) ? opacityFactor : 1;
             mLayerItems.value(layer)->setOpacity(layer->opacity() * multiplier);
         }
+    }
+}
+
+void MapItem::updateOverlayState()
+{
+    if (mDisplayMode == ReadOnly) {
+        mTileSelectionItem.reset();
+        mTileGridItem.reset();
+
+        if (!mShowWorldLabels) {
+            mObjectSelectionItem.reset();
+        } else {
+            if (!mObjectSelectionItem) {
+                mObjectSelectionItem = std::make_unique<ObjectSelectionItem>(mapDocument(), this);
+                mObjectSelectionItem->setZValue(10000 - 1);
+            }
+            mObjectSelectionItem->setLabelsOnly(true);
+            mObjectSelectionItem->setShowAllLabels(true);
+        }
+    } else {
+        if (!mTileSelectionItem) {
+            mTileSelectionItem = std::make_unique<TileSelectionItem>(mapDocument(), this);
+            mTileSelectionItem->setZValue(10000 - 3);
+        }
+        if (!mTileGridItem) {
+            mTileGridItem = std::make_unique<TileGridItem>(mapDocument(), this);
+            mTileGridItem->setZValue(10000 - 2);
+        }
+        if (!mObjectSelectionItem) {
+            mObjectSelectionItem = std::make_unique<ObjectSelectionItem>(mapDocument(), this);
+            mObjectSelectionItem->setZValue(10000 - 1);
+        }
+        mObjectSelectionItem->setLabelsOnly(false);
+        mObjectSelectionItem->setShowAllLabels(false);
     }
 }
 

--- a/src/tiled/mapitem.h
+++ b/src/tiled/mapitem.h
@@ -73,6 +73,7 @@ public:
 
     void setDisplayMode(DisplayMode displayMode);
     void setShowTileCollisionShapes(bool enabled);
+    void setShowWorldLabels(bool show);
 
     void updateLayerPositions();
 
@@ -133,6 +134,7 @@ private:
 
     void updateBoundingRect();
     void updateSelectedLayersHighlight();
+    void updateOverlayState();
 
     MapDocumentPtr mMapDocument;
     QGraphicsRectItem *mDarkRectangle;
@@ -145,6 +147,7 @@ private:
     DisplayMode mDisplayMode;
     QRectF mBoundingRect;
     bool mIsHovered = false;
+    bool mShowWorldLabels = false;
 };
 
 inline MapDocument *MapItem::mapDocument() const

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -70,6 +70,9 @@ MapScene::MapScene(QObject *parent)
     WorldManager &worldManager = WorldManager::instance();
     connect(&worldManager, &WorldManager::worldsChanged, this, &MapScene::refreshScene);
 
+    connect(Preferences::instance(), &Preferences::worldObjectLabelVisibilityChanged,
+            this, &MapScene::refreshScene);
+
     // Install an event filter so that we can get key events on behalf of the
     // active tool without having to have the current focus.
     qApp->installEventFilter(this);
@@ -310,10 +313,29 @@ void MapScene::refreshScene()
 
             if (mapDocument) {
                 MapItem::DisplayMode displayMode = MapItem::ReadOnly;
-                if (mapDocument == mMapDocument)
+                bool showWorldLabels = false;
+
+                if (mapDocument == mMapDocument) {
                     displayMode = MapItem::Editable;
+                } else {
+                    auto mode = Preferences::instance()->worldObjectLabelVisibility();
+                    if (mode == Preferences::WorldLabelsAll) {
+                        showWorldLabels = true;
+                    } else if (mode == Preferences::WorldLabelsNearest) {
+                        QRect activeRect = mMapDocument->renderer()->mapBoundingRect();
+                        activeRect.translate(currentMapPosition);
+
+                        QRect contextRect = mapDocument->renderer()->mapBoundingRect();
+                        contextRect.translate(mapEntry.rect.topLeft());
+
+                        if (activeRect.adjusted(-1, -1, 1, 1).intersects(contextRect)) {
+                            showWorldLabels = true;
+                        }
+                    }
+                }
 
                 auto mapItem = takeOrCreateMapItem(mapDocument, displayMode);
+                mapItem->setShowWorldLabels(showWorldLabels);
                 mapItem->setPos(mapEntry.rect.topLeft() - currentMapPosition);
                 mapItem->setVisible(mWorldsEnabled || mapDocument == mMapDocument);
                 mapItems.insert(mapDocument.data(), mapItem);

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -350,6 +350,48 @@ const MapRenderer &ObjectSelectionItem::mapRenderer() const
     return *mMapDocument->renderer();
 }
 
+void ObjectSelectionItem::setShowAllLabels(bool show)
+{
+    if (mShowAllLabels == show)
+        return;
+    mShowAllLabels = show;
+    addRemoveObjectLabels();
+}
+
+void ObjectSelectionItem::setLabelsOnly(bool labelsOnly)
+{
+    if (mLabelsOnly == labelsOnly)
+        return;
+
+    mLabelsOnly = labelsOnly;
+
+    if (mLabelsOnly) {
+        qDeleteAll(mObjectOutlines);
+        mObjectOutlines.clear();
+
+        qDeleteAll(mObjectHoverItems);
+        mObjectHoverItems.clear();
+
+        mHoveredMapObjectItem.reset();
+
+        for (const auto &items : std::as_const(mReferencesBySourceObject))
+            qDeleteAll(items);
+        mReferencesBySourceObject.clear();
+        mReferencesByTargetObject.clear();
+    } else {
+        addRemoveObjectOutlines();
+        addRemoveObjectHoverItems();
+
+        if (MapObject *hovered = mMapDocument->hoveredMapObject())
+            hoveredMapObjectChanged(hovered, nullptr);
+
+        if (Preferences::instance()->showObjectReferences())
+            addRemoveObjectReferences();
+    }
+
+    addRemoveObjectLabels();
+}
+
 QVariant ObjectSelectionItem::itemChange(GraphicsItemChange change, const QVariant &value)
 {
     if (change == ItemSceneChange) {
@@ -486,6 +528,11 @@ void ObjectSelectionItem::hoveredMapObjectChanged(MapObject *object,
                 mObjectLabels.remove(previous);
             }
         }
+    }
+
+    if (mLabelsOnly) {
+        mHoveredMapObjectItem.reset();
+        return;
     }
 
     if (object && prefs->highlightHoveredObject()) {
@@ -791,7 +838,12 @@ void ObjectSelectionItem::addRemoveObjectLabels()
         if (MapObject *object = mMapDocument->hoveredMapObject())
             ensureLabel(object);
 
-    switch (objectLabelVisibility()) {
+    auto visibility = objectLabelVisibility();
+    if (mShowAllLabels) {
+        visibility = Preferences::AllObjectLabels;
+    }
+
+    switch (visibility) {
     case Preferences::AllObjectLabels: {
         LayerIterator iterator(mMapDocument->map(), Layer::ObjectGroupType);
         while (auto objectGroup = static_cast<ObjectGroup*>(iterator.next())) {
@@ -820,6 +872,9 @@ void ObjectSelectionItem::addRemoveObjectLabels()
 
 void ObjectSelectionItem::addRemoveObjectOutlines()
 {
+    if (mLabelsOnly)
+        return;
+
     QHash<MapObject*, MapObjectOutline*> outlineItems;
     const MapRenderer &renderer = *mMapDocument->renderer();
 
@@ -838,6 +893,9 @@ void ObjectSelectionItem::addRemoveObjectOutlines()
 
 void ObjectSelectionItem::addRemoveObjectHoverItems()
 {
+    if (mLabelsOnly)
+        return;
+
     QHash<MapObject*, MapObjectOutline*> hoverItems;
     const MapRenderer &renderer = *mMapDocument->renderer();
 
@@ -889,6 +947,9 @@ static void forEachObjectReference(const QVariant &value, Callback callback)
 
 void ObjectSelectionItem::addRemoveObjectReferences()
 {
+    if (mLabelsOnly)
+        return;
+
     QHash<MapObject*, QList<ObjectReferenceItem*>> referencesBySourceObject;
     QHash<MapObject*, QList<ObjectReferenceItem*>> referencesByTargetObject;
     const MapRenderer &renderer = *mMapDocument->renderer();
@@ -948,6 +1009,9 @@ void ObjectSelectionItem::addRemoveObjectReferences()
 
 void ObjectSelectionItem::addRemoveObjectReferences(MapObject *object)
 {
+    if (mLabelsOnly)
+        return;
+
     QList<ObjectReferenceItem*> &items = mReferencesBySourceObject[object];
     QList<ObjectReferenceItem*> existingItems;
     items.swap(existingItems);

--- a/src/tiled/objectselectionitem.h
+++ b/src/tiled/objectselectionitem.h
@@ -86,6 +86,10 @@ public:
     QRectF boundingRect() const override { return QRectF(); }
     void paint(QPainter *, const QStyleOptionGraphicsItem *, QWidget *) override {}
 
+    void setShowAllLabels(bool show);
+    void setLabelsOnly(bool labelsOnly);
+    bool isLabelsOnly() const { return mLabelsOnly; }
+
 protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
@@ -126,6 +130,9 @@ private:
     QHash<MapObject*, QList<ObjectReferenceItem*>> mReferencesBySourceObject;
     QHash<MapObject*, QList<ObjectReferenceItem*>> mReferencesByTargetObject;
     std::unique_ptr<MapObjectItem> mHoveredMapObjectItem;
+
+    bool mShowAllLabels = false;
+    bool mLabelsOnly = false;
 };
 
 } // namespace Tiled

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -259,6 +259,17 @@ void Preferences::setObjectLabelVisibility(ObjectLabelVisiblity visibility)
     emit objectLabelVisibilityChanged(visibility);
 }
 
+Preferences::WorldObjectLabelVisibility Preferences::worldObjectLabelVisibility() const
+{
+    return static_cast<WorldObjectLabelVisibility>(get<int>("Interface/WorldObjectLabelVisibility", WorldLabelsActiveOnly));
+}
+
+void Preferences::setWorldObjectLabelVisibility(WorldObjectLabelVisibility visibility)
+{
+    setValue(QLatin1String("Interface/WorldObjectLabelVisibility"), static_cast<int>(visibility));
+    emit worldObjectLabelVisibilityChanged(visibility);
+}
+
 bool Preferences::labelForHoveredObject() const
 {
     return get("Interface/LabelForHoveredObject", false);

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -88,6 +88,15 @@ public:
     ObjectLabelVisiblity objectLabelVisibility() const;
     void setObjectLabelVisibility(ObjectLabelVisiblity visibility);
 
+    enum WorldObjectLabelVisibility {
+        WorldLabelsActiveOnly,
+        WorldLabelsNearest,
+        WorldLabelsAll
+    };
+
+    WorldObjectLabelVisibility worldObjectLabelVisibility() const;
+    void setWorldObjectLabelVisibility(WorldObjectLabelVisibility visibility);
+
     bool labelForHoveredObject() const;
     void setLabelForHoveredObject(bool enabled);
 
@@ -237,6 +246,7 @@ signals:
     void highlightHoveredObjectChanged(bool highlight);
     void showTilesetGridChanged(bool showTilesetGrid);
     void objectLabelVisibilityChanged(ObjectLabelVisiblity);
+    void worldObjectLabelVisibilityChanged(WorldObjectLabelVisibility visibility);
     void labelForHoveredObjectChanged(bool enabled);
 
     void applicationStyleChanged(ApplicationStyle);


### PR DESCRIPTION
Closes #4078

**Summary**
Adds options to display object names across multiple maps when working in a World. 

**Changes**
* Added `WorldObjectLabelVisibility` preferences and UI toggles (`Active Map Only`, `Nearest Maps`, `All Maps`).
* Background maps now only process labels, suspending other updates to prevent CPU overhead.

**How to test**
1. Open a World with multiple maps containing named objects.
2. Toggle `View -> Show World Object Names` modes and verify label visibility on adjacent/distant maps.