### PR TITLE
Fix: trim whitespace in tileset name when renaming

### DIFF
--- a/src/tiled/tilesetchanges.cpp
+++ b/src/tiled/tilesetchanges.cpp
@@ -36,7 +36,7 @@ RenameTileset::RenameTileset(TilesetDocument *tilesetDocument,
                                                "Change Tileset Name"))
     , mTilesetDocument(tilesetDocument)
     , mOldName(tilesetDocument->tileset()->name())
-    , mNewName(newName)
+    , mNewName(newName.trimmed())
 {}
 
 void RenameTileset::undo()

--- a/src/tiled/tilesetdocument.cpp
+++ b/src/tiled/tilesetdocument.cpp
@@ -297,7 +297,7 @@ void TilesetDocument::removeMapDocument(MapDocument *mapDocument)
 
 void TilesetDocument::setTilesetName(const QString &name)
 {
-    mTileset->setName(name);
+    mTileset->setName(name.trimmed());
     emit tilesetNameChanged(mTileset.data());
 
     for (MapDocument *mapDocument : mapDocuments())


### PR DESCRIPTION
### **Problem:**
1. Renaming a tileset allowed whitespace-only names.
2. Leading and trailing spaces were not trimmed, resulting in inconsistent naming.

### **Fix:**
Applied QString::trimmed() to sanitize input:
In tilesetchanges.cpp using newName.trimmed()
In tilesetdocument.cpp using name.trimmed()

This ensures:
Whitespace-only names are rejected.
Leading and trailing spaces are removed before further processing.

### **Result:**
Prevents invalid or empty tileset names.
Improves consistency and reliability of naming behavior.

### **Future Work:**
As suggested by @kunal649, consider introducing a CENTRALIZED VALIDATION UTILITY.
This would help enforce consistent naming rules across the codebase and reduce duplication.