### PR TITLE
tBIN plugin: Made it compile with QT_NO_CAST_FROM_ASCII

### DIFF
--- a/src/plugins/tbin/tbin.qbs
+++ b/src/plugins/tbin/tbin.qbs
@@ -1,5 +1,9 @@
 TiledPlugin {
-    cpp.defines: base.concat(["TBIN_LIBRARY"])
+    cpp.defines: base.concat([
+        "TBIN_LIBRARY",
+        "QT_NO_CAST_FROM_ASCII",
+        "QT_NO_CAST_TO_ASCII",
+    ])
 
     files: [
         "tbin_global.h",

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -167,8 +167,8 @@ std::unique_ptr< Tiled::Map > TbinPlugin::fromTbin( const tbin::Map& tmap, const
         if (ttilesheet.margin.x != ttilesheet.margin.y)
             throw std::invalid_argument(QT_TR_NOOP("Tilesheet must have equal margins."));
 
-        auto tileset = Tiled::Tileset::create(ttilesheet.id.c_str(), ttilesheet.tileSize.x, ttilesheet.tileSize.y, ttilesheet.spacing.x, ttilesheet.margin.x);
-        tileset->setImageSource(Tiled::toUrl(QString::fromStdString(ttilesheet.image).replace("\\", "/"), fileDir));
+        auto tileset = Tiled::Tileset::create(QString::fromStdString(ttilesheet.id), ttilesheet.tileSize.x, ttilesheet.tileSize.y, ttilesheet.spacing.x, ttilesheet.margin.x);
+        tileset->setImageSource(Tiled::toUrl(QString::fromStdString(ttilesheet.image).replace(QLatin1Char('\\'), QLatin1Char('/')), fileDir));
         tileset->loadImage();
 
         tbinToTiledProperties(ttilesheet.props, *tileset);
@@ -235,7 +235,7 @@ std::unique_ptr< Tiled::Map > TbinPlugin::fromTbin( const tbin::Map& tmap, const
 
             if (ttile.props.size() > 0)
             {
-                auto obj = std::make_unique<Tiled::MapObject>("TileData");
+                auto obj = std::make_unique<Tiled::MapObject>(QStringLiteral("TileData"));
                 obj->setPosition(QPointF(ix * tlayer.tileSize.x, iy * tlayer.tileSize.y));
                 obj->setSize(QSizeF(tlayer.tileSize.x, tlayer.tileSize.y));
                 tbinToTiledProperties(ttile.props, *obj);
@@ -342,7 +342,7 @@ tbin::Map TbinPlugin::toTbin( const Tiled::Map* map, const QDir &fileDir )
     for (const Tiled::SharedTileset& tilesheet : map->tilesets()) {
         tbin::TileSheet ttilesheet;
         ttilesheet.id = tilesheet->name().toStdString();
-        ttilesheet.image = Tiled::toFileReference(tilesheet->imageSource(), fileDir).replace("/", "\\").toStdString();
+        ttilesheet.image = Tiled::toFileReference(tilesheet->imageSource(), fileDir).replace(QLatin1Char('/'), QLatin1Char('\\')).toStdString();
         ttilesheet.margin.x = ttilesheet.margin.y = tilesheet->margin();
         ttilesheet.spacing.x = ttilesheet.spacing.y = tilesheet->tileSpacing();
         ttilesheet.sheetSize.x = tilesheet->columnCount();
@@ -355,7 +355,7 @@ tbin::Map TbinPlugin::toTbin( const Tiled::Map* map, const QDir &fileDir )
         for (auto tile : tilesheet->tiles()) {
             const auto &props = tile->properties();
             for (auto it = props.begin(), it_end = props.end(); it != it_end; ++it) {
-                tilesetTileProperties.insert("@TileIndex@" + QString::number(tile->id()) + "@" + it.key(), it.value());
+                tilesetTileProperties.insert(QLatin1String("@TileIndex@") + QString::number(tile->id()) + QLatin1Char('@') + it.key(), it.value());
             }
         }
         tiledToTbinProperties(tilesetTileProperties, ttilesheet.props, fileDir);
@@ -385,7 +385,7 @@ tbin::Map TbinPlugin::toTbin( const Tiled::Map* map, const QDir &fileDir )
                     ttile.staticData.tileIndex = -1;
 
                     if (hasUnsupportedFlags(cell)) {
-                        Tiled::ERROR("tBIN: Flipped and/or rotated tiles are not supported.",
+                        Tiled::ERROR(QLatin1String("tBIN: Flipped and/or rotated tiles are not supported."),
                                         Tiled::JumpToTile { map, QPoint(ix + layer->x(), iy + layer->y()), layer });
                     }
 
@@ -400,7 +400,7 @@ tbin::Map TbinPlugin::toTbin( const Tiled::Map* map, const QDir &fileDir )
 
                             for (Tiled::Frame frame : tile->frames()) {
                                 if (frame.duration != ttile.animatedData.frameInterval) {
-                                    Tiled::ERROR("tBIN: Frames with different duration are not supported.",
+                                    Tiled::ERROR(QLatin1String("tBIN: Frames with different duration are not supported."),
                                                     Tiled::SelectTile { tile });
                                 }
 

--- a/src/plugins/tbin/tidemapformat.cpp
+++ b/src/plugins/tbin/tidemapformat.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
         tbin::Map tmap;
 
         const QXmlStreamAttributes mapAttrs = xml.attributes();
-        tmap.id = mapAttrs.value( "Id" ).toString().toStdString();
+        tmap.id = mapAttrs.value( QLatin1String("Id") ).toString().toStdString();
 
         auto readProps = [&xml]() -> tbin::Properties
         {
@@ -69,31 +69,31 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
             while ( xml.readNextStartElement() )
             {
-                if ( xml.name() == "Property" )
+                if ( xml.name() == QLatin1String("Property") )
                 {
                     const QXmlStreamAttributes attrs = xml.attributes();
 
-                    const std::string key = attrs.value( "Key" ).toString().toStdString();
-                    const QString type = attrs.value( "Type" ).toString();
+                    const std::string key = attrs.value( QLatin1String("Key") ).toString().toStdString();
+                    const QString type = attrs.value( QLatin1String("Type") ).toString();
                     const QString value = xml.readElementText();
 
                     tbin::PropertyValue prop;
-                    if ( type == "Boolean" )
+                    if ( type == QLatin1String("Boolean") )
                     {
                         prop.type = tbin::PropertyValue::Bool;
-                        prop.data.b = QString::compare( value, "true", Qt::CaseInsensitive ) == 0;
+                        prop.data.b = QString::compare( value, QLatin1String("true"), Qt::CaseInsensitive ) == 0;
                     }
-                    if ( type == "Int32" )
+                    if ( type == QLatin1String("Int32") )
                     {
                         prop.type = tbin::PropertyValue::Integer;
                         prop.data.i = value.toInt();
                     }
-                    if ( type == "Single" )
+                    if ( type == QLatin1String("Single") )
                     {
                         prop.type = tbin::PropertyValue::Float;
                         prop.data.f = value.toFloat();
                     }
-                    if ( type == "String" )
+                    if ( type == QLatin1String("String") )
                     {
                         prop.type = tbin::PropertyValue::String;
                         prop.dataStr = value.toStdString();
@@ -111,11 +111,11 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
         {
             if ( xml.name() == QLatin1String( "Description" ) )
                 tmap.desc = xml.readElementText().toStdString();
-            else if ( xml.name() == "TileSheets" )
+            else if ( xml.name() == QLatin1String("TileSheets") )
             {
                 while ( xml.readNextStartElement() )
                 {
-                    if ( xml.name() != "TileSheet" )
+                    if ( xml.name() != QLatin1String("TileSheet") )
                     {
                         xml.skipCurrentElement();
                         continue;
@@ -124,27 +124,27 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                     const QXmlStreamAttributes tsAttrs = xml.attributes();
 
                     tbin::TileSheet ts;
-                    ts.id = tsAttrs.value( "Id" ).toString().toStdString();
+                    ts.id = tsAttrs.value( QLatin1String("Id") ).toString().toStdString();
 
                     while ( xml.readNextStartElement() )
                     {
                         if ( xml.name() == QLatin1String( "Description" ) )
                             ts.desc = xml.readElementText().toStdString();
-                        else if ( xml.name() == "ImageSource" )
+                        else if ( xml.name() == QLatin1String("ImageSource") )
                             ts.image = xml.readElementText().toStdString();
-                        else if ( xml.name() == "Alignment" )
+                        else if ( xml.name() == QLatin1String("Alignment") )
                         {
                             const QXmlStreamAttributes alignAttrs = xml.attributes();
 
-                            const QString sheetSizeStr = alignAttrs.value( "SheetSize" ).toString();
-                            const QString tileSizeStr = alignAttrs.value( "TileSize" ).toString();
-                            const QString marginStr = alignAttrs.value( "Margin" ).toString();
-                            const QString spacingStr = alignAttrs.value( "Spacing" ).toString();
+                            const QString sheetSizeStr = alignAttrs.value( QLatin1String("SheetSize") ).toString();
+                            const QString tileSizeStr = alignAttrs.value( QLatin1String("TileSize") ).toString();
+                            const QString marginStr = alignAttrs.value( QLatin1String("Margin") ).toString();
+                            const QString spacingStr = alignAttrs.value( QLatin1String("Spacing") ).toString();
 
-                            qsizetype sheetSizeSep = sheetSizeStr.indexOf( " x " );
-                            qsizetype tileSizeSep = tileSizeStr.indexOf( " x " );
-                            qsizetype marginSep = marginStr.indexOf( " x " );
-                            qsizetype spacingSep = spacingStr.indexOf( " x " );
+                            qsizetype sheetSizeSep = sheetSizeStr.indexOf( QLatin1String(" x ") );
+                            qsizetype tileSizeSep = tileSizeStr.indexOf( QLatin1String(" x ") );
+                            qsizetype marginSep = marginStr.indexOf( QLatin1String(" x ") );
+                            qsizetype spacingSep = spacingStr.indexOf( QLatin1String(" x ") );
 
                             ts.sheetSize = tbin::Vector2i( sheetSizeStr.mid( 0, sheetSizeSep ).toInt(), sheetSizeStr.mid( sheetSizeSep + 3 ).toInt() );
                             ts.tileSize = tbin::Vector2i( tileSizeStr.mid( 0, tileSizeSep ).toInt(), tileSizeStr.mid( tileSizeSep + 3 ).toInt() );
@@ -153,7 +153,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
                             xml.skipCurrentElement();
                         }
-                        else if (xml.name() == "Properties")
+                        else if (xml.name() == QLatin1String("Properties"))
                             ts.props = readProps();
                         else xml.skipCurrentElement();
                     }
@@ -161,11 +161,11 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                     tmap.tilesheets.push_back( ts );
                 }
             }
-            else if ( xml.name() == "Layers" )
+            else if ( xml.name() == QLatin1String("Layers") )
             {
                 while ( xml.readNextStartElement() )
                 {
-                    if ( xml.name() != "Layer" )
+                    if ( xml.name() != QLatin1String("Layer") )
                     {
                         xml.skipCurrentElement();
                         continue;
@@ -173,30 +173,30 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                     const QXmlStreamAttributes layerAttrs = xml.attributes();
 
                     tbin::Layer layer;
-                    layer.id = layerAttrs.value( "Id" ).toString().toStdString();
-                    auto vis = layerAttrs.value( "Visible" ).toString().toStdString();
-                    layer.visible = QString::compare( layerAttrs.value( "Visible" ).toString(), "true", Qt::CaseInsensitive ) == 0;
+                    layer.id = layerAttrs.value( QLatin1String("Id") ).toString().toStdString();
+                    auto vis = layerAttrs.value( QLatin1String("Visible") ).toString().toStdString();
+                    layer.visible = QString::compare( layerAttrs.value( QLatin1String("Visible") ).toString(), QLatin1String("true"), Qt::CaseInsensitive ) == 0;
 
                     while ( xml.readNextStartElement() )
                     {
                         if ( xml.name() == QLatin1String( "Description" ) )
                             layer.desc = xml.readElementText().toStdString();
-                        else if ( xml.name() == "Dimensions" )
+                        else if ( xml.name() == QLatin1String("Dimensions") )
                         {
                             const QXmlStreamAttributes alignAttrs = xml.attributes();
 
-                            const QString layerSizeStr = alignAttrs.value( "LayerSize" ).toString();
-                            const QString tileSizeStr = alignAttrs.value( "TileSize" ).toString();
+                            const QString layerSizeStr = alignAttrs.value( QLatin1String("LayerSize") ).toString();
+                            const QString tileSizeStr = alignAttrs.value( QLatin1String("TileSize") ).toString();
 
-                            qsizetype layerSizeSep = layerSizeStr.indexOf( " x " );
-                            qsizetype tileSizeSep = tileSizeStr.indexOf( " x " );
+                            qsizetype layerSizeSep = layerSizeStr.indexOf( QLatin1String(" x ") );
+                            qsizetype tileSizeSep = tileSizeStr.indexOf( QLatin1String(" x ") );
 
                             layer.layerSize = tbin::Vector2i( layerSizeStr.mid( 0, layerSizeSep ).toInt(), layerSizeStr.mid( layerSizeSep + 3 ).toInt() );
                             layer.tileSize = tbin::Vector2i( tileSizeStr.mid( 0, tileSizeSep ).toInt(), tileSizeStr.mid( tileSizeSep + 3 ).toInt() );
 
                             xml.skipCurrentElement();
                         }
-                        else if ( xml.name() == "TileArray" )
+                        else if ( xml.name() == QLatin1String("TileArray") )
                         {
                             tbin::Tile nullTile;
                             nullTile.staticData.tileIndex = -1;
@@ -208,8 +208,8 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
                                 tbin::Tile tile;
                                 tile.tilesheet = tilesheetToUse;
-                                tile.staticData.tileIndex = tileAttrs.value( "Index" ).toString().toInt();
-                                tile.staticData.blendMode = tileAttrs.value( "BlendMode" ).toString() == "Alpha" ? 0 : 1;
+                                tile.staticData.tileIndex = tileAttrs.value( QLatin1String("Index") ).toString().toInt();
+                                tile.staticData.blendMode = tileAttrs.value( QLatin1String("BlendMode") ).toString() == QLatin1String("Alpha") ? 0 : 1;
 
                                 // tIDE (the xTile tile editor) uses a self-closing element when there are no properties.
                                 // However, Qt seems to represent these simply as empty elements when reading.
@@ -218,7 +218,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                                 // for compatibility with xTile code.
                                 while ( xml.readNextStartElement() )
                                 {
-                                    if (xml.name() == "Properties")
+                                    if (xml.name() == QLatin1String("Properties"))
                                         tile.props = readProps();
                                     else xml.skipCurrentElement();
                                 }
@@ -230,7 +230,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                             tbin::Vector2i tilePos;
                             while ( xml.readNextStartElement() )
                             {
-                                if (xml.name() != "Row" )
+                                if (xml.name() != QLatin1String("Row") )
                                 {
                                     xml.skipCurrentElement();
                                     continue;
@@ -238,43 +238,43 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
 
                                 while ( xml.readNextStartElement() )
                                 {
-                                    if ( xml.name() == "TileSheet" )
+                                    if ( xml.name() == QLatin1String("TileSheet") )
                                     {
                                         const QXmlStreamAttributes tsAttrs = xml.attributes();
-                                        lastTilesheet = tsAttrs.value( "Ref" ).toString().toStdString();
+                                        lastTilesheet = tsAttrs.value( QLatin1String("Ref") ).toString().toStdString();
                                         xml.skipCurrentElement();
                                     }
-                                    else if ( xml.name() == "Static" )
+                                    else if ( xml.name() == QLatin1String("Static") )
                                     {
                                         layer.tiles[ tilePos.x + tilePos.y * layer.layerSize.x ] = readStaticTile( lastTilesheet );
                                         tilePos.x += 1;
                                     }
-                                    else if ( xml.name() == "Animated" )
+                                    else if ( xml.name() == QLatin1String("Animated") )
                                     {
                                         const QXmlStreamAttributes tileAttrs = xml.attributes();
 
                                         tbin::Tile tile;
-                                        tile.animatedData.frameInterval = tileAttrs.value( "Interval" ).toString().toInt();
+                                        tile.animatedData.frameInterval = tileAttrs.value( QLatin1String("Interval") ).toString().toInt();
 
                                         while ( xml.readNextStartElement() )
                                         {
-                                            if (xml.name() == "Frames" )
+                                            if (xml.name() == QLatin1String("Frames") )
                                             {
                                                 std::string lastTilesheet; // Shadowing the previous declaration intentionally, because we explicitly do not want to use/affect it
                                                 while ( xml.readNextStartElement() )
                                                 {
-                                                    if ( xml.name() == "TileSheet" )
+                                                    if ( xml.name() == QLatin1String("TileSheet") )
                                                     {
                                                         const QXmlStreamAttributes tsAttrs = xml.attributes();
-                                                        lastTilesheet = tsAttrs.value( "Ref" ).toString().toStdString();
+                                                        lastTilesheet = tsAttrs.value( QLatin1String("Ref") ).toString().toStdString();
                                                         xml.skipCurrentElement();
                                                     }
-                                                    else if (xml.name() == "Static")
+                                                    else if (xml.name() == QLatin1String("Static"))
                                                         tile.animatedData.frames.push_back( readStaticTile( lastTilesheet ) );
                                                     else xml.skipCurrentElement();
                                                 }
                                             }
-                                            else if (xml.name() == "Properties")
+                                            else if (xml.name() == QLatin1String("Properties"))
                                                 tile.props = readProps();
                                             else xml.skipCurrentElement();
                                         }
@@ -282,10 +282,10 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                                         layer.tiles[ tilePos.x + tilePos.y * layer.layerSize.x ] = tile;
                                         tilePos.x += 1;
                                     }
-                                    else if ( xml.name() == "Null" )
+                                    else if ( xml.name() == QLatin1String("Null") )
                                     {
                                         const QXmlStreamAttributes tileAttrs = xml.attributes();
-                                        tilePos.x += tileAttrs.value( "Count" ).toString().toInt();
+                                        tilePos.x += tileAttrs.value( QLatin1String("Count") ).toString().toInt();
                                         xml.skipCurrentElement();
                                     }
                                     else xml.skipCurrentElement();
@@ -295,7 +295,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                                 tilePos.y += 1;
                             }
                         }
-                        else if (xml.name() == "Properties")
+                        else if (xml.name() == QLatin1String("Properties"))
                             layer.props = readProps();
                         else xml.skipCurrentElement();
                     }
@@ -303,7 +303,7 @@ std::unique_ptr<Tiled::Map> TideMapFormat::read(const QString &fileName)
                     tmap.layers.push_back( layer );
                 }
             }
-            else if (xml.name() == "Properties")
+            else if (xml.name() == QLatin1String("Properties"))
                 tmap.props = readProps();
             else xml.skipCurrentElement();
         }
@@ -339,28 +339,28 @@ bool TideMapFormat::write(const Tiled::Map *map, const QString &fileName, Option
 
         auto writeProps = [&xml](const tbin::Properties& props)
         {
-            xml.writeStartElement( "Properties" );
+            xml.writeStartElement( QStringLiteral("Properties") );
             for ( const auto& prop : props )
             {
-                xml.writeStartElement( "Property" );
-                xml.writeAttribute( "Key", QString(prop.first.c_str()) );
+                xml.writeStartElement( QStringLiteral("Property") );
+                xml.writeAttribute( QStringLiteral("Key"), QString::fromStdString(prop.first) );
                 switch ( prop.second.type )
                 {
                     case tbin::PropertyValue::Bool:
-                        xml.writeAttribute( "Type", "Boolean" );
-                        xml.writeCDATA( prop.second.data.b ? "True" : "False" );
+                        xml.writeAttribute( QStringLiteral("Type"), QStringLiteral("Boolean") );
+                        xml.writeCDATA( prop.second.data.b ? QStringLiteral("True") : QStringLiteral("False") );
                         break;
                     case tbin::PropertyValue::Integer:
-                        xml.writeAttribute( "Type", "Int32" );
+                        xml.writeAttribute( QStringLiteral("Type"), QStringLiteral("Int32") );
                         xml.writeCDATA( QString::number( prop.second.data.i ) );
                         break;
                     case tbin::PropertyValue::Float:
-                        xml.writeAttribute( "Type", "Single" );
+                        xml.writeAttribute( QStringLiteral("Type"), QStringLiteral("Single") );
                         xml.writeCDATA( QString::number( prop.second.data.f ) );
                         break;
                     case tbin::PropertyValue::String:
-                        xml.writeAttribute( "Type", "String" );
-                        xml.writeCDATA( QString(prop.second.dataStr.c_str()) );
+                        xml.writeAttribute( QStringLiteral("Type"), QStringLiteral("String") );
+                        xml.writeCDATA( QString::fromStdString(prop.second.dataStr) );
                         break;
                     default:
                         throw std::invalid_argument( "Unknown property type" );
@@ -371,34 +371,34 @@ bool TideMapFormat::write(const Tiled::Map *map, const QString &fileName, Option
         };
 
         xml.writeStartDocument();
-        xml.writeStartElement( "Map" );
+        xml.writeStartElement( QStringLiteral("Map") );
         {
-            xml.writeAttribute( "Id", QString(tmap.id.c_str()) );
+            xml.writeAttribute( QStringLiteral("Id"), QString::fromStdString(tmap.id) );
 
-            xml.writeStartElement( "Description" );
-            xml.writeCDATA( QString(tmap.desc.c_str()) );
+            xml.writeStartElement( QStringLiteral("Description") );
+            xml.writeCDATA( QString::fromStdString(tmap.desc) );
             xml.writeEndElement();
 
-            xml.writeStartElement("TileSheets");
+            xml.writeStartElement(QStringLiteral("TileSheets"));
             {
                 for ( const auto& ts : tmap.tilesheets )
                 {
-                    xml.writeStartElement( "TileSheet" );
-                    xml.writeAttribute( "Id", QString(ts.id.c_str()) );
+                    xml.writeStartElement( QStringLiteral("TileSheet") );
+                    xml.writeAttribute( QStringLiteral("Id"), QString::fromStdString(ts.id) );
 
-                    xml.writeStartElement( "Description" );
-                    xml.writeCDATA( QString(ts.desc.c_str()) );
+                    xml.writeStartElement( QStringLiteral("Description") );
+                    xml.writeCDATA( QString::fromStdString(ts.desc) );
                     xml.writeEndElement();
 
-                    xml.writeStartElement( "ImageSource" );
-                    xml.writeCDATA( QString(ts.image.c_str()) );
+                    xml.writeStartElement( QStringLiteral("ImageSource") );
+                    xml.writeCDATA( QString::fromStdString(ts.image) );
                     xml.writeEndElement();
 
-                    xml.writeEmptyElement( "Alignment" );
-                    xml.writeAttribute( "SheetSize", QStringLiteral( "%1 x %2" ).arg( ts.sheetSize.x ).arg( ts.sheetSize.y ) );
-                    xml.writeAttribute( "TileSize",  QStringLiteral( "%1 x %2" ).arg( ts.tileSize.x  ).arg( ts.tileSize.y  ) );
-                    xml.writeAttribute( "Margin",    QStringLiteral( "%1 x %2" ).arg( ts.margin.x    ).arg( ts.margin.y    ) );
-                    xml.writeAttribute( "Spacing",   QStringLiteral( "%1 x %2" ).arg( ts.spacing.x   ).arg( ts.spacing.y   ) );
+                    xml.writeEmptyElement( QStringLiteral("Alignment") );
+                    xml.writeAttribute( QStringLiteral("SheetSize"), QStringLiteral( "%1 x %2" ).arg( ts.sheetSize.x ).arg( ts.sheetSize.y ) );
+                    xml.writeAttribute( QStringLiteral("TileSize"),  QStringLiteral( "%1 x %2" ).arg( ts.tileSize.x  ).arg( ts.tileSize.y  ) );
+                    xml.writeAttribute( QStringLiteral("Margin"),    QStringLiteral( "%1 x %2" ).arg( ts.margin.x    ).arg( ts.margin.y    ) );
+                    xml.writeAttribute( QStringLiteral("Spacing"),   QStringLiteral( "%1 x %2" ).arg( ts.spacing.x   ).arg( ts.spacing.y   ) );
 
                     writeProps( ts.props );
 
@@ -407,33 +407,33 @@ bool TideMapFormat::write(const Tiled::Map *map, const QString &fileName, Option
             }
             xml.writeEndElement();
 
-            xml.writeStartElement("Layers");
+            xml.writeStartElement(QStringLiteral("Layers"));
             {
                 for ( const auto& layer : tmap.layers )
                 {
-                    xml.writeStartElement( "Layer" );
-                    xml.writeAttribute( "Id", QString(layer.id.c_str()) );
-                    xml.writeAttribute( "Visible", layer.visible ? "True" : "False" );
+                    xml.writeStartElement( QStringLiteral("Layer") );
+                    xml.writeAttribute( QStringLiteral("Id"), QString::fromStdString(layer.id) );
+                    xml.writeAttribute( QStringLiteral("Visible"), layer.visible ? QStringLiteral("True") : QStringLiteral("False") );
 
-                    xml.writeStartElement( "Description" );
-                    xml.writeCDATA( QString(layer.desc.c_str()) );
+                    xml.writeStartElement( QStringLiteral("Description") );
+                    xml.writeCDATA( QString::fromStdString(layer.desc) );
                     xml.writeEndElement();
 
-                    xml.writeEmptyElement( "Dimensions" );
-                    xml.writeAttribute( "LayerSize", QStringLiteral( "%1 x %2" ).arg( layer.layerSize.x ).arg( layer.layerSize.y ) );
-                    xml.writeAttribute( "TileSize",  QStringLiteral( "%1 x %2" ).arg( layer.tileSize.x  ).arg( layer.tileSize.y  ) );
+                    xml.writeEmptyElement( QStringLiteral("Dimensions") );
+                    xml.writeAttribute( QStringLiteral("LayerSize"), QStringLiteral( "%1 x %2" ).arg( layer.layerSize.x ).arg( layer.layerSize.y ) );
+                    xml.writeAttribute( QStringLiteral("TileSize"),  QStringLiteral( "%1 x %2" ).arg( layer.tileSize.x  ).arg( layer.tileSize.y  ) );
 
                     auto writeStaticTile = [&xml, &writeProps](const tbin::Tile& tile)
                     {
                         if ( tile.props.size() == 0 )
-                            xml.writeEmptyElement( "Static" );
+                            xml.writeEmptyElement( QStringLiteral("Static") );
                         else
-                            xml.writeStartElement( "Static" );
-                        xml.writeAttribute( "Index", QString::number( tile.staticData.tileIndex ) );
+                            xml.writeStartElement( QStringLiteral("Static") );
+                        xml.writeAttribute( QStringLiteral("Index"), QString::number( tile.staticData.tileIndex ) );
                         switch ( tile.staticData.blendMode )
                         {
-                            case 0: xml.writeAttribute( "BlendMode", "Alpha" ); break;
-                            case 1: xml.writeAttribute( "BlendMode", "Additive" ); break;
+                            case 0: xml.writeAttribute( QStringLiteral("BlendMode"), QStringLiteral("Alpha") ); break;
+                            case 1: xml.writeAttribute( QStringLiteral("BlendMode"), QStringLiteral("Additive") ); break;
                             default: throw std::invalid_argument( "Unsupported tile blend mode" );
                         }
                         if ( tile.props.size() > 0 )
@@ -442,18 +442,18 @@ bool TideMapFormat::write(const Tiled::Map *map, const QString &fileName, Option
                             xml.writeEndElement();
                         }
                     };
-                    xml.writeStartElement( "TileArray" );
+                    xml.writeStartElement( QStringLiteral("TileArray") );
                     std::string lastTilesheet;
                     for ( int iy = 0; iy < layer.layerSize.y; ++iy )
                     {
-                        xml.writeStartElement( "Row" );
+                        xml.writeStartElement( QStringLiteral("Row") );
                         for ( int ix = 0; ix < layer.layerSize.x; ++ix )
                         {
                             tbin::Tile tile = layer.tiles[ ix + iy * layer.layerSize.x ];
                             if ( tile.tilesheet != "" && tile.tilesheet != lastTilesheet )
                             {
-                                xml.writeEmptyElement( "TileSheet" );
-                                xml.writeAttribute( "Ref", QString(tile.tilesheet.c_str()) );
+                                xml.writeEmptyElement( QStringLiteral("TileSheet") );
+                                xml.writeAttribute( QStringLiteral("Ref"), QString::fromStdString(tile.tilesheet) );
                                 lastTilesheet = tile.tilesheet;
                             }
 
@@ -470,8 +470,8 @@ bool TideMapFormat::write(const Tiled::Map *map, const QString &fileName, Option
                                     nullCount += 1;
                                 }
 
-                                xml.writeEmptyElement( "Null" );
-                                xml.writeAttribute( "Count", QString::number( nullCount ) );
+                                xml.writeEmptyElement( QStringLiteral("Null") );
+                                xml.writeAttribute( QStringLiteral("Count"), QString::number( nullCount ) );
                             }
                             else if ( tile.staticData.tileIndex != -1 )
                             {
@@ -479,17 +479,17 @@ bool TideMapFormat::write(const Tiled::Map *map, const QString &fileName, Option
                             }
                             else if ( tile.animatedData.frames.size() > 0 )
                             {
-                                xml.writeStartElement( "Animated" );
-                                xml.writeAttribute( "Interval", QString::number( tile.animatedData.frameInterval ) );
+                                xml.writeStartElement( QStringLiteral("Animated") );
+                                xml.writeAttribute( QStringLiteral("Interval"), QString::number( tile.animatedData.frameInterval ) );
 
-                                xml.writeStartElement( "Frames" );
+                                xml.writeStartElement( QStringLiteral("Frames") );
                                 std::string lastTilesheet; // Shadowing the previous declaration intentionally, because we explicitly do not want to use/affect it
                                 for ( const auto& tile : tile.animatedData.frames )
                                 {
                                     if ( tile.tilesheet != "" && tile.tilesheet != lastTilesheet )
                                     {
-                                        xml.writeEmptyElement( "TileSheet" );
-                                        xml.writeAttribute( "Ref", QString(tile.tilesheet.c_str()) );
+                                        xml.writeEmptyElement( QStringLiteral("TileSheet") );
+                                        xml.writeAttribute( QStringLiteral("Ref"), QString::fromStdString(tile.tilesheet) );
                                         lastTilesheet = tile.tilesheet;
                                     }
                                     writeStaticTile( tile );


### PR DESCRIPTION
Fixes build errors against Qt 6.4 (Ubuntu 24.04) where `QStringView` comparisons with `const char*` literals cause compilation issues.

Wrapped string literals in `QLatin1String`/`QStringLiteral` and replaced implicit `const char*` conversions with explicit `QString::fromStdString` / `QLatin1Char`.

The build errors were discovered as part of #4470.