### PR TITLE
Fix: prevent whitespaces-only property names by trimming input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 * Added 'Collapse All' action and 'Only Expand to Current' mode to Project view (with rhythmcache, #4346)
+* Added whitespace trimming for custom property names (with Praagya26, #4486)
 * Reduced animated tile marker opacity during terrain editing (by Huy Vũ, #4449)
 * Fixed ability to change properties after deselecting the current object (#4440)
 * Fixed Properties view getting stuck with updates disabled (#4506)

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -2904,22 +2904,15 @@ void PropertiesWidget::renameProperty(const QString &name)
     dialog->setTextValue(name);
     dialog->setWindowTitle(QCoreApplication::translate("Tiled::PropertiesDock", "Rename Property"));
 
-    connect(dialog, &QInputDialog::textValueSelected, this, [=](const QString &newName) {
-        QString trimmedName = newName.trimmed();
-
-        if (trimmedName.isEmpty())
+    connect(dialog, &QInputDialog::textValueSelected, this, [=] (const QString &text) {
+        const QString newName = text.trimmed();
+        if (newName.isEmpty())
             return;
-
-        if (trimmedName == name)
+        if (newName == name)
             return;
 
         QUndoStack *undoStack = mDocument->undoStack();
-        undoStack->push(new RenameProperty(
-            mDocument,
-            mDocument->currentObjects(),
-            name,
-            trimmedName
-            ));
+        undoStack->push(new RenameProperty(mDocument, mDocument->currentObjects(), name, newName));
     });
 
     dialog->open();

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -2904,14 +2904,22 @@ void PropertiesWidget::renameProperty(const QString &name)
     dialog->setTextValue(name);
     dialog->setWindowTitle(QCoreApplication::translate("Tiled::PropertiesDock", "Rename Property"));
 
-    connect(dialog, &QInputDialog::textValueSelected, this, [=] (const QString &newName) {
-        if (newName.isEmpty())
+    connect(dialog, &QInputDialog::textValueSelected, this, [=](const QString &newName) {
+        QString trimmedName = newName.trimmed();
+
+        if (trimmedName.isEmpty())
             return;
-        if (newName == name)
+
+        if (trimmedName == name)
             return;
 
         QUndoStack *undoStack = mDocument->undoStack();
-        undoStack->push(new RenameProperty(mDocument, mDocument->currentObjects(), name, newName));
+        undoStack->push(new RenameProperty(
+            mDocument,
+            mDocument->currentObjects(),
+            name,
+            trimmedName
+            ));
     });
 
     dialog->open();

--- a/src/tiled/variantmapproperty.cpp
+++ b/src/tiled/variantmapproperty.cpp
@@ -755,7 +755,9 @@ QWidget *AddValueProperty::createLabel(int level, QWidget *parent)
 
     nameEdit->setContentsMargins(margins);
 
-    connect(nameEdit, &QLineEdit::textChanged, this, &Property::setName);
+    connect(nameEdit, &QLineEdit::textChanged, this, [this](const QString &name) {
+        setName(name.trimmed());
+    });
     connect(nameEdit, &QLineEdit::returnPressed, this, [this] {
         if (!name().isEmpty())
             emit addRequested();


### PR DESCRIPTION
Fix: Prevent whitespace-only property names

This PR improves validation when renaming properties by ensuring that user input is properly sanitized before being applied.

### **Problem**
Previously, the rename dialog accepted names that:
- Contained only whitespace (e.g. "   ")
- Had leading/trailing spaces (e.g. "  name  ")
- Resulted in unintended or inconsistent property names

This could lead to:
- Invisible or confusing property names (whitespace-only)
- Duplicate-like names that differ only by spaces
- Poor UX when managing properties

**### Solution:**
- Trim the input string using `QString::trimmed()`
- Reject names that become empty after trimming
- Prevent redundant renames when the trimmed name matches the existing name
- Apply the trimmed value for valid renames

**### Examples:**
 Input                  Previous Behavior        New Behavior        

 `"   "`                    Accepted                       Rejected        
`"  name  "`           Saved as `"  name  "`     Saved as `"name"`  
`"name"` (same)   Renamed again             Ignored           
`"newName"`        Renamed                      Renamed 
 
**### Impact:**
- Improves data consistency
- Prevents invalid or misleading property names
- Enhances overall user experience

This complements my previous PR #4481 related to property renaming and ensures more consistent behavior.