### PR TITLE
Add tint color support for tiles and tile objects #3950 

### DIFF
--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -352,7 +352,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         QRectF bounds = { pixelToScreenCoords(object->position()), object->size() };
         bounds.translate(-alignmentOffset(bounds, object->alignment(map())));
 
-        CellRenderer(painter, this, object->objectGroup()->effectiveTintColor())
+        CellRenderer(painter, this, object->effectiveTintColor())
                 .render(cell, bounds.topLeft(), bounds.size());
 
         if (testFlag(ShowTileObjectOutlines)) {

--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -315,6 +315,7 @@ QVariant MapObject::mapObjectProperty(Property property) const
     case RotationProperty:      return mRotation;
     case OpacityProperty:       return mOpacity;
     case CellProperty:          Q_ASSERT(false); break;
+    case TintColorProperty:     return mTintColor;
     case ShapeProperty:         return mShape;
     case TemplateProperty:      Q_ASSERT(false); break;
     case CustomProperties:      Q_ASSERT(false); break;
@@ -338,6 +339,7 @@ void MapObject::setMapObjectProperty(Property property, const QVariant &value)
     case RotationProperty:      setRotation(value.toReal()); break;
     case OpacityProperty:       setOpacity(value.toReal()); break;
     case CellProperty:          Q_ASSERT(false); break;
+    case TintColorProperty:     setTintColor(value.value<QColor>()); break;
     case ShapeProperty:         setShape(value.value<Shape>()); break;
     case TemplateProperty:      Q_ASSERT(false); break;
     case CustomProperties:      Q_ASSERT(false); break;
@@ -534,6 +536,25 @@ void MapObject::flipInPixelCoordinates(FlipDirection direction, const QPointF &p
         const QPointF newPos = flipAroundOriginTransform.map(position() + rotationTransform.map(newOrigin));
         setPosition(newPos);
     }
+}
+
+static QColor multiplyColors(QColor color1, QColor color2)
+{
+    return QColor::fromRgbF(color1.redF() * color2.redF(),
+                            color1.greenF() * color2.greenF(),
+                            color1.blueF() * color2.blueF(),
+                            color1.alphaF() * color2.alphaF());
+}
+
+QColor MapObject::effectiveTintColor() const {
+    auto tintColor = mTintColor.isValid() ? mTintColor : QColor(255, 255, 255, 255);
+
+    if (ObjectGroup *group = objectGroup()) {
+        if (group->effectiveTintColor().isValid()) {
+            tintColor = multiplyColors(tintColor, group->effectiveTintColor());
+        }
+    }
+    return tintColor;
 }
 
 } // namespace Tiled

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -123,6 +123,7 @@ public:
         ShapeProperty           = 1 << 12,
         TemplateProperty        = 1 << 13,
         CustomProperties        = 1 << 14,
+        TintColorProperty       = 1 << 15,
         AllProperties           = 0xFF
     };
 
@@ -237,6 +238,10 @@ public:
     bool isTemplateBase() const;
     void markAsTemplateBase();
 
+    const QColor &tintColor() const { return mTintColor; }
+    void setTintColor(const QColor &color) { mTintColor = color; }
+    QColor effectiveTintColor() const;
+
 private:
     void flipInScreenCoordinates(FlipDirection direction, const QPointF &screenOrigin);
     void flipInPixelCoordinates(FlipDirection direction, const QPointF &pixelOrigin);
@@ -256,6 +261,7 @@ private:
     bool mVisible = true;
     bool mTemplateBase = false;
     ChangedProperties mChangedProperties;
+    QColor mTintColor;
 };
 
 /**

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -541,6 +541,11 @@ void MapReaderPrivate::readTilesetTile(Tileset &tileset)
     if (!probability.isEmpty())
         tile->setProbability(probability.toDouble());
 
+    // Read tile tint color
+    const auto tintColor = atts.value(QLatin1String("tintcolor"));
+    if (!tintColor.isEmpty())
+        tile->setTintColor(QColor(tintColor));
+
     while (xml.readNextStartElement()) {
         if (xml.name() == QLatin1String("properties")) {
             tile->mergeProperties(readProperties());

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -1236,6 +1236,12 @@ std::unique_ptr<MapObject> MapReaderPrivate::readObject()
         object->setPropertyChanged(MapObject::OpacityProperty);
     }
 
+    const QString tintColorStr = atts.value(QLatin1String("tintcolor")).toString();
+    if(!tintColorStr.isEmpty()){
+        object->setTintColor(QColor(tintColorStr));
+        object->setPropertyChanged(MapObject::TintColorProperty);
+    }
+
     if (gid) {
         object->setCell(cellForGid(gid));
         object->setPropertyChanged(MapObject::CellProperty);

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -89,6 +89,13 @@ static inline qsizetype cost(const QPixmap &pixmap)
     return static_cast<qsizetype>(qBound(1LL, costKb, costMax));
 }
 
+static QColor multiplyColors(const QColor color1, const QColor color2) {
+    return QColor::fromRgbF(color1.redF() * color2.redF(),
+                            color1.greenF() * color2.greenF(),
+                            color1.blueF() * color2.blueF(),
+                            color1.alphaF() *color2.alphaF());
+}
+
 static bool needsTint(const QColor &color)
 {
     return color.isValid() &&
@@ -420,6 +427,7 @@ CellRenderer::CellRenderer(QPainter *painter, const MapRenderer *renderer, const
     , mRenderer(renderer)
     , mTile(nullptr)
     , mIsOpenGL(hasOpenGLEngine(painter))
+    , mLayerTintColor(tintColor)
     , mTintColor(tintColor)
 {
 }
@@ -452,10 +460,12 @@ void CellRenderer::render(const Cell &cell, const QPointF &screenPos, const QSiz
         return;
     }
 
+    const QColor newTintColor = multiplyColors(mLayerTintColor, mTintColor);
     // The USHRT_MAX limit is rather arbitrary but avoids a crash in
     // drawPixmapFragments for a large number of fragments.
-    if (mTile != tile || mFragments.size() == USHRT_MAX)
+    if (mTile != tile || mFragments.size() == USHRT_MAX || newTintColor != mTintColor)
         flush();
+    mTintColor = newTintColor;
 
     const QPixmap &image = tile->image();
     QRect imageRect = tile->imageRect();

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -460,7 +460,7 @@ void CellRenderer::render(const Cell &cell, const QPointF &screenPos, const QSiz
         return;
     }
 
-    const QColor newTintColor = multiplyColors(mLayerTintColor, mTintColor);
+    const QColor newTintColor = multiplyColors(mLayerTintColor, tile->effectiveTintColor());
     // The USHRT_MAX limit is rather arbitrary but avoids a crash in
     // drawPixmapFragments for a large number of fragments.
     if (mTile != tile || mFragments.size() == USHRT_MAX || newTintColor != mTintColor)

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -347,7 +347,8 @@ private:
     const Tile *mTile;
     QVector<QPainter::PixmapFragment> mFragments;
     const bool mIsOpenGL;
-    const QColor mTintColor;
+    const QColor mLayerTintColor;
+    QColor mTintColor;
 };
 
 } // namespace Tiled

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -597,6 +597,9 @@ QVariant MapToVariantConverter::toVariant(const MapObject &object) const
     if (notTemplateInstance || object.propertyChanged(MapObject::VisibleProperty))
         objectVariant[QStringLiteral("visible")] = object.isVisible();
 
+    if (notTemplateInstance || object.propertyChanged(MapObject::TintColorProperty))
+        objectVariant[QStringLiteral("tintcolor")] = colorToString(object.tintColor());
+
     /* Polygons are stored in this format:
      *
      *   "polygon/polyline": [

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -297,6 +297,8 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
             tileVariant[FileFormat::classPropertyNameForObject()] = tile->className();
         if (tile->probability() != 1.0)
             tileVariant[QStringLiteral("probability")] = tile->probability();
+        if (tile->tintColor().isValid())
+            tileVariant[QStringLiteral("tintcolor")] = colorToString(tile->tintColor());
         if (!tile->imageSource().isEmpty()) {
             const QString rel = toFileReference(tile->imageSource(), mDir);
             tileVariant[QStringLiteral("image")] = rel;

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -1,4 +1,4 @@
-/*
+    /*
  * mapwriter.cpp
  * Copyright 2008-2014, Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
  * Copyright 2010, Jeff Bland <jksb@member.fsf.org>
@@ -771,6 +771,9 @@ void MapWriterPrivate::writeObject(QXmlStreamWriter &w,
 
     if (shouldWrite(!mapObject.isVisible(), isTemplateInstance, mapObject.propertyChanged(MapObject::VisibleProperty)))
         w.writeAttribute(QStringLiteral("visible"), QLatin1String(mapObject.isVisible() ? "1" : "0"));
+
+    if (shouldWrite(mapObject.tintColor().isValid(), isTemplateInstance, mapObject.propertyChanged((MapObject::TintColorProperty))))
+        w.writeAttribute(QStringLiteral("tintcolor"), colorToString(mapObject.tintColor()));
 
     writeProperties(w, mapObject.properties());
 

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -300,6 +300,8 @@ static bool includeTile(const Tile *tile)
         return true;
     if (tile->probability() != 1.0)
         return true;
+    if (tile->tintColor().isValid())
+        return true;
 
     return false;
 }
@@ -442,6 +444,8 @@ void MapWriterPrivate::writeTileset(QXmlStreamWriter &w, const Tileset &tileset,
                 w.writeAttribute(FileFormat::classPropertyNameForObject(), tile->className());
             if (tile->probability() != 1.0)
                 w.writeAttribute(QStringLiteral("probability"), QString::number(tile->probability()));
+            if (tile->tintColor().isValid())
+                w.writeAttribute(QStringLiteral("tintcolor"), colorToString(tile->tintColor()));
             if (!tile->properties().isEmpty())
                 writeProperties(w, tile->properties());
             if (isCollection)

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -356,7 +356,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
     const Cell &cell = object->cell();
 
     if (!cell.isEmpty()) {
-        CellRenderer(painter, this, object->objectGroup()->effectiveTintColor())
+        CellRenderer(painter, this, object->effectiveTintColor())
                 .render(cell, QPointF(), bounds.size());
 
         if (testFlag(ShowTileObjectOutlines)) {

--- a/src/libtiled/tile.cpp
+++ b/src/libtiled/tile.cpp
@@ -257,3 +257,7 @@ Tile *Tile::clone(Tileset *tileset) const
 
     return c;
 }
+
+QColor Tile::effectiveTintColor() const {
+    return mTintColor.isValid() ? mTintColor : QColor(255, 255, 255, 255);
+}

--- a/src/libtiled/tile.h
+++ b/src/libtiled/tile.h
@@ -98,6 +98,10 @@ public:
     qreal probability() const;
     void setProbability(qreal probability);
 
+    const QColor &tintColor() const {return mTintColor;}
+    void setTintColor(const QColor color) { mTintColor = color;}
+    QColor effectiveTintColor() const;
+
     ObjectGroup *objectGroup() const;
     void setObjectGroup(std::unique_ptr<ObjectGroup> objectGroup);
     void swapObjectGroup(std::unique_ptr<ObjectGroup> &objectGroup);
@@ -123,6 +127,7 @@ private:
     QRect mImageRect;
     LoadingStatus mImageStatus;
     qreal mProbability;
+    QColor mTintColor;
     std::unique_ptr<ObjectGroup> mObjectGroup;
 
     QVector<Frame> mFrames;

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -757,6 +757,7 @@ std::unique_ptr<MapObject> VariantToMapConverter::toMapObject(const QVariantMap 
     const qreal height = variantMap[QStringLiteral("height")].toReal();
     const qreal rotation = variantMap[QStringLiteral("rotation")].toReal();
     const qreal opacity = variantMap[QStringLiteral("opacity")].toReal();
+    const QColor tintColor = variantMap[QStringLiteral("tintcolor")].value<QColor>();
 
     QString className = variantMap[QStringLiteral("class")].toString();
     if (className.isEmpty())    // fallback for compatibility
@@ -776,6 +777,11 @@ std::unique_ptr<MapObject> VariantToMapConverter::toMapObject(const QVariantMap 
     if (variantMap.contains(QLatin1String("opacity"))) {
         object->setOpacity(opacity);
         object->setPropertyChanged(MapObject::OpacityProperty);
+    }
+
+    if (variantMap.contains(QLatin1String("tintcolor"))){
+        object->setTintColor(tintColor);
+        object->setPropertyChanged(MapObject::TintColorProperty);
     }
 
     if (!templateVariant.isNull()) { // This object is a template instance

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -396,6 +396,9 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
         if (ok)
             tile->setProbability(probability);
 
+        QString tintColorStr = tileVar[QStringLiteral("tintcolor")].toString();
+        if (!tintColorStr.isEmpty())
+            tile->setTintColor(QColor(tintColorStr));
         QVariant imageVariant = tileVar[QStringLiteral("image")];
         if (!imageVariant.isNull()) {
             const QUrl imagePath = toUrl(imageVariant.toString(), mDir);

--- a/src/tiled/changetile.cpp
+++ b/src/tiled/changetile.cpp
@@ -84,25 +84,28 @@ void ChangeTileImageRect::setValue(Tile *tile, const QRect &rect) const
         emit mapDocument->tileImageSourceChanged(tile);
 }
 
-ChangeTileColor::ChangeTileColor(TilesetDocument *tilesetDocument,
+ChangeTileTintColor::ChangeTileTintColor(TilesetDocument *tilesetDocument,
                                  const QList<Tile*> &tiles,
                                  const QColor &color,
                                  QUndoCommand *parent)
     : ChangeValue(tilesetDocument, tiles, color, parent)
 {
-    setText(QCoreApplication::translate("Indo Commands",
-                                        "Change Tile Color"));
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Tile Tint Color"));
+
 }
 
-QColor ChangeTileColor::getValue(const Tile *tile) const
+QColor ChangeTileTintColor::getValue(const Tile *tile) const
 {
     return tile->tintColor();
 }
 
-void ChangeTileColor::setValue(Tile *tile, const QColor &color) const
+void ChangeTileTintColor::setValue(Tile *tile, const QColor &color) const
 {
     tile->setTintColor(color);
-    emit static_cast<TilesetDocument*>(document())->tileColorChanged(tile);
+    emit static_cast<TilesetDocument*>(document())->tileTintColorChanged(tile);
+    for (MapDocument *mapDocument : static_cast<TilesetDocument*>(document())->mapDocuments())
+        emit mapDocument->tileTintColorChanged(tile);
 }
 
 } // namespace Tiled

--- a/src/tiled/changetile.cpp
+++ b/src/tiled/changetile.cpp
@@ -84,4 +84,25 @@ void ChangeTileImageRect::setValue(Tile *tile, const QRect &rect) const
         emit mapDocument->tileImageSourceChanged(tile);
 }
 
+ChangeTileColor::ChangeTileColor(TilesetDocument *tilesetDocument,
+                                 const QList<Tile*> &tiles,
+                                 const QColor &color,
+                                 QUndoCommand *parent)
+    : ChangeValue(tilesetDocument, tiles, color, parent)
+{
+    setText(QCoreApplication::translate("Indo Commands",
+                                        "Change Tile Color"));
+}
+
+QColor ChangeTileColor::getValue(const Tile *tile) const
+{
+    return tile->tintColor();
+}
+
+void ChangeTileColor::setValue(Tile *tile, const QColor &color) const
+{
+    tile->setTintColor(color);
+    emit static_cast<TilesetDocument*>(document())->tileColorChanged(tile);
+}
+
 } // namespace Tiled

--- a/src/tiled/changetile.h
+++ b/src/tiled/changetile.h
@@ -66,4 +66,14 @@ protected:
     void setValue(Tile *tile, const QRect &rect) const override;
 };
 
+class ChangeTileColor : public ChangeValue<Tile, QColor> {
+public:
+    ChangeTileColor(TilesetDocument *tilesetDocument,
+                   const QList<Tile*> &tiles,
+                   const QColor &color,
+                   QUndoCommand *parent = nullptr);
+    QColor getValue(const Tile *tile) const override;
+    void setValue(Tile *tile, const QColor &color) const override;
+
+};
 } // namespace Tiled

--- a/src/tiled/changetile.h
+++ b/src/tiled/changetile.h
@@ -66,12 +66,14 @@ protected:
     void setValue(Tile *tile, const QRect &rect) const override;
 };
 
-class ChangeTileColor : public ChangeValue<Tile, QColor> {
+class ChangeTileTintColor : public ChangeValue<Tile, QColor> {
 public:
-    ChangeTileColor(TilesetDocument *tilesetDocument,
+    ChangeTileTintColor(TilesetDocument *tilesetDocument,
                    const QList<Tile*> &tiles,
                    const QColor &color,
                    QUndoCommand *parent = nullptr);
+    int id() const override { return Cmd_ChangeTileTintColor; }
+protected:
     QColor getValue(const Tile *tile) const override;
     void setValue(Tile *tile, const QColor &color) const override;
 

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -374,6 +374,7 @@ signals:
     void tilesetTilePositioningChanged(Tileset *tileset);
     void tileImageSourceChanged(Tile *tile);
     void tileProbabilityChanged(Tile *tile);
+    void tileTintColorChanged(Tile *tile);
     void tileObjectGroupChanged(Tile *tile);
 
 public slots:

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -108,6 +108,8 @@ void MapScene::setMapDocument(MapDocument *mapDocument)
                 this, [this] { update(); });
         connect(mMapDocument, &MapDocument::tilesetReplaced,
                 this, &MapScene::tilesetReplaced);
+        connect(mMapDocument, &MapDocument::tileTintColorChanged,
+                this, [this] { update(); });
     }
 
     refreshScene();

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -2000,8 +2000,8 @@ public:
                     [this]{ return tile()->tintColor();},
                     [this](const QColor &value) {
                         push(new ChangeTileTintColor(tilesetDocument(),
-                                                { tile() },
-                                                value));
+                                                    { tile() },
+                                                    value));
                     });
         mTileProperties = new GroupProperty(tr("Tile"));
         mTileProperties->addProperty(mIdProperty);
@@ -2073,6 +2073,7 @@ private:
         mImageProperty->setEnabled(hasTilesetDocument && isCollection);
         mRectangleProperty->setEnabled(hasTilesetDocument && isCollection);
         mProbabilityProperty->setEnabled(hasTilesetDocument);
+        mTintColorProperty->setEnabled(hasTilesetDocument);
     }
 
     TilesetDocument *tilesetDocument() const

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -1995,6 +1995,14 @@ public:
         mProbabilityProperty->setToolTip(tr("Relative chance this tile will be picked"));
         mProbabilityProperty->setMinimum(0.0);
 
+        mTintColorProperty = new ColorProperty(
+                    tr("Tint color"),
+                    [this]{ return tile()->tintColor();},
+                    [this](const QColor &value) {
+                        push(new ChangeTileTintColor(tilesetDocument(),
+                                                { tile() },
+                                                value));
+                    });
         mTileProperties = new GroupProperty(tr("Tile"));
         mTileProperties->addProperty(mIdProperty);
         mTileProperties->addProperty(mClassProperty);
@@ -2005,6 +2013,7 @@ public:
 
         mTileProperties->addProperty(mRectangleProperty);
         mTileProperties->addProperty(mProbabilityProperty);
+        mTileProperties->addProperty(mTintColorProperty);
 
         addProperty(mTileProperties);
 
@@ -2015,12 +2024,18 @@ public:
 
             connect(tilesetDocument, &TilesetDocument::tileProbabilityChanged,
                     this, &TileProperties::tileProbabilityChanged);
+
+            connect(tilesetDocument, &TilesetDocument::tileTintColorChanged,
+                    this, &TileProperties::tileTintColorChanged);
         } else if (auto mapDocument = qobject_cast<MapDocument*>(document)) {
             connect(mapDocument, &MapDocument::tileImageSourceChanged,
                     this, &TileProperties::tileImageSourceChanged);
 
             connect(mapDocument, &MapDocument::tileProbabilityChanged,
                     this, &TileProperties::tileProbabilityChanged);
+
+            connect(mapDocument, &MapDocument::tileTintColorChanged,
+                    this, &TileProperties::tileTintColorChanged);
         }
 
         updateEnabledState();
@@ -2041,6 +2056,13 @@ private:
         if (tile != this->tile())
             return;
         emit mProbabilityProperty->valueChanged();
+    }
+
+    void tileTintColorChanged(Tile *tile)
+    {
+        if (tile != this->tile())
+            return;
+        emit mTintColorProperty->valueChanged();
     }
 
     void updateEnabledState()
@@ -2068,6 +2090,7 @@ private:
     UrlProperty *mImageProperty;
     RectProperty *mRectangleProperty;
     FloatProperty *mProbabilityProperty;
+    ColorProperty *mTintColorProperty;
 };
 
 class WangSetProperties : public ObjectProperties

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -1754,6 +1754,15 @@ public:
                         push(command);
                     });
 
+        mTintColorProperty = new ColorProperty(
+                    tr("Tint color"),
+                    [this] {
+                        return mapObject()->tintColor();
+                    },
+                    [this](const QColor &value){
+                        changeMapObject(MapObject::TintColorProperty, value);
+                    });
+
         mTextProperty = new MultilineStringProperty(
                     tr("Text"),
                     [this] {
@@ -1823,6 +1832,7 @@ public:
         if (mapObject()->isTileObject()) {
             mObjectProperties->addSeparator();
             mObjectProperties->addProperty(mFlippingProperty);
+            mObjectProperties->addProperty(mTintColorProperty);
         }
 
         if (mapObject()->shape() == MapObject::Text) {
@@ -1868,6 +1878,8 @@ private:
             emit mRotationProperty->valueChanged();
         if (change.properties & MapObject::CellProperty)
             emit mFlippingProperty->valueChanged();
+        if (change.properties & MapObject::TintColorProperty)
+            emit mTintColorProperty->valueChanged();
         if (change.properties & MapObject::TextProperty)
             emit mTextProperty->valueChanged();
         if (change.properties & MapObject::TextFontProperty)
@@ -1939,6 +1951,7 @@ private:
     Property *mPositionProperty;
     Property *mBoundsProperty;
     FloatProperty *mRotationProperty;
+    Property *mTintColorProperty;
 
     // for tile objects
     Property *mFlippingProperty;

--- a/src/tiled/tilecollisiondock.cpp
+++ b/src/tiled/tilecollisiondock.cpp
@@ -297,6 +297,11 @@ void TileCollisionDock::setTilesetDocument(TilesetDocument *tilesetDocument)
                 this, &TileCollisionDock::tilesetTileOffsetChanged);
         connect(mTilesetDocument, &TilesetDocument::tilesetChanged,
                 this, &TileCollisionDock::tilesetChanged);
+        connect(mTilesetDocument, &TilesetDocument::tileTintColorChanged,
+                this, [this](Tile *tile) {
+                if (tile == mTile)
+                mMapScene->update();
+        });
 
         mMapScene->setOverrideBackgroundColor(mTilesetDocument->tileset()->backgroundColor());
     } else {

--- a/src/tiled/tilesetdocument.h
+++ b/src/tiled/tilesetdocument.h
@@ -150,6 +150,10 @@ signals:
     void tileProbabilityChanged(Tile *tile);
 
     /**
+     * Emitted when the tint color of a tile is changed
+     */
+    void tileTintColorChanged(Tile *tile);
+    /**
      * Notifies the TileCollisionDock about the object group of a tile changing.
      */
     void tileObjectGroupChanged(Tile *tile);

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -393,6 +393,8 @@ void TilesetView::setTilesetDocument(TilesetDocument *tilesetDocument)
         connect(mTilesetDocument, &Document::changed, this, &TilesetView::onChange);
         connect(mTilesetDocument, &TilesetDocument::tilesAdded, this, &TilesetView::refreshColumnCount);
         connect(mTilesetDocument, &TilesetDocument::tilesRemoved, this, &TilesetView::refreshColumnCount);
+        connect(mTilesetDocument, &TilesetDocument::tileTintColorChanged,
+                this, [this] { viewport()->update(); });
     }
 }
 

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -77,6 +77,44 @@ static void setupTilesetGridTransform(const Tileset &tileset, QTransform &transf
     }
 }
 
+// copy of tinted function from maprender.cpp
+static QPixmap tintedPixmap(const QPixmap &pixmap, const QRect &rect, const QColor &color)
+{
+    if (!color.isValid() || color == QColor(255, 255, 255, 255))
+        return pixmap.copy(rect);
+
+    QPixmap result = pixmap.copy(rect);
+
+    // tinting with a non-fully opaque color needs an alpha channel to work properly
+    if (color.alpha() < 255 && !result.hasAlphaChannel()) {
+        auto imageWithAlpha = result.toImage();
+        imageWithAlpha.convertTo(QImage::Format_ARGB32_Premultiplied);
+        result = QPixmap::fromImage(std::move(imageWithAlpha), Qt::NoOpaqueDetection);
+    }
+
+    QPainter painter(&result);
+
+    QColor fullOpacity = color;
+    fullOpacity.setAlpha(255);
+
+    // tint the final color (this will mess up the alpha which we will fix in
+    // the next lines)
+    painter.setCompositionMode(QPainter::CompositionMode_Multiply);
+    painter.fillRect(result.rect(), fullOpacity);
+
+    // apply the original alpha to the final image
+    painter.setCompositionMode(QPainter::CompositionMode_DestinationIn);
+    painter.drawPixmap(result.rect(), pixmap, rect);
+
+    // apply the alpha of the tint color so that we can use it to make the image
+    // transparent instead of just increasing or decreasing the tint effect
+    painter.setCompositionMode(QPainter::CompositionMode_DestinationIn);
+    painter.fillRect(result.rect(), color);
+
+    painter.end();
+    return result;
+}
+
 /**
  * The delegate for drawing tile items in the tileset view.
  */
@@ -153,8 +191,15 @@ void TileDelegate::paint(QPainter *painter,
         if (zoomable->smoothTransform())
             painter->setRenderHint(QPainter::SmoothPixmapTransform);
 
-    if (!tileImage.isNull())
+    if (!tileImage.isNull()){
+        const QColor tintColor = tile->effectiveTintColor();
+        if (tintColor.isValid() && tintColor != QColor(255, 255, 255, 255)){
+            const QPixmap t = tintedPixmap(tileImage, tile->imageRect(), tintColor);
+            painter->drawPixmap(targetRect, t, t.rect());
+        } else {
         painter->drawPixmap(targetRect, tileImage, tile->imageRect());
+        }
+    }
     else
         mTilesetView->imageMissingIcon().paint(painter, targetRect, Qt::AlignBottom | Qt::AlignLeft);
 

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -77,6 +77,39 @@ static void setupTilesetGridTransform(const Tileset &tileset, QTransform &transf
 
 namespace {
 
+// copy of tinted function from maprenderer.cpp
+static QPixmap tintedPixmap(const QPixmap &pixmap, const QRect &rect, const QColor &color)
+{
+    if (!color.isValid() || color == QColor(255, 255, 255, 255))
+        return pixmap.copy(rect);
+
+    QPixmap result = pixmap.copy(rect);
+
+    // tinting with a non-fully opaque color needs an alpha channel to work properly
+    if (color.alpha() < 255 && !result.hasAlphaChannel()) {
+        auto imageWithAlpha = result.toImage();
+        imageWithAlpha.convertTo(QImage::Format_ARGB32_Premultiplied);
+        result = QPixmap::fromImage(std::move(imageWithAlpha), Qt::NoOpaqueDetection);
+    }
+
+    QPainter painter(&result);
+
+    QColor fullOpacity = color;
+    fullOpacity.setAlpha(255);
+
+    painter.setCompositionMode(QPainter::CompositionMode_Multiply);
+    painter.fillRect(result.rect(), fullOpacity);
+
+    painter.setCompositionMode(QPainter::CompositionMode_DestinationIn);
+    painter.drawPixmap(result.rect(), pixmap, rect);
+
+    painter.setCompositionMode(QPainter::CompositionMode_DestinationIn);
+    painter.fillRect(result.rect(), color);
+
+    painter.end();
+    return result;
+}
+
 /**
  * The delegate for drawing tile items in the tileset view.
  */

--- a/src/tiled/undocommands.h
+++ b/src/tiled/undocommands.h
@@ -62,6 +62,7 @@ enum UndoCommands {
     Cmd_ChangeSelectedArea,
     Cmd_ChangeTileImageRect,
     Cmd_ChangeTileProbability,
+    Cmd_ChangeTileTintColor,
     Cmd_ChangeTileWangId,
     Cmd_ChangeTilesetName,
     Cmd_ChangeTilesetTileOffset,


### PR DESCRIPTION
Closes #3950 

Additions:
This PR introduces tinting for individual tiles through the tileset view, and tile objects for tilemaps.
Currently as of this PR, the tint color of both tiles and tile objects, and the Layer's tint color multiply together (respectively depending on type of layer). The issue thread had discussion about how the tints should affect each other, but I've implemented them to multiply - for now - as I think actually using the feature will give a better idea about how this part should be handled.

Missing:
While currently saving work fine for both tsx and json files, there's no support for exports yet (for example, exporting the tint color as modulate property for godot tiles).

Looking forward for feedback on this. :)