### PR TITLE
Implement ClonableUndoCommand for object commands (undo/redo)

### DIFF
--- a/src/tiled/addremovemapobject.cpp
+++ b/src/tiled/addremovemapobject.cpp
@@ -25,6 +25,7 @@
 #include "map.h"
 #include "mapobject.h"
 #include "objectgroup.h"
+#include "undocommands.h"
 
 #include <QCoreApplication>
 
@@ -143,6 +144,37 @@ void AddMapObjects::redo()
     mOwnsObjects = false;
 }
 
+QUndoCommand *AddMapObjects::clone(QUndoCommand *parent) const
+{
+    auto *clone = new AddMapObjects(mDocument, mEntries, parent);
+    clone->setText(text());
+    
+    // Transfer ownership of objects from original to clone
+    clone->mEntries = mEntries;
+    const_cast<AddMapObjects*>(this)->mOwnsObjects = false;
+    
+    return clone;
+}
+
+bool AddMapObjects::mergeWith(const QUndoCommand *other)
+{
+    const auto *o = static_cast<const AddMapObjects*>(other);
+    if (mDocument != o->mDocument)
+        return false;
+    
+    if (!cloneChildren(other, this))
+        return false;
+    
+    // Append entries from other command
+    for (const Entry &entry : o->mEntries)
+        mEntries.append(entry);
+    
+    // Transfer ownership from other to this
+    const_cast<AddMapObjects*>(o)->mOwnsObjects = false;
+    
+    return true;
+}
+
 
 RemoveMapObjects::RemoveMapObjects(Document *document,
                                    MapObject *mapObject,
@@ -199,4 +231,35 @@ void RemoveMapObjects::redo()
     emit mDocument->changed(mapObjectsEvent);
 
     mOwnsObjects = true;
+}
+
+QUndoCommand *RemoveMapObjects::clone(QUndoCommand *parent) const
+{
+    auto *clone = new RemoveMapObjects(mDocument, objects(mEntries), parent);
+    clone->setText(text());
+    
+    // Transfer ownership of objects from original to clone
+    clone->mEntries = mEntries;
+    const_cast<RemoveMapObjects*>(this)->mOwnsObjects = false;
+    
+    return clone;
+}
+
+bool RemoveMapObjects::mergeWith(const QUndoCommand *other)
+{
+    const auto *o = static_cast<const RemoveMapObjects*>(other);
+    if (mDocument != o->mDocument)
+        return false;
+    
+    if (!cloneChildren(other, this))
+        return false;
+    
+    // Append entries from other command
+    for (const Entry &entry : o->mEntries)
+        mEntries.append(entry);
+    
+    // Transfer ownership from other to this
+    const_cast<RemoveMapObjects*>(o)->mOwnsObjects = false;
+    
+    return true;
 }

--- a/src/tiled/addremovemapobject.h
+++ b/src/tiled/addremovemapobject.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "undocommands.h"
+
 #include <QUndoCommand>
 #include <QVector>
 
@@ -69,7 +71,7 @@ protected:
 /**
  * Undo command that adds an object to a map.
  */
-class AddMapObjects : public AddRemoveMapObjects
+class AddMapObjects : public AddRemoveMapObjects, public ClonableUndoCommand
 {
 public:
     AddMapObjects(Document *document,
@@ -83,12 +85,15 @@ public:
 
     void undo() override;
     void redo() override;
+
+    QUndoCommand *clone(QUndoCommand *parent = nullptr) const override;
+    bool mergeWith(const QUndoCommand *other) override;
 };
 
 /**
  * Undo command that removes one or more objects from a map.
  */
-class RemoveMapObjects : public AddRemoveMapObjects
+class RemoveMapObjects : public AddRemoveMapObjects, public ClonableUndoCommand
 {
 public:
     RemoveMapObjects(Document *document,
@@ -101,6 +106,9 @@ public:
 
     void undo() override;
     void redo() override;
+
+    QUndoCommand *clone(QUndoCommand *parent = nullptr) const override;
+    bool mergeWith(const QUndoCommand *other) override;
 };
 
 } // namespace Tiled


### PR DESCRIPTION
Closes #3471 

### Problem
When Automapping rules placed both tiles and objects, you had to press Ctrl+Z multiple times (2-3 times) to fully undo the operation. Tiles-only rules worked fine with a single undo.

### Solution
Implemented the `ClonableUndoCommand` interface in `AddMapObjects` and `RemoveMapObjects`. This allows the undo system to properly clone and merge object commands, so they undo together with tiles in a single step.

###Changes
- `src/tiled/addremovemapobject.h` - Added interface inheritance and method declarations
- `src/tiled/addremovemapobject.cpp` - Implemented `clone()` and `mergeWith()` methods with proper ownership transfer

I am adding screenshots produced by my manual testing, along with it tests are also added.

<img width="1846" height="1048" alt="Screenshot from 2026-03-15 04-53-29" src="https://github.com/user-attachments/assets/36c0c5fd-7c8a-4a8d-8f21-d90110ecd9bb" />

<img width="1846" height="1048" alt="Screenshot from 2026-03-15 04-53-48" src="https://github.com/user-attachments/assets/7d9b534f-4064-4610-8346-2649306c5811" />

<img width="1846" height="1048" alt="Screenshot from 2026-03-15 04-53-54" src="https://github.com/user-attachments/assets/630d3846-9bcb-4890-bbc4-630eaff24c14" />
