### PR TITLE
Fix Properties view flicker when switching between objects

### DIFF
--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -75,14 +75,18 @@ namespace Tiled {
 class ScopedUpdatesDisabler
 {
 public:
-    ScopedUpdatesDisabler(QWidget *widget)
+    explicit ScopedUpdatesDisabler(QWidget *widget)
         : mWidget(widget)
+        , mHadUpdatesEnabled(widget->updatesEnabled())
     {
         widget->setUpdatesEnabled(false);
     }
 
     ~ScopedUpdatesDisabler()
     {
+        if (!mHadUpdatesEnabled)
+            return;
+
         QTimer::singleShot(0, mWidget, [w = mWidget] {
             QTimer::singleShot(0, w, [w] {
                 w->setUpdatesEnabled(true);
@@ -94,6 +98,7 @@ public:
 
 private:
     QWidget *mWidget;
+    bool mHadUpdatesEnabled;
 };
 
 


### PR DESCRIPTION
Suppress updates on the scroll widget during the properties rebuild and re-enable them with a deferred `QTimer::singleShot(0)` call. This ensures that all scheduled layout requests are fully processed before the next paint.