### PR TITLE
Update Info.plist with Tiled file types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
 * Fixed crash when the selection becomes empty while starting a move (#4536)
 * Linux: Added file associations for .tmj, .tsj, .tiled-project and .world files (by miffe, #4550)
+* macOS: Declared UTIs and file associations for all supported Tiled formats (with Jyotish, #4469)
 * snap: Updated to Qt 6
 * Raised the minimum Qt version to 6.2 (drops Qt 5 support)
 

--- a/src/tiledapp/Info.plist
+++ b/src/tiledapp/Info.plist
@@ -2,14 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+
 	<key>CSResourcesFileMapped</key>
 	<true/>
+
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2008-2020 Thorbjørn Lindeijer</string>
+
 	<key>NSHighResolutionCapable</key>
 	<true/>
+
 	<key>CFBundleDocumentTypes</key>
 	<array>
+
 		<dict>
 			<key>CFBundleTypeName</key>
 			<string>Tiled Map</string>
@@ -21,9 +26,74 @@
 			<array>
 				<string>tmx</string>
 			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.mapeditor.tiled.tmx</string>
+			</array>
 		</dict>
+
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Tiled Tileset</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>tmx-icon-mac</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>tsx</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.mapeditor.tiled.tsx</string>
+			</array>
+		</dict>
+
 	</array>
+
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.mapeditor.tiled.tmx</string>
+			<key>UTTypeDescription</key>
+			<string>Tiled Map File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.xml</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tmx</string>
+				</array>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.mapeditor.tiled.tsx</string>
+			<key>UTTypeDescription</key>
+			<string>Tiled Tileset File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.xml</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tsx</string>
+				</array>
+			</dict>
+		</dict>
+
+	</array>
+
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+
 </dict>
 </plist>

--- a/src/tiledapp/Info.plist
+++ b/src/tiledapp/Info.plist
@@ -25,10 +25,12 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>tmx</string>
+				<string>tmj</string>
 			</array>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>org.mapeditor.tiled.tmx</string>
+				<string>org.mapeditor.tiled.tmj</string>
 			</array>
 		</dict>
 
@@ -42,10 +44,65 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>tsx</string>
+				<string>tsj</string>
 			</array>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>org.mapeditor.tiled.tsx</string>
+				<string>org.mapeditor.tiled.tsj</string>
+			</array>
+		</dict>
+
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Tiled Object Template</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>tmx-icon-mac</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>tx</string>
+				<string>tj</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.mapeditor.tiled.tx</string>
+				<string>org.mapeditor.tiled.tj</string>
+			</array>
+		</dict>
+
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Tiled Project</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>tmx-icon-mac</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>tiled-project</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.mapeditor.tiled.project</string>
+			</array>
+		</dict>
+
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Tiled World</string>
+			<key>CFBundleTypeIconFile</key>
+			<string>tmx-icon-mac</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>world</string>
+			</array>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.mapeditor.tiled.world</string>
 			</array>
 		</dict>
 
@@ -86,6 +143,114 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>tsx</string>
+				</array>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.mapeditor.tiled.tmj</string>
+			<key>UTTypeDescription</key>
+			<string>Tiled Map File (JSON)</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tmj</string>
+				</array>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.mapeditor.tiled.tsj</string>
+			<key>UTTypeDescription</key>
+			<string>Tiled Tileset File (JSON)</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tsj</string>
+				</array>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.mapeditor.tiled.tx</string>
+			<key>UTTypeDescription</key>
+			<string>Tiled Object Template File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.xml</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tx</string>
+				</array>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.mapeditor.tiled.tj</string>
+			<key>UTTypeDescription</key>
+			<string>Tiled Object Template File (JSON)</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tj</string>
+				</array>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.mapeditor.tiled.project</string>
+			<key>UTTypeDescription</key>
+			<string>Tiled Project File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tiled-project</string>
+				</array>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.mapeditor.tiled.world</string>
+			<key>UTTypeDescription</key>
+			<string>Tiled World File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>world</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
Fix macOS UTI declarations for Tiled file types
This PR improves macOS file type recognition by properly declaring Uniform Type Identifiers (UTIs).
Changes:
Added LSItemContentTypes for .tmx and .tsx
Added UTExportedTypeDeclarations
Added support for .tsx files (tilesets)
Ensured valid and clean Info.plist structure
Result:
macOS can reliably identify Tiled file types
Double-clicking .tsx files should open correctly
Improves integration with Spotlight and Quick Look
Fixes #4450 