### PR TITLE
Using linear sRGB blending for tint colors

### DIFF
--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -116,6 +116,13 @@ static QPixmap tinted(const QPixmap &pixmap, const QRect &rect, const QColor &co
         resultImage = QPixmap::fromImage(std::move(imageWithAlpha), Qt::NoOpaqueDetection);
     }
 
+    // converting to linear light before blending
+    QImage linearImage = resultImage.toImage();
+    linearImage = linearImage.convertToFormat(QImage::Format_ARGB32);
+    linearImage.setColorSpace(QColorSpace(QColorSpace::SRgb));
+    linearImage = linearImage.convertedToColorSpace(QColorSpace(QColorSpace::SRgbLinear));
+    resultImage = QPixmap::fromImage(linearImage, Qt::NoOpaqueDetection);
+
     QPainter painter(&resultImage);
 
     QColor fullOpacity = color;
@@ -135,6 +142,12 @@ static QPixmap tinted(const QPixmap &pixmap, const QRect &rect, const QColor &co
     painter.fillRect(resultImage.rect(), color);
 
     painter.end();
+
+    // converting back to sRGB 
+    QImage srgbImage = resultImage.toImage();
+    srgbImage = srgbImage.convertedToColorSpace(QColorSpace(QColorSpace::SRgb));
+    srgbImage = srgbImage.convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    resultImage = QPixmap::fromImage(std::move(srgbImage), Qt::NoOpaqueDetection);
 
     cache.insert(tintedKey, new QPixmap(resultImage), cost(resultImage));
 


### PR DESCRIPTION
Fixed the issue in #3385 

QPainter composites tint color in gamma-compressed sRGB state which results in a more darker/ unnatural looking tint.

This change adds a step in the process where we convert the image first to linear light and then back to sRGB state which ends up giving a more bright/natural looking tints.

The tiles at 50% opacitywith no tint color (Initial state):
<img width="641" height="605" alt="Screenshot 2026-03-24 150750" src="https://github.com/user-attachments/assets/85c6d3fa-ce12-4ef9-94e8-715deb8d0f20" />

Previous version:
<img width="819" height="810" alt="Screenshot 2026-03-24 145650" src="https://github.com/user-attachments/assets/27ccf56c-6bdc-425e-b436-0240edb233c1" />

This version:
<img width="700" height="669" alt="Screenshot 2026-03-24 150709" src="https://github.com/user-attachments/assets/c0957e47-e591-4f07-b189-544859c37a27" />

