### PR TITLE
Made indexes in the TilesetModel without tiles invalid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Fixed locale-aware parsing of numbers in expression-capable spin boxes
 * Fixed Tile Animation Editor update after tileset image reload (#3923)
 * Fixed runtime language switching in many editor widgets and models (by SIDDHAARTHAA, #4411)
+* Fixed non-tile locations in wrapping Tilesets view being selectable (#3498)
 
 ### Tiled 1.12.1 (25 March 2026)
 

--- a/src/tiled/tilesetmodel.cpp
+++ b/src/tiled/tilesetmodel.cpp
@@ -44,6 +44,17 @@ TilesetModel::TilesetModel(TilesetDocument *tilesetDocument, QObject *parent)
             this, &TilesetModel::tileChanged);
 }
 
+/**
+ * Override to return an invalid index if the tile index is out of range.
+ */
+QModelIndex TilesetModel::index(int row, int column, const QModelIndex &parent) const
+{
+    const int tileIndex = column + row * columnCount();
+    if (tileIndex >= mTileIds.size())
+        return QModelIndex();
+    return QAbstractListModel::index(row, column, parent);
+}
+
 int TilesetModel::rowCount(const QModelIndex &parent) const
 {
     if (parent.isValid())

--- a/src/tiled/tilesetmodel.h
+++ b/src/tiled/tilesetmodel.h
@@ -45,6 +45,8 @@ public:
      */
     TilesetModel(TilesetDocument *tilesetDocument, QObject *parent = nullptr);
 
+    QModelIndex index(int row, int column = 0, const QModelIndex &parent = {}) const override;
+
     /**
      * Returns the number of rows.
      */

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -111,8 +111,8 @@ void TileDelegate::paint(QPainter *painter,
                          const QStyleOptionViewItem &option,
                          const QModelIndex &index) const
 {
-    const TilesetModel *model = static_cast<const TilesetModel*>(index.model());
-    const Tile *tile = model->tileAt(index);
+    auto model = static_cast<const TilesetModel*>(index.model());
+    auto tile = model->tileAt(index);
     if (!tile)
         return;
 
@@ -177,12 +177,27 @@ void TileDelegate::paint(QPainter *painter,
 
     if (mTilesetView->isEditWangSet())
         drawWangOverlay(painter, tile, targetRect, index);
+
+    // draw the focus rect
+    if (option.state & QStyle::State_HasFocus) {
+        auto style = option.widget->style();
+        QStyleOptionFocusRect o;
+        o.QStyleOption::operator=(option);
+        o.rect = style->subElementRect(QStyle::SE_ItemViewItemFocusRect, &option);
+        o.state |= QStyle::State_KeyboardFocusChange;
+        o.state |= QStyle::State_Item;
+        QPalette::ColorGroup cg = (option.state & QStyle::State_Enabled)
+                                      ? QPalette::Normal : QPalette::Disabled;
+        o.backgroundColor = option.palette.color(cg, (option.state & QStyle::State_Selected)
+                                                         ? QPalette::Highlight : QPalette::Window);
+        style->drawPrimitive(QStyle::PE_FrameFocusRect, &o, painter);
+    }
 }
 
 QSize TileDelegate::sizeHint(const QStyleOptionViewItem & /* option */,
                              const QModelIndex &index) const
 {
-    const TilesetModel *m = static_cast<const TilesetModel*>(index.model());
+    auto m = static_cast<const TilesetModel*>(index.model());
     const int extra = mTilesetView->drawGrid() ? 1 : 0;
     const qreal scale = mTilesetView->scale();
 
@@ -444,7 +459,7 @@ void TilesetView::setMarkAnimatedTiles(bool enabled)
 bool TilesetView::event(QEvent *event)
 {
     if (event->type() == QEvent::Gesture) {
-        QGestureEvent *gestureEvent = static_cast<QGestureEvent *>(event);
+        auto gestureEvent = static_cast<QGestureEvent *>(event);
         if (QGesture *gesture = gestureEvent->gesture(Qt::PinchGesture))
             mZoomable->handlePinchGesture(static_cast<QPinchGesture *>(gesture));
     } else if (event->type() == QEvent::ShortcutOverride) {


### PR DESCRIPTION
This way, those indexes can't be navigated to using the keyboard nor selected using the mouse.

I've also added rendering of the focused tile in `TileDelegate`, which helps a little bit to give additional context in some cases like multi-selection or when toggling selection.

Closes #3498