### PR TITLE
Add agent-oriented Tiled bridge and orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ util/java/tmxviewer-java/target
 util/java/libtiled-java/target
 /util/java/target/
 
+# Node.js
+node_modules/
+tools/tiled-agent-orchestrator/dist/
+
 # Linux perf/debugging
 gmon.out
 

--- a/src/tiledagentbridge/CMakeLists.txt
+++ b/src/tiledagentbridge/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(tiledagentbridge LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Test)
+find_package(ZLIB REQUIRED)
+
+file(GLOB LIBTILED_SOURCES CONFIGURE_DEPENDS
+  "${CMAKE_CURRENT_SOURCE_DIR}/../libtiled/*.cpp"
+)
+
+add_library(tiledagent_libtiled STATIC ${LIBTILED_SOURCES})
+target_include_directories(tiledagent_libtiled
+  PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/../libtiled"
+)
+target_link_libraries(tiledagent_libtiled
+  PUBLIC
+    Qt6::Core
+    Qt6::Gui
+    ZLIB::ZLIB
+)
+
+add_executable(tiledagentbridge
+  bridge_main.cpp
+  bridgeengine.cpp
+  jsonrpcserver.cpp
+)
+target_include_directories(tiledagentbridge PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(tiledagentbridge PRIVATE tiledagent_libtiled Qt6::Core Qt6::Gui)
+
+add_executable(tiledagentbridge_tests
+  test_bridgeengine.cpp
+  bridgeengine.cpp
+)
+target_include_directories(tiledagentbridge_tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_compile_definitions(tiledagentbridge_tests PRIVATE
+  TEST_SOURCE_ROOT="${PROJECT_SOURCE_DIR}/../.."
+)
+target_link_libraries(tiledagentbridge_tests PRIVATE tiledagent_libtiled Qt6::Core Qt6::Gui Qt6::Test)
+
+include(CTest)
+add_test(NAME tiledagentbridge_tests COMMAND tiledagentbridge_tests)

--- a/src/tiledagentbridge/bridge_main.cpp
+++ b/src/tiledagentbridge/bridge_main.cpp
@@ -1,0 +1,18 @@
+#include "bridgeengine.h"
+#include "jsonrpcserver.h"
+
+#include <QGuiApplication>
+
+int main(int argc, char *argv[])
+{
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM"))
+        qputenv("QT_QPA_PLATFORM", QByteArrayLiteral("offscreen"));
+
+    QGuiApplication app(argc, argv);
+    app.setApplicationName(QStringLiteral("tiledagentbridge"));
+    app.setApplicationVersion(QStringLiteral("0.1.0"));
+
+    tiledagent::BridgeEngine engine;
+    tiledagent::JsonRpcServer server(engine);
+    return server.run();
+}

--- a/src/tiledagentbridge/bridgeengine.cpp
+++ b/src/tiledagentbridge/bridgeengine.cpp
@@ -1,0 +1,913 @@
+#include "bridgeengine.h"
+
+#include "grouplayer.h"
+#include "layer.h"
+#include "map.h"
+#include "mapobject.h"
+#include "mapreader.h"
+#include "maptovariantconverter.h"
+#include "mapwriter.h"
+#include "objectgroup.h"
+#include "savefile.h"
+#include "tilelayer.h"
+#include "tileset.h"
+#include "varianttomapconverter.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QSaveFile>
+#include <QSet>
+
+#include <algorithm>
+
+namespace {
+
+using tiledagent::BridgeEngine;
+
+QVariant toVariant(const QJsonObject &object)
+{
+    return QJsonDocument(object).toVariant();
+}
+
+QJsonObject wrapSnapshot(const QJsonObject &payload, const QString &documentType)
+{
+    QJsonObject snapshot;
+    snapshot.insert(QStringLiteral("documentType"), documentType);
+    snapshot.insert(documentType, payload);
+    return snapshot;
+}
+
+QJsonObject toJsonObject(const QVariant &variant)
+{
+    return QJsonDocument::fromVariant(variant).object();
+}
+
+QJsonArray stringArray(const QStringList &values)
+{
+    QJsonArray result;
+    for (const QString &value : values)
+        result.append(value);
+    return result;
+}
+
+QJsonObject changedEntity(const QString &entityType, int entityId, const QString &changeType)
+{
+    return QJsonObject{
+        { QStringLiteral("entityType"), entityType },
+        { QStringLiteral("entityId"), entityId },
+        { QStringLiteral("changeType"), changeType },
+    };
+}
+
+Tiled::Cell cellForGid(const Tiled::Map &map, int gid, QString *errorMessage)
+{
+    if (gid == 0)
+        return Tiled::Cell::empty;
+
+    int firstGid = 1;
+    for (const Tiled::SharedTileset &tileset : map.tilesets()) {
+        const int nextFirstGid = firstGid + tileset->nextTileId();
+        if (gid >= firstGid && gid < nextFirstGid) {
+            const int tileId = gid - firstGid;
+            if (!tileset->findTile(tileId)) {
+                if (errorMessage)
+                    *errorMessage = QStringLiteral("Unknown gid: %1").arg(gid);
+                return Tiled::Cell::empty;
+            }
+            return Tiled::Cell(tileset.data(), tileId);
+        }
+        firstGid = nextFirstGid;
+    }
+
+    if (errorMessage)
+        *errorMessage = QStringLiteral("Unknown gid: %1").arg(gid);
+    return Tiled::Cell::empty;
+}
+
+Tiled::Properties propertiesFromJson(const QJsonObject &json)
+{
+    Tiled::Properties properties;
+    for (auto it = json.begin(); it != json.end(); ++it)
+        properties.insert(it.key(), it.value().toVariant());
+    return properties;
+}
+
+QJsonObject tilesetSnapshot(const Tiled::Tileset &tileset)
+{
+    QJsonObject object;
+    object.insert(QStringLiteral("name"), tileset.name());
+    object.insert(QStringLiteral("tileWidth"), tileset.tileWidth());
+    object.insert(QStringLiteral("tileHeight"), tileset.tileHeight());
+    object.insert(QStringLiteral("tileCount"), tileset.tileCount());
+    object.insert(QStringLiteral("columns"), tileset.columnCount());
+    if (!tileset.fileName().isEmpty())
+        object.insert(QStringLiteral("source"), tileset.fileName());
+    if (!tileset.imageSource().isEmpty())
+        object.insert(QStringLiteral("image"), tileset.imageSource().toString());
+    return object;
+}
+
+QJsonObject mapSnapshot(const Tiled::Map &map, const QString &path)
+{
+    Tiled::MapToVariantConverter converter;
+    const auto variant = converter.toVariant(map, QFileInfo(path).dir());
+    return toJsonObject(variant);
+}
+
+bool saveJsonVariant(const QVariant &variant, const QString &path, QString *errorMessage)
+{
+    Tiled::SaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        if (errorMessage)
+            *errorMessage = file.errorString();
+        return false;
+    }
+
+    const auto json = QJsonDocument::fromVariant(variant).toJson(QJsonDocument::Indented);
+    if (file.device()->write(json) != json.size()) {
+        if (errorMessage)
+            *errorMessage = file.errorString();
+        return false;
+    }
+
+    if (!file.commit()) {
+        if (errorMessage)
+            *errorMessage = file.errorString();
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+namespace tiledagent {
+
+BridgeEngine::BridgeEngine() = default;
+
+BridgeEngine::SessionState *BridgeEngine::session(const QString &sessionId)
+{
+    const auto it = mSessions.find(sessionId);
+    if (it == mSessions.end())
+        return nullptr;
+    return it.value().get();
+}
+
+const BridgeEngine::SessionState *BridgeEngine::session(const QString &sessionId) const
+{
+    const auto it = mSessions.constFind(sessionId);
+    if (it == mSessions.constEnd())
+        return nullptr;
+    return it.value().get();
+}
+
+BridgeEngine::SerializedState BridgeEngine::serializeState(const SessionState &session) const
+{
+    Tiled::MapToVariantConverter converter;
+    const QDir directory = QFileInfo(session.path).dir();
+
+    if (session.kind == DocumentKind::Map)
+        return { session.kind, converter.toVariant(*session.map, directory) };
+
+    return { session.kind, converter.toVariant(*session.tileset, directory) };
+}
+
+bool BridgeEngine::restoreState(SessionState &session, const SerializedState &state, QString *errorMessage) const
+{
+    Tiled::VariantToMapConverter converter;
+    const QDir directory = QFileInfo(session.path).dir();
+
+    if (state.kind == DocumentKind::Map) {
+        auto map = converter.toMap(state.variant, directory);
+        if (!map) {
+            if (errorMessage)
+                *errorMessage = converter.errorString();
+            return false;
+        }
+        map->fileName = session.path;
+        session.kind = DocumentKind::Map;
+        session.map = std::move(map);
+        session.tileset.clear();
+        return true;
+    }
+
+    auto tileset = converter.toTileset(state.variant, directory);
+    if (!tileset) {
+        if (errorMessage)
+            *errorMessage = converter.errorString();
+        return false;
+    }
+    tileset->setFileName(session.path);
+    session.kind = DocumentKind::Tileset;
+    session.tileset = tileset;
+    session.map.reset();
+    return true;
+}
+
+bool BridgeEngine::hasLoadedDocument(const SessionState &session)
+{
+    return (session.kind == DocumentKind::Map && session.map != nullptr)
+        || (session.kind == DocumentKind::Tileset && !session.tileset.isNull());
+}
+
+SnapshotResult BridgeEngine::snapshotResultFromSession(const SessionState &session) const
+{
+    SnapshotResult result;
+    result.success = true;
+    result.revision = session.revision;
+    result.documentType = session.kind == DocumentKind::Map ? QStringLiteral("map") : QStringLiteral("tileset");
+    if (session.kind == DocumentKind::Map)
+        result.snapshot = wrapSnapshot(mapSnapshot(*session.map, session.path), result.documentType);
+    else
+        result.snapshot = wrapSnapshot(tilesetSnapshot(*session.tileset), result.documentType);
+    return result;
+}
+
+CommandResult BridgeEngine::commandFailure(const SessionState *session, const QString &code, const QString &message) const
+{
+    CommandResult result;
+    result.success = false;
+    result.errorCode = code;
+    result.errorMessage = message;
+    if (session) {
+        result.revisionBefore = session->revision;
+        result.revisionAfter = session->revision;
+        result.undoDepth = session->undoStack.size();
+        result.redoDepth = session->redoStack.size();
+    }
+    result.errors = stringArray(QStringList{ message });
+    return result;
+}
+
+ValidationResult BridgeEngine::validationFailure(const SessionState *session, const QString &code, const QString &message) const
+{
+    ValidationResult result;
+    result.success = false;
+    result.errorCode = code;
+    result.errorMessage = message;
+    if (session)
+        result.revision = session->revision;
+    result.diagnostics.append(QJsonObject{
+        { QStringLiteral("severity"), QStringLiteral("error") },
+        { QStringLiteral("code"), code },
+        { QStringLiteral("message"), message },
+    });
+    return result;
+}
+
+SaveResult BridgeEngine::saveFailure(const SessionState *session, const QString &code, const QString &message) const
+{
+    SaveResult result;
+    result.success = false;
+    result.errorCode = code;
+    result.errorMessage = message;
+    if (session)
+        result.revision = session->revision;
+    return result;
+}
+
+SnapshotResult BridgeEngine::openDocument(const QString &sessionId, const QString &documentPath)
+{
+    const QFileInfo fileInfo(documentPath);
+    const QString suffix = fileInfo.suffix().toLower();
+
+    SessionState state;
+    state.path = fileInfo.absoluteFilePath();
+    state.revision = 0;
+
+    if (suffix == QStringLiteral("tmx")) {
+        Tiled::MapReader reader;
+        state.map = reader.readMap(state.path);
+        if (!state.map) {
+            SnapshotResult result;
+            result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+            result.errorMessage = reader.errorString();
+            return result;
+        }
+        state.map->fileName = state.path;
+        state.kind = DocumentKind::Map;
+    } else if (suffix == QStringLiteral("tmj") || suffix == QStringLiteral("json")) {
+        QFile file(state.path);
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            SnapshotResult result;
+            result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+            result.errorMessage = file.errorString();
+            return result;
+        }
+
+        QJsonParseError parseError;
+        const auto document = QJsonDocument::fromJson(file.readAll(), &parseError);
+        if (parseError.error != QJsonParseError::NoError) {
+            SnapshotResult result;
+            result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+            result.errorMessage = parseError.errorString();
+            return result;
+        }
+
+        const auto object = document.object();
+        Tiled::VariantToMapConverter converter;
+        if (object.value(QStringLiteral("type")).toString() == QStringLiteral("tileset")) {
+            state.tileset = converter.toTileset(document.toVariant(), fileInfo.dir());
+            if (!state.tileset) {
+                SnapshotResult result;
+                result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+                result.errorMessage = converter.errorString();
+                return result;
+            }
+            state.tileset->setFileName(state.path);
+            state.kind = DocumentKind::Tileset;
+        } else {
+            state.map = converter.toMap(document.toVariant(), fileInfo.dir());
+            if (!state.map) {
+                SnapshotResult result;
+                result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+                result.errorMessage = converter.errorString();
+                return result;
+            }
+            state.map->fileName = state.path;
+            state.kind = DocumentKind::Map;
+        }
+    } else if (suffix == QStringLiteral("tsx") || suffix == QStringLiteral("tsj")) {
+        if (suffix == QStringLiteral("tsx")) {
+            Tiled::MapReader reader;
+            state.tileset = reader.readTileset(state.path);
+            if (!state.tileset) {
+                SnapshotResult result;
+                result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+                result.errorMessage = reader.errorString();
+                return result;
+            }
+            state.tileset->setFileName(state.path);
+            state.kind = DocumentKind::Tileset;
+        } else {
+            QFile file(state.path);
+            if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                SnapshotResult result;
+                result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+                result.errorMessage = file.errorString();
+                return result;
+            }
+
+            QJsonParseError parseError;
+            const auto document = QJsonDocument::fromJson(file.readAll(), &parseError);
+            if (parseError.error != QJsonParseError::NoError) {
+                SnapshotResult result;
+                result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+                result.errorMessage = parseError.errorString();
+                return result;
+            }
+
+            Tiled::VariantToMapConverter converter;
+            state.tileset = converter.toTileset(document.toVariant(), fileInfo.dir());
+            if (!state.tileset) {
+                SnapshotResult result;
+                result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+                result.errorMessage = converter.errorString();
+                return result;
+            }
+            state.tileset->setFileName(state.path);
+            state.kind = DocumentKind::Tileset;
+        }
+    } else {
+        SnapshotResult result;
+        result.errorCode = QStringLiteral("DOCUMENT_ERROR");
+        result.errorMessage = QStringLiteral("Unsupported document extension: %1").arg(suffix);
+        return result;
+    }
+
+    mSessions.insert(sessionId, std::make_shared<SessionState>(std::move(state)));
+    return snapshotResultFromSession(*session(sessionId));
+}
+
+SnapshotResult BridgeEngine::getSnapshot(const QString &sessionId) const
+{
+    const auto currentSession = session(sessionId);
+    if (!currentSession) {
+        SnapshotResult result;
+        result.errorCode = QStringLiteral("SESSION_NOT_FOUND");
+        result.errorMessage = QStringLiteral("Unknown session: %1").arg(sessionId);
+        return result;
+    }
+    if (!hasLoadedDocument(*currentSession)) {
+        SnapshotResult result;
+        result.errorCode = QStringLiteral("DOCUMENT_NOT_OPEN");
+        result.errorMessage = QStringLiteral("No document is open for session: %1").arg(sessionId);
+        return result;
+    }
+    return snapshotResultFromSession(*currentSession);
+}
+
+bool BridgeEngine::applyCommand(SessionState &session, const QJsonObject &command, QString *errorMessage, QJsonArray *changedEntities) const
+{
+    if (session.kind != DocumentKind::Map) {
+        if (errorMessage)
+            *errorMessage = QStringLiteral("Commands are only supported for map documents.");
+        return false;
+    }
+
+    const QString type = command.value(QStringLiteral("type")).toString();
+    const auto payload = command.value(QStringLiteral("payload")).toObject();
+    auto map = session.map->clone();
+
+    if (type == QStringLiteral("create_layer")) {
+        const QString layerType = payload.value(QStringLiteral("layerType")).toString();
+        const QString name = payload.value(QStringLiteral("name")).toString();
+        std::unique_ptr<Tiled::Layer> layer;
+
+        if (layerType == QStringLiteral("tile")) {
+            layer = std::make_unique<Tiled::TileLayer>(name, 0, 0, map->width(), map->height());
+        } else if (layerType == QStringLiteral("object")) {
+            layer = std::make_unique<Tiled::ObjectGroup>(name);
+        } else if (layerType == QStringLiteral("group")) {
+            layer = std::make_unique<Tiled::GroupLayer>(name, 0, 0);
+        } else {
+            if (errorMessage)
+                *errorMessage = QStringLiteral("Unsupported layer type: %1").arg(layerType);
+            return false;
+        }
+
+        layer->setId(map->takeNextLayerId());
+        const int layerId = layer->id();
+        map->addLayer(std::move(layer));
+        session.undoStack.append(serializeState(session));
+        session.redoStack.clear();
+        session.map = std::move(map);
+        changedEntities->append(changedEntity(QStringLiteral("layer"), layerId, QStringLiteral("created")));
+        return true;
+    }
+
+    if (type == QStringLiteral("delete_layer")) {
+        const int layerId = payload.value(QStringLiteral("layerId")).toInt();
+        for (int index = 0; index < map->layerCount(); ++index) {
+            if (map->layerAt(index)->id() == layerId) {
+                std::unique_ptr<Tiled::Layer> removed(map->takeLayerAt(index));
+                session.undoStack.append(serializeState(session));
+                session.redoStack.clear();
+                session.map = std::move(map);
+                changedEntities->append(changedEntity(QStringLiteral("layer"), layerId, QStringLiteral("deleted")));
+                return true;
+            }
+        }
+        if (errorMessage)
+            *errorMessage = QStringLiteral("Unknown layer id: %1").arg(layerId);
+        return false;
+    }
+
+    if (type == QStringLiteral("move_layer")) {
+        const int layerId = payload.value(QStringLiteral("layerId")).toInt();
+        const int newIndex = payload.value(QStringLiteral("index")).toInt(-1);
+        if (newIndex < 0 || newIndex >= map->layerCount()) {
+            if (errorMessage)
+                *errorMessage = QStringLiteral("Invalid layer index: %1").arg(newIndex);
+            return false;
+        }
+
+        for (int index = 0; index < map->layerCount(); ++index) {
+            if (map->layerAt(index)->id() == layerId) {
+                std::unique_ptr<Tiled::Layer> moved(map->takeLayerAt(index));
+                map->insertLayer(newIndex, moved.release());
+                session.undoStack.append(serializeState(session));
+                session.redoStack.clear();
+                session.map = std::move(map);
+                changedEntities->append(changedEntity(QStringLiteral("layer"), layerId, QStringLiteral("moved")));
+                return true;
+            }
+        }
+
+        if (errorMessage)
+            *errorMessage = QStringLiteral("Unknown layer id: %1").arg(layerId);
+        return false;
+    }
+
+    if (type == QStringLiteral("set_layer_properties")) {
+        const int layerId = payload.value(QStringLiteral("layerId")).toInt();
+        auto *layer = map->findLayerById(layerId);
+        if (!layer) {
+            if (errorMessage)
+                *errorMessage = QStringLiteral("Unknown layer id: %1").arg(layerId);
+            return false;
+        }
+
+        if (payload.contains(QStringLiteral("name")))
+            layer->setName(payload.value(QStringLiteral("name")).toString());
+        if (payload.contains(QStringLiteral("visible")))
+            layer->setVisible(payload.value(QStringLiteral("visible")).toBool());
+        if (payload.contains(QStringLiteral("opacity")))
+            layer->setOpacity(payload.value(QStringLiteral("opacity")).toDouble());
+        if (payload.contains(QStringLiteral("x")))
+            layer->setX(payload.value(QStringLiteral("x")).toInt());
+        if (payload.contains(QStringLiteral("y")))
+            layer->setY(payload.value(QStringLiteral("y")).toInt());
+        if (payload.contains(QStringLiteral("properties")))
+            layer->mergeProperties(propertiesFromJson(payload.value(QStringLiteral("properties")).toObject()));
+
+        session.undoStack.append(serializeState(session));
+        session.redoStack.clear();
+        session.map = std::move(map);
+        changedEntities->append(changedEntity(QStringLiteral("layer"), layerId, QStringLiteral("updated")));
+        return true;
+    }
+
+    if (type == QStringLiteral("paint_tiles") || type == QStringLiteral("erase_tiles")) {
+        const int layerId = payload.value(QStringLiteral("layerId")).toInt();
+        auto *layer = dynamic_cast<Tiled::TileLayer*>(map->findLayerById(layerId));
+        if (!layer) {
+            if (errorMessage)
+                *errorMessage = QStringLiteral("Unknown tile layer id: %1").arg(layerId);
+            return false;
+        }
+
+        const auto cells = payload.value(QStringLiteral("cells")).toArray();
+        for (const auto &cellValue : cells) {
+            const auto cellObject = cellValue.toObject();
+            const int x = cellObject.value(QStringLiteral("x")).toInt();
+            const int y = cellObject.value(QStringLiteral("y")).toInt();
+
+            if (!map->infinite() && !layer->contains(x, y)) {
+                if (errorMessage)
+                    *errorMessage = QStringLiteral("Cell (%1, %2) is outside layer bounds.").arg(x).arg(y);
+                return false;
+            }
+
+            if (type == QStringLiteral("erase_tiles")) {
+                layer->setCell(x, y, Tiled::Cell::empty);
+                continue;
+            }
+
+            QString gidError;
+            const auto cell = cellForGid(*map, cellObject.value(QStringLiteral("gid")).toInt(), &gidError);
+            if (!gidError.isEmpty()) {
+                if (errorMessage)
+                    *errorMessage = gidError;
+                return false;
+            }
+            layer->setCell(x, y, cell);
+        }
+
+        session.undoStack.append(serializeState(session));
+        session.redoStack.clear();
+        session.map = std::move(map);
+        changedEntities->append(changedEntity(QStringLiteral("layer"), layerId, QStringLiteral("updated")));
+        return true;
+    }
+
+    if (type == QStringLiteral("create_object")) {
+        const int layerId = payload.value(QStringLiteral("layerId")).toInt();
+        auto *group = dynamic_cast<Tiled::ObjectGroup*>(map->findLayerById(layerId));
+        if (!group) {
+            if (errorMessage)
+                *errorMessage = QStringLiteral("Unknown object layer id: %1").arg(layerId);
+            return false;
+        }
+
+        auto object = std::make_unique<Tiled::MapObject>(
+            payload.value(QStringLiteral("name")).toString(),
+            payload.value(QStringLiteral("className")).toString(),
+            QPointF(payload.value(QStringLiteral("x")).toDouble(), payload.value(QStringLiteral("y")).toDouble()),
+            QSizeF(payload.value(QStringLiteral("width")).toDouble(), payload.value(QStringLiteral("height")).toDouble())
+        );
+        object->setId(map->takeNextObjectId());
+        if (payload.contains(QStringLiteral("rotation")))
+            object->setRotation(payload.value(QStringLiteral("rotation")).toDouble());
+        if (payload.contains(QStringLiteral("visible")))
+            object->setVisible(payload.value(QStringLiteral("visible")).toBool());
+        if (payload.contains(QStringLiteral("properties")))
+            object->mergeProperties(propertiesFromJson(payload.value(QStringLiteral("properties")).toObject()));
+
+        const int objectId = object->id();
+        group->addObject(std::move(object));
+        session.undoStack.append(serializeState(session));
+        session.redoStack.clear();
+        session.map = std::move(map);
+        changedEntities->append(changedEntity(QStringLiteral("object"), objectId, QStringLiteral("created")));
+        return true;
+    }
+
+    if (type == QStringLiteral("update_object") || type == QStringLiteral("move_object")) {
+        const int objectId = payload.value(QStringLiteral("objectId")).toInt();
+        auto *object = map->findObjectById(objectId);
+        if (!object) {
+            if (errorMessage)
+                *errorMessage = QStringLiteral("Unknown object id: %1").arg(objectId);
+            return false;
+        }
+
+        if (payload.contains(QStringLiteral("name")))
+            object->setName(payload.value(QStringLiteral("name")).toString());
+        if (payload.contains(QStringLiteral("className")))
+            object->setClassName(payload.value(QStringLiteral("className")).toString());
+        if (payload.contains(QStringLiteral("x")))
+            object->setX(payload.value(QStringLiteral("x")).toDouble());
+        if (payload.contains(QStringLiteral("y")))
+            object->setY(payload.value(QStringLiteral("y")).toDouble());
+        if (payload.contains(QStringLiteral("width")))
+            object->setWidth(payload.value(QStringLiteral("width")).toDouble());
+        if (payload.contains(QStringLiteral("height")))
+            object->setHeight(payload.value(QStringLiteral("height")).toDouble());
+        if (payload.contains(QStringLiteral("rotation")))
+            object->setRotation(payload.value(QStringLiteral("rotation")).toDouble());
+        if (payload.contains(QStringLiteral("visible")))
+            object->setVisible(payload.value(QStringLiteral("visible")).toBool());
+        if (payload.contains(QStringLiteral("properties")))
+            object->mergeProperties(propertiesFromJson(payload.value(QStringLiteral("properties")).toObject()));
+
+        session.undoStack.append(serializeState(session));
+        session.redoStack.clear();
+        session.map = std::move(map);
+        changedEntities->append(changedEntity(QStringLiteral("object"), objectId, QStringLiteral("updated")));
+        return true;
+    }
+
+    if (type == QStringLiteral("delete_object")) {
+        const int objectId = payload.value(QStringLiteral("objectId")).toInt();
+        auto *object = map->findObjectById(objectId);
+        if (!object || !object->objectGroup()) {
+            if (errorMessage)
+                *errorMessage = QStringLiteral("Unknown object id: %1").arg(objectId);
+            return false;
+        }
+
+        std::unique_ptr<Tiled::MapObject> removed(object);
+        object->objectGroup()->removeObject(object);
+        session.undoStack.append(serializeState(session));
+        session.redoStack.clear();
+        session.map = std::move(map);
+        changedEntities->append(changedEntity(QStringLiteral("object"), objectId, QStringLiteral("deleted")));
+        return true;
+    }
+
+    if (type == QStringLiteral("set_custom_properties")) {
+        const QString targetType = payload.value(QStringLiteral("targetType")).toString();
+        const auto properties = propertiesFromJson(payload.value(QStringLiteral("properties")).toObject());
+
+        if (targetType == QStringLiteral("map")) {
+            map->mergeProperties(properties);
+            session.undoStack.append(serializeState(session));
+            session.redoStack.clear();
+            session.map = std::move(map);
+            changedEntities->append(changedEntity(QStringLiteral("map"), 0, QStringLiteral("updated")));
+            return true;
+        }
+
+        if (targetType == QStringLiteral("layer")) {
+            const int layerId = payload.value(QStringLiteral("targetId")).toInt();
+            auto *layer = map->findLayerById(layerId);
+            if (!layer) {
+                if (errorMessage)
+                    *errorMessage = QStringLiteral("Unknown layer id: %1").arg(layerId);
+                return false;
+            }
+            layer->mergeProperties(properties);
+            session.undoStack.append(serializeState(session));
+            session.redoStack.clear();
+            session.map = std::move(map);
+            changedEntities->append(changedEntity(QStringLiteral("layer"), layerId, QStringLiteral("updated")));
+            return true;
+        }
+
+        if (targetType == QStringLiteral("object")) {
+            const int objectId = payload.value(QStringLiteral("targetId")).toInt();
+            auto *object = map->findObjectById(objectId);
+            if (!object) {
+                if (errorMessage)
+                    *errorMessage = QStringLiteral("Unknown object id: %1").arg(objectId);
+                return false;
+            }
+            object->mergeProperties(properties);
+            session.undoStack.append(serializeState(session));
+            session.redoStack.clear();
+            session.map = std::move(map);
+            changedEntities->append(changedEntity(QStringLiteral("object"), objectId, QStringLiteral("updated")));
+            return true;
+        }
+
+        if (errorMessage)
+            *errorMessage = QStringLiteral("Unsupported targetType: %1").arg(targetType);
+        return false;
+    }
+
+    if (errorMessage)
+        *errorMessage = QStringLiteral("Unsupported command: %1").arg(type);
+    return false;
+}
+
+CommandResult BridgeEngine::executeCommand(const QString &sessionId, const QJsonObject &command)
+{
+    auto *currentSession = session(sessionId);
+    if (!currentSession)
+        return commandFailure(nullptr, QStringLiteral("SESSION_NOT_FOUND"), QStringLiteral("Unknown session: %1").arg(sessionId));
+    if (!hasLoadedDocument(*currentSession))
+        return commandFailure(currentSession, QStringLiteral("DOCUMENT_NOT_OPEN"), QStringLiteral("No document is open for this session."));
+
+    QString errorMessage;
+    QJsonArray changedEntities;
+    const int revisionBefore = currentSession->revision;
+    if (!applyCommand(*currentSession, command, &errorMessage, &changedEntities))
+        return commandFailure(currentSession, QStringLiteral("COMMAND_ERROR"), errorMessage);
+
+    currentSession->revision += 1;
+    CommandResult result;
+    result.success = true;
+    result.revisionBefore = revisionBefore;
+    result.revisionAfter = currentSession->revision;
+    result.changedEntities = changedEntities;
+    result.undoDepth = currentSession->undoStack.size();
+    result.redoDepth = currentSession->redoStack.size();
+    return result;
+}
+
+ValidationResult BridgeEngine::validateDocument(const QString &sessionId) const
+{
+    const auto *currentSession = session(sessionId);
+    if (!currentSession)
+        return validationFailure(nullptr, QStringLiteral("SESSION_NOT_FOUND"), QStringLiteral("Unknown session: %1").arg(sessionId));
+    if (!hasLoadedDocument(*currentSession))
+        return validationFailure(currentSession, QStringLiteral("DOCUMENT_NOT_OPEN"), QStringLiteral("No document is open for this session."));
+
+    ValidationResult result;
+    result.success = true;
+    result.revision = currentSession->revision;
+
+    if (currentSession->kind == DocumentKind::Map) {
+        QSet<int> layerIds;
+        for (Tiled::Layer *layer : currentSession->map->layers()) {
+            if (layerIds.contains(layer->id())) {
+                result.diagnostics.append(QJsonObject{
+                    { QStringLiteral("severity"), QStringLiteral("error") },
+                    { QStringLiteral("code"), QStringLiteral("DUPLICATE_LAYER_ID") },
+                    { QStringLiteral("message"), QStringLiteral("Duplicate layer id: %1").arg(layer->id()) },
+                    { QStringLiteral("target"), QStringLiteral("layer:%1").arg(layer->id()) },
+                });
+            }
+            layerIds.insert(layer->id());
+        }
+
+        QSet<int> objectIds;
+        for (Tiled::Layer *layer : currentSession->map->layers()) {
+            if (auto *group = dynamic_cast<Tiled::ObjectGroup*>(layer)) {
+                for (Tiled::MapObject *object : group->objects()) {
+                    if (objectIds.contains(object->id())) {
+                        result.diagnostics.append(QJsonObject{
+                            { QStringLiteral("severity"), QStringLiteral("error") },
+                            { QStringLiteral("code"), QStringLiteral("DUPLICATE_OBJECT_ID") },
+                            { QStringLiteral("message"), QStringLiteral("Duplicate object id: %1").arg(object->id()) },
+                            { QStringLiteral("target"), QStringLiteral("object:%1").arg(object->id()) },
+                        });
+                    }
+                    objectIds.insert(object->id());
+                }
+            }
+        }
+
+        const QDir baseDir = QFileInfo(currentSession->path).dir();
+        for (const Tiled::SharedTileset &tileset : currentSession->map->tilesets()) {
+            if (!tileset->fileName().isEmpty() && !QFileInfo::exists(tileset->fileName())) {
+                result.diagnostics.append(QJsonObject{
+                    { QStringLiteral("severity"), QStringLiteral("error") },
+                    { QStringLiteral("code"), QStringLiteral("MISSING_TILESET") },
+                    { QStringLiteral("message"), QStringLiteral("Missing tileset file: %1").arg(tileset->fileName()) },
+                    { QStringLiteral("path"), tileset->fileName() },
+                });
+            }
+
+            if (!tileset->imageSource().isEmpty()) {
+                const QString imagePath = baseDir.absoluteFilePath(tileset->imageSource().toString());
+                if (!QFileInfo::exists(imagePath)) {
+                    result.diagnostics.append(QJsonObject{
+                        { QStringLiteral("severity"), QStringLiteral("warning") },
+                        { QStringLiteral("code"), QStringLiteral("MISSING_TILESET_IMAGE") },
+                        { QStringLiteral("message"), QStringLiteral("Missing tileset image: %1").arg(imagePath) },
+                        { QStringLiteral("path"), imagePath },
+                    });
+                }
+            }
+        }
+    } else if (!currentSession->tileset->imageSource().isEmpty()) {
+        const QDir baseDir = QFileInfo(currentSession->path).dir();
+        const QString imagePath = baseDir.absoluteFilePath(currentSession->tileset->imageSource().toString());
+        if (!QFileInfo::exists(imagePath)) {
+            result.diagnostics.append(QJsonObject{
+                { QStringLiteral("severity"), QStringLiteral("warning") },
+                { QStringLiteral("code"), QStringLiteral("MISSING_TILESET_IMAGE") },
+                { QStringLiteral("message"), QStringLiteral("Missing tileset image: %1").arg(imagePath) },
+                { QStringLiteral("path"), imagePath },
+            });
+        }
+    }
+
+    return result;
+}
+
+SaveResult BridgeEngine::saveDocument(const QString &sessionId)
+{
+    auto *currentSession = session(sessionId);
+    if (!currentSession)
+        return saveFailure(nullptr, QStringLiteral("SESSION_NOT_FOUND"), QStringLiteral("Unknown session: %1").arg(sessionId));
+    if (!hasLoadedDocument(*currentSession))
+        return saveFailure(currentSession, QStringLiteral("DOCUMENT_NOT_OPEN"), QStringLiteral("No document is open for this session."));
+
+    const auto validation = validateDocument(sessionId);
+    if (!validation.success)
+        return saveFailure(currentSession, validation.errorCode, validation.errorMessage);
+    for (const auto diagnosticValue : validation.diagnostics) {
+        if (diagnosticValue.toObject().value(QStringLiteral("severity")).toString() == QStringLiteral("error"))
+            return saveFailure(currentSession, QStringLiteral("SAVE_BLOCKED_BY_VALIDATION"), QStringLiteral("Document validation failed."));
+    }
+
+    QString errorMessage;
+    const QFileInfo fileInfo(currentSession->path);
+    const QString suffix = fileInfo.suffix().toLower();
+
+    bool saved = false;
+    if (currentSession->kind == DocumentKind::Map && suffix == QStringLiteral("tmx")) {
+        Tiled::MapWriter writer;
+        saved = writer.writeMap(currentSession->map.get(), currentSession->path);
+        if (!saved)
+            errorMessage = writer.errorString();
+    } else if (currentSession->kind == DocumentKind::Map && (suffix == QStringLiteral("tmj") || suffix == QStringLiteral("json"))) {
+        const auto serialized = serializeState(*currentSession);
+        saved = saveJsonVariant(serialized.variant, currentSession->path, &errorMessage);
+    } else if (currentSession->kind == DocumentKind::Tileset && (suffix == QStringLiteral("tsj") || suffix == QStringLiteral("json"))) {
+        const auto serialized = serializeState(*currentSession);
+        saved = saveJsonVariant(serialized.variant, currentSession->path, &errorMessage);
+    } else if (currentSession->kind == DocumentKind::Tileset && suffix == QStringLiteral("tsx")) {
+        Tiled::MapWriter writer;
+        saved = writer.writeTileset(*currentSession->tileset, currentSession->path);
+        if (!saved)
+            errorMessage = writer.errorString();
+    } else {
+        errorMessage = QStringLiteral("Unsupported save format for %1").arg(currentSession->path);
+    }
+
+    if (!saved)
+        return saveFailure(currentSession, QStringLiteral("SAVE_ERROR"), errorMessage);
+
+    SaveResult result;
+    result.success = true;
+    result.path = currentSession->path;
+    result.revision = currentSession->revision;
+    return result;
+}
+
+CommandResult BridgeEngine::undo(const QString &sessionId)
+{
+    auto *currentSession = session(sessionId);
+    if (!currentSession)
+        return commandFailure(nullptr, QStringLiteral("SESSION_NOT_FOUND"), QStringLiteral("Unknown session: %1").arg(sessionId));
+    if (!hasLoadedDocument(*currentSession))
+        return commandFailure(currentSession, QStringLiteral("DOCUMENT_NOT_OPEN"), QStringLiteral("No document is open for this session."));
+    if (currentSession->undoStack.isEmpty())
+        return commandFailure(currentSession, QStringLiteral("COMMAND_ERROR"), QStringLiteral("Undo stack is empty."));
+
+    const auto previous = currentSession->undoStack.takeLast();
+    currentSession->redoStack.append(serializeState(*currentSession));
+    QString errorMessage;
+    if (!restoreState(*currentSession, previous, &errorMessage))
+        return commandFailure(currentSession, QStringLiteral("ENGINE_ERROR"), errorMessage);
+
+    currentSession->revision = std::max(0, currentSession->revision - 1);
+
+    CommandResult result;
+    result.success = true;
+    result.revisionBefore = currentSession->revision + 1;
+    result.revisionAfter = currentSession->revision;
+    result.undoDepth = currentSession->undoStack.size();
+    result.redoDepth = currentSession->redoStack.size();
+    return result;
+}
+
+CommandResult BridgeEngine::redo(const QString &sessionId)
+{
+    auto *currentSession = session(sessionId);
+    if (!currentSession)
+        return commandFailure(nullptr, QStringLiteral("SESSION_NOT_FOUND"), QStringLiteral("Unknown session: %1").arg(sessionId));
+    if (!hasLoadedDocument(*currentSession))
+        return commandFailure(currentSession, QStringLiteral("DOCUMENT_NOT_OPEN"), QStringLiteral("No document is open for this session."));
+    if (currentSession->redoStack.isEmpty())
+        return commandFailure(currentSession, QStringLiteral("COMMAND_ERROR"), QStringLiteral("Redo stack is empty."));
+
+    const int revisionBefore = currentSession->revision;
+    const auto next = currentSession->redoStack.takeLast();
+    currentSession->undoStack.append(serializeState(*currentSession));
+    QString errorMessage;
+    if (!restoreState(*currentSession, next, &errorMessage))
+        return commandFailure(currentSession, QStringLiteral("ENGINE_ERROR"), errorMessage);
+
+    currentSession->revision += 1;
+
+    CommandResult result;
+    result.success = true;
+    result.revisionBefore = revisionBefore;
+    result.revisionAfter = currentSession->revision;
+    result.undoDepth = currentSession->undoStack.size();
+    result.redoDepth = currentSession->redoStack.size();
+    return result;
+}
+
+bool BridgeEngine::closeSession(const QString &sessionId)
+{
+    return mSessions.remove(sessionId) > 0;
+}
+
+} // namespace tiledagent

--- a/src/tiledagentbridge/bridgeengine.h
+++ b/src/tiledagentbridge/bridgeengine.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QHash>
+#include <QSharedPointer>
+#include <QString>
+#include <QVariant>
+#include <QVector>
+
+#include <memory>
+
+namespace Tiled {
+class Map;
+class Tileset;
+using SharedTileset = QSharedPointer<Tileset>;
+}
+
+namespace tiledagent {
+
+struct SnapshotResult {
+    bool success = false;
+    QString errorCode;
+    QString errorMessage;
+    QString documentType;
+    int revision = -1;
+    QJsonObject snapshot;
+};
+
+struct CommandResult {
+    bool success = false;
+    QString errorCode;
+    QString errorMessage;
+    int revisionBefore = -1;
+    int revisionAfter = -1;
+    QJsonArray changedEntities;
+    QJsonArray warnings;
+    QJsonArray errors;
+    int undoDepth = 0;
+    int redoDepth = 0;
+};
+
+struct ValidationResult {
+    bool success = false;
+    QString errorCode;
+    QString errorMessage;
+    int revision = -1;
+    QJsonArray diagnostics;
+};
+
+struct SaveResult {
+    bool success = false;
+    QString errorCode;
+    QString errorMessage;
+    QString path;
+    int revision = -1;
+};
+
+class BridgeEngine
+{
+public:
+    BridgeEngine();
+
+    SnapshotResult openDocument(const QString &sessionId, const QString &documentPath);
+    SnapshotResult getSnapshot(const QString &sessionId) const;
+    CommandResult executeCommand(const QString &sessionId, const QJsonObject &command);
+    ValidationResult validateDocument(const QString &sessionId) const;
+    SaveResult saveDocument(const QString &sessionId);
+    CommandResult undo(const QString &sessionId);
+    CommandResult redo(const QString &sessionId);
+    bool closeSession(const QString &sessionId);
+
+private:
+    enum class DocumentKind {
+        Map,
+        Tileset,
+    };
+
+    struct SerializedState {
+        DocumentKind kind;
+        QVariant variant;
+    };
+
+    struct SessionState {
+        QString path;
+        DocumentKind kind = DocumentKind::Map;
+        std::unique_ptr<Tiled::Map> map;
+        Tiled::SharedTileset tileset;
+        int revision = 0;
+        QVector<SerializedState> undoStack;
+        QVector<SerializedState> redoStack;
+    };
+
+    SessionState *session(const QString &sessionId);
+    const SessionState *session(const QString &sessionId) const;
+
+    SerializedState serializeState(const SessionState &session) const;
+    bool restoreState(SessionState &session, const SerializedState &state, QString *errorMessage) const;
+    static bool hasLoadedDocument(const SessionState &session);
+
+    SnapshotResult snapshotResultFromSession(const SessionState &session) const;
+    CommandResult commandFailure(const SessionState *session, const QString &code, const QString &message) const;
+    ValidationResult validationFailure(const SessionState *session, const QString &code, const QString &message) const;
+    SaveResult saveFailure(const SessionState *session, const QString &code, const QString &message) const;
+
+    bool applyCommand(SessionState &session, const QJsonObject &command, QString *errorMessage, QJsonArray *changedEntities) const;
+
+    QHash<QString, std::shared_ptr<SessionState>> mSessions;
+};
+
+} // namespace tiledagent

--- a/src/tiledagentbridge/jsonrpcserver.cpp
+++ b/src/tiledagentbridge/jsonrpcserver.cpp
@@ -1,0 +1,165 @@
+#include "jsonrpcserver.h"
+
+#include <QJsonDocument>
+
+namespace tiledagent {
+
+JsonRpcServer::JsonRpcServer(BridgeEngine &engine, QTextStream *input, QTextStream *output)
+    : mEngine(engine)
+    , mInput(input)
+    , mOutput(output)
+{
+}
+
+QJsonObject JsonRpcServer::makeErrorResponse(const QJsonValue &id, const QString &code, const QString &message) const
+{
+    return QJsonObject{
+        { QStringLiteral("jsonrpc"), QStringLiteral("2.0") },
+        { QStringLiteral("id"), id },
+        { QStringLiteral("error"), QJsonObject{
+            { QStringLiteral("code"), code },
+            { QStringLiteral("message"), message },
+        } }
+    };
+}
+
+QJsonObject JsonRpcServer::makeSuccessResponse(const QJsonValue &id, const QJsonObject &result) const
+{
+    return QJsonObject{
+        { QStringLiteral("jsonrpc"), QStringLiteral("2.0") },
+        { QStringLiteral("id"), id },
+        { QStringLiteral("result"), result }
+    };
+}
+
+QJsonObject JsonRpcServer::dispatch(const QJsonObject &request)
+{
+    const QJsonValue id = request.value(QStringLiteral("id"));
+    const QString method = request.value(QStringLiteral("method")).toString();
+    const auto params = request.value(QStringLiteral("params")).toObject();
+    const QString sessionId = params.value(QStringLiteral("sessionId")).toString();
+
+    if (method == QStringLiteral("openDocument")) {
+        const auto result = mEngine.openDocument(sessionId, params.value(QStringLiteral("documentPath")).toString());
+        if (!result.success)
+            return makeErrorResponse(id, result.errorCode, result.errorMessage);
+        return makeSuccessResponse(id, QJsonObject{
+            { QStringLiteral("documentType"), result.documentType },
+            { QStringLiteral("revision"), result.revision },
+            { QStringLiteral("snapshot"), result.snapshot },
+        });
+    }
+
+    if (method == QStringLiteral("getSnapshot")) {
+        const auto result = mEngine.getSnapshot(sessionId);
+        if (!result.success)
+            return makeErrorResponse(id, result.errorCode, result.errorMessage);
+        return makeSuccessResponse(id, QJsonObject{
+            { QStringLiteral("documentType"), result.documentType },
+            { QStringLiteral("revision"), result.revision },
+            { QStringLiteral("snapshot"), result.snapshot },
+        });
+    }
+
+    if (method == QStringLiteral("executeCommand")) {
+        const auto result = mEngine.executeCommand(sessionId, params.value(QStringLiteral("command")).toObject());
+        if (!result.success)
+            return makeErrorResponse(id, result.errorCode, result.errorMessage);
+        return makeSuccessResponse(id, QJsonObject{
+            { QStringLiteral("revisionBefore"), result.revisionBefore },
+            { QStringLiteral("revisionAfter"), result.revisionAfter },
+            { QStringLiteral("changedEntities"), result.changedEntities },
+            { QStringLiteral("warnings"), result.warnings },
+            { QStringLiteral("errors"), result.errors },
+            { QStringLiteral("undoDepth"), result.undoDepth },
+            { QStringLiteral("redoDepth"), result.redoDepth },
+        });
+    }
+
+    if (method == QStringLiteral("validateDocument")) {
+        const auto result = mEngine.validateDocument(sessionId);
+        if (!result.success)
+            return makeErrorResponse(id, result.errorCode, result.errorMessage);
+        return makeSuccessResponse(id, QJsonObject{
+            { QStringLiteral("revision"), result.revision },
+            { QStringLiteral("diagnostics"), result.diagnostics },
+        });
+    }
+
+    if (method == QStringLiteral("saveDocument")) {
+        const auto result = mEngine.saveDocument(sessionId);
+        if (!result.success)
+            return makeErrorResponse(id, result.errorCode, result.errorMessage);
+        return makeSuccessResponse(id, QJsonObject{
+            { QStringLiteral("path"), result.path },
+            { QStringLiteral("revision"), result.revision },
+        });
+    }
+
+    if (method == QStringLiteral("undo")) {
+        const auto result = mEngine.undo(sessionId);
+        if (!result.success)
+            return makeErrorResponse(id, result.errorCode, result.errorMessage);
+        return makeSuccessResponse(id, QJsonObject{
+            { QStringLiteral("revisionBefore"), result.revisionBefore },
+            { QStringLiteral("revisionAfter"), result.revisionAfter },
+            { QStringLiteral("changedEntities"), result.changedEntities },
+            { QStringLiteral("warnings"), result.warnings },
+            { QStringLiteral("errors"), result.errors },
+            { QStringLiteral("undoDepth"), result.undoDepth },
+            { QStringLiteral("redoDepth"), result.redoDepth },
+        });
+    }
+
+    if (method == QStringLiteral("redo")) {
+        const auto result = mEngine.redo(sessionId);
+        if (!result.success)
+            return makeErrorResponse(id, result.errorCode, result.errorMessage);
+        return makeSuccessResponse(id, QJsonObject{
+            { QStringLiteral("revisionBefore"), result.revisionBefore },
+            { QStringLiteral("revisionAfter"), result.revisionAfter },
+            { QStringLiteral("changedEntities"), result.changedEntities },
+            { QStringLiteral("warnings"), result.warnings },
+            { QStringLiteral("errors"), result.errors },
+            { QStringLiteral("undoDepth"), result.undoDepth },
+            { QStringLiteral("redoDepth"), result.redoDepth },
+        });
+    }
+
+    if (method == QStringLiteral("closeSession")) {
+        return makeSuccessResponse(id, QJsonObject{
+            { QStringLiteral("closed"), mEngine.closeSession(sessionId) },
+        });
+    }
+
+    return makeErrorResponse(id, QStringLiteral("METHOD_NOT_FOUND"), QStringLiteral("Unknown method: %1").arg(method));
+}
+
+int JsonRpcServer::run()
+{
+    QTextStream stdIn(stdin);
+    QTextStream stdOut(stdout);
+    QTextStream &input = mInput ? *mInput : stdIn;
+    QTextStream &output = mOutput ? *mOutput : stdOut;
+
+    while (!input.atEnd()) {
+        const QString line = input.readLine().trimmed();
+        if (line.isEmpty())
+            continue;
+
+        QJsonParseError parseError;
+        const auto document = QJsonDocument::fromJson(line.toUtf8(), &parseError);
+        if (parseError.error != QJsonParseError::NoError) {
+            output << QJsonDocument(makeErrorResponse(QJsonValue(), QStringLiteral("PARSE_ERROR"), parseError.errorString())).toJson(QJsonDocument::Compact) << '\n';
+            output.flush();
+            continue;
+        }
+
+        output << QJsonDocument(dispatch(document.object())).toJson(QJsonDocument::Compact) << '\n';
+        output.flush();
+    }
+
+    return 0;
+}
+
+} // namespace tiledagent

--- a/src/tiledagentbridge/jsonrpcserver.h
+++ b/src/tiledagentbridge/jsonrpcserver.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "bridgeengine.h"
+
+#include <QTextStream>
+
+namespace tiledagent {
+
+class JsonRpcServer
+{
+public:
+    explicit JsonRpcServer(BridgeEngine &engine, QTextStream *input = nullptr, QTextStream *output = nullptr);
+
+    int run();
+
+private:
+    QJsonObject dispatch(const QJsonObject &request);
+    QJsonObject makeErrorResponse(const QJsonValue &id, const QString &code, const QString &message) const;
+    QJsonObject makeSuccessResponse(const QJsonValue &id, const QJsonObject &result) const;
+
+    BridgeEngine &mEngine;
+    QTextStream *mInput;
+    QTextStream *mOutput;
+};
+
+} // namespace tiledagent

--- a/src/tiledagentbridge/test_bridgeengine.cpp
+++ b/src/tiledagentbridge/test_bridgeengine.cpp
@@ -1,0 +1,98 @@
+#include "bridgeengine.h"
+
+#include <QtTest/QtTest>
+
+class BridgeEngineTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void opensMapAndReturnsSnapshot();
+    void appliesCommandsAndSupportsUndoRedo();
+};
+
+void BridgeEngineTest::opensMapAndReturnsSnapshot()
+{
+    tiledagent::BridgeEngine engine;
+
+    const QString path = QStringLiteral(TEST_SOURCE_ROOT) + QStringLiteral("/tests/data/mapobject.tmx");
+    const auto result = engine.openDocument(QStringLiteral("session-1"), path);
+
+    QVERIFY2(result.success, qPrintable(result.errorMessage));
+    QCOMPARE(result.documentType, QStringLiteral("map"));
+    QCOMPARE(result.revision, 0);
+    QCOMPARE(result.snapshot.value(QStringLiteral("documentType")).toString(), QStringLiteral("map"));
+
+    const auto map = result.snapshot.value(QStringLiteral("map")).toObject();
+    QCOMPARE(map.value(QStringLiteral("width")).toInt(), 100);
+    QCOMPARE(map.value(QStringLiteral("height")).toInt(), 80);
+}
+
+void BridgeEngineTest::appliesCommandsAndSupportsUndoRedo()
+{
+    tiledagent::BridgeEngine engine;
+    const QString sessionId = QStringLiteral("session-2");
+    const QString path = QStringLiteral(TEST_SOURCE_ROOT) + QStringLiteral("/tests/automapping/simple-2x2-rule/map.tmx");
+
+    const auto openResult = engine.openDocument(sessionId, path);
+    QVERIFY2(openResult.success, qPrintable(openResult.errorMessage));
+
+    const auto layerResult = engine.executeCommand(sessionId, QJsonObject{
+        { QStringLiteral("type"), QStringLiteral("create_layer") },
+        { QStringLiteral("payload"), QJsonObject{
+            { QStringLiteral("layerType"), QStringLiteral("object") },
+            { QStringLiteral("name"), QStringLiteral("Objects") },
+        } }
+    });
+    QVERIFY2(layerResult.success, qPrintable(layerResult.errorMessage));
+    QCOMPARE(layerResult.revisionAfter, 1);
+
+    const auto objectResult = engine.executeCommand(sessionId, QJsonObject{
+        { QStringLiteral("type"), QStringLiteral("create_object") },
+        { QStringLiteral("payload"), QJsonObject{
+            { QStringLiteral("layerId"), 6 },
+            { QStringLiteral("name"), QStringLiteral("Spawn") },
+            { QStringLiteral("className"), QStringLiteral("spawn") },
+            { QStringLiteral("x"), 32.0 },
+            { QStringLiteral("y"), 48.0 },
+            { QStringLiteral("width"), 16.0 },
+            { QStringLiteral("height"), 16.0 },
+        } }
+    });
+    QVERIFY2(objectResult.success, qPrintable(objectResult.errorMessage));
+    QCOMPARE(objectResult.revisionAfter, 2);
+
+    const auto paintResult = engine.executeCommand(sessionId, QJsonObject{
+        { QStringLiteral("type"), QStringLiteral("paint_tiles") },
+        { QStringLiteral("payload"), QJsonObject{
+            { QStringLiteral("layerId"), 1 },
+            { QStringLiteral("cells"), QJsonArray{
+                QJsonObject{
+                    { QStringLiteral("x"), 0 },
+                    { QStringLiteral("y"), 0 },
+                    { QStringLiteral("gid"), 1 },
+                }
+            } }
+        } }
+    });
+    QVERIFY2(paintResult.success, qPrintable(paintResult.errorMessage));
+    QCOMPARE(paintResult.revisionAfter, 3);
+
+    const auto undoResult = engine.undo(sessionId);
+    QVERIFY2(undoResult.success, qPrintable(undoResult.errorMessage));
+    QCOMPARE(undoResult.revisionAfter, 2);
+
+    const auto redoResult = engine.redo(sessionId);
+    QVERIFY2(redoResult.success, qPrintable(redoResult.errorMessage));
+    QCOMPARE(redoResult.revisionAfter, 3);
+
+    const auto snapshot = engine.getSnapshot(sessionId);
+    QVERIFY2(snapshot.success, qPrintable(snapshot.errorMessage));
+    const auto map = snapshot.snapshot.value(QStringLiteral("map")).toObject();
+    const auto layers = map.value(QStringLiteral("layers")).toArray();
+
+    QCOMPARE(layers.size(), 2);
+}
+
+QTEST_MAIN(BridgeEngineTest)
+#include "test_bridgeengine.moc"

--- a/tools/tiled-agent-orchestrator/package-lock.json
+++ b/tools/tiled-agent-orchestrator/package-lock.json
@@ -1,0 +1,2771 @@
+{
+  "name": "tiled-agent-orchestrator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tiled-agent-orchestrator",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.18.1",
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^24.9.2",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.7.tgz",
+      "integrity": "sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/tools/tiled-agent-orchestrator/package.json
+++ b/tools/tiled-agent-orchestrator/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "tiled-agent-orchestrator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx src/index.ts",
+    "mcp": "tsx src/mcp.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.18.1",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.2",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/tools/tiled-agent-orchestrator/public/index.html
+++ b/tools/tiled-agent-orchestrator/public/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tiled Agent Debug</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        background: #101318;
+        color: #f3f5f7;
+      }
+
+      body {
+        margin: 0;
+        padding: 2rem;
+        background:
+          radial-gradient(circle at top left, rgba(92, 225, 230, 0.2), transparent 30%),
+          radial-gradient(circle at top right, rgba(255, 180, 0, 0.18), transparent 28%),
+          #101318;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+      }
+
+      h1 {
+        margin-top: 0;
+        font-size: 2rem;
+      }
+
+      .panel {
+        padding: 1rem 1.25rem;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        border-radius: 14px;
+        background: rgba(17, 24, 39, 0.72);
+        backdrop-filter: blur(10px);
+      }
+
+      code {
+        color: #8ee8ff;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Tiled Agent Debug</h1>
+      <div class="panel">
+        <p>HTTP API and session state will appear here once the orchestrator starts with a live bridge process.</p>
+        <p>Use <code>POST /workspaces</code>, <code>POST /sessions</code>, and <code>GET /sessions/:id/snapshot</code> to drive the backend.</p>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tools/tiled-agent-orchestrator/src/contracts.ts
+++ b/tools/tiled-agent-orchestrator/src/contracts.ts
@@ -1,0 +1,138 @@
+export type DocumentType = "map" | "tileset";
+
+export interface ChangedEntity {
+  entityType: "layer" | "object" | "map" | "tileset" | "property";
+  entityId: string | number;
+  changeType: "created" | "updated" | "deleted" | "moved";
+}
+
+export interface TileCellSummary {
+  x: number;
+  y: number;
+  gid: number;
+}
+
+export interface LayerSummary {
+  id: number;
+  name: string;
+  type: "tilelayer" | "objectgroup" | "imagelayer" | "grouplayer";
+  visible: boolean;
+  opacity: number;
+  x: number;
+  y: number;
+  properties: Record<string, unknown>;
+  cells?: TileCellSummary[];
+  objects?: ObjectSummary[];
+}
+
+export interface ObjectSummary {
+  id: number;
+  name: string;
+  className: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+  visible: boolean;
+  shape: string;
+  properties: Record<string, unknown>;
+}
+
+export interface TilesetSummary {
+  firstGid?: number;
+  name: string;
+  tileWidth: number;
+  tileHeight: number;
+  tileCount: number;
+  columns: number;
+  source?: string;
+  image?: string;
+}
+
+export interface MapSnapshot {
+  width: number;
+  height: number;
+  tileWidth: number;
+  tileHeight: number;
+  orientation: string;
+  infinite: boolean;
+  tilesets: TilesetSummary[];
+  layers: LayerSummary[];
+}
+
+export interface StandaloneTilesetSnapshot {
+  name: string;
+  tileWidth: number;
+  tileHeight: number;
+  tileCount: number;
+  columns: number;
+  image?: string;
+  source?: string;
+}
+
+export type DocumentSnapshot =
+  | {
+      documentType: "map";
+      map: MapSnapshot;
+    }
+  | {
+      documentType: "tileset";
+      tileset: StandaloneTilesetSnapshot;
+    };
+
+export interface OpenDocumentResult {
+  documentType: DocumentType;
+  revision: number;
+  snapshot: DocumentSnapshot;
+}
+
+export interface BridgeCommandRequest {
+  type:
+    | "create_layer"
+    | "delete_layer"
+    | "move_layer"
+    | "set_layer_properties"
+    | "paint_tiles"
+    | "erase_tiles"
+    | "create_object"
+    | "update_object"
+    | "delete_object"
+    | "move_object"
+    | "set_custom_properties";
+  payload: Record<string, unknown>;
+}
+
+export interface BridgeCommandResult {
+  revisionBefore: number;
+  revisionAfter: number;
+  changedEntities: ChangedEntity[];
+  warnings: string[];
+  errors: string[];
+  undoDepth: number;
+  redoDepth: number;
+}
+
+export interface ValidationDiagnostic {
+  severity: "warning" | "error";
+  code: string;
+  message: string;
+  path?: string;
+  target?: string;
+}
+
+export interface ValidationReport {
+  revision: number;
+  diagnostics: ValidationDiagnostic[];
+}
+
+export interface BridgeClient {
+  openDocument(sessionId: string, documentPath: string): Promise<OpenDocumentResult>;
+  getSnapshot(sessionId: string): Promise<DocumentSnapshot>;
+  executeCommand(sessionId: string, command: BridgeCommandRequest): Promise<BridgeCommandResult>;
+  validateDocument(sessionId: string): Promise<ValidationReport>;
+  saveDocument(sessionId: string): Promise<{ path: string; revision: number }>;
+  undo(sessionId: string): Promise<BridgeCommandResult>;
+  redo(sessionId: string): Promise<BridgeCommandResult>;
+  closeSession(sessionId: string): Promise<void>;
+}

--- a/tools/tiled-agent-orchestrator/src/http-server.ts
+++ b/tools/tiled-agent-orchestrator/src/http-server.ts
@@ -1,0 +1,215 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  SessionManager,
+  SessionNotFoundError,
+  WorkspaceNotFoundError,
+  WorkspacePathError,
+} from "./session-manager.js";
+
+interface CreateAgentServerOptions {
+  sessionManager: SessionManager;
+  port: number;
+}
+
+interface StartedAgentServer {
+  baseUrl: string;
+  close: () => Promise<void>;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const debugPagePath = path.resolve(__dirname, "../public/index.html");
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.from(chunk));
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function sendJson(response: ServerResponse, statusCode: number, body: unknown): void {
+  response.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+  });
+  response.end(JSON.stringify(body));
+}
+
+async function sendDebugPage(response: ServerResponse): Promise<void> {
+  const contents = await readFile(debugPagePath, "utf8");
+  response.writeHead(200, {
+    "content-type": "text/html; charset=utf-8",
+  });
+  response.end(contents);
+}
+
+function mapError(error: unknown): { statusCode: number; body: { error: { code: string; message: string } } } {
+  if (error instanceof WorkspacePathError) {
+    return {
+      statusCode: 400,
+      body: {
+        error: {
+          code: "WORKSPACE_PATH_ERROR",
+          message: error.message,
+        },
+      },
+    };
+  }
+
+  if (error instanceof WorkspaceNotFoundError || error instanceof SessionNotFoundError) {
+    return {
+      statusCode: 404,
+      body: {
+        error: {
+          code: error.name,
+          message: error.message,
+        },
+      },
+    };
+  }
+
+  return {
+    statusCode: 500,
+    body: {
+      error: {
+        code: "INTERNAL_ERROR",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+    },
+  };
+}
+
+async function routeRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  sessionManager: SessionManager,
+): Promise<void> {
+  const requestUrl = new URL(request.url ?? "/", "http://localhost");
+  const pathname = requestUrl.pathname;
+
+  if (request.method === "GET" && pathname === "/") {
+    await sendDebugPage(response);
+    return;
+  }
+
+  if (request.method === "POST" && pathname === "/workspaces") {
+    const payload = (await readJsonBody(request)) as { rootPath: string };
+    const workspace = sessionManager.createWorkspace(payload.rootPath);
+    sendJson(response, 201, { workspace });
+    return;
+  }
+
+  if (request.method === "POST" && pathname === "/sessions") {
+    const payload = (await readJsonBody(request)) as { workspaceId: string };
+    const session = sessionManager.createSession(payload.workspaceId);
+    sendJson(response, 201, { session });
+    return;
+  }
+
+  const openMatch = pathname.match(/^\/sessions\/([^/]+)\/documents\/open$/);
+  if (request.method === "POST" && openMatch) {
+    const payload = (await readJsonBody(request)) as { documentPath: string };
+    const result = await sessionManager.openDocument(openMatch[1], payload.documentPath);
+    sendJson(response, 200, result);
+    return;
+  }
+
+  const snapshotMatch = pathname.match(/^\/sessions\/([^/]+)\/snapshot$/);
+  if (request.method === "GET" && snapshotMatch) {
+    const snapshot = await sessionManager.getSnapshot(snapshotMatch[1]);
+    sendJson(response, 200, { snapshot });
+    return;
+  }
+
+  const commandMatch = pathname.match(/^\/sessions\/([^/]+)\/commands$/);
+  if (request.method === "POST" && commandMatch) {
+    const payload = await readJsonBody(request);
+    const result = await sessionManager.executeCommand(commandMatch[1], payload as any);
+    sendJson(response, 200, result);
+    return;
+  }
+
+  const validateMatch = pathname.match(/^\/sessions\/([^/]+)\/validate$/);
+  if (request.method === "POST" && validateMatch) {
+    const report = await sessionManager.validateDocument(validateMatch[1]);
+    sendJson(response, 200, report);
+    return;
+  }
+
+  const saveMatch = pathname.match(/^\/sessions\/([^/]+)\/save$/);
+  if (request.method === "POST" && saveMatch) {
+    const result = await sessionManager.saveDocument(saveMatch[1]);
+    sendJson(response, 200, result);
+    return;
+  }
+
+  const undoMatch = pathname.match(/^\/sessions\/([^/]+)\/undo$/);
+  if (request.method === "POST" && undoMatch) {
+    const result = await sessionManager.undo(undoMatch[1]);
+    sendJson(response, 200, result);
+    return;
+  }
+
+  const redoMatch = pathname.match(/^\/sessions\/([^/]+)\/redo$/);
+  if (request.method === "POST" && redoMatch) {
+    const result = await sessionManager.redo(redoMatch[1]);
+    sendJson(response, 200, result);
+    return;
+  }
+
+  sendJson(response, 404, {
+    error: {
+      code: "NOT_FOUND",
+      message: `Unknown route: ${request.method} ${pathname}`,
+    },
+  });
+}
+
+export async function createAgentServer(options: CreateAgentServerOptions): Promise<StartedAgentServer> {
+  const server = createServer(async (request, response) => {
+    try {
+      await routeRequest(request, response, options.sessionManager);
+    } catch (error) {
+      const mapped = mapError(error);
+      sendJson(response, mapped.statusCode, mapped.body);
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to determine listening address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () =>
+      await new Promise<void>((resolve, reject) => {
+        server.close((error?: Error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+  };
+}
+
+export type { Server };

--- a/tools/tiled-agent-orchestrator/src/index.ts
+++ b/tools/tiled-agent-orchestrator/src/index.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+
+import { createAgentServer } from "./http-server.js";
+import { ProcessBridgeClient } from "./process-bridge-client.js";
+import { SessionManager } from "./session-manager.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const bridgeBinaryPath =
+  process.env.TILED_AGENT_BRIDGE_BINARY ??
+  path.join(repoRoot, "build", "tiledagentbridge", "tiledagentbridge");
+const port = Number(process.env.TILED_AGENT_PORT ?? "3017");
+
+const bridgeClient = new ProcessBridgeClient({
+  binaryPath: bridgeBinaryPath,
+});
+const sessionManager = new SessionManager(bridgeClient);
+const server = await createAgentServer({
+  sessionManager,
+  port,
+});
+
+const shutdown = async () => {
+  await server.close();
+  await bridgeClient.dispose();
+};
+
+process.on("SIGINT", async () => {
+  await shutdown();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  await shutdown();
+  process.exit(0);
+});
+
+console.error(`Tiled Agent orchestrator listening on ${server.baseUrl}`);

--- a/tools/tiled-agent-orchestrator/src/mcp.ts
+++ b/tools/tiled-agent-orchestrator/src/mcp.ts
@@ -1,0 +1,230 @@
+import path from "node:path";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import * as z from "zod/v4";
+
+import type { BridgeCommandRequest } from "./contracts.js";
+import { ProcessBridgeClient } from "./process-bridge-client.js";
+import { SessionManager } from "./session-manager.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const bridgeBinaryPath =
+  process.env.TILED_AGENT_BRIDGE_BINARY ??
+  path.join(repoRoot, "build", "tiledagentbridge", "tiledagentbridge");
+
+const bridgeClient = new ProcessBridgeClient({
+  binaryPath: bridgeBinaryPath,
+});
+const sessionManager = new SessionManager(bridgeClient);
+
+const toStructuredContent = (value: unknown): Record<string, unknown> =>
+  JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+
+const server = new McpServer({
+  name: "tiled-agent",
+  version: "0.1.0",
+});
+
+server.registerTool(
+  "tiled_open_document",
+  {
+    description: "Create a workspace/session and open a Tiled map or tileset document.",
+    inputSchema: {
+      rootPath: z.string(),
+      documentPath: z.string(),
+    },
+  },
+  async ({ rootPath, documentPath }) => {
+    const workspace = sessionManager.createWorkspace(rootPath);
+    const session = sessionManager.createSession(workspace.id);
+    const opened = await sessionManager.openDocument(session.id, documentPath);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              workspace,
+              session,
+              opened,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+      structuredContent: {
+        workspace,
+        session,
+        opened,
+      } satisfies Record<string, unknown>,
+    };
+  },
+);
+
+server.registerTool(
+  "tiled_get_snapshot",
+  {
+    description: "Fetch the current normalized snapshot for a session.",
+    inputSchema: {
+      sessionId: z.string(),
+    },
+  },
+  async ({ sessionId }) => {
+    const snapshot = await sessionManager.getSnapshot(sessionId);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(snapshot, null, 2),
+        },
+      ],
+      structuredContent: toStructuredContent(snapshot),
+    };
+  },
+);
+
+server.registerTool(
+  "tiled_execute_command",
+  {
+    description: "Execute a typed editing command against the current session.",
+    inputSchema: {
+      sessionId: z.string(),
+      type: z.string(),
+      payload: z.record(z.string(), z.any()),
+    },
+  },
+  async ({ sessionId, type, payload }) => {
+    const result = await sessionManager.executeCommand(sessionId, {
+      type,
+      payload,
+    } as BridgeCommandRequest);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+      structuredContent: toStructuredContent(result),
+    };
+  },
+);
+
+server.registerTool(
+  "tiled_validate",
+  {
+    description: "Validate the currently open document and return diagnostics.",
+    inputSchema: {
+      sessionId: z.string(),
+    },
+  },
+  async ({ sessionId }) => {
+    const report = await sessionManager.validateDocument(sessionId);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(report, null, 2),
+        },
+      ],
+      structuredContent: toStructuredContent(report),
+    };
+  },
+);
+
+server.registerTool(
+  "tiled_save",
+  {
+    description: "Persist the current session document to disk using its original path.",
+    inputSchema: {
+      sessionId: z.string(),
+    },
+  },
+  async ({ sessionId }) => {
+    const saved = await sessionManager.saveDocument(sessionId);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(saved, null, 2),
+        },
+      ],
+      structuredContent: toStructuredContent(saved),
+    };
+  },
+);
+
+server.registerTool(
+  "tiled_undo",
+  {
+    description: "Undo the last bridge command in the session.",
+    inputSchema: {
+      sessionId: z.string(),
+    },
+  },
+  async ({ sessionId }) => {
+    const result = await sessionManager.undo(sessionId);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+      structuredContent: toStructuredContent(result),
+    };
+  },
+);
+
+server.registerTool(
+  "tiled_redo",
+  {
+    description: "Redo the last undone bridge command in the session.",
+    inputSchema: {
+      sessionId: z.string(),
+    },
+  },
+  async ({ sessionId }) => {
+    const result = await sessionManager.redo(sessionId);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+      structuredContent: toStructuredContent(result),
+    };
+  },
+);
+
+server.registerTool(
+  "tiled_close_session",
+  {
+    description: "Close a bridge-backed editing session.",
+    inputSchema: {
+      sessionId: z.string(),
+    },
+  },
+  async ({ sessionId }) => {
+    await sessionManager.closeSession(sessionId);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Closed session ${sessionId}`,
+        },
+      ],
+      structuredContent: {
+        closed: true,
+        sessionId,
+      },
+    };
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/tools/tiled-agent-orchestrator/src/process-bridge-client.ts
+++ b/tools/tiled-agent-orchestrator/src/process-bridge-client.ts
@@ -1,0 +1,175 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import readline from "node:readline";
+
+import type {
+  BridgeClient,
+  BridgeCommandRequest,
+  BridgeCommandResult,
+  DocumentSnapshot,
+  OpenDocumentResult,
+  ValidationReport,
+} from "./contracts.js";
+
+interface ProcessBridgeClientOptions {
+  binaryPath: string;
+  args?: string[];
+  cwd?: string;
+}
+
+interface JsonRpcError {
+  code: string;
+  message: string;
+}
+
+interface PendingRequest {
+  resolve: (value: any) => void;
+  reject: (reason?: unknown) => void;
+}
+
+export class ProcessBridgeClient implements BridgeClient {
+  private readonly pendingRequests = new Map<number, PendingRequest>();
+  private nextId = 1;
+  private child?: ChildProcess;
+  private stdoutReader?: readline.Interface;
+
+  constructor(private readonly options: ProcessBridgeClientOptions) {
+    this.ensureStarted();
+  }
+
+  async openDocument(sessionId: string, documentPath: string): Promise<OpenDocumentResult> {
+    return await this.request("openDocument", { sessionId, documentPath });
+  }
+
+  async getSnapshot(sessionId: string): Promise<DocumentSnapshot> {
+    const result = await this.request<{
+      snapshot: DocumentSnapshot;
+    }>("getSnapshot", { sessionId });
+    return result.snapshot;
+  }
+
+  async executeCommand(sessionId: string, command: BridgeCommandRequest): Promise<BridgeCommandResult> {
+    return await this.request("executeCommand", { sessionId, command });
+  }
+
+  async validateDocument(sessionId: string): Promise<ValidationReport> {
+    return await this.request("validateDocument", { sessionId });
+  }
+
+  async saveDocument(sessionId: string): Promise<{ path: string; revision: number }> {
+    return await this.request("saveDocument", { sessionId });
+  }
+
+  async undo(sessionId: string): Promise<BridgeCommandResult> {
+    return await this.request("undo", { sessionId });
+  }
+
+  async redo(sessionId: string): Promise<BridgeCommandResult> {
+    return await this.request("redo", { sessionId });
+  }
+
+  async closeSession(sessionId: string): Promise<void> {
+    await this.request("closeSession", { sessionId });
+  }
+
+  async dispose(): Promise<void> {
+    if (!this.child) {
+      return;
+    }
+
+    this.stdoutReader?.close();
+    this.stdoutReader = undefined;
+
+    const child = this.child;
+    this.child = undefined;
+
+    await new Promise<void>((resolve) => {
+      child.once("exit", () => resolve());
+      child.kill();
+    });
+  }
+
+  private ensureStarted(): void {
+    if (this.child) {
+      return;
+    }
+
+    const child = spawn(this.options.binaryPath, this.options.args ?? [], {
+      cwd: this.options.cwd,
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+    this.child = child;
+
+    child.on("exit", (code, signal) => {
+      const message = signal
+        ? `Bridge exited with signal ${signal}`
+        : `Bridge exited with code ${code ?? 0}`;
+
+      for (const pending of this.pendingRequests.values()) {
+        pending.reject(new Error(message));
+      }
+      this.pendingRequests.clear();
+      this.child = undefined;
+      this.stdoutReader = undefined;
+    });
+
+    if (!child.stdout) {
+      throw new Error("Bridge stdout is not available");
+    }
+
+    this.stdoutReader = readline.createInterface({
+      input: child.stdout,
+    });
+
+    this.stdoutReader.on("line", (line) => {
+      const parsed = JSON.parse(line) as {
+        id: number;
+        result?: unknown;
+        error?: JsonRpcError;
+      };
+
+      const pending = this.pendingRequests.get(parsed.id);
+      if (!pending) {
+        return;
+      }
+
+      this.pendingRequests.delete(parsed.id);
+      if (parsed.error) {
+        pending.reject(new Error(`${parsed.error.code}: ${parsed.error.message}`));
+        return;
+      }
+
+      pending.resolve(parsed.result);
+    });
+  }
+
+  private async request<TResult>(method: string, params: Record<string, unknown>): Promise<TResult> {
+    this.ensureStarted();
+    if (!this.child) {
+      throw new Error("Bridge process is not available");
+    }
+    const stdin = this.child.stdin;
+    if (!stdin) {
+      throw new Error("Bridge stdin is not available");
+    }
+
+    const id = this.nextId++;
+    const payload = JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method,
+      params,
+    });
+
+    const result = await new Promise<TResult>((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject });
+      stdin.write(`${payload}\n`, "utf8", (error) => {
+        if (error) {
+          this.pendingRequests.delete(id);
+          reject(error);
+        }
+      });
+    });
+
+    return result;
+  }
+}

--- a/tools/tiled-agent-orchestrator/src/session-manager.ts
+++ b/tools/tiled-agent-orchestrator/src/session-manager.ts
@@ -1,0 +1,166 @@
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import type {
+  BridgeClient,
+  BridgeCommandRequest,
+  BridgeCommandResult,
+  DocumentSnapshot,
+  OpenDocumentResult,
+  ValidationReport,
+} from "./contracts.js";
+
+export class SessionNotFoundError extends Error {
+  constructor(sessionId: string) {
+    super(`Unknown session: ${sessionId}`);
+    this.name = "SessionNotFoundError";
+  }
+}
+
+export class WorkspaceNotFoundError extends Error {
+  constructor(workspaceId: string) {
+    super(`Unknown workspace: ${workspaceId}`);
+    this.name = "WorkspaceNotFoundError";
+  }
+}
+
+export class WorkspacePathError extends Error {
+  constructor(documentPath: string) {
+    super(`Path escapes workspace root: ${documentPath}`);
+    this.name = "WorkspacePathError";
+  }
+}
+
+export interface WorkspaceRecord {
+  id: string;
+  rootPath: string;
+  createdAt: string;
+}
+
+export interface SessionRecord {
+  id: string;
+  workspaceId: string;
+  createdAt: string;
+  documentPath?: string;
+  revision?: number;
+}
+
+interface SessionState {
+  record: SessionRecord;
+}
+
+export class SessionManager {
+  private readonly workspaces = new Map<string, WorkspaceRecord>();
+  private readonly sessions = new Map<string, SessionState>();
+
+  constructor(private readonly bridgeClient: BridgeClient) {}
+
+  createWorkspace(rootPath: string): WorkspaceRecord {
+    const resolvedRootPath = path.resolve(rootPath);
+    const workspace: WorkspaceRecord = {
+      id: randomUUID(),
+      rootPath: resolvedRootPath,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.workspaces.set(workspace.id, workspace);
+    return workspace;
+  }
+
+  createSession(workspaceId: string): SessionRecord {
+    this.getWorkspace(workspaceId);
+
+    const record: SessionRecord = {
+      id: randomUUID(),
+      workspaceId,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.sessions.set(record.id, { record });
+    return record;
+  }
+
+  getWorkspace(workspaceId: string): WorkspaceRecord {
+    const workspace = this.workspaces.get(workspaceId);
+    if (!workspace) {
+      throw new WorkspaceNotFoundError(workspaceId);
+    }
+    return workspace;
+  }
+
+  getSession(sessionId: string): SessionRecord {
+    return this.getSessionState(sessionId).record;
+  }
+
+  async openDocument(sessionId: string, documentPath: string): Promise<OpenDocumentResult> {
+    const sessionState = this.getSessionState(sessionId);
+    const workspace = this.getWorkspace(sessionState.record.workspaceId);
+    const resolvedPath = this.resolveWithinWorkspace(workspace.rootPath, documentPath);
+
+    const result = await this.bridgeClient.openDocument(sessionId, resolvedPath);
+    sessionState.record.documentPath = resolvedPath;
+    sessionState.record.revision = result.revision;
+    return result;
+  }
+
+  async getSnapshot(sessionId: string): Promise<DocumentSnapshot> {
+    this.getSessionState(sessionId);
+    return this.bridgeClient.getSnapshot(sessionId);
+  }
+
+  async executeCommand(sessionId: string, command: BridgeCommandRequest): Promise<BridgeCommandResult> {
+    const sessionState = this.getSessionState(sessionId);
+    const result = await this.bridgeClient.executeCommand(sessionId, command);
+    sessionState.record.revision = result.revisionAfter;
+    return result;
+  }
+
+  async validateDocument(sessionId: string): Promise<ValidationReport> {
+    this.getSessionState(sessionId);
+    return this.bridgeClient.validateDocument(sessionId);
+  }
+
+  async saveDocument(sessionId: string): Promise<{ path: string; revision: number }> {
+    const sessionState = this.getSessionState(sessionId);
+    const result = await this.bridgeClient.saveDocument(sessionId);
+    sessionState.record.revision = result.revision;
+    return result;
+  }
+
+  async undo(sessionId: string): Promise<BridgeCommandResult> {
+    const sessionState = this.getSessionState(sessionId);
+    const result = await this.bridgeClient.undo(sessionId);
+    sessionState.record.revision = result.revisionAfter;
+    return result;
+  }
+
+  async redo(sessionId: string): Promise<BridgeCommandResult> {
+    const sessionState = this.getSessionState(sessionId);
+    const result = await this.bridgeClient.redo(sessionId);
+    sessionState.record.revision = result.revisionAfter;
+    return result;
+  }
+
+  async closeSession(sessionId: string): Promise<void> {
+    this.getSessionState(sessionId);
+    await this.bridgeClient.closeSession(sessionId);
+    this.sessions.delete(sessionId);
+  }
+
+  private getSessionState(sessionId: string): SessionState {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new SessionNotFoundError(sessionId);
+    }
+    return session;
+  }
+
+  private resolveWithinWorkspace(rootPath: string, documentPath: string): string {
+    const resolvedPath = path.resolve(rootPath, documentPath);
+    const relativePath = path.relative(rootPath, resolvedPath);
+    if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+      throw new WorkspacePathError(documentPath);
+    }
+    return resolvedPath;
+  }
+}

--- a/tools/tiled-agent-orchestrator/test/http-server.test.ts
+++ b/tools/tiled-agent-orchestrator/test/http-server.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { BridgeClient, DocumentSnapshot, OpenDocumentResult, ValidationReport } from "../src/contracts.js";
+import { createAgentServer } from "../src/http-server.js";
+import { SessionManager } from "../src/session-manager.js";
+
+class StubBridgeClient implements BridgeClient {
+  async openDocument(_sessionId: string, _documentPath: string): Promise<OpenDocumentResult> {
+    return {
+      documentType: "map",
+      revision: 0,
+      snapshot: {
+        documentType: "map",
+        map: {
+          width: 4,
+          height: 4,
+          tileWidth: 16,
+          tileHeight: 16,
+          orientation: "orthogonal",
+          infinite: false,
+          tilesets: [],
+          layers: [],
+        },
+      },
+    };
+  }
+
+  async getSnapshot(_sessionId: string): Promise<DocumentSnapshot> {
+    return {
+      documentType: "map",
+      map: {
+        width: 4,
+        height: 4,
+        tileWidth: 16,
+        tileHeight: 16,
+        orientation: "orthogonal",
+        infinite: false,
+        tilesets: [],
+        layers: [],
+      },
+    };
+  }
+
+  async executeCommand(): Promise<any> {
+    return {
+      revisionBefore: 0,
+      revisionAfter: 1,
+      changedEntities: [],
+      warnings: [],
+      errors: [],
+      undoDepth: 1,
+      redoDepth: 0,
+    };
+  }
+
+  async validateDocument(): Promise<ValidationReport> {
+    return {
+      revision: 0,
+      diagnostics: [],
+    };
+  }
+
+  async saveDocument(): Promise<{ path: string; revision: number }> {
+    return {
+      path: "tests/data/mapobject.tmx",
+      revision: 0,
+    };
+  }
+
+  async undo(): Promise<any> {
+    return {
+      revisionBefore: 1,
+      revisionAfter: 0,
+      changedEntities: [],
+      warnings: [],
+      errors: [],
+      undoDepth: 0,
+      redoDepth: 1,
+    };
+  }
+
+  async redo(): Promise<any> {
+    return {
+      revisionBefore: 0,
+      revisionAfter: 1,
+      changedEntities: [],
+      warnings: [],
+      errors: [],
+      undoDepth: 1,
+      redoDepth: 0,
+    };
+  }
+
+  async closeSession(): Promise<void> {}
+}
+
+const servers: Array<{ close: () => Promise<void> }> = [];
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    await servers.pop()!.close();
+  }
+});
+
+describe("HTTP server", () => {
+  it("세션 생성, 문서 열기, 스냅샷 조회를 노출한다", async () => {
+    const manager = new SessionManager(new StubBridgeClient());
+    const server = await createAgentServer({
+      sessionManager: manager,
+      port: 0,
+    });
+    servers.push(server);
+
+    const workspaceResponse = await fetch(`${server.baseUrl}/workspaces`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        rootPath: process.cwd(),
+      }),
+    });
+    expect(workspaceResponse.status).toBe(201);
+    const workspace = await workspaceResponse.json();
+
+    const sessionResponse = await fetch(`${server.baseUrl}/sessions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        workspaceId: workspace.workspace.id,
+      }),
+    });
+    expect(sessionResponse.status).toBe(201);
+    const session = await sessionResponse.json();
+
+    const openResponse = await fetch(`${server.baseUrl}/sessions/${session.session.id}/documents/open`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        documentPath: "tests/data/mapobject.tmx",
+      }),
+    });
+    expect(openResponse.status).toBe(200);
+
+    const snapshotResponse = await fetch(`${server.baseUrl}/sessions/${session.session.id}/snapshot`);
+    expect(snapshotResponse.status).toBe(200);
+
+    const snapshot = await snapshotResponse.json();
+    expect(snapshot.snapshot.documentType).toBe("map");
+    expect(snapshot.snapshot.map.width).toBe(4);
+  });
+
+  it("디버그 UI 페이지를 제공한다", async () => {
+    const manager = new SessionManager(new StubBridgeClient());
+    const server = await createAgentServer({
+      sessionManager: manager,
+      port: 0,
+    });
+    servers.push(server);
+
+    const response = await fetch(server.baseUrl);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("Tiled Agent Debug");
+  });
+});

--- a/tools/tiled-agent-orchestrator/test/process-bridge-client.integration.test.ts
+++ b/tools/tiled-agent-orchestrator/test/process-bridge-client.integration.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { ProcessBridgeClient } from "../src/process-bridge-client.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const bridgeBuildDir = path.join(repoRoot, "build", "tiledagentbridge");
+const bridgeBinary = path.join(bridgeBuildDir, "tiledagentbridge");
+
+describe("ProcessBridgeClient", () => {
+  let bridgeClient: ProcessBridgeClient | undefined;
+
+  beforeAll(() => {
+    if (!existsSync(bridgeBinary)) {
+      execFileSync("cmake", ["--build", bridgeBuildDir, "--target", "tiledagentbridge", "-j4"], {
+        cwd: repoRoot,
+        stdio: "inherit",
+      });
+    }
+
+    bridgeClient = new ProcessBridgeClient({
+      binaryPath: bridgeBinary,
+    });
+  });
+
+  afterAll(async () => {
+    await bridgeClient?.dispose();
+  });
+
+  it("실제 bridge 프로세스와 문서 열기/명령 실행/undo를 수행한다", async () => {
+    const sessionId = "integration-session";
+    const documentPath = path.join(repoRoot, "tests", "automapping", "simple-2x2-rule", "map.tmx");
+
+    const opened = await bridgeClient!.openDocument(sessionId, documentPath);
+    expect(opened.documentType).toBe("map");
+    if (opened.snapshot.documentType !== "map") {
+      throw new Error("expected map snapshot");
+    }
+    expect(opened.snapshot.map.layers).toHaveLength(1);
+
+    const command = await bridgeClient!.executeCommand(sessionId, {
+      type: "create_layer",
+      payload: {
+        layerType: "object",
+        name: "Objects",
+      },
+    });
+
+    expect(command.revisionAfter).toBe(1);
+    expect(command.changedEntities[0]?.entityType).toBe("layer");
+
+    const undone = await bridgeClient!.undo(sessionId);
+    expect(undone.revisionAfter).toBe(0);
+  });
+});

--- a/tools/tiled-agent-orchestrator/test/session-manager.test.ts
+++ b/tools/tiled-agent-orchestrator/test/session-manager.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  BridgeClient,
+  BridgeCommandRequest,
+  BridgeCommandResult,
+  DocumentSnapshot,
+  OpenDocumentResult,
+  ValidationReport,
+} from "../src/contracts.js";
+import {
+  SessionManager,
+  SessionNotFoundError,
+  WorkspacePathError,
+} from "../src/session-manager.js";
+
+class FakeBridgeClient implements BridgeClient {
+  public openedPaths: string[] = [];
+  public executedCommands: BridgeCommandRequest[] = [];
+
+  async openDocument(sessionId: string, documentPath: string): Promise<OpenDocumentResult> {
+    this.openedPaths.push(`${sessionId}:${documentPath}`);
+    return {
+      documentType: "map",
+      revision: 0,
+      snapshot: {
+        documentType: "map",
+        map: {
+          width: 8,
+          height: 8,
+          tileWidth: 16,
+          tileHeight: 16,
+          orientation: "orthogonal",
+          infinite: false,
+          tilesets: [],
+          layers: [],
+        },
+      },
+    };
+  }
+
+  async getSnapshot(_sessionId: string): Promise<DocumentSnapshot> {
+    return {
+      documentType: "map",
+      map: {
+        width: 8,
+        height: 8,
+        tileWidth: 16,
+        tileHeight: 16,
+        orientation: "orthogonal",
+        infinite: false,
+        tilesets: [],
+        layers: [],
+      },
+    };
+  }
+
+  async executeCommand(_sessionId: string, command: BridgeCommandRequest): Promise<BridgeCommandResult> {
+    this.executedCommands.push(command);
+    return {
+      revisionBefore: 0,
+      revisionAfter: 1,
+      changedEntities: [
+        {
+          entityType: "layer",
+          entityId: 1,
+          changeType: "created",
+        },
+      ],
+      warnings: [],
+      errors: [],
+      undoDepth: 1,
+      redoDepth: 0,
+    };
+  }
+
+  async validateDocument(_sessionId: string): Promise<ValidationReport> {
+    return {
+      revision: 1,
+      diagnostics: [],
+    };
+  }
+
+  async saveDocument(_sessionId: string): Promise<{ path: string; revision: number }> {
+    return {
+      path: "/tmp/test.tmx",
+      revision: 1,
+    };
+  }
+
+  async undo(_sessionId: string): Promise<BridgeCommandResult> {
+    return {
+      revisionBefore: 1,
+      revisionAfter: 0,
+      changedEntities: [],
+      warnings: [],
+      errors: [],
+      undoDepth: 0,
+      redoDepth: 1,
+    };
+  }
+
+  async redo(_sessionId: string): Promise<BridgeCommandResult> {
+    return {
+      revisionBefore: 0,
+      revisionAfter: 1,
+      changedEntities: [],
+      warnings: [],
+      errors: [],
+      undoDepth: 1,
+      redoDepth: 0,
+    };
+  }
+
+  async closeSession(_sessionId: string): Promise<void> {}
+}
+
+describe("SessionManager", () => {
+  it("워크스페이스와 세션을 만들고 문서를 연다", async () => {
+    const manager = new SessionManager(new FakeBridgeClient());
+
+    const workspace = manager.createWorkspace(process.cwd());
+    const session = manager.createSession(workspace.id);
+    const result = await manager.openDocument(session.id, "tests/data/mapobject.tmx");
+
+    expect(result.documentType).toBe("map");
+    expect(result.revision).toBe(0);
+
+    const snapshot = await manager.getSnapshot(session.id);
+    expect(snapshot.documentType).toBe("map");
+    if (snapshot.documentType !== "map") {
+      throw new Error("expected map snapshot");
+    }
+    expect(snapshot.map.layers).toEqual([]);
+  });
+
+  it("워크스페이스 루트 밖 경로를 거부한다", async () => {
+    const manager = new SessionManager(new FakeBridgeClient());
+    const workspace = manager.createWorkspace(process.cwd());
+    const session = manager.createSession(workspace.id);
+
+    await expect(manager.openDocument(session.id, "../outside.tmx")).rejects.toBeInstanceOf(
+      WorkspacePathError,
+    );
+  });
+
+  it("세션이 없으면 명령 실행을 거부한다", async () => {
+    const manager = new SessionManager(new FakeBridgeClient());
+
+    await expect(
+      manager.executeCommand("missing", {
+        type: "create_layer",
+        payload: {
+          layerType: "tile",
+          name: "Ground",
+        },
+      }),
+    ).rejects.toBeInstanceOf(SessionNotFoundError);
+  });
+});

--- a/tools/tiled-agent-orchestrator/tsconfig.json
+++ b/tools/tiled-agent-orchestrator/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": [
+      "node",
+      "vitest/globals"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a standalone `tiledagentbridge` C++ bridge that reuses `libtiled` for map and tileset open/save, typed edit commands, validation, and undo/redo over JSON-RPC stdio
- add a Node.js/TypeScript orchestrator with workspace/session management, HTTP/JSON endpoints, MCP tools, and a minimal debug UI
- add bridge and orchestrator tests, including a real child-process integration test against the bridge binary

## Test Plan
- [x] `cd tools/tiled-agent-orchestrator && npm run build`
- [x] `cd tools/tiled-agent-orchestrator && npm test`
- [x] `ctest --test-dir build/tiledagentbridge --output-on-failure`
