### PR TITLE
Fix Properties view getting stuck with updates disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Added 'Collapse All' action and 'Only Expand to Current' mode to Project view (with rhythmcache, #4346)
 * Reduced animated tile marker opacity during terrain editing (by Huy Vũ, #4449)
 * Fixed ability to change properties after deselecting the current object (#4440)
+* Fixed Properties view getting stuck with updates disabled (#4506)
 
 ### Tiled 1.12.1 (25 March 2026)
 

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -76,15 +76,16 @@ class ScopedUpdatesDisabler
 {
 public:
     explicit ScopedUpdatesDisabler(QWidget *widget)
-        : mWidget(widget)
-        , mHadUpdatesEnabled(widget->updatesEnabled())
+        // If updates are already effectively disabled, leave the widget alone
+        : mWidget(widget->updatesEnabled() ? widget : nullptr)
     {
-        widget->setUpdatesEnabled(false);
+        if (mWidget)
+            mWidget->setUpdatesEnabled(false);
     }
 
     ~ScopedUpdatesDisabler()
     {
-        if (!mHadUpdatesEnabled)
+        if (!mWidget)
             return;
 
         QTimer::singleShot(0, mWidget, [w = mWidget] {
@@ -98,7 +99,6 @@ public:
 
 private:
     QWidget *mWidget;
-    bool mHadUpdatesEnabled;
 };
 
 


### PR DESCRIPTION
Regression introduced in 17a47f40107e3354b7103592e3261e55d22bc6df (#4460).

When switching from a map to the tile collision editor and back while a collision object was selected, the Properties view could stop updating entirely.

`ScopedUpdatesDisabler` unconditionally called `setUpdatesEnabled(false)` on the widget, but only called `setUpdatesEnabled(true)` when they were previously enabled. However, updates can be disabled due to them being disabled on a parent widget as well, in which case the updates could remain explicitly disabled for the child widget.

Now we skip the disable when updates are already effectively disabled, so they will effectively re-enable as well.