### PR TITLE
Add double click empty area to add custom property

### DIFF
--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -3093,6 +3093,10 @@ bool PropertiesWidget::event(QEvent *event)
     case QEvent::LanguageChange:
         retranslateUi();
         break;
+    case QEvent::MouseButtonDblClick: {
+        mActionAddProperty->trigger();
+        break;
+    }
     default:
         break;
     }


### PR DESCRIPTION
Fixes #845 

Triggers the mMouseAddProperty action when a double click is fired.

Opening this as draft pr since I am not sure if there are other places that need this to be handled.