### PR TITLE
Feature: Add dockable File Dependencies view with context menu (#4446)

### DIFF
--- a/src/libtiled/filedependencies.cpp
+++ b/src/libtiled/filedependencies.cpp
@@ -1,0 +1,162 @@
+/*
+ * filedependencies.cpp
+ * Copyright 2024, File Dependencies Contributor
+ *
+ * This file is part of libtiled.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "filedependencies.h"
+
+#include "imagelayer.h"
+#include "layer.h"
+#include "map.h"
+#include "mapobject.h"
+#include "objectgroup.h"
+#include "objecttemplate.h"
+#include "tile.h"
+#include "tileset.h"
+
+#include <QCoreApplication>
+#include <QSet>
+#include <QUrl>
+
+namespace Tiled {
+
+static QString urlToPath(const QUrl &url)
+{
+    return url.isLocalFile() ? url.toLocalFile() : url.toString();
+}
+
+static bool isMappable(const QString &filePath)
+{
+    const QString lowerPath = filePath.toLower();
+    return lowerPath.endsWith(QLatin1String(".tmx")) ||
+           lowerPath.endsWith(QLatin1String(".tsx")) ||
+           lowerPath.endsWith(QLatin1String(".tx"));
+}
+
+static void collectFromTilesetInternal(const Tileset *tileset, QList<FileReference> &references, QSet<QString> &seenPaths)
+{
+    if (!tileset)
+        return;
+
+    // External tileset file
+    if (!tileset->fileName().isEmpty()) {
+        const QString path = tileset->fileName();
+        if (!seenPaths.contains(path)) {
+            seenPaths.insert(path);
+            references.append({path, QCoreApplication::translate("FileDependencies", "Tileset"), isMappable(path)});
+        }
+    }
+
+    // Tileset image
+    if (!tileset->imageSource().isEmpty()) {
+        const QString path = urlToPath(tileset->imageSource());
+        if (!seenPaths.contains(path)) {
+            seenPaths.insert(path);
+            references.append({path, QCoreApplication::translate("FileDependencies", "Tileset Image"), isMappable(path)});
+        }
+    }
+
+    // Per-tile images (for image collection tilesets)
+    for (const Tile *tile : tileset->tiles()) {
+        if (!tile->imageSource().isEmpty()) {
+            const QString path = urlToPath(tile->imageSource());
+            if (!seenPaths.contains(path)) {
+                seenPaths.insert(path);
+                references.append({path, QCoreApplication::translate("FileDependencies", "Tile Image"), isMappable(path)});
+            }
+        }
+    }
+}
+
+QList<FileReference> FileDependencyCollector::collectFromTileset(const Tileset *tileset)
+{
+    QList<FileReference> references;
+    QSet<QString> seenPaths;
+    collectFromTilesetInternal(tileset, references, seenPaths);
+    return references;
+}
+
+QList<FileReference> FileDependencyCollector::collectFromMap(const Map *map)
+{
+    QList<FileReference> references;
+    QSet<QString> seenPaths;
+
+    if (!map)
+        return references;
+
+    // Collect from all map tilesets
+    for (const SharedTileset &tileset : map->tilesets()) {
+        collectFromTilesetInternal(tileset.data(), references, seenPaths);
+    }
+
+    // Collect from layers (image layers, object templates)
+    for (Layer *layer : map->allLayers()) {
+        if (ImageLayer *imageLayer = layer->asImageLayer()) {
+            if (!imageLayer->imageSource().isEmpty()) {
+                const QString path = urlToPath(imageLayer->imageSource());
+                if (!seenPaths.contains(path)) {
+                    seenPaths.insert(path);
+                    references.append({path, QCoreApplication::translate("FileDependencies", "Image Layer"), isMappable(path)});
+                }
+            }
+        } else if (ObjectGroup *objectGroup = layer->asObjectGroup()) {
+            for (const MapObject *mapObject : *objectGroup) {
+                if (const ObjectTemplate *objectTemplate = mapObject->objectTemplate()) {
+                    // Template file itself
+                    if (!objectTemplate->fileName().isEmpty()) {
+                        const QString path = objectTemplate->fileName();
+                        if (!seenPaths.contains(path)) {
+                            seenPaths.insert(path);
+                            references.append({path, QCoreApplication::translate("FileDependencies", "Object Template"), isMappable(path)});
+                        }
+                    }
+
+                    // Template's tileset
+                    if (const MapObject *templateObject = objectTemplate->object()) {
+                        if (const Tileset *templateTileset = templateObject->cell().tileset()) {
+                            // Recursively collect from the template's tileset.
+                            // We use a different translated type name here if it's the main file,
+                            // but internal collection labels it as "Tileset".
+                            if (!templateTileset->fileName().isEmpty()) {
+                                const QString path = templateTileset->fileName();
+                                if (!seenPaths.contains(path)) {
+                                    seenPaths.insert(path);
+                                    references.append({path, QCoreApplication::translate("FileDependencies", "Template Tileset"), isMappable(path)});
+                                }
+                            }
+                            // Also need to get its images if not seen yet
+                            collectFromTilesetInternal(templateTileset, references, seenPaths);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return references;
+}
+
+} // namespace Tiled

--- a/src/libtiled/filedependencies.h
+++ b/src/libtiled/filedependencies.h
@@ -1,0 +1,57 @@
+/*
+ * filedependencies.h
+ * Copyright 2024, File Dependencies Contributor
+ *
+ * This file is part of libtiled.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "tiled_global.h"
+
+#include <QList>
+#include <QString>
+
+namespace Tiled {
+
+class Map;
+class Tileset;
+
+struct TILEDSHARED_EXPORT FileReference {
+    QString filePath;
+    QString type;
+    bool canOpenInTiled;
+
+    bool operator==(const FileReference &other) const {
+        return filePath == other.filePath && type == other.type && canOpenInTiled == other.canOpenInTiled;
+    }
+};
+
+class TILEDSHARED_EXPORT FileDependencyCollector {
+public:
+    static QList<FileReference> collectFromMap(const Map *map);
+    static QList<FileReference> collectFromTileset(const Tileset *tileset);
+};
+
+} // namespace Tiled

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -101,6 +101,8 @@ DynamicLibrary {
         "fileformat.h",
         "filesystemwatcher.cpp",
         "filesystemwatcher.h",
+        "filedependencies.cpp",
+        "filedependencies.h",
         "gidmapper.cpp",
         "gidmapper.h",
         "grid.h",

--- a/src/tiled/filedependenciesdock.cpp
+++ b/src/tiled/filedependenciesdock.cpp
@@ -1,0 +1,161 @@
+/*
+ * filedependenciesdock.cpp
+ * Copyright 2024, File Dependencies Contributor
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "filedependenciesdock.h"
+
+#include "documentmanager.h"
+#include "mapdocument.h"
+#include "tilesetdocument.h"
+
+#include <QAction>
+#include <QDesktopServices>
+#include <QDir>
+#include <QFileInfo>
+#include <QHeaderView>
+#include <QMenu>
+#include <QSortFilterProxyModel>
+#include <QStandardItemModel>
+#include <QTreeView>
+#include <QVBoxLayout>
+
+namespace Tiled {
+
+FileDependenciesDock::FileDependenciesDock(QWidget *parent)
+    : QDockWidget(parent)
+    , mModel(new QStandardItemModel(0, 3, this))
+    , mProxyModel(new QSortFilterProxyModel(this))
+    , mView(new QTreeView(this))
+{
+    setWindowTitle(tr("File Dependencies"));
+    setObjectName(QLatin1String("fileDependenciesDock"));
+
+    mModel->setHeaderData(0, Qt::Horizontal, tr("File name"));
+    mModel->setHeaderData(1, Qt::Horizontal, tr("Location"));
+    mModel->setHeaderData(2, Qt::Horizontal, tr("Type"));
+
+    mProxyModel->setSourceModel(mModel);
+    mProxyModel->setSortLocaleAware(true);
+    mProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    mView->setModel(mProxyModel);
+    mView->setRootIsDecorated(false);
+    mView->setItemsExpandable(false);
+    mView->setSortingEnabled(true);
+    mView->setSelectionMode(QAbstractItemView::SingleSelection);
+    mView->sortByColumn(0, Qt::AscendingOrder);
+
+    mView->header()->setStretchLastSection(false);
+    mView->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    mView->header()->setSectionResizeMode(1, QHeaderView::Stretch);
+    mView->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+
+    mView->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    QWidget *widget = new QWidget(this);
+    QVBoxLayout *layout = new QVBoxLayout(widget);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->addWidget(mView);
+    setWidget(widget);
+
+    connect(mView, &QTreeView::doubleClicked, this, &FileDependenciesDock::doubleClicked);
+    connect(mView, &QTreeView::customContextMenuRequested, this, &FileDependenciesDock::showContextMenu);
+}
+
+FileDependenciesDock::~FileDependenciesDock()
+{
+}
+
+void FileDependenciesDock::setDocument(Document *document)
+{
+    mModel->removeRows(0, mModel->rowCount());
+    mReferences.clear();
+
+    if (auto mapDocument = qobject_cast<MapDocument*>(document)) {
+        mReferences = FileDependencyCollector::collectFromMap(mapDocument->map());
+    } else if (auto tilesetDocument = qobject_cast<TilesetDocument*>(document)) {
+        mReferences = FileDependencyCollector::collectFromTileset(tilesetDocument->tileset().data());
+    }
+
+    mModel->setRowCount(mReferences.size());
+    for (int i = 0; i < mReferences.size(); ++i) {
+        const FileReference &ref = mReferences.at(i);
+        QFileInfo info(ref.filePath);
+
+        auto nameItem = new QStandardItem(info.fileName());
+        nameItem->setEditable(false);
+        auto pathItem = new QStandardItem(QDir::toNativeSeparators(info.path()));
+        pathItem->setEditable(false);
+        auto typeItem = new QStandardItem(ref.type);
+        typeItem->setEditable(false);
+
+        mModel->setItem(i, 0, nameItem);
+        mModel->setItem(i, 1, pathItem);
+        mModel->setItem(i, 2, typeItem);
+    }
+}
+
+void FileDependenciesDock::doubleClicked(const QModelIndex &proxyIndex)
+{
+    const auto index = mProxyModel->mapToSource(proxyIndex);
+    const FileReference &ref = mReferences.at(index.row());
+
+    if (ref.canOpenInTiled) {
+        openFile(ref.filePath);
+    }
+}
+
+void FileDependenciesDock::showContextMenu(const QPoint &pos)
+{
+    QModelIndex proxyIndex = mView->indexAt(pos);
+    if (!proxyIndex.isValid())
+        return;
+
+    const auto index = mProxyModel->mapToSource(proxyIndex);
+    const FileReference &ref = mReferences.at(index.row());
+
+    QMenu menu(this);
+
+    if (ref.canOpenInTiled) {
+        QAction *openAction = menu.addAction(tr("Open in Tiled"));
+        connect(openAction, &QAction::triggered, this, [this, filePath = ref.filePath]() {
+            openFile(filePath);
+        });
+    }
+
+    QAction *showManagerAction = menu.addAction(tr("Show in File Manager"));
+    connect(showManagerAction, &QAction::triggered, this, [this, filePath = ref.filePath]() {
+        showInFileManager(filePath);
+    });
+
+    menu.exec(mView->viewport()->mapToGlobal(pos));
+}
+
+void FileDependenciesDock::openFile(const QString &filePath)
+{
+    DocumentManager::instance()->openFile(filePath);
+}
+
+void FileDependenciesDock::showInFileManager(const QString &filePath)
+{
+    QFileInfo info(filePath);
+    QDesktopServices::openUrl(QUrl::fromLocalFile(info.absolutePath()));
+}
+
+} // namespace Tiled

--- a/src/tiled/filedependenciesdock.h
+++ b/src/tiled/filedependenciesdock.h
@@ -1,0 +1,59 @@
+/*
+ * filedependenciesdock.h
+ * Copyright 2024, File Dependencies Contributor
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "filedependencies.h"
+
+#include <QDockWidget>
+#include <QList>
+
+class QSortFilterProxyModel;
+class QStandardItemModel;
+class QTreeView;
+
+namespace Tiled {
+
+class Document;
+
+class FileDependenciesDock : public QDockWidget
+{
+    Q_OBJECT
+
+public:
+    explicit FileDependenciesDock(QWidget *parent = nullptr);
+    ~FileDependenciesDock() override;
+
+    void setDocument(Document *document);
+
+private:
+    void doubleClicked(const QModelIndex &index);
+    void showContextMenu(const QPoint &pos);
+    void openFile(const QString &filePath);
+    void showInFileManager(const QString &filePath);
+
+    QStandardItemModel *mModel;
+    QSortFilterProxyModel *mProxyModel;
+    QTreeView *mView;
+
+    QList<FileReference> mReferences;
+};
+
+} // namespace Tiled

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -253,6 +253,8 @@ DynamicLibrary {
         "expressionspinbox.h",
         "filechangedwarning.cpp",
         "filechangedwarning.h",
+        "filedependenciesdock.cpp",
+        "filedependenciesdock.h",
         "fileedit.cpp",
         "fileedit.h",
         "filteredit.cpp",

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -41,6 +41,7 @@
 #include "exporthelper.h"
 #include "issuescounter.h"
 #include "issuesdock.h"
+#include "filedependenciesdock.h"
 #include "layer.h"
 #include "locatorwidget.h"
 #include "map.h"
@@ -384,14 +385,17 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     mProjectDock = new ProjectDock(this);   // uses some actions registered above
     mConsoleDock = new ConsoleDock(this);
     mIssuesDock = new IssuesDock(this);
+    mFileDependenciesDock = new FileDependenciesDock(this);
 
     addDockWidget(Qt::LeftDockWidgetArea, mProjectDock);
     addDockWidget(Qt::BottomDockWidgetArea, mConsoleDock);
     addDockWidget(Qt::BottomDockWidgetArea, mIssuesDock);
+    addDockWidget(Qt::RightDockWidgetArea, mFileDependenciesDock);
     tabifyDockWidget(mConsoleDock, mIssuesDock);
 
     mConsoleDock->setVisible(false);
     mIssuesDock->setVisible(false);
+    mFileDependenciesDock->setVisible(false);
 
     mMapEditor = new MapEditor;
     mTilesetEditor = new TilesetEditor;
@@ -844,6 +848,8 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
             this, &MainWindow::saveFile);
     connect(mDocumentManager, &DocumentManager::currentDocumentChanged,
             this, &MainWindow::documentChanged);
+    connect(mDocumentManager, &DocumentManager::currentDocumentChanged,
+            mFileDependenciesDock, &FileDependenciesDock::setDocument);
     connect(mDocumentManager, &DocumentManager::documentCloseRequested,
             this, &MainWindow::closeDocument);
     connect(mDocumentManager, &DocumentManager::reloadError,
@@ -2144,12 +2150,15 @@ void MainWindow::resetToDefaultLayout()
     mProjectDock->setFloating(false);
     mConsoleDock->setFloating(false);
     mIssuesDock->setFloating(false);
+    mFileDependenciesDock->setFloating(false);
     addDockWidget(Qt::LeftDockWidgetArea, mProjectDock);
     addDockWidget(Qt::BottomDockWidgetArea, mConsoleDock);
     addDockWidget(Qt::BottomDockWidgetArea, mIssuesDock);
+    addDockWidget(Qt::RightDockWidgetArea, mFileDependenciesDock);
     mProjectDock->setVisible(true);
     mConsoleDock->setVisible(false);
     mIssuesDock->setVisible(false);
+    mFileDependenciesDock->setVisible(false);
     tabifyDockWidget(mConsoleDock, mIssuesDock);
 
     // Reset the layout of the current editor
@@ -2164,6 +2173,7 @@ void MainWindow::updateViewsAndToolbarsMenu()
     mViewsAndToolbarsMenu->addAction(mProjectDock->toggleViewAction());
     mViewsAndToolbarsMenu->addAction(mConsoleDock->toggleViewAction());
     mViewsAndToolbarsMenu->addAction(mIssuesDock->toggleViewAction());
+    mViewsAndToolbarsMenu->addAction(mFileDependenciesDock->toggleViewAction());
 
     if (Editor *editor = mDocumentManager->currentEditor()) {
         mViewsAndToolbarsMenu->addSeparator();
@@ -2486,8 +2496,6 @@ void MainWindow::documentChanged(Document *document)
                 this, &MainWindow::updateWindowTitle);
         connect(document, &Document::modifiedChanged,
                 this, &MainWindow::updateWindowTitle);
-
-        mProjectDock->selectFile(document->fileName());
     }
 
     MapDocument *mapDocument = qobject_cast<MapDocument*>(document);

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -51,6 +51,7 @@ class AutomappingManager;
 class ConsoleDock;
 class DocumentManager;
 class Editor;
+class FileDependenciesDock;
 class IssuesDock;
 class LocatorSource;
 class LocatorWidget;
@@ -242,6 +243,7 @@ private:
     ConsoleDock *mConsoleDock;
     ProjectDock *mProjectDock;
     IssuesDock *mIssuesDock;
+    FileDependenciesDock *mFileDependenciesDock;
     PropertyTypesEditor *mPropertyTypesEditor;
     QPointer<LocatorWidget> mLocatorWidget;
     QPointer<QWidget> mPopupWidget;


### PR DESCRIPTION
- Refactored `FileDependenciesDialog` into a dockable `FileDependenciesDock`
- Added Context Menu support for 'Open in Tiled' and 'Show in File Manager'
- Safely extracts and deduplicates tilesheet and per-tile image dependencies
- Registered the dock toggle action in the Views and Toolbars menu