### PR TITLE
Don't update selection mode indicator when Alt would move objects

### DIFF
--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -741,11 +741,15 @@ void ObjectSelectionTool::modifiersChanged(Qt::KeyboardModifiers modifiers)
 {
     mModifiers = modifiers;
 
-    if ((mSelectionMode == Qt::IntersectsItemShape) ^ modifiers.testFlag(Qt::AltModifier))
-        mSelectIntersected->setChecked(true);
-    else
-        mSelectContained->setChecked(true);
+    const bool hasSelection = mapDocument() && !mapDocument()->selectedObjects().isEmpty();
+    const bool altWillMove = !mMousePressed && hasSelection; 
 
+    if (!altWillMove) {
+        if ((mSelectionMode == Qt::IntersectsItemShape) ^ modifiers.testFlag(Qt::AltModifier))
+            mSelectIntersected->setChecked(true);
+        else
+            mSelectContained->setChecked(true);
+    }
     refreshCursor();
 }
 


### PR DESCRIPTION
when objects are already selected and Alt is pressed before clicking, `modifiersChanged` was updating the toolbar to "Select Enclosed" even though Alt would be used for moving objects, not changing selection mode. Now that indicator misleading is fixed. 
the fix now - skips the toolbar update when !mMousePressed && !selectedObjects().isEmpty(), which is consistent with the existing move-on-alt logic already in mouseMoved.
I've mentioned in : [comment](https://github.com/mapeditor/tiled/issues/3719#issuecomment-4054201846)

fixes #3719
Thanks : ) 

https://github.com/user-attachments/assets/81b2db0e-420e-4343-b5d3-d9d172f26cfa




