### PR TITLE
Fix locale-aware parsing of numbers in expression-capable spin boxes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Reduced animated tile marker opacity during terrain editing (by Huy Vũ, #4449)
 * Fixed ability to change properties after deselecting the current object (#4440)
 * Fixed Properties view getting stuck with updates disabled (#4506)
+* Fixed locale-aware parsing of numbers in expression-capable spin boxes
 
 ### Tiled 1.12.1 (25 March 2026)
 

--- a/src/tiled/expressionspinbox.cpp
+++ b/src/tiled/expressionspinbox.cpp
@@ -48,6 +48,13 @@ ExpressionSpinBox::ExpressionSpinBox(QWidget *parent)
 
 int ExpressionSpinBox::valueFromText(const QString &text) const
 {
+    // First try locale-aware number parsing, so that input like "1,000"
+    // works as expected in locales using a thousands separator.
+    bool ok = false;
+    const int number = locale().toInt(text, &ok);
+    if (ok)
+        return number;
+
     const QJSValue result = ExpressionEvaluator::evaluate(text);
     if (result.isNumber())
         return result.toNumber();
@@ -94,6 +101,13 @@ ExpressionDoubleSpinBox::ExpressionDoubleSpinBox(QWidget *parent)
 
 double ExpressionDoubleSpinBox::valueFromText(const QString &text) const
 {
+    // First try locale-aware number parsing, so that input like "3,14"
+    // works as expected in locales using a comma as decimal separator.
+    bool ok = false;
+    const double number = locale().toDouble(text, &ok);
+    if (ok)
+        return number;
+
     const QJSValue result = ExpressionEvaluator::evaluate(text);
     if (result.isNumber())
         return result.toNumber();


### PR DESCRIPTION
## Summary

When the ability to evaluate expressions was added to the spin boxes, it bypassed the locale-aware number parsing normally performed by `QSpinBox`/`QDoubleSpinBox`. As a result, users in locales using a comma as decimal separator could no longer enter values like `3,14` in an `ExpressionDoubleSpinBox` — the JavaScript engine interpreted the comma as a sequence expression and returned `14`.

The fix is straightforward: before evaluating the input as a JavaScript expression, first try to parse it as a number using the widget's locale. Only fall back to expression evaluation when locale-aware parsing fails.

The same treatment is applied to `ExpressionSpinBox` so that integer input with a thousands separator (e.g. `1,000` in en-US) also works as expected.

## Test plan

- [x] In a locale that uses `,` as decimal separator, enter `3,14` in a double spin box and confirm it becomes 3.14.
- [x] In a locale that uses `.` as decimal separator, enter `3.14` and confirm it still works.
- [x] Enter an expression like `1+2` and confirm it is still evaluated.
- [x] Enter `1,000` in an integer spin box in en-US locale and confirm it becomes 1000.