### PR TITLE
Scripting: Pass writable copies to scripted write()

### DIFF
--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -2696,8 +2696,14 @@ interface ScriptedMapFormat {
   read?(fileName: string): TileMap;
 
   /**
-   * A function that writes a map to the given
-   * file. Can use {@link TextFile} or {@link BinaryFile} to write the file. * When a non-empty string is returned, it is shown as error message.
+   * A function that writes a map to the given file.
+   *
+   * Can use {@link TextFile} or {@link BinaryFile} to write the file.
+   *
+   * The passed map can be modified and any changes only apply to this write.
+   * The original asset remains unchanged.
+   *
+   * When a non-empty string is returned, it is shown as error message.
    */
   write?(map: TileMap, fileName: string): string | undefined;
 
@@ -4337,6 +4343,10 @@ interface ScriptedTilesetFormat {
    * A function that writes a tileset to the given file.
    *
    * Can use {@link TextFile} or {@link BinaryFile} to write the file.
+   *
+   * The passed tileset can be modified and any changes only apply to this
+   * write. The original asset remains unchanged.
+   *
    * When a non-empty string is returned, it is shown as error message.
    */
   write?(tileset: Tileset, fileName: string): string | undefined;

--- a/src/tiled/editabletileset.cpp
+++ b/src/tiled/editabletileset.cpp
@@ -50,6 +50,12 @@ EditableTileset::EditableTileset(const Tileset *tileset, QObject *parent)
 {
 }
 
+EditableTileset::EditableTileset(const SharedTileset &tileset, QObject *parent)
+    : EditableAsset(tileset.data(), parent)
+    , mTileset(tileset)
+{
+}
+
 EditableTileset::EditableTileset(TilesetDocument *tilesetDocument,
                                  QObject *parent)
     : EditableAsset(tilesetDocument->tileset().data(), parent)

--- a/src/tiled/editabletileset.h
+++ b/src/tiled/editabletileset.h
@@ -113,6 +113,7 @@ public:
     Q_INVOKABLE explicit EditableTileset(const QString &name = QString(),
                                          QObject *parent = nullptr);
     explicit EditableTileset(const Tileset *tileset, QObject *parent = nullptr);
+    explicit EditableTileset(const SharedTileset &tileset, QObject *parent = nullptr);
     explicit EditableTileset(TilesetDocument *tilesetDocument,
                              QObject *parent = nullptr);
     ~EditableTileset() override;

--- a/src/tiled/scriptedfileformat.cpp
+++ b/src/tiled/scriptedfileformat.cpp
@@ -203,7 +203,8 @@ std::unique_ptr<Map> ScriptedMapFormat::read(const QString &fileName)
 
 bool ScriptedMapFormat::write(const Map *map, const QString &fileName, Options options)
 {
-    EditableMap editable(map);
+    auto editableMap = map->clone();
+    EditableMap editable(std::move(editableMap));
     return mFormat.write(&editable, fileName, options, mError);
 }
 
@@ -248,7 +249,8 @@ SharedTileset ScriptedTilesetFormat::read(const QString &fileName)
 
 bool ScriptedTilesetFormat::write(const Tileset &tileset, const QString &fileName, FileFormat::Options options)
 {
-    EditableTileset editable(&tileset);
+    const auto editableTileset = tileset.clone();
+    EditableTileset editable(editableTileset);
     return mFormat.write(&editable, fileName, options, mError);
 }
 


### PR DESCRIPTION
Implemented #3986 by making scripted `MapFormat.write()` and `TilesetFormat.write()` receive writable cloned assets instead of read-only wrappers. This allows last-second script-side modifications during write while keeping the original open asset unchanged. Updated scripting API docs accordingly. Closes #3986.