### PR TITLE
Fixed Tile Animation Editor update after tileset image reload

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Fixed ability to change properties after deselecting the current object (#4440)
 * Fixed Properties view getting stuck with updates disabled (#4506)
 * Fixed locale-aware parsing of numbers in expression-capable spin boxes
+* Fixed Tile Animation Editor update after tileset image reload (#3923)
 
 ### Tiled 1.12.1 (25 March 2026)
 

--- a/src/tiled/tileanimationeditor.cpp
+++ b/src/tiled/tileanimationeditor.cpp
@@ -30,6 +30,7 @@
 #include "tiled.h"
 #include "tileset.h"
 #include "tilesetdocument.h"
+#include "tilesetmanager.h"
 #include "utils.h"
 #include "zoomable.h"
 
@@ -318,6 +319,9 @@ TileAnimationEditor::TileAnimationEditor(QWidget *parent)
     connect(mUi->setFrameTimeButton, &QAbstractButton::clicked,
             this, &TileAnimationEditor::setFrameTime);
 
+    connect(TilesetManager::instance(), &TilesetManager::tilesetImagesChanged,
+            this, &TileAnimationEditor::tilesetImagesChanged);
+
     QShortcut *undoShortcut = new QShortcut(QKeySequence::Undo, this);
     QShortcut *redoShortcut = new QShortcut(QKeySequence::Redo, this);
     QShortcut *cutShortcut = new QShortcut(QKeySequence::Cut, mUi->frameList, nullptr, nullptr, Qt::WidgetShortcut);
@@ -442,6 +446,14 @@ void TileAnimationEditor::tilesetChanged()
 
     tilesetView->updateBackgroundColor();
     model->tilesetChanged();
+}
+
+void TileAnimationEditor::tilesetImagesChanged(Tileset *tileset)
+{
+    if (mTilesetDocument && mTilesetDocument->tileset() == tileset) {
+        mUi->tilesetView->tilesetModel()->tilesetChanged();
+        mUi->frameList->viewport()->update();
+    }
 }
 
 void TileAnimationEditor::setDefaultFrameTime(int duration)

--- a/src/tiled/tileanimationeditor.h
+++ b/src/tiled/tileanimationeditor.h
@@ -65,6 +65,7 @@ protected:
 private:
     void framesEdited();
     void tilesetChanged();
+    void tilesetImagesChanged(Tileset *tileset);
     void tileAnimationChanged(Tile *tile);
     void currentObjectChanged(Object *object);
 

--- a/src/tiled/tilesetmodel.h
+++ b/src/tiled/tilesetmodel.h
@@ -62,8 +62,6 @@ public:
     QVariant data(const QModelIndex &index,
                   int role = Qt::DisplayRole) const override;
 
-
-
     /**
      * Returns a small size hint, to prevent the headers from affecting the
      * minimum width and height of the sections.


### PR DESCRIPTION
When a tileset image was reloaded, the Tile Animation Editor didn't immediately repaint and failed to show any new tiles until switching tilesets. Now it updates immediately.

Closes #3923