### PR TITLE
Add initial glTF export plugin scaffold

### DIFF
--- a/src/plugins/gltf/gltf.qbs
+++ b/src/plugins/gltf/gltf.qbs
@@ -1,0 +1,14 @@
+TiledPlugin {
+    condition: false   // WIP scaffold — not built by default. See #2741.
+
+    cpp.defines: base.concat(["GLTF_LIBRARY"])
+
+    files: [
+        "gltfexporter.cpp",
+        "gltfexporter.h",
+        "gltf_global.h",
+        "gltfplugin.cpp",
+        "gltfplugin.h",
+        "plugin.json",
+    ]
+}

--- a/src/plugins/gltf/gltf_global.h
+++ b/src/plugins/gltf/gltf_global.h
@@ -1,0 +1,29 @@
+/*
+ * glTF Tiled Plugin
+ * Copyright 2026, Prateek Singh <prateeksingh765000017@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtCore/qglobal.h>
+
+#if defined(GLTF_LIBRARY)
+#  define GLTFSHARED_EXPORT Q_DECL_EXPORT
+#else
+#  define GLTFSHARED_EXPORT Q_DECL_IMPORT
+#endif

--- a/src/plugins/gltf/gltfexporter.cpp
+++ b/src/plugins/gltf/gltfexporter.cpp
@@ -1,0 +1,74 @@
+/*
+ * glTF Tiled Plugin
+ * Copyright 2026, Prateek Singh <prateeksingh765000017@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "gltfexporter.h"
+
+#include "map.h"
+
+#include <QFileInfo>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+using namespace Gltf;
+
+GltfExporter::ContainerFormat GltfExporter::containerFormat(const QString &fileName)
+{
+    const QString suffix = QFileInfo(fileName).suffix().toLower();
+    if (suffix == QLatin1String("gltf"))
+        return ContainerFormat::Gltf;
+    if (suffix == QLatin1String("glb"))
+        return ContainerFormat::Glb;
+    return ContainerFormat::Unknown;
+}
+
+QStringList GltfExporter::outputFiles(const QString &fileName)
+{
+    QStringList files;
+    files << fileName;
+
+    // A text .gltf writes vertex/index data to a sibling .bin file. A binary
+    // .glb embeds it, so only the single file is produced. Enumerating these
+    // lets Tiled's "export as" UI warn before overwriting the .bin.
+    if (containerFormat(fileName) == ContainerFormat::Gltf) {
+        QFileInfo info(fileName);
+        files << info.absolutePath() + QLatin1Char('/') + info.completeBaseName() + QLatin1String(".bin");
+    }
+
+    return files;
+}
+
+bool GltfExporter::write(const Tiled::Map *map,
+                         const QString &fileName,
+                         Tiled::MapFormat::Options options,
+                         QString *error) const
+{
+    Q_UNUSED(map)
+    Q_UNUSED(fileName)
+    Q_UNUSED(options)
+
+    // The actual writer is the subject of the GSoC 2026 proposal
+    // (https://github.com/mapeditor/tiled/issues/2741). This scaffold
+    // registers the format and name filter so the plumbing can be reviewed
+    // separately from the exporter logic.
+    if (error)
+        *error = QObject::tr("glTF export is not implemented yet (GSoC 2026 work in progress).");
+    return false;
+}

--- a/src/plugins/gltf/gltfexporter.h
+++ b/src/plugins/gltf/gltfexporter.h
@@ -1,0 +1,52 @@
+/*
+ * glTF Tiled Plugin
+ * Copyright 2026, Prateek Singh <prateeksingh765000017@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "mapformat.h"
+
+class QString;
+
+namespace Tiled {
+class Map;
+}
+
+namespace Gltf {
+
+class GltfExporter
+{
+public:
+    enum class ContainerFormat
+    {
+        Unknown,
+        Gltf,
+        Glb
+    };
+
+    static ContainerFormat containerFormat(const QString &fileName);
+    static QStringList outputFiles(const QString &fileName);
+
+    bool write(const Tiled::Map *map,
+               const QString &fileName,
+               Tiled::MapFormat::Options options,
+               QString *error) const;
+};
+
+} // namespace Gltf

--- a/src/plugins/gltf/gltfplugin.cpp
+++ b/src/plugins/gltf/gltfplugin.cpp
@@ -1,0 +1,57 @@
+/*
+ * glTF Tiled Plugin
+ * Copyright 2026, Prateek Singh <prateeksingh765000017@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "gltfplugin.h"
+
+#include "gltfexporter.h"
+
+using namespace Gltf;
+
+GltfPlugin::GltfPlugin()
+{
+}
+
+bool GltfPlugin::write(const Tiled::Map *map, const QString &fileName, Options options)
+{
+    mError.clear();
+    const GltfExporter exporter;
+    return exporter.write(map, fileName, options, &mError);
+}
+
+QString GltfPlugin::errorString() const
+{
+    return mError;
+}
+
+QStringList GltfPlugin::outputFiles(const Tiled::Map *map, const QString &fileName) const
+{
+    Q_UNUSED(map)
+    return GltfExporter::outputFiles(fileName);
+}
+
+QString GltfPlugin::nameFilter() const
+{
+    return tr("glTF files (*.gltf *.glb)");
+}
+
+QString GltfPlugin::shortName() const
+{
+    return QStringLiteral("gltf");
+}

--- a/src/plugins/gltf/gltfplugin.h
+++ b/src/plugins/gltf/gltfplugin.h
@@ -1,0 +1,49 @@
+/*
+ * glTF Tiled Plugin
+ * Copyright 2026, Prateek Singh <prateeksingh765000017@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "mapformat.h"
+
+#include "gltf_global.h"
+
+namespace Gltf {
+
+class GLTFSHARED_EXPORT GltfPlugin : public Tiled::WritableMapFormat
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.mapeditor.MapFormat" FILE "plugin.json")
+
+public:
+    GltfPlugin();
+
+    bool write(const Tiled::Map *map, const QString &fileName, Options options) override;
+    QString errorString() const override;
+    QStringList outputFiles(const Tiled::Map *map, const QString &fileName) const override;
+    QString shortName() const override;
+
+protected:
+    QString nameFilter() const override;
+
+private:
+    QString mError;
+};
+
+} // namespace Gltf

--- a/src/plugins/gltf/plugin.json
+++ b/src/plugins/gltf/plugin.json
@@ -1,0 +1,1 @@
+{ "defaultEnable": false }

--- a/src/plugins/plugins.qbs
+++ b/src/plugins/plugins.qbs
@@ -8,6 +8,7 @@ Project {
         "droidcraft",
         "flare",
         "gmx",
+        "gltf",
         "json",
         "json1",
         "lua",


### PR DESCRIPTION
Scaffold only — not ready for review as an exporter. This PR adds the plumbing a glTF / .glb map format plugin would need (plugin.json, qbs, the `Tiled::WritableMapFormat`-derived class, name filter, output-file enumeration) and nothing else.

Scope after cleanup:

- `src/plugins/gltf/` — seven new files
- `src/plugins/plugins.qbs` — one line registering the plugin

The plugin is disabled by default (`condition: false` in `gltf.qbs`, and `"defaultEnable": false` in `plugin.json`), so this has no effect on default builds. The exporter's `write()` currently returns `false` with a "glTF export is not implemented yet (GSoC 2026 work in progress)" error, which is the honest state rather than a half-working writer.

I'm keeping this open mainly as evidence attached to the GSoC 2026 proposal for mapeditor/tiled#2741. If the proposal is accepted, I'll reopen the actual exporter work as reviewable chunks (vertex/index buffers, embedded textures, .glb container, validator integration) rather than as one large PR. Happy to close this if maintainers would rather not carry an inert scaffold branch.

Earlier iterations of this branch touched unrelated files (a CI workflow, NEWS.md, a doc reference page, and two unrelated Tiled widgets). All of that has been dropped; the branch has been rebased onto current master and squashed to one commit containing only the scaffold files.
