### PR TITLE
Add functionality for Delete Template

### DIFF
--- a/src/libtiled/templatemanager.cpp
+++ b/src/libtiled/templatemanager.cpp
@@ -83,6 +83,11 @@ ObjectTemplate *TemplateManager::loadObjectTemplate(const QString &fileName, QSt
     return objectTemplate;
 }
 
+void TemplateManager::deleteTemplate(const QString &fileName)
+{
+    mWatcher->removePath(fileName);
+}
+
 void TemplateManager::pathsChanged(const QStringList &paths)
 {
     for (const QString &fileName : paths) {

--- a/src/libtiled/templatemanager.h
+++ b/src/libtiled/templatemanager.h
@@ -42,6 +42,7 @@ public:
     ObjectTemplate *findObjectTemplate(const QString &fileName);
     ObjectTemplate *loadObjectTemplate(const QString &fileName,
                                        QString *error = nullptr);
+    void deleteTemplate(const QString &fileName);
 
 signals:
     /**

--- a/src/tiled/projectdock.cpp
+++ b/src/tiled/projectdock.cpp
@@ -23,8 +23,12 @@
 #include "actionmanager.h"
 #include "addremovetileset.h"
 #include "documentmanager.h"
+#include "layer.h"
+#include "mapdocument.h"
 #include "mapdocumentactionhandler.h"
 #include "mapeditor.h"
+#include "mapobject.h"
+#include "objectgroup.h"
 #include "objecttemplate.h"
 #include "preferences.h"
 #include "projectmanager.h"
@@ -36,9 +40,11 @@
 #include "utils.h"
 
 #include <QBoxLayout>
+#include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QMenu>
+#include <QMessageBox>
 #include <QMouseEvent>
 #include <QScrollBar>
 #include <QSet>
@@ -80,6 +86,7 @@ private:
     void onRowsInserted(const QModelIndex &parent);
 
     void restoreExpanded(const QModelIndex &parent);
+    void deleteTemplate(const QString &templatePath);
 
     ProjectModel *mProjectModel;
     ProjectProxyModel *mProxyModel;
@@ -276,6 +283,9 @@ void ProjectView::contextMenuEvent(QContextMenuEvent *event)
                 menu.addAction(tr("Select Template Instances"), [=] {
                     mapDocumentActionHandler->selectAllInstances(objectTemplate);
                 })->setEnabled(mapDocument != nullptr);
+                menu.addAction(tr("Delete"), [=] {
+                    deleteTemplate(path);
+                });
             }
             // Add tileset-specific actions
             else if (auto tileset = TilesetManager::instance()->loadTileset(path)) {
@@ -343,6 +353,34 @@ void ProjectView::restoreExpanded(const QModelIndex &parent)
         for (int row = 0, count = model()->rowCount(parent); row < count; ++row)
             restoreExpanded(model()->index(row, 0, parent));
     }
+}
+
+static bool isTemplateInUse(const ObjectTemplate *objectTemplate)
+{
+    for (const auto &doc : DocumentManager::instance()->documents()) {
+        if (auto mapDoc = qobject_cast<MapDocument*>(doc.data())) {
+            for (Layer *layer : mapDoc->map()->objectGroups()) {
+                for (MapObject *obj : static_cast<ObjectGroup*>(layer)->objects()) {
+                    if (obj->objectTemplate() == objectTemplate)
+                        return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+void ProjectView::deleteTemplate(const QString &templatePath)
+{
+    auto objectTemplate = TemplateManager::instance()->loadObjectTemplate(templatePath);
+
+    if (isTemplateInUse(objectTemplate)) {
+        if (QMessageBox::warning(window(), tr("Delete Template"), tr("This template is in use. Delete anyway?"),
+                                 QMessageBox::Yes | QMessageBox::Cancel) != QMessageBox::Yes)
+            return;
+    }
+    QFile::remove(templatePath);
+    TemplateManager::instance()->deleteTemplate(templatePath);
 }
 
 } // namespace Tiled


### PR DESCRIPTION
ref #1723 
I have added the delete functionality for templates. Please check it out if the changes are alright.

![menu](https://github.com/user-attachments/assets/1ff0b133-7065-4a2f-ac02-38776f638ba2)

Currently after deleting a template it takes 10-15s to disappear from the file list during Folders referesh using `FileSystemWatcher`.
Do you think that's an issue?
