### PR TITLE
Fix transparent tiles being saved with tile ID instead of 0

### DIFF
--- a/src/libtiled/gidmapper.cpp
+++ b/src/libtiled/gidmapper.cpp
@@ -133,6 +133,27 @@ unsigned GidMapper::cellToGid(const Cell &cell) const
     if (i == i_end) // tileset not found
         return 0;
 
+    // Check if the tile is completely transparent, treat as empty
+    Tile *tile = tileset->tileAt(cell.tileId());
+    if (tile) {
+        const QPixmap &img = tile->image();
+        if (!img.isNull() && img.hasAlphaChannel()) {
+            // Extract just this tile's region and check if all pixels are transparent
+            QPixmap tilePixmap = img.copy(tile->imageRect());
+            QImage imgData = tilePixmap.toImage();
+
+            bool allTransparent = true;
+            for (int y = 0; y < imgData.height() && allTransparent; ++y) {
+                for (int x = 0; x < imgData.width() && allTransparent; ++x) {
+                    if (qAlpha(imgData.pixel(x, y)) > 0)
+                        allTransparent = false;
+                }
+            }
+            if (allTransparent)
+                return 0;
+        }
+    }
+
     unsigned gid = i.key() + cell.tileId();
     if (cell.flippedHorizontally())
         gid |= FlippedHorizontallyFlag;


### PR DESCRIPTION
## Summary
Transparent tiles in tilesets are now correctly serialized as GID 0 (empty) instead of their actual tile ID when
saving maps.

## Problem
When a tile in a tileset is completely transparent (all pixels have zero alpha), painting with it and saving the
map would incorrectly save that tile's ID instead of 0, resulting in invisible tiles appearing on the map.

## Solution
Added a transparency check in `GidMapper::cellToGid()` that:
- Extracts each tile's region from a tileset image
- Checks if all pixels are completely transparent (alpha = 0)
- Returns GID 0 for fully transparent tiles instead of their actual ID

This fix applies to all export formats (JSON, TMX, etc.) since they all use the GID mapper for serialization.

## Testing
- Paint with a transparent tile from a tileset
- Save the map to JSON
- Verify that the painted areas have GID 0 instead of the transparent tile's ID