### PR TITLE
macOS: Add UTI declaration for TMX files

### DIFF
--- a/src/tiledapp/Info.plist
+++ b/src/tiledapp/Info.plist
@@ -4,25 +4,59 @@
 <dict>
 	<key>CSResourcesFileMapped</key>
 	<true/>
+
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2008-2020 Thorbjørn Lindeijer</string>
+
 	<key>NSHighResolutionCapable</key>
 	<true/>
+
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleTypeName</key>
 			<string>Tiled Map</string>
+
 			<key>CFBundleTypeIconFile</key>
 			<string>tmx-icon-mac</string>
+
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>tmx</string>
 			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.mapeditor.tiled.tmx</string>
+			</array>
 		</dict>
 	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.mapeditor.tiled.tmx</string>
+
+			<key>UTTypeDescription</key>
+			<string>Tiled Map File</string>
+
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.xml</string>
+			</array>
+
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tmx</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
 </dict>


### PR DESCRIPTION
This PR adds a Uniform Type Identifier (UTI) declaration for TMX files on macOS.

Previously, Tiled only declared file types using extensions, which caused macOS to assign a dynamic UTI. This could lead to inconsistent file recognition across systems.

Changes made:
- Added LSItemContentTypes to CFBundleDocumentTypes for TMX files
- Declared UTExportedTypeDeclarations for a stable UTI (org.mapeditor.tiled.tmx)

This improves file association and ensures macOS can reliably recognize .tmx files as Tiled map files.