### PR TITLE
Auto select property name text in rename dialog

### DIFF
--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -19,8 +19,7 @@
  */
 
 #include "propertieswidget.h"
-#include <QTimer>
-#include <QLineEdit>
+
 #include "actionmanager.h"
 #include "changeimagelayerproperty.h"
 #include "changelayer.h"
@@ -2903,10 +2902,6 @@ void PropertiesWidget::renameProperty(const QString &name)
     dialog->setInputMode(QInputDialog::TextInput);
     dialog->setLabelText(QCoreApplication::translate("Tiled::PropertiesDock", "Name:"));
     dialog->setTextValue(name);
-    QTimer::singleShot(0, dialog, [dialog]() {
-        if (auto lineEdit = dialog->findChild<QLineEdit*>())
-            lineEdit->selectAll();
-    });
     dialog->setWindowTitle(QCoreApplication::translate("Tiled::PropertiesDock", "Rename Property"));
 
     connect(dialog, &QInputDialog::textValueSelected, this, [=] (const QString &newName) {
@@ -2920,6 +2915,9 @@ void PropertiesWidget::renameProperty(const QString &name)
     });
 
     dialog->open();
+
+    if (auto lineEdit = dialog->findChild<QLineEdit*>())
+        lineEdit->selectAll();
 }
 
 bool PropertiesWidget::SelectionState::canCopy() const

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -19,7 +19,8 @@
  */
 
 #include "propertieswidget.h"
-
+#include <QTimer>
+#include <QLineEdit>
 #include "actionmanager.h"
 #include "changeimagelayerproperty.h"
 #include "changelayer.h"
@@ -2902,6 +2903,10 @@ void PropertiesWidget::renameProperty(const QString &name)
     dialog->setInputMode(QInputDialog::TextInput);
     dialog->setLabelText(QCoreApplication::translate("Tiled::PropertiesDock", "Name:"));
     dialog->setTextValue(name);
+    QTimer::singleShot(0, dialog, [dialog]() {
+        if (auto lineEdit = dialog->findChild<QLineEdit*>())
+            lineEdit->selectAll();
+    });
     dialog->setWindowTitle(QCoreApplication::translate("Tiled::PropertiesDock", "Rename Property"));
 
     connect(dialog, &QInputDialog::textValueSelected, this, [=] (const QString &newName) {


### PR DESCRIPTION
### **Summary**

Automatically select the full property name when opening the rename dialog for custom properties.

### **Problem**

Previously, the cursor was placed at the end of the property name, requiring manual selection before typing a new name.

### **Fix**

Use QTimer::singleShot(0) to select all text in the internal QLineEdit once the dialog is shown.

BEFORE: 
<img width="1514" height="1004" alt="image" src="https://github.com/user-attachments/assets/910aed7e-66e0-463e-9a68-c5f287fa74ea" />

AFTER:
<img width="1349" height="826" alt="image" src="https://github.com/user-attachments/assets/bce84506-0a0a-4787-8ff2-9b9ff26807cf" />


### **Result**

Improves rename workflow by allowing users to immediately overwrite the property name.