### PR TITLE
Using linear sRGB blending for tint colors

### DIFF
--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -43,6 +43,8 @@
 #include <QPaintEngine>
 #include <QPainter>
 #include <QVector2D>
+#include <QColorSpace>
+
 
 #include <cmath>
 
@@ -116,6 +118,13 @@ static QPixmap tinted(const QPixmap &pixmap, const QRect &rect, const QColor &co
         resultImage = QPixmap::fromImage(std::move(imageWithAlpha), Qt::NoOpaqueDetection);
     }
 
+    // converting to linear light before blending
+    QImage linearImage = resultImage.toImage();
+    linearImage = linearImage.convertToFormat(QImage::Format_ARGB32);
+    linearImage.setColorSpace(QColorSpace(QColorSpace::SRgb));
+    linearImage = linearImage.convertedToColorSpace(QColorSpace(QColorSpace::SRgbLinear));
+    resultImage = QPixmap::fromImage(linearImage, Qt::NoOpaqueDetection);
+
     QPainter painter(&resultImage);
 
     QColor fullOpacity = color;
@@ -135,6 +144,12 @@ static QPixmap tinted(const QPixmap &pixmap, const QRect &rect, const QColor &co
     painter.fillRect(resultImage.rect(), color);
 
     painter.end();
+
+    // converting back to sRGB 
+    QImage srgbImage = resultImage.toImage();
+    srgbImage = srgbImage.convertedToColorSpace(QColorSpace(QColorSpace::SRgb));
+    srgbImage = srgbImage.convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    resultImage = QPixmap::fromImage(std::move(srgbImage), Qt::NoOpaqueDetection);
 
     cache.insert(tintedKey, new QPixmap(resultImage), cost(resultImage));
 


### PR DESCRIPTION
Fixed the issue in #3385 

Qpainter composites tint color in gamma-compressed sRGB state which results in a more darker/ unnatural looking tint.
This change adds a step in the process where we convert the image first to linear light and then back to sRGB state which ends up giving a more bright/natural looking tints.

The tiles at 50% occupation with no tint color (Initial state):
<img width="641" height="605" alt="Screenshot 2026-03-24 150750" src="https://github.com/user-attachments/assets/37ecb87f-ffc7-47b5-a3fa-e904429ffeca" />

Previous version:
<img width="819" height="810" alt="Screenshot 2026-03-24 145650" src="https://github.com/user-attachments/assets/9841e340-1868-4efa-b6f5-659ebad64df7" />


This version:
<img width="700" height="669" alt="Screenshot 2026-03-24 150709" src="https://github.com/user-attachments/assets/abfdc178-8610-4626-b87e-b34ff2c6f01e" />
