### PR TITLE
Restore expanded state persistence for custom class properties

### DIFF
--- a/src/tiled/variantmapproperty.cpp
+++ b/src/tiled/variantmapproperty.cpp
@@ -334,6 +334,9 @@ bool VariantMapProperty::createOrUpdateProperty(int index,
                 addMember(name, mSuggestions.value(name));
             });
 
+            if (auto groupProperty = qobject_cast<GroupProperty*>(property))
+                setupExpandedState(groupProperty, { name });
+
             insertProperty(index, property);
             mPropertyMap.insert(name, property);
         } else {
@@ -440,6 +443,26 @@ void VariantMapProperty::propertyTypesChanged()
         return;
 
     setValue(mValue, mSuggestions);
+}
+
+void VariantMapProperty::setupExpandedState(GroupProperty *group, const QStringList &path)
+{
+    group->setExpanded(mExpandedProperties.contains(path));
+
+    connect(group, &GroupProperty::expandedChanged, this, [this, path](bool expanded) {
+        if (expanded)
+            mExpandedProperties.insert(path);
+        else
+            mExpandedProperties.remove(path);
+    });
+
+    for (auto subProperty : group->subProperties()) {
+        if (auto subGroup = qobject_cast<GroupProperty*>(subProperty)) {
+            QStringList subPath = path;
+            subPath.append(subGroup->name());
+            setupExpandedState(subGroup, subPath);
+        }
+    }
 }
 
 void VariantMapProperty::emitMemberValueChanged(const PropertyPath &path, const QVariant &value)

--- a/src/tiled/variantmapproperty.h
+++ b/src/tiled/variantmapproperty.h
@@ -76,6 +76,7 @@ private:
                                 const QVariant &oldValue,
                                 const QVariant &newValue);
 
+    void setupExpandedState(GroupProperty *group, const QStringList &path);
     void emitMemberValueChanged(const PropertyPath &path, const QVariant &value);
 
     bool mEmittingValueChanged = false;


### PR DESCRIPTION
Hi @bjorn @joereynolds

This PR Fixes #4035

I have changed,  verified and tested the following things 
1. `setupExpandedState`is called when a new class GroupProperty is created
2. It reads initial state from `mExpandedProperties` (empty set → defaults to collapsed, matching the maintainer's requirement)
3. Connects `expandedChanged` to update the set reactively
4. Recurses into nested class properties using path-based keys (e.g., ["ClassName", "SubclassName"])
5. Qt's 4-arg connect with this as context handles cleanup automatically

Ready for inputs and Review.
Thanks