### PR TITLE
docs: clarify GPL is version 2 or later (COPYING)

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -15,3 +15,16 @@ tmxviewer-java       util/java/tmxviewer-java  BSD 2-clause license
 
 The full text of each license is provided in the files LICENSE.GPL
 and LICENSE.BSD.
+
+GPL version (2 only vs 2 or later)
+----------------------------------
+The Tiled application and its bundled plugins (see table above) are
+licensed under the GNU General Public License **version 2 or later**.
+Each source file in those directories states this in its header (the
+standard "either version 2 of the License, or (at your option) any later
+version" wording). SPDX identifier: GPL-2.0-or-later.
+
+The file LICENSE.GPL contains the complete text of GNU GPL version 2.
+The "or later" option refers to any subsequent version of the GNU GPL
+published by the Free Software Foundation, as permitted by that license
+text.


### PR DESCRIPTION
Clarifies that Tiled is licensed under "GPL v2 or later" in `COPYING`.

The project's actual licensing (GPL-2.0-or-later, matching `README.md` and source file headers) wasn't reflected in `COPYING`, which just included the bare GPL v2 text. This adds a short header above the license text making the "or later" intent explicit, so anyone opening `COPYING` sees the same licensing statement that's in the source headers.

Branch rebased onto current master; one-file change only.
