### PR TITLE
Fix object reference arrows not hiding with per-object visibility

### DIFF
--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -411,9 +411,15 @@ void ObjectSelectionItem::changeEvent(const ChangeEvent &event)
     case ChangeEvent::LayerChanged:
         layerChanged(static_cast<const LayerChangeEvent&>(event));
         break;
-    case ChangeEvent::MapObjectsChanged:
-        syncOverlayItems(static_cast<const MapObjectsChangeEvent&>(event).mapObjects);
+    case ChangeEvent::MapObjectsChanged: {
+        const auto &mapObjectsChange = static_cast<const MapObjectsChangeEvent&>(event);
+        if (mapObjectsChange.properties & MapObject::VisibleProperty) {
+            if (Preferences::instance()->showObjectReferences())
+                addRemoveObjectReferences();
+        }
+        syncOverlayItems(mapObjectsChange.mapObjects);
         break;
+    }
     case ChangeEvent::MapObjectsAdded:
         objectsAdded(static_cast<const MapObjectsEvent&>(event).mapObjects);
         break;
@@ -931,7 +937,13 @@ void ObjectSelectionItem::addRemoveObjectReferences()
                 continue;
 
             for (MapObject *object : objectGroup->objects()) {
+                if (!object->isVisible())
+                    continue;
+
                 forEachObjectReference(object->properties(), [&] (ObjectRef ref) {
+                    MapObject *targetObject = DisplayObjectRef(ref, mMapDocument).object();
+                    if (targetObject && !targetObject->isVisible())
+                        return;
                     ensureReferenceItem(object, ref);
                 });
             }


### PR DESCRIPTION
Object reference arrows were correctly hidden when hiding an entire layer, but remained visible when toggling the visibility of individual objects.

The root cause was in addRemoveObjectReferences(): it checked objectGroup->isHidden() to skip hidden layers, but never checked object->isVisible() for individual objects. Additionally, when a MapObjectsChanged event was emitted for a visibility toggle, only syncOverlayItems() was called (which only syncs positions), so the arrows were never removed.

Fix:
- In addRemoveObjectReferences(), skip invisible source objects and skip creating arrows that point to invisible target objects.
- In changeEvent(), when MapObjectsChanged carries VisibleProperty, call addRemoveObjectReferences() to rebuild arrows.

Fixes #4451