### PR TITLE
GitHub Actions: Updated supported macOS versions

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -196,12 +196,12 @@ jobs:
         include:
         - qt_version: 5.15.2
           qt_modules: ""
-          version_suffix: "10.13-10.15"
+          version_suffix: "10.13-12"
           architectures: x86_64
           cmake_architectures: x86_64
         - qt_version: 6.10.2
           qt_modules: "qtimageformats"
-          version_suffix: "11+"
+          version_suffix: "13+"
           architectures: x86_64,arm64
           cmake_architectures: x86_64;arm64
 


### PR DESCRIPTION
Since the update to Qt 6.10, the minimum supported macOS version is 13, so the Qt 5 build now applies to macOS 10.13 till macOS 12.

I forgot to update this for the Tiled 1.11.1 and 1.11.2 releases, which due to the upgrade to Qt 6.8 at the time had a minimum supported version of macOS 12.