### PR TITLE
Fix adding non-string properties on macOS (#4445)

### DIFF
--- a/src/tiled/propertyeditorwidgets.cpp
+++ b/src/tiled/propertyeditorwidgets.cpp
@@ -287,6 +287,14 @@ bool ComboBox::event(QEvent *event)
     return QComboBox::event(event);
 }
 
+void ComboBox::showPopup()
+{
+    // Ensure the combo box has focus before opening the popup, so that focus
+    // returns to it when the popup closes (fails without this on macOS).
+    setFocus();
+    QComboBox::showPopup();
+}
+
 void ComboBox::keyPressEvent(QKeyEvent *event)
 {
     switch (event->key()) {

--- a/src/tiled/propertyeditorwidgets.h
+++ b/src/tiled/propertyeditorwidgets.h
@@ -79,6 +79,7 @@ signals:
 
 protected:
     bool event(QEvent *event) override;
+    void showPopup() override;
     void keyPressEvent(QKeyEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
 };

--- a/src/tiled/variantmapproperty.cpp
+++ b/src/tiled/variantmapproperty.cpp
@@ -37,6 +37,7 @@
 #include <QKeyEvent>
 #include <QMenu>
 #include <QScopedValueRollback>
+#include <QTimer>
 
 namespace Tiled {
 
@@ -767,18 +768,26 @@ QWidget *AddValueProperty::createLabel(int level, QWidget *parent)
 
     nameEdit->installEventFilter(this);
 
-    connect(qApp, &QApplication::focusChanged, this, [=](QWidget *, QWidget *focusWidget) {
-        // Ignore focus in different windows (popups, dialogs, etc.)
-        if (!focusWidget || focusWidget->window() != parent->window())
-            return;
+    QPointer<AddValueProperty> self = this;
 
-        // Request add or removal if focus moved elsewhere
-        if (!parent->isAncestorOf(focusWidget)) {
-            if (!name().isEmpty())
-                emit addRequested(false);   // add without focusing, in response to focus out
+    // Request add or removal if focus moved elsewhere. Use a delayed check
+    // to allow for transient focus changes (necessary on macOS).
+    connect(qApp, &QApplication::focusChanged, parent, [self, parent] {
+        QTimer::singleShot(0, parent, [self, parent] {
+            if (!self || QApplication::activePopupWidget())
+                return;
+
+            auto currentFocus = QApplication::focusWidget();
+            if (!currentFocus || currentFocus->window() != parent->window())
+                return;
+            if (parent->isAncestorOf(currentFocus))
+                return;
+
+            if (!self->name().isEmpty())
+                emit self->addRequested(false);   // add without focusing, in response to focus out
             else
-                emit removeRequested();
-        }
+                emit self->removeRequested();
+        });
     });
 
     return nameEdit;


### PR DESCRIPTION
On macOS, combo boxes use native popup menus which cause transient focus changes. The focus-loss handler would fire prematurely when clicking the type combo box, either adding the property as a string or canceling the addition entirely before the user could select a type.

Defer the focus check to the next event loop iteration, allowing the combo box interaction to settle. If focus returns to the row widget, the deferred check recognizes this and does nothing.

Fixes #4445