### PR TITLE
Fix "Detach templates" not working when export target is the same file

### DIFF
--- a/src/tiled/document.cpp
+++ b/src/tiled/document.cpp
@@ -313,6 +313,11 @@ void Document::setIgnoreBrokenLinks(bool ignoreBrokenLinks)
     emit ignoreBrokenLinksChanged(ignoreBrokenLinks);
 }
 
+void Document::refreshLastSaved(const QString &fileName)
+{
+    mLastSaved = QFileInfo(fileName).lastModified();
+}
+
 void Document::setChangedOnDisk(bool changedOnDisk)
 {
     mChangedOnDisk = changedOnDisk;

--- a/src/tiled/document.h
+++ b/src/tiled/document.h
@@ -93,6 +93,7 @@ public:
     virtual FileFormat *writerFormat() const = 0;
 
     QDateTime lastSaved() const { return mLastSaved; }
+    void refreshLastSaved(const QString &fileName);
 
     QUndoStack *undoStack() const;
     bool isModified() const;

--- a/src/tiled/exporthelper.cpp
+++ b/src/tiled/exporthelper.cpp
@@ -24,6 +24,8 @@
 #include "objectgroup.h"
 #include "wangset.h"
 
+#include <QFileInfo>
+
 namespace Tiled {
 
 /**
@@ -106,8 +108,15 @@ const Map *ExportHelper::prepareExportMap(const Map *map, std::unique_ptr<Map> &
     // Make a copy to which export options are applied
     exportMap = map->clone();
 
-    // We don't want to save the export options in the exported file
-    if (hasExportSettings) {
+    // We don't want to save the export options in the exported file,
+    // unless we're exporting to the same file (to preserve the export settings
+    // so they can be picked up again on the next save)
+    const auto canonicalMapFile = QFileInfo(map->fileName).canonicalFilePath();
+    const auto canonicalExportFile = QFileInfo(map->exportFileName).canonicalFilePath();
+    const bool isSelfExport = !canonicalMapFile.isEmpty()
+            && canonicalMapFile == canonicalExportFile;
+
+    if (hasExportSettings && !isSelfExport) {
         exportMap->exportFileName.clear();
         exportMap->exportFormat.clear();
     }

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -1342,6 +1342,10 @@ bool MainWindow::exportDocument(Document *document)
 
             if (exportFormat->write(map, exportFileName, exportHelper.formatOptions())) {
                 statusBar()->showMessage(tr("Exported to %1").arg(exportFileName), 3000);
+                // When exporting to the same file, update the saved timestamp
+                // to avoid triggering an unnecessary auto-reload
+                if (exportFileName == document->fileName())
+                    document->refreshLastSaved(exportFileName);
                 return true;
             }
 
@@ -1356,6 +1360,10 @@ bool MainWindow::exportDocument(Document *document)
 
             if (exportFormat->write(*tileset, exportFileName, exportHelper.formatOptions())) {
                 statusBar()->showMessage(tr("Exported to %1").arg(exportFileName), 3000);
+                // When exporting to the same file, update the saved timestamp
+                // to avoid triggering an unnecessary auto-reload
+                if (exportFileName == document->fileName())
+                    document->refreshLastSaved(exportFileName);
                 return true;
             }
 
@@ -2432,6 +2440,10 @@ void MainWindow::exportMapAs(MapDocument *mapDocument)
         // Remember export parameters, so subsequent exports can be done faster
         mapDocument->setLastExportFileName(exportDetails.mFileName);
         mapDocument->setExportFormat(exportDetails.mFormat);
+        // When exporting to the same file, update the saved timestamp to avoid
+        // triggering an unnecessary auto-reload
+        if (exportDetails.mFileName == mapDocument->fileName())
+            mapDocument->refreshLastSaved(exportDetails.mFileName);
     }
 }
 
@@ -2471,6 +2483,10 @@ void MainWindow::exportTilesetAs(TilesetDocument *tilesetDocument)
         // Remember export parameters, so subsequent exports can be done faster
         tilesetDocument->setLastExportFileName(exportDetails.mFileName);
         tilesetDocument->setExportFormat(exportDetails.mFormat);
+        // When exporting to the same file, update the saved timestamp to avoid
+        // triggering an unnecessary auto-reload
+        if (exportDetails.mFileName == tilesetDocument->fileName())
+            tilesetDocument->refreshLastSaved(exportDetails.mFileName);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #4456 — when **Detach template instances** and **Repeat last export on save** are both enabled and the export target is set to the same file as the map itself, templates were not being detached on subsequent saves.

**Root cause (two interacting bugs):**

1. `ExportHelper::prepareExportMap` always clears `exportFileName`/`exportFormat` from the exported clone — so the file on disk loses the export settings. On the next reload triggered by the file watcher, those settings are gone, causing `exportDocument` to early-exit with an empty export filename.

2. The export write updates the file's on-disk timestamp, but `mLastSaved` is only updated during the regular save. The file watcher therefore treats the export write as an external change and auto-reloads the document, which replaces the in-memory map (including its export settings) with the freshly-loaded one that has no export settings.

**Fix:**

- In `ExportHelper::prepareExportMap`, preserve `exportFileName` and `exportFormat` in the exported file when the export target and the map file resolve to the same canonical path. This restores persistence across reloads and Tiled restarts.
- Add `Document::refreshLastSaved(fileName)` and call it after a successful export to the same file (in `exportDocument`, `exportMapAs`, and `exportTilesetAs`). This prevents the file watcher from treating the export write as an external change and triggering an unnecessary auto-reload.

## Test plan

- [ ] Enable **Detach template instances** and **Repeat last export on save** in preferences
- [ ] Open a map, do **File → Export As…** targeting the same `.tmx` file
- [ ] Add template instances to the map, then press Ctrl+S
- [ ] Open the saved file in a text editor — template objects should be fully detached (no `template=` attribute)
- [ ] Press Ctrl+S again — templates should continue to be detached on each save
- [ ] Close and reopen Tiled, reload the file — export-on-save should still work (export settings persisted in file)
- [ ] Verify that exporting to a *different* file still clears export settings from the exported file (no regression)