### PR TITLE
Add Shift+Enter to finish polygon creation by closing the shape

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Fixed ability to change properties after deselecting the current object (#4440)
 * Fixed Properties view getting stuck with updates disabled (#4506)
 * Fixed locale-aware parsing of numbers in expression-capable spin boxes
+* Added Shift+Enter to finish polygon creation by closing the shape
 
 ### Tiled 1.12.1 (25 March 2026)
 

--- a/docs/manual/keyboard-shortcuts.rst
+++ b/docs/manual/keyboard-shortcuts.rst
@@ -120,7 +120,8 @@ When an object layer is selected
 -  ``C`` - Activate :ref:`insert-ellipse-tool`
 -  ``P`` - Activate :ref:`insert-polygon-tool`
 
-   -  ``Enter`` - Finish creating object
+   -  ``Enter`` - Finish creating object (as polyline)
+   -  ``Shift+Enter`` - Finish creating object as polygon (closing the shape)
    -  ``Escape`` - Cancel creating object
    -  ``Backspace`` - Remove previously added point while creating or extending
       polygons and polylines

--- a/docs/manual/keyboard-shortcuts.rst
+++ b/docs/manual/keyboard-shortcuts.rst
@@ -121,7 +121,7 @@ When an object layer is selected
 -  ``P`` - Activate :ref:`insert-polygon-tool`
 
    -  ``Enter`` - Finish creating object (as polyline)
-   -  ``Shift+Enter`` - Finish creating object as polygon (closing the shape)
+   -  ``Shift + Enter`` - Finish creating object as polygon (closing the shape)
    -  ``Escape`` - Cancel creating object
    -  ``Backspace`` - Remove previously added point while creating or extending
       polygons and polylines

--- a/docs/manual/objects.rst
+++ b/docs/manual/objects.rst
@@ -109,8 +109,8 @@ When placing a polygon, the first click determines the location of the
 object as well as the location of the first point of the polygon.
 Subsequent clicks are used to add additional points to the polygon.
 Polygons needs to have at least three points. Click the first point
-again to finish creating the polygon. You can press ``Escape`` to cancel
-the creation of the polygon.
+again or press ``Shift+Enter`` to finish creating the polygon. You can
+press ``Escape`` to cancel the creation of the polygon.
 
 When you want to change a polygon after it has been placed, you need to
 use the :ref:`edit-polygons-tool` tool.

--- a/docs/manual/objects.rst
+++ b/docs/manual/objects.rst
@@ -108,8 +108,8 @@ They are most commonly used for defining collision shapes.
 When placing a polygon, the first click determines the location of the
 object as well as the location of the first point of the polygon.
 Subsequent clicks are used to add additional points to the polygon.
-Polygons needs to have at least three points. Click the first point
-again or press ``Shift+Enter`` to finish creating the polygon. You can
+Polygons need to have at least three points. Click the first point
+again or press ``Shift + Enter`` to finish creating the polygon. You can
 press ``Escape`` to cancel the creation of the polygon.
 
 When you want to change a polygon after it has been placed, you need to

--- a/src/tiled/createpolygonobjecttool.cpp
+++ b/src/tiled/createpolygonobjecttool.cpp
@@ -114,7 +114,15 @@ void CreatePolygonObjectTool::deactivate(MapScene *scene)
 
 void CreatePolygonObjectTool::keyPressed(QKeyEvent *event)
 {
-    // TODO: Modifier for finishing as polygon (Shift+Enter)
+    if ((event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
+            && (event->modifiers() & Qt::ShiftModifier)
+            && state() == CreatingObject) {
+        if (mNewMapObjectItem->mapObject()->polygon().size() > 2) {
+            mFinishAsPolygon = true;
+            finishNewMapObject();
+        }
+        return;
+    }
 
     // Backspace removes the last added point (or first, when extending from the beginning)
     if (event->key() == Qt::Key_Backspace && state() == CreatingObject) {


### PR DESCRIPTION
While creating a polygon or extending a polyline, pressing Shift+Enter now closes the shape as a polygon. This requires at least three points, matching the existing behavior when clicking the first point to close. Plain Enter still finishes as a polyline.

Implements the TODO left in createpolygonobjecttool.cpp and follows up on the Backspace support added in #4372.