### PR TITLE
Add preference to disable layer synchronization in World Tool

### DIFF
--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -335,9 +335,16 @@ void MapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         MapView *view = static_cast<MapView*>(event->widget()->parent());
         QRectF viewRect { view->viewport()->rect() };
         QRectF sceneViewRect = view->viewportTransform().inverted().mapRect(viewRect);
-        DocumentManager::instance()->switchToDocumentAndHandleSimiliarTileset(mMapDocument.data(),
-                                                                              sceneViewRect.center() - pos(),
-                                                                              view->zoomable()->scale());
+        
+        if (Preferences::instance()->syncLayersInWorldTool()) {
+            DocumentManager::instance()->switchToDocumentAndHandleSimiliarTileset(mMapDocument.data(),
+                                                                                  sceneViewRect.center() - pos(),
+                                                                                  view->zoomable()->scale());
+        } else {
+            DocumentManager::instance()->switchToDocument(mMapDocument.data(),
+                                                          sceneViewRect.center() - pos(),
+                                                          view->zoomable()->scale());
+        }
         return;
     }
 

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -744,6 +744,11 @@ bool Preferences::wheelZoomsByDefault() const
     return get("Interface/WheelZoomsByDefault", false);
 }
 
+bool Preferences::syncLayersInWorldTool() const
+{
+    return get("Interface/SyncLayersInWorldTool", true);
+}
+
 void Preferences::setRestoreSessionOnStartup(bool enabled)
 {
     setValue(QLatin1String("Startup/RestorePreviousSession"), enabled);
@@ -782,6 +787,12 @@ void Preferences::setPluginEnabled(const QString &fileName, bool enabled)
 void Preferences::setWheelZoomsByDefault(bool mode)
 {
     setValue(QLatin1String("Interface/WheelZoomsByDefault"), mode);
+}
+
+void Preferences::setSyncLayersInWorldTool(bool sync)
+{
+    setValue(QLatin1String("Interface/SyncLayersInWorldTool"), sync);
+    emit syncLayersInWorldToolChanged(sync);
 }
 
 QString Preferences::homeLocation()

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -179,6 +179,7 @@ public:
     void setDisplayNews(bool on);
 
     bool wheelZoomsByDefault() const;
+    bool syncLayersInWorldTool() const;
 
     template <typename T>
     T get(const char *key, const T &defaultValue = T()) const
@@ -216,6 +217,7 @@ public slots:
     void setRestoreSessionOnStartup(bool enabled);
     void setPluginEnabled(const QString &fileName, bool enabled);
     void setWheelZoomsByDefault(bool mode);
+    void setSyncLayersInWorldTool(bool sync);
 
     void clearRecentFiles();
     void clearRecentProjects();
@@ -238,6 +240,7 @@ signals:
     void showTilesetGridChanged(bool showTilesetGrid);
     void objectLabelVisibilityChanged(ObjectLabelVisiblity);
     void labelForHoveredObjectChanged(bool enabled);
+    void syncLayersInWorldToolChanged(bool sync);
 
     void applicationStyleChanged(ApplicationStyle);
     void baseColorChanged(const QColor &baseColor);

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -140,6 +140,9 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             preferences, &Preferences::setUseOpenGL);
     connect(mUi->wheelZoomsByDefault, &QCheckBox::toggled,
             preferences, &Preferences::setWheelZoomsByDefault);
+    connect(mUi->syncLayersInWorldTool, &QCheckBox::toggled,
+            preferences, &Preferences::setSyncLayersInWorldTool);
+
     connect(mUi->autoScrolling, &QCheckBox::toggled,
             this, [] (bool checked) { MapView::ourAutoScrollingEnabled = checked; });
     connect(mUi->smoothScrolling, &QCheckBox::toggled,
@@ -235,6 +238,7 @@ void PreferencesDialog::fromPreferences()
     if (mUi->openGL->isEnabled())
         mUi->openGL->setChecked(prefs->useOpenGL());
     mUi->wheelZoomsByDefault->setChecked(prefs->wheelZoomsByDefault());
+    mUi->syncLayersInWorldTool->setChecked(prefs->syncLayersInWorldTool());
     mUi->autoScrolling->setChecked(MapView::ourAutoScrollingEnabled);
     mUi->smoothScrolling->setChecked(MapView::ourSmoothScrollingEnabled);
     mUi->duplicateAddsCopy->setChecked(Editor::duplicateAddsCopy);

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -433,6 +433,13 @@
             </property>
            </widget>
           </item>
+          <item row="6" column="0" colspan="3">
+           <widget class="QCheckBox" name="syncLayersInWorldTool">
+            <property name="text">
+             <string>Sync layers when switching maps in World Tool</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -709,6 +716,7 @@
   <tabstop>autoScrolling</tabstop>
   <tabstop>smoothScrolling</tabstop>
   <tabstop>duplicateAddsCopy</tabstop>
+  <tabstop>syncLayersInWorldTool</tabstop>
   <tabstop>styleCombo</tabstop>
   <tabstop>baseColor</tabstop>
   <tabstop>selectionColor</tabstop>

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -210,9 +210,15 @@ void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
             }
         } else {
             // switch to the document
-            manager->switchToDocumentAndHandleSimiliarTileset(draggedMap,
-                                                              sceneViewRect.center() - mDraggedMapStartPos,
-                                                              view->zoomable()->scale());
+            if (Preferences::instance()->syncLayersInWorldTool()) {
+                manager->switchToDocumentAndHandleSimiliarTileset(draggedMap,
+                                                                  sceneViewRect.center() - mDraggedMapStartPos,
+                                                                  view->zoomable()->scale());
+            } else { 
+                manager->switchToDocument(draggedMap,
+                                    sceneViewRect.center() - mDraggedMapStartPos,
+                                    view->zoomable()->scale());
+           }
         }
 
         refreshCursor();


### PR DESCRIPTION
As discussed in issue #3282, the automatic layer synchronization (`switchToDocumentAndHandleSimiliarTileset`) actively overwrites user's selected layer on target map ,, which breaks the copy/paste workflow between maps. 
Through this PR, i introduced a toggle in the Preferences (Interface --> Behavior) to give users control over this behavior. 

following changes made: 
1. Added `syncLayersInWorldTool` boolean to `Preferences`. 
2. Added a checkbox to `preferencesdialog.ui` and linked it in `preferencesdialog.cpp`.
3. Updated `MapItem::mouseReleaseEvent` and `WorldMoveMapTool::mouseReleased` to check this preference. And if unchecked, it falls back to standard `switchToDocument` logic, preserving the individual layer state of each map.


Fixes : #3282 
Below is the proof of successfully working. Let me know if I missed something. 

https://github.com/user-attachments/assets/2caa7f60-5b19-425b-9856-414cf573df7e

<img width="501" height="472" alt="tgl" src="https://github.com/user-attachments/assets/29be8d31-fcc9-4f6d-a6cb-1297290711f3" />


