### PR TITLE
Enable renaming custom property keys via double-click

### DIFF
--- a/src/tiled/propertiesview.cpp
+++ b/src/tiled/propertiesview.cpp
@@ -35,6 +35,7 @@
 #include <QGuiApplication>
 #include <QLabel>
 #include <QLineEdit>
+#include <QInputDialog>
 #include <QMenu>
 #include <QMetaProperty>
 #include <QPainter>
@@ -1399,6 +1400,25 @@ PropertiesView::PropertyWidgets PropertiesView::createPropertyWidgets(Property *
     });
 
     widgets.label = property->createLabel(level, rowWidget);    // todo: fix level
+
+    if (auto label = qobject_cast<PropertyLabel *>(widgets.label)) {
+        label->setProperty(property);
+    }
+    connect(property, &Property::renameRequested, this, [=]() {
+        bool ok;
+        QString newName = QInputDialog::getText(
+            nullptr,
+            QStringLiteral("Rename Property"),
+            QStringLiteral("Enter new name:"),
+            QLineEdit::Normal,
+            property->name(),
+            &ok
+            );
+
+        if (ok && !newName.isEmpty()) {
+            property->setName(newName);
+        }
+    });
 
     if (displayMode != Property::DisplayMode::Header) {
         if (isLeftToRight())

--- a/src/tiled/propertiesview.h
+++ b/src/tiled/propertiesview.h
@@ -121,6 +121,7 @@ signals:
     void addRequested(bool focus = true);
 
     void contextMenuRequested(const QPoint &globalPos);
+    void renameRequested();
 
 private:
     friend class GroupProperty;

--- a/src/tiled/propertyeditorwidgets.cpp
+++ b/src/tiled/propertyeditorwidgets.cpp
@@ -852,6 +852,15 @@ PropertyLabel::PropertyLabel(QWidget *parent)
     updateContentMargins();
 }
 
+void PropertyLabel::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    ElidingLabel::mouseDoubleClickEvent(event);
+
+    if (m_property) {
+        emit m_property->renameRequested();
+    }
+}
+
 void PropertyLabel::setLevel(int level)
 {
     if (m_level == level)

--- a/src/tiled/propertyeditorwidgets.h
+++ b/src/tiled/propertyeditorwidgets.h
@@ -374,6 +374,7 @@ public:
     void setModified(bool modified);
 
     QSize sizeHint() const override;
+    void setProperty(Property *property) { m_property = property; }
 
 signals:
     void toggled(bool expanded);
@@ -381,10 +382,12 @@ signals:
 protected:
     bool event(QEvent *event) override;
     void paintEvent(QPaintEvent *) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
 
 private:
     void updateContentMargins();
     QRect branchIndicatorRect() const;
+    Property *m_property = nullptr;
 
     int m_level = 0;
     bool m_header = false;


### PR DESCRIPTION
This PR adds support for renaming custom property keys by double-clicking on the property label in the Properties view.

Implementation details:
- Added handling of double-click events in PropertyLabel
- Introduced a renameRequested signal in Property
- Connected the signal in PropertiesView to open a rename dialog
- Updates the property name using Property::setName()

Currently, this uses a dialog-based approach (QInputDialog) for renaming.

Future improvement:
The property name could be made editable inline (similar to value editing) for a smoother user experience.