### PR TITLE
Fix copy/paste of list properties (#4514) and clean up RecursiveBehavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Reduced animated tile marker opacity during terrain editing (by Huy Vũ, #4449)
 * Fixed ability to change properties after deselecting the current object (#4440)
 * Fixed Properties view getting stuck with updates disabled (#4506)
+* Fixed copy/paste of list properties losing item types (#4514)
 * Fixed locale-aware parsing of numbers in expression-capable spin boxes
 * Fixed Tile Animation Editor update after tileset image reload (#3923)
 * Fixed runtime language switching in many editor widgets and models (by SIDDHAARTHAA, #4411)

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -1433,10 +1433,7 @@ Properties MapReaderPrivate::readProperties()
     Q_ASSERT(xml.isStartElement() && xml.name() == QLatin1String("properties"));
 
     Properties properties;
-    ExportContext context(mPath.path());
-    // The XML reader builds list values from <item> elements directly, so the
-    // ExportContext should not try to expand list items.
-    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::NoRecursion);
+    const ExportContext context(mPath.path());  // NoRecursion mode
 
     while (xml.readNextStartElement()) {
         if (xml.name() == QLatin1String("property"))

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -1433,7 +1433,10 @@ Properties MapReaderPrivate::readProperties()
     Q_ASSERT(xml.isStartElement() && xml.name() == QLatin1String("properties"));
 
     Properties properties;
-    const ExportContext context(mPath.path());
+    ExportContext context(mPath.path());
+    // The XML reader builds list values from <item> elements directly, so the
+    // ExportContext should not try to expand list items.
+    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::NoRecursion);
 
     while (xml.readNextStartElement()) {
         if (xml.name() == QLatin1String("property"))

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -834,7 +834,7 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
         variantMap[QStringLiteral("properties")] = std::move(propertiesMap);
         variantMap[QStringLiteral("propertytypes")] = std::move(propertyTypesMap);
     } else {
-        context.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+        context.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
 
         QVariantList propertiesVariantList;
 

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -834,6 +834,8 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
         variantMap[QStringLiteral("properties")] = std::move(propertiesMap);
         variantMap[QStringLiteral("propertytypes")] = std::move(propertyTypesMap);
     } else {
+        context.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+
         QVariantList propertiesVariantList;
 
         Properties::const_iterator it = properties.constBegin();
@@ -841,50 +843,16 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
         for (; it != it_end; ++it) {
             const auto exportValue = context.toExportValue(it.value());
 
-            QVariantMap propertyVariantMap = toVariantMap(exportValue);
+            QVariantMap propertyVariantMap;
             propertyVariantMap[QStringLiteral("name")] = it.key();
+            propertyVariantMap[QStringLiteral("type")] = exportValue.typeName;
+            propertyVariantMap[QStringLiteral("value")] = exportValue.value;
+            if (!exportValue.propertyTypeName.isEmpty())
+                propertyVariantMap[QStringLiteral("propertytype")] = exportValue.propertyTypeName;
 
             propertiesVariantList << std::move(propertyVariantMap);
         }
 
         variantMap[QStringLiteral("properties")] = propertiesVariantList;
-    }
-}
-
-QVariantMap MapToVariantConverter::toVariantMap(const ExportValue &exportValue) const
-{
-    QVariantMap propertyVariantMap;
-
-    QVariant value = exportValue.value;
-    exportValuesToVariantMap(value);
-
-    propertyVariantMap[QStringLiteral("type")] = exportValue.typeName;
-    propertyVariantMap[QStringLiteral("value")] = value;
-    if (!exportValue.propertyTypeName.isEmpty())
-        propertyVariantMap[QStringLiteral("propertytype")] = exportValue.propertyTypeName;
-
-    return propertyVariantMap;
-}
-
-void MapToVariantConverter::exportValuesToVariantMap(QVariant &value) const
-{
-    switch (value.userType()) {
-    case QMetaType::QVariantMap: {
-        auto map = value.toMap();
-        for (auto &value : map)
-            exportValuesToVariantMap(value);
-        value = std::move(map);
-        break;
-    }
-    case QMetaType::QVariantList: {
-        auto list = value.toList();
-        for (QVariant &item : list)
-            item = toVariantMap(item.value<ExportValue>());
-        value = std::move(list);
-        break;
-    }
-    default:
-        // No conversion needed for other types
-        break;
     }
 }

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -365,7 +365,10 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
 QVariant MapToVariantConverter::toVariant(const Properties &properties) const
 {
     QVariantMap variantMap;
-    const ExportContext context(mDir.path());
+    ExportContext context(mDir.path());
+    // The JSON1 format can't represent typed lists, but classes still need
+    // their members converted to scalars.
+    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::ValuesOnly);
 
     Properties::const_iterator it = properties.constBegin();
     Properties::const_iterator it_end = properties.constEnd();

--- a/src/libtiled/maptovariantconverter.h
+++ b/src/libtiled/maptovariantconverter.h
@@ -86,8 +86,6 @@ private:
 
     void addProperties(QVariantMap &variantMap,
                        const Properties &properties) const;
-    QVariantMap toVariantMap(const ExportValue &exportValue) const;
-    void exportValuesToVariantMap(QVariant &value) const;
 
     int mVersion;
     QDir mDir;

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -909,10 +909,7 @@ void MapWriterPrivate::writeProperties(QXmlStreamWriter &w,
 
     w.writeStartElement(QStringLiteral("properties"));
 
-    ExportContext context(mUseAbsolutePaths ? QString() : mDir.path());
-    // The writer drives recursion into lists and class members itself, so the
-    // ExportContext should not transform compound values.
-    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::NoRecursion);
+    const ExportContext context(mUseAbsolutePaths ? QString() : mDir.path());  // NoRecursion mode
 
     Properties::const_iterator it = properties.constBegin();
     Properties::const_iterator it_end = properties.constEnd();

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -94,7 +94,9 @@ private:
     void writeGroupLayer(QXmlStreamWriter &w, const GroupLayer &groupLayer);
     void writeProperties(QXmlStreamWriter &w,
                          const Properties &properties);
-    void writeExportValue(QXmlStreamWriter &w, const ExportValue &value);
+    void writePropertyValue(QXmlStreamWriter &w,
+                            const QVariant &value,
+                            const ExportContext &context);
     void writeImage(QXmlStreamWriter &w,
                     const QUrl &source,
                     const QPixmap &image,
@@ -908,66 +910,64 @@ void MapWriterPrivate::writeProperties(QXmlStreamWriter &w,
     w.writeStartElement(QStringLiteral("properties"));
 
     ExportContext context(mUseAbsolutePaths ? QString() : mDir.path());
-    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::ExportValuesOnly);
+    // The writer drives recursion into lists and class members itself, so the
+    // ExportContext should not transform compound values.
+    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::NoRecursion);
 
     Properties::const_iterator it = properties.constBegin();
     Properties::const_iterator it_end = properties.constEnd();
     for (; it != it_end; ++it) {
         w.writeStartElement(QStringLiteral("property"));
         w.writeAttribute(QStringLiteral("name"), it.key());
-
-        writeExportValue(w, context.toExportValue(it.value()));
-
+        writePropertyValue(w, it.value(), context);
         w.writeEndElement(); // </property>
     }
 
     w.writeEndElement(); // </properties>
 }
 
-void MapWriterPrivate::writeExportValue(QXmlStreamWriter &w, const ExportValue &exportValue)
+void MapWriterPrivate::writePropertyValue(QXmlStreamWriter &w,
+                                          const QVariant &value,
+                                          const ExportContext &context)
 {
+    const ExportValue exportValue = context.toExportValue(value);
+
     if (exportValue.typeName != QLatin1String("string"))
         w.writeAttribute(QStringLiteral("type"), exportValue.typeName);
     if (!exportValue.propertyTypeName.isEmpty())
         w.writeAttribute(QStringLiteral("propertytype"), exportValue.propertyTypeName);
 
-    switch (exportValue.value.userType()) {
-    case QMetaType::QVariantList: {
-        const auto values = exportValue.value.toList();
-        for (const QVariant &value : values) {
-            w.writeStartElement(QStringLiteral("item"));
-            writeExportValue(w, value.value<ExportValue>());
-            w.writeEndElement(); // </item>
-        }
-        break;
-    }
-    case QMetaType::QVariantMap: {
-        const auto map = exportValue.value.toMap();
-        if (map.isEmpty())
-            break;
+    if (exportValue.typeName == QLatin1String("class")) {
+        QVariantMap members;
+        if (value.userType() == propertyValueId())
+            members = value.value<PropertyValue>().value.toMap();
+        else
+            members = value.toMap();
+
+        if (members.isEmpty())
+            return;
 
         w.writeStartElement(QStringLiteral("properties"));
-        Properties::const_iterator it = map.constBegin();
-        Properties::const_iterator it_end = map.constEnd();
-        for (; it != it_end; ++it) {
+        for (auto it = members.constBegin(); it != members.constEnd(); ++it) {
             w.writeStartElement(QStringLiteral("property"));
             w.writeAttribute(QStringLiteral("name"), it.key());
-
-            writeExportValue(w, it.value().value<ExportValue>());
-
+            writePropertyValue(w, it.value(), context);
             w.writeEndElement(); // </property>
         }
         w.writeEndElement(); // </properties>
-        break;
-    }
-    default:
-        const QString value = exportValue.value.toString();
-
-        if (value.contains(QLatin1Char('\n')))
-            w.writeCharacters(value);
+    } else if (exportValue.typeName == QLatin1String("list")) {
+        const auto list = value.toList();
+        for (const QVariant &item : list) {
+            w.writeStartElement(QStringLiteral("item"));
+            writePropertyValue(w, item, context);
+            w.writeEndElement(); // </item>
+        }
+    } else {
+        const QString stringValue = exportValue.value.toString();
+        if (stringValue.contains(QLatin1Char('\n')))
+            w.writeCharacters(stringValue);
         else
-            w.writeAttribute(QStringLiteral("value"), value);
-        break;
+            w.writeAttribute(QStringLiteral("value"), stringValue);
     }
 }
 

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -938,12 +938,7 @@ void MapWriterPrivate::writePropertyValue(QXmlStreamWriter &w,
         w.writeAttribute(QStringLiteral("propertytype"), exportValue.propertyTypeName);
 
     if (exportValue.typeName == QLatin1String("class")) {
-        QVariantMap members;
-        if (value.userType() == propertyValueId())
-            members = value.value<PropertyValue>().value.toMap();
-        else
-            members = value.toMap();
-
+        const QVariantMap members = exportValue.value.toMap();
         if (members.isEmpty())
             return;
 
@@ -956,7 +951,7 @@ void MapWriterPrivate::writePropertyValue(QXmlStreamWriter &w,
         }
         w.writeEndElement(); // </properties>
     } else if (exportValue.typeName == QLatin1String("list")) {
-        const auto list = value.toList();
+        const auto list = exportValue.value.toList();
         for (const QVariant &item : list) {
             w.writeStartElement(QStringLiteral("item"));
             writePropertyValue(w, item, context);

--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -456,12 +456,8 @@ ExportValue ExportContext::toExportValue(const QVariant &value) const
 
 QVariant ExportContext::toPropertyValue(const ExportValue &exportValue) const
 {
-    QVariant value = exportValue.value;
-    if (mRecursiveBehavior == RecursiveBehavior::TypedListValues)
-        convertListValues(value);
-
     const int metaType = nameToType(exportValue.typeName);
-    QVariant propertyValue = toPropertyValue(value, metaType);
+    QVariant propertyValue = toPropertyValue(exportValue.value, metaType);
 
     // Wrap the value in its custom property type when applicable
     if (!exportValue.propertyTypeName.isEmpty()) {
@@ -476,16 +472,14 @@ QVariant ExportContext::toPropertyValue(const ExportValue &exportValue) const
     return propertyValue;
 }
 
-/**
- * Walks the given value tree (in TypedListValues form), converting each list
- * element from a {type, propertytype, value} map back into a typed value.
- * Recurses into class maps so list members nested within classes are also
- * converted.
- */
-void ExportContext::convertListValues(QVariant &value) const
+QVariant ExportContext::toPropertyValue(const QVariant &value, int metaType) const
 {
-    switch (value.userType()) {
-    case QMetaType::QVariantList: {
+    if (metaType == QMetaType::QVariantList) {
+        if (mRecursiveBehavior != RecursiveBehavior::TypedListValues)
+            return value;   // list elements are already in their final form
+
+        // Each list element is a {type, propertytype, value} map. Reconstruct
+        // its ExportValue and recurse, which decodes any nested lists too.
         QVariantList list = value.toList();
         for (QVariant &item : list) {
             const QVariantMap itemMap = item.toMap();
@@ -495,31 +489,14 @@ void ExportContext::convertListValues(QVariant &value) const
             elementExport.propertyTypeName = itemMap.value(QLatin1String("propertytype")).toString();
             item = toPropertyValue(elementExport);
         }
-        value = std::move(list);
-        break;
+        return list;
     }
-    case QMetaType::QVariantMap: {
-        QVariantMap map = value.toMap();
-        for (QVariant &v : map)
-            convertListValues(v);
-        value = std::move(map);
-        break;
-    }
-    default:
-        break;
-    }
-}
 
-QVariant ExportContext::toPropertyValue(const QVariant &value, int metaType) const
-{
     if (metaType == QMetaType::UnknownType || value.userType() == metaType)
         return value;   // value possibly already converted
 
     if (metaType == QMetaType::QVariantMap || metaType == propertyValueId())
         return value;   // should be covered by property type
-
-    if (metaType == QMetaType::QVariantList)
-        return value;   // list elements should be converted individually
 
     if (metaType == filePathTypeId()) {
         const QUrl url = toUrl(value.toString(), mPath);

--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -206,8 +206,7 @@ void mergeProperties(Properties &target, const Properties &source)
 
 QJsonArray propertiesToJson(const Properties &properties, const ExportContext &context)
 {
-    ExportContext jsonContext = context;
-    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
+    Q_ASSERT(context.recursiveBehavior() == ExportContext::RecursiveBehavior::TypedListValues);
 
     QJsonArray json;
 
@@ -215,7 +214,7 @@ QJsonArray propertiesToJson(const Properties &properties, const ExportContext &c
     const Properties::const_iterator it_end = properties.end();
     for (; it != it_end; ++it) {
         const QString &name = it.key();
-        const auto exportValue = jsonContext.toExportValue(it.value());
+        const auto exportValue = context.toExportValue(it.value());
 
         QJsonObject propertyObject;
         propertyObject.insert(QLatin1String("name"), name);
@@ -230,10 +229,16 @@ QJsonArray propertiesToJson(const Properties &properties, const ExportContext &c
     return json;
 }
 
+QJsonArray propertiesToJson(const Properties &properties, const QString &path)
+{
+    ExportContext context(path);
+    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
+    return propertiesToJson(properties, context);
+}
+
 Properties propertiesFromJson(const QJsonArray &json, const ExportContext &context)
 {
-    ExportContext jsonContext = context;
-    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
+    Q_ASSERT(context.recursiveBehavior() == ExportContext::RecursiveBehavior::TypedListValues);
 
     Properties properties;
 
@@ -246,21 +251,28 @@ Properties propertiesFromJson(const QJsonArray &json, const ExportContext &conte
         exportValue.typeName = propertyObject.value(QLatin1String("type")).toString();
         exportValue.propertyTypeName = propertyObject.value(QLatin1String("propertytype")).toString();
 
-        properties.insert(name, jsonContext.toPropertyValue(exportValue));
+        properties.insert(name, context.toPropertyValue(exportValue));
     }
 
     return properties;
 }
 
-QJsonArray valuesToJson(const QVariantList &values, const ExportContext &context)
+Properties propertiesFromJson(const QJsonArray &json, const QString &path)
 {
-    ExportContext jsonContext = context;
-    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
+    ExportContext context(path);
+    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
+    return propertiesFromJson(json, context);
+}
+
+QJsonArray valuesToJson(const QVariantList &values, const QString &path)
+{
+    ExportContext context(path);
+    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
 
     QJsonArray json;
 
     for (auto &value : values) {
-        const auto exportValue = jsonContext.toExportValue(value);
+        const auto exportValue = context.toExportValue(value);
 
         QJsonObject propertyObject;
         propertyObject.insert(QLatin1String("type"), exportValue.typeName);
@@ -274,10 +286,10 @@ QJsonArray valuesToJson(const QVariantList &values, const ExportContext &context
     return json;
 }
 
-QVariantList valuesFromJson(const QJsonArray &json, const ExportContext &context)
+QVariantList valuesFromJson(const QJsonArray &json, const QString &path)
 {
-    ExportContext jsonContext = context;
-    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
+    ExportContext context(path);
+    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
 
     QVariantList values;
 
@@ -289,7 +301,7 @@ QVariantList valuesFromJson(const QJsonArray &json, const ExportContext &context
         exportValue.typeName = valueObject.value(QLatin1String("type")).toString();
         exportValue.propertyTypeName = valueObject.value(QLatin1String("propertytype")).toString();
 
-        values.append(jsonContext.toPropertyValue(exportValue));
+        values.append(context.toPropertyValue(exportValue));
     }
 
     return values;

--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -421,7 +421,6 @@ ExportValue ExportContext::toExportValue(const QVariant &value) const
             for (const QVariant &element : list)
                 exportValues.append(toExportValue(element).value);
             break;
-        case RecursiveBehavior::ListsAsExportValues:
         case RecursiveBehavior::ExportValuesOnly:
             for (const QVariant &element : list)
                 exportValues.append(QVariant::fromValue(toExportValue(element)));
@@ -491,7 +490,13 @@ void ExportContext::convertListValues(QVariant &value) const
     case QMetaType::QVariantList: {
         QVariantList list = value.toList();
         for (QVariant &item : list) {
+            // Only items that look like JsonReady wrappers are converted, so
+            // already-typed values (e.g. from the XML reader) pass through.
+            if (item.userType() != QMetaType::QVariantMap)
+                continue;
             const QVariantMap itemMap = item.toMap();
+            if (!itemMap.contains(QLatin1String("type")))
+                continue;
             ExportValue elementExport;
             elementExport.value = itemMap.value(QLatin1String("value"));
             elementExport.typeName = itemMap.value(QLatin1String("type")).toString();

--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -206,19 +206,23 @@ void mergeProperties(Properties &target, const Properties &source)
 
 QJsonArray propertiesToJson(const Properties &properties, const ExportContext &context)
 {
+    ExportContext jsonContext = context;
+    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+
     QJsonArray json;
 
     Properties::const_iterator it = properties.begin();
     const Properties::const_iterator it_end = properties.end();
     for (; it != it_end; ++it) {
         const QString &name = it.key();
-        const auto exportValue = context.toExportValue(it.value());
+        const auto exportValue = jsonContext.toExportValue(it.value());
 
         QJsonObject propertyObject;
         propertyObject.insert(QLatin1String("name"), name);
         propertyObject.insert(QLatin1String("value"), QJsonValue::fromVariant(exportValue.value));
         propertyObject.insert(QLatin1String("type"), exportValue.typeName);
-        propertyObject.insert(QLatin1String("propertytype"), exportValue.propertyTypeName);
+        if (!exportValue.propertyTypeName.isEmpty())
+            propertyObject.insert(QLatin1String("propertytype"), exportValue.propertyTypeName);
 
         json.append(propertyObject);
     }
@@ -228,6 +232,9 @@ QJsonArray propertiesToJson(const Properties &properties, const ExportContext &c
 
 Properties propertiesFromJson(const QJsonArray &json, const ExportContext &context)
 {
+    ExportContext jsonContext = context;
+    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+
     Properties properties;
 
     for (const QJsonValue &property : json) {
@@ -239,7 +246,7 @@ Properties propertiesFromJson(const QJsonArray &json, const ExportContext &conte
         exportValue.typeName = propertyObject.value(QLatin1String("type")).toString();
         exportValue.propertyTypeName = propertyObject.value(QLatin1String("propertytype")).toString();
 
-        properties.insert(name, context.toPropertyValue(exportValue));
+        properties.insert(name, jsonContext.toPropertyValue(exportValue));
     }
 
     return properties;
@@ -247,19 +254,19 @@ Properties propertiesFromJson(const QJsonArray &json, const ExportContext &conte
 
 QJsonArray valuesToJson(const QVariantList &values, const ExportContext &context)
 {
+    ExportContext jsonContext = context;
+    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+
     QJsonArray json;
 
     for (auto &value : values) {
-        const auto exportValue = context.toExportValue(value);
+        const auto exportValue = jsonContext.toExportValue(value);
 
         QJsonObject propertyObject;
         propertyObject.insert(QLatin1String("type"), exportValue.typeName);
-        propertyObject.insert(QLatin1String("propertytype"), exportValue.propertyTypeName);
-
-        if (value.userType() == QMetaType::QVariantList)
-            propertyObject.insert(QLatin1String("value"), valuesToJson(value.toList(), context));
-        else
-            propertyObject.insert(QLatin1String("value"), QJsonValue::fromVariant(exportValue.value));
+        if (!exportValue.propertyTypeName.isEmpty())
+            propertyObject.insert(QLatin1String("propertytype"), exportValue.propertyTypeName);
+        propertyObject.insert(QLatin1String("value"), QJsonValue::fromVariant(exportValue.value));
 
         json.append(propertyObject);
     }
@@ -269,6 +276,9 @@ QJsonArray valuesToJson(const QVariantList &values, const ExportContext &context
 
 QVariantList valuesFromJson(const QJsonArray &json, const ExportContext &context)
 {
+    ExportContext jsonContext = context;
+    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+
     QVariantList values;
 
     for (const QJsonValue &value : json) {
@@ -279,7 +289,7 @@ QVariantList valuesFromJson(const QJsonArray &json, const ExportContext &context
         exportValue.typeName = valueObject.value(QLatin1String("type")).toString();
         exportValue.propertyTypeName = valueObject.value(QLatin1String("propertytype")).toString();
 
-        values.append(context.toPropertyValue(exportValue));
+        values.append(jsonContext.toPropertyValue(exportValue));
     }
 
     return values;
@@ -406,12 +416,27 @@ ExportValue ExportContext::toExportValue(const QVariant &value) const
         QVariantList exportValues;
         const auto list = value.toList();
         exportValues.reserve(list.size());
-        if (mRecursiveBehavior == RecursiveBehavior::ValuesOnly) {
+        switch (mRecursiveBehavior) {
+        case RecursiveBehavior::ValuesOnly:
             for (const QVariant &element : list)
                 exportValues.append(toExportValue(element).value);
-        } else {
+            break;
+        case RecursiveBehavior::ListsAsExportValues:
+        case RecursiveBehavior::ExportValuesOnly:
             for (const QVariant &element : list)
                 exportValues.append(QVariant::fromValue(toExportValue(element)));
+            break;
+        case RecursiveBehavior::JsonReady:
+            for (const QVariant &element : list) {
+                const ExportValue elementExport = toExportValue(element);
+                QVariantMap mapItem;
+                mapItem.insert(QLatin1String("type"), elementExport.typeName);
+                if (!elementExport.propertyTypeName.isEmpty())
+                    mapItem.insert(QLatin1String("propertytype"), elementExport.propertyTypeName);
+                mapItem.insert(QLatin1String("value"), elementExport.value);
+                exportValues.append(mapItem);
+            }
+            break;
         }
         exportValue.value = exportValues;
     } else if (metaType == QMetaType::QColor) {
@@ -434,8 +459,12 @@ ExportValue ExportContext::toExportValue(const QVariant &value) const
 
 QVariant ExportContext::toPropertyValue(const ExportValue &exportValue) const
 {
+    QVariant value = exportValue.value;
+    if (mRecursiveBehavior == RecursiveBehavior::JsonReady)
+        convertListValues(value);
+
     const int metaType = nameToType(exportValue.typeName);
-    QVariant propertyValue = toPropertyValue(exportValue.value, metaType);
+    QVariant propertyValue = toPropertyValue(value, metaType);
 
     // Wrap the value in its custom property type when applicable
     if (!exportValue.propertyTypeName.isEmpty()) {
@@ -448,6 +477,40 @@ QVariant ExportContext::toPropertyValue(const ExportValue &exportValue) const
     }
 
     return propertyValue;
+}
+
+/**
+ * Walks the given value tree (in JsonReady form), converting each list
+ * element from a {type, propertytype, value} map back into a typed value.
+ * Recurses into class maps so list members nested within classes are also
+ * converted.
+ */
+void ExportContext::convertListValues(QVariant &value) const
+{
+    switch (value.userType()) {
+    case QMetaType::QVariantList: {
+        QVariantList list = value.toList();
+        for (QVariant &item : list) {
+            const QVariantMap itemMap = item.toMap();
+            ExportValue elementExport;
+            elementExport.value = itemMap.value(QLatin1String("value"));
+            elementExport.typeName = itemMap.value(QLatin1String("type")).toString();
+            elementExport.propertyTypeName = itemMap.value(QLatin1String("propertytype")).toString();
+            item = toPropertyValue(elementExport);
+        }
+        value = std::move(list);
+        break;
+    }
+    case QMetaType::QVariantMap: {
+        QVariantMap map = value.toMap();
+        for (QVariant &v : map)
+            convertListValues(v);
+        value = std::move(map);
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 QVariant ExportContext::toPropertyValue(const QVariant &value, int metaType) const

--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -412,11 +412,13 @@ ExportValue ExportContext::toExportValue(const QVariant &value) const
 
     ExportValue exportValue;
 
-    if (metaType == QMetaType::QVariantList) {
+    if (metaType == QMetaType::QVariantList && mRecursiveBehavior != RecursiveBehavior::NoRecursion) {
         QVariantList exportValues;
         const auto list = value.toList();
         exportValues.reserve(list.size());
         switch (mRecursiveBehavior) {
+        case RecursiveBehavior::NoRecursion:
+            break;  // unreachable, handled above
         case RecursiveBehavior::ValuesOnly:
             for (const QVariant &element : list)
                 exportValues.append(toExportValue(element).value);
@@ -490,13 +492,7 @@ void ExportContext::convertListValues(QVariant &value) const
     case QMetaType::QVariantList: {
         QVariantList list = value.toList();
         for (QVariant &item : list) {
-            // Only items that look like TypedListValues wrappers are converted, so
-            // already-typed values (e.g. from the XML reader) pass through.
-            if (item.userType() != QMetaType::QVariantMap)
-                continue;
             const QVariantMap itemMap = item.toMap();
-            if (!itemMap.contains(QLatin1String("type")))
-                continue;
             ExportValue elementExport;
             elementExport.value = itemMap.value(QLatin1String("value"));
             elementExport.typeName = itemMap.value(QLatin1String("type")).toString();

--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -423,10 +423,6 @@ ExportValue ExportContext::toExportValue(const QVariant &value) const
             for (const QVariant &element : list)
                 exportValues.append(toExportValue(element).value);
             break;
-        case RecursiveBehavior::ExportValuesOnly:
-            for (const QVariant &element : list)
-                exportValues.append(QVariant::fromValue(toExportValue(element)));
-            break;
         case RecursiveBehavior::TypedListValues:
             for (const QVariant &element : list) {
                 const ExportValue elementExport = toExportValue(element);

--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -207,7 +207,7 @@ void mergeProperties(Properties &target, const Properties &source)
 QJsonArray propertiesToJson(const Properties &properties, const ExportContext &context)
 {
     ExportContext jsonContext = context;
-    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
 
     QJsonArray json;
 
@@ -233,7 +233,7 @@ QJsonArray propertiesToJson(const Properties &properties, const ExportContext &c
 Properties propertiesFromJson(const QJsonArray &json, const ExportContext &context)
 {
     ExportContext jsonContext = context;
-    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
 
     Properties properties;
 
@@ -255,7 +255,7 @@ Properties propertiesFromJson(const QJsonArray &json, const ExportContext &conte
 QJsonArray valuesToJson(const QVariantList &values, const ExportContext &context)
 {
     ExportContext jsonContext = context;
-    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
 
     QJsonArray json;
 
@@ -277,7 +277,7 @@ QJsonArray valuesToJson(const QVariantList &values, const ExportContext &context
 QVariantList valuesFromJson(const QJsonArray &json, const ExportContext &context)
 {
     ExportContext jsonContext = context;
-    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+    jsonContext.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
 
     QVariantList values;
 
@@ -425,7 +425,7 @@ ExportValue ExportContext::toExportValue(const QVariant &value) const
             for (const QVariant &element : list)
                 exportValues.append(QVariant::fromValue(toExportValue(element)));
             break;
-        case RecursiveBehavior::JsonReady:
+        case RecursiveBehavior::TypedListValues:
             for (const QVariant &element : list) {
                 const ExportValue elementExport = toExportValue(element);
                 QVariantMap mapItem;
@@ -459,7 +459,7 @@ ExportValue ExportContext::toExportValue(const QVariant &value) const
 QVariant ExportContext::toPropertyValue(const ExportValue &exportValue) const
 {
     QVariant value = exportValue.value;
-    if (mRecursiveBehavior == RecursiveBehavior::JsonReady)
+    if (mRecursiveBehavior == RecursiveBehavior::TypedListValues)
         convertListValues(value);
 
     const int metaType = nameToType(exportValue.typeName);
@@ -479,7 +479,7 @@ QVariant ExportContext::toPropertyValue(const ExportValue &exportValue) const
 }
 
 /**
- * Walks the given value tree (in JsonReady form), converting each list
+ * Walks the given value tree (in TypedListValues form), converting each list
  * element from a {type, propertytype, value} map back into a typed value.
  * Recurses into class maps so list members nested within classes are also
  * converted.
@@ -490,7 +490,7 @@ void ExportContext::convertListValues(QVariant &value) const
     case QMetaType::QVariantList: {
         QVariantList list = value.toList();
         for (QVariant &item : list) {
-            // Only items that look like JsonReady wrappers are converted, so
+            // Only items that look like TypedListValues wrappers are converted, so
             // already-typed values (e.g. from the XML reader) pass through.
             if (item.userType() != QMetaType::QVariantMap)
                 continue;

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -101,6 +101,9 @@ public:
         ValuesOnly,             // Lua and JSON1 formats (loses types in lists)
         ListsAsExportValues,    // JSON2 format
         ExportValuesOnly,       // XML format (keep superfluous types in classes)
+        JsonReady,              // List elements expanded to {type, propertytype,
+                                // value} maps so the result can be passed
+                                // directly to QJsonValue::fromVariant.
     };
 
     explicit ExportContext(const QString &path = QString());
@@ -124,6 +127,8 @@ public:
     QVariant toPropertyValue(const QVariant &value, int metaType) const;
 
 private:
+    void convertListValues(QVariant &value) const;
+
     const PropertyTypes &mTypes;
     const QString mPath;
     RecursiveBehavior mRecursiveBehavior = RecursiveBehavior::ListsAsExportValues;

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -98,9 +98,12 @@ class TILEDSHARED_EXPORT ExportContext
 {
 public:
     enum class RecursiveBehavior {
+        NoRecursion,            // Values are taken as-is. Used by readers that
+                                // already produce list elements as typed values
+                                // (e.g. the XML map reader).
         ValuesOnly,             // Lua and JSON1 formats (loses types in lists)
         ExportValuesOnly,       // XML format (keep superfluous types in classes)
-        TypedListValues,              // List elements expanded to {type, propertytype,
+        TypedListValues,        // List elements expanded to {type, propertytype,
                                 // value} maps so the result can be passed
                                 // directly to QJsonValue::fromVariant.
     };
@@ -130,7 +133,7 @@ private:
 
     const PropertyTypes &mTypes;
     const QString mPath;
-    RecursiveBehavior mRecursiveBehavior = RecursiveBehavior::TypedListValues;
+    RecursiveBehavior mRecursiveBehavior = RecursiveBehavior::NoRecursion;
 };
 
 class TILEDSHARED_EXPORT AggregatedPropertyData

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -127,8 +127,6 @@ public:
     QVariant toPropertyValue(const QVariant &value, int metaType) const;
 
 private:
-    void convertListValues(QVariant &value) const;
-
     const PropertyTypes &mTypes;
     const QString mPath;
     RecursiveBehavior mRecursiveBehavior = RecursiveBehavior::NoRecursion;

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -98,11 +98,9 @@ class TILEDSHARED_EXPORT ExportContext
 {
 public:
     enum class RecursiveBehavior {
-        NoRecursion,            // Values are taken as-is. Used by readers that
-                                // already produce list elements as typed values
-                                // (e.g. the XML map reader).
+        NoRecursion,            // Values are taken as-is. Used by readers and
+                                // writers that walk compound values themselves.
         ValuesOnly,             // Lua and JSON1 formats (loses types in lists)
-        ExportValuesOnly,       // XML format (keep superfluous types in classes)
         TypedListValues,        // List elements expanded to {type, propertytype,
                                 // value} maps so the result can be passed
                                 // directly to QJsonValue::fromVariant.

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -200,14 +200,19 @@ TILEDSHARED_EXPORT void aggregateProperties(AggregatedProperties &aggregated, co
 TILEDSHARED_EXPORT void mergeProperties(Properties &target, const Properties &source);
 
 TILEDSHARED_EXPORT QJsonArray propertiesToJson(const Properties &properties,
-                                               const ExportContext &context = ExportContext());
+                                               const ExportContext &context);
+TILEDSHARED_EXPORT QJsonArray propertiesToJson(const Properties &properties,
+                                               const QString &path = QString());
+
 TILEDSHARED_EXPORT Properties propertiesFromJson(const QJsonArray &json,
-                                                 const ExportContext &context = ExportContext());
+                                                 const ExportContext &context);
+TILEDSHARED_EXPORT Properties propertiesFromJson(const QJsonArray &json,
+                                                 const QString &path = QString());
 
 TILEDSHARED_EXPORT QJsonArray valuesToJson(const QVariantList &values,
-                                           const ExportContext &context = ExportContext());
+                                           const QString &path = QString());
 TILEDSHARED_EXPORT QVariantList valuesFromJson(const QJsonArray &json,
-                                               const ExportContext &context = ExportContext());
+                                               const QString &path = QString());
 
 constexpr int propertyValueId() { return qMetaTypeId<PropertyValue>(); }
 constexpr int filePathTypeId() { return qMetaTypeId<FilePath>(); }

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -99,7 +99,6 @@ class TILEDSHARED_EXPORT ExportContext
 public:
     enum class RecursiveBehavior {
         ValuesOnly,             // Lua and JSON1 formats (loses types in lists)
-        ListsAsExportValues,    // JSON2 format
         ExportValuesOnly,       // XML format (keep superfluous types in classes)
         JsonReady,              // List elements expanded to {type, propertytype,
                                 // value} maps so the result can be passed
@@ -131,7 +130,7 @@ private:
 
     const PropertyTypes &mTypes;
     const QString mPath;
-    RecursiveBehavior mRecursiveBehavior = RecursiveBehavior::ListsAsExportValues;
+    RecursiveBehavior mRecursiveBehavior = RecursiveBehavior::JsonReady;
 };
 
 class TILEDSHARED_EXPORT AggregatedPropertyData

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -100,7 +100,7 @@ public:
     enum class RecursiveBehavior {
         ValuesOnly,             // Lua and JSON1 formats (loses types in lists)
         ExportValuesOnly,       // XML format (keep superfluous types in classes)
-        JsonReady,              // List elements expanded to {type, propertytype,
+        TypedListValues,              // List elements expanded to {type, propertytype,
                                 // value} maps so the result can be passed
                                 // directly to QJsonValue::fromVariant.
     };
@@ -130,7 +130,7 @@ private:
 
     const PropertyTypes &mTypes;
     const QString mPath;
-    RecursiveBehavior mRecursiveBehavior = RecursiveBehavior::JsonReady;
+    RecursiveBehavior mRecursiveBehavior = RecursiveBehavior::TypedListValues;
 };
 
 class TILEDSHARED_EXPORT AggregatedPropertyData

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -242,12 +242,14 @@ ExportValue ClassPropertyType::toExportValue(const QVariant &value, const Export
 {
     Properties properties = value.toMap();
 
-    for (auto &value : properties) {
-        ExportValue exportValue = context.toExportValue(value);
-        if (context.recursiveBehavior() == ExportContext::RecursiveBehavior::ExportValuesOnly)
-            value = QVariant::fromValue(std::move(exportValue));
-        else
-            value = exportValue.value;
+    if (context.recursiveBehavior() != ExportContext::RecursiveBehavior::NoRecursion) {
+        for (auto &value : properties) {
+            ExportValue exportValue = context.toExportValue(value);
+            if (context.recursiveBehavior() == ExportContext::RecursiveBehavior::ExportValuesOnly)
+                value = QVariant::fromValue(std::move(exportValue));
+            else
+                value = exportValue.value;
+        }
     }
 
     return PropertyType::toExportValue(properties, context);

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -266,8 +266,12 @@ QVariant ClassPropertyType::toPropertyValue(const QVariant &value, const ExportC
         if (!classMember.isValid())
             continue; // ignore removed members
 
-        if (it.value().userType() == classMember.userType())
-            continue; // leave members alone that already have the expected type
+        // Members that already match the expected type can be left alone,
+        // except for lists where the items themselves may still need decoding
+        // (in TypedListValues mode each item is a wrapper map).
+        if (it.value().userType() == classMember.userType()
+                && classMember.userType() != QMetaType::QVariantList)
+            continue;
 
         QVariant propertyValue = context.toPropertyValue(it.value(), classMember.userType());
 

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -245,10 +245,7 @@ ExportValue ClassPropertyType::toExportValue(const QVariant &value, const Export
     if (context.recursiveBehavior() != ExportContext::RecursiveBehavior::NoRecursion) {
         for (auto &value : properties) {
             ExportValue exportValue = context.toExportValue(value);
-            if (context.recursiveBehavior() == ExportContext::RecursiveBehavior::ExportValuesOnly)
-                value = QVariant::fromValue(std::move(exportValue));
-            else
-                value = exportValue.value;
+            value = exportValue.value;
         }
     }
 
@@ -307,20 +304,21 @@ static const struct  {
     { ClassPropertyType::ProjectClass,          QLatin1String("project") },
 };
 
-QJsonValue exportValueToJson(const ExportValue &exportValue)
+QJsonValue exportValueToJson(const QVariant &value, const ExportContext &context)
 {
-    switch (exportValue.value.userType()) {
-    case QMetaType::QVariantList: {
+    const ExportValue exportValue = context.toExportValue(value);
+
+    if (exportValue.typeName == QLatin1String("list")) {
         // We have to include the type and possibly propertyType for each value
         // in the list so that we know the type of the values when loading the
         // list.
         QJsonArray jsonArray;
         const auto list = exportValue.value.toList();
-        for (const auto &item : list) {
-            const auto itemExportValue = item.value<ExportValue>();
+        for (const QVariant &item : list) {
+            const ExportValue itemExportValue = context.toExportValue(item);
             QJsonObject member {
-               { QStringLiteral("type"), itemExportValue.typeName },
-               { QStringLiteral("value"), exportValueToJson(itemExportValue) },
+                { QStringLiteral("type"), itemExportValue.typeName },
+                { QStringLiteral("value"), exportValueToJson(item, context) },
             };
 
             if (!itemExportValue.propertyTypeName.isEmpty())
@@ -330,18 +328,18 @@ QJsonValue exportValueToJson(const ExportValue &exportValue)
         }
         return jsonArray;
     }
-    case QMetaType::QVariantMap: {
+
+    if (exportValue.typeName == QLatin1String("class")) {
         // For classes we only store the values, because the type of the
         // members is defined by the class.
         QJsonObject jsonObject;
-        const auto map = exportValue.value.toMap();
-        for (auto it = map.constBegin(); it != map.constEnd(); ++it)
-            jsonObject.insert(it.key(), exportValueToJson(it.value().value<ExportValue>()));
+        const QVariantMap members = exportValue.value.toMap();
+        for (auto it = members.constBegin(); it != members.constEnd(); ++it)
+            jsonObject.insert(it.key(), exportValueToJson(it.value(), context));
         return jsonObject;
     }
-    default:
-        return QJsonValue::fromVariant(exportValue.value);
-    }
+
+    return QJsonValue::fromVariant(exportValue.value);
 }
 
 QJsonObject ClassPropertyType::toJson(const ExportContext &context) const
@@ -357,7 +355,7 @@ QJsonObject ClassPropertyType::toJson(const ExportContext &context) const
         QJsonObject member {
             { QStringLiteral("name"), it.key() },
             { QStringLiteral("type"), exportValue.typeName },
-            { QStringLiteral("value"), exportValueToJson(exportValue) },
+            { QStringLiteral("value"), exportValueToJson(it.value(), context) },
         };
 
         if (!exportValue.propertyTypeName.isEmpty())
@@ -785,8 +783,7 @@ void PropertyTypes::resolveMemberValues(ClassPropertyType *classType,
 
 QJsonArray PropertyTypes::toJson(const QString &path) const
 {
-    ExportContext context(*this, path);
-    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::ExportValuesOnly);
+    const ExportContext context(*this, path);  // NoRecursion mode
 
     QJsonArray propertyTypesJson;
     for (const auto &type : mTypes)

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -185,7 +185,7 @@ Properties VariantToMapConverter::toProperties(const QVariant &propertiesVariant
     // read array-based format (1.2)
     const QVariantList propertiesList = propertiesVariant.toList();
     if (!propertiesList.isEmpty())
-        context.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
+        context.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
     for (const QVariant &propertyVariant : propertiesList) {
         const QVariantMap propertyVariantMap = propertyVariant.toMap();
         const QString propertyName = propertyVariantMap[QStringLiteral("name")].toString();

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -166,7 +166,7 @@ Properties VariantToMapConverter::toProperties(const QVariant &propertiesVariant
 {
     Properties properties;
 
-    const ExportContext context(mDir.path());
+    ExportContext context(mDir.path());
 
     // read object-based format (1.0)
     const QVariantMap propertiesMap = propertiesVariant.toMap();
@@ -184,47 +184,21 @@ Properties VariantToMapConverter::toProperties(const QVariant &propertiesVariant
 
     // read array-based format (1.2)
     const QVariantList propertiesList = propertiesVariant.toList();
+    if (!propertiesList.isEmpty())
+        context.setRecursiveBehavior(ExportContext::RecursiveBehavior::JsonReady);
     for (const QVariant &propertyVariant : propertiesList) {
         const QVariantMap propertyVariantMap = propertyVariant.toMap();
         const QString propertyName = propertyVariantMap[QStringLiteral("name")].toString();
 
-        properties[propertyName] = toPropertyValue(propertyVariantMap, context);
+        ExportValue exportValue;
+        exportValue.value = propertyVariantMap[QStringLiteral("value")];
+        exportValue.typeName = propertyVariantMap[QStringLiteral("type")].toString();
+        exportValue.propertyTypeName = propertyVariantMap[QStringLiteral("propertytype")].toString();
+
+        properties[propertyName] = context.toPropertyValue(exportValue);
     }
 
     return properties;
-}
-
-QVariant VariantToMapConverter::toPropertyValue(const QVariantMap &valueVariantMap,
-                                                const ExportContext &context) const
-{
-    ExportValue exportValue;
-    exportValue.value = valueVariantMap[QStringLiteral("value")];
-    exportValue.typeName = valueVariantMap[QStringLiteral("type")].toString();
-    exportValue.propertyTypeName = valueVariantMap[QStringLiteral("propertytype")].toString();
-
-    convertListValues(exportValue.value, context);
-
-    return context.toPropertyValue(exportValue);
-}
-
-void VariantToMapConverter::convertListValues(QVariant &value, const ExportContext &context) const
-{
-    switch (value.userType()) {
-    case QMetaType::QVariantList: {
-        QVariantList list = value.toList();
-        for (QVariant &item : list)
-            item = toPropertyValue(item.toMap(), context);
-        value = std::move(list);
-        break;
-    }
-    case QMetaType::QVariantMap: {
-        QVariantMap map = value.toMap();
-        for (QVariant &value : map)
-            convertListValues(value, context);
-        value = std::move(map);
-        break;
-    }
-    }
 }
 
 SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)

--- a/src/libtiled/varianttomapconverter.h
+++ b/src/libtiled/varianttomapconverter.h
@@ -84,9 +84,6 @@ public:
 private:
     Properties toProperties(const QVariant &propertiesVariant,
                             const QVariant &propertyTypesVariant) const;
-    QVariant toPropertyValue(const QVariantMap &valueVariantMap,
-                             const ExportContext &context) const;
-    void convertListValues(QVariant &value, const ExportContext &context) const;
 
     SharedTileset toTileset(const QVariant &variant);
     std::unique_ptr<WangSet> toWangSet(const QVariantMap &variantMap, Tileset *tileset);

--- a/src/libtiled/world.cpp
+++ b/src/libtiled/world.cpp
@@ -301,8 +301,7 @@ std::unique_ptr<World> World::load(const QString &fileName,
     }
 
     const QJsonArray properties = object.value(QLatin1String("properties")).toArray();
-    const ExportContext context(dir.path());
-    world->setProperties(propertiesFromJson(properties, context));
+    world->setProperties(propertiesFromJson(properties, dir.path()));
 
     world->onlyShowAdjacentMaps = object.value(QLatin1String("onlyShowAdjacentMaps")).toBool();
 
@@ -350,8 +349,7 @@ bool World::save(World &world, QString *errorString)
         patterns.append(jsonPattern);
     }
 
-    const ExportContext context(worldDir.path());
-    const QJsonArray properties = propertiesToJson(world.properties(), context);
+    const QJsonArray properties = propertiesToJson(world.properties(), worldDir.path());
 
     QJsonObject document;
     if (!maps.isEmpty())

--- a/src/tiled/project.cpp
+++ b/src/tiled/project.cpp
@@ -75,7 +75,8 @@ bool Project::save(const QString &fileName)
         commands.append(QJsonObject::fromVariantHash(command.toVariant()));
 
     const QJsonArray propertyTypes = mPropertyTypes->toJson(dir.path());
-    const ExportContext context(*mPropertyTypes, dir.path());
+    ExportContext context(*mPropertyTypes, dir.path());
+    context.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
     const QJsonArray projectProperties = propertiesToJson(properties(), context);
     QJsonObject project {
         { QStringLiteral("propertyTypes"), propertyTypes },
@@ -131,7 +132,8 @@ std::unique_ptr<Project> Project::load(const QString &fileName)
 
     const QString projectPropertiesKey = QLatin1String("properties");
     if (projectJson.contains(projectPropertiesKey)) {
-        const ExportContext context(*project->mPropertyTypes, dir.path());
+        ExportContext context(*project->mPropertyTypes, dir.path());
+        context.setRecursiveBehavior(ExportContext::RecursiveBehavior::TypedListValues);
         const Properties loadedProperties = propertiesFromJson(projectJson.value(projectPropertiesKey).toArray(), context);
         project->setProperties(loadedProperties);
     }

--- a/tests/mapreader/test_mapreader.cpp
+++ b/tests/mapreader/test_mapreader.cpp
@@ -1,12 +1,9 @@
 #include "map.h"
 #include "mapobject.h"
-#include "mapwriter.h"
 #include "objectgroup.h"
-#include "propertytype.h"
 #include "tilelayer.h"
 #include "mapreader.h"
 
-#include <QBuffer>
 #include <QtTest/QtTest>
 
 using namespace Tiled;
@@ -17,7 +14,6 @@ class test_MapReader : public QObject
 
 private slots:
     void loadMap();
-    void roundTripListProperties();
 };
 
 void test_MapReader::loadMap()
@@ -55,43 +51,6 @@ void test_MapReader::loadMap()
     QCOMPARE(mapObject->y(), qreal(200));
     QCOMPARE(mapObject->width(), qreal(128));
     QCOMPARE(mapObject->height(), qreal(64));
-}
-
-void test_MapReader::roundTripListProperties()
-{
-    auto classWithList = SharedPropertyType(new ClassPropertyType(QStringLiteral("ClassWithList")));
-    classWithList->id = 1;
-    static_cast<ClassPropertyType&>(*classWithList).members
-        .insert(QStringLiteral("items"), QVariantList());
-
-    SharedPropertyTypes types(new PropertyTypes());
-    types->add(classWithList);
-    Object::setPropertyTypes(types);
-
-    Map map(Map::Parameters{});
-    Properties properties;
-    properties.insert(QStringLiteral("ParallaxLayers"),
-                      QVariantList { QStringLiteral("layer1"), QStringLiteral("layer2") });
-
-    QVariantMap classValue;
-    classValue.insert(QStringLiteral("items"),
-                      QVariantList { QStringLiteral("x"), QStringLiteral("y") });
-    properties.insert(QStringLiteral("Container"), classWithList->wrap(classValue));
-
-    map.setProperties(properties);
-
-    QBuffer buffer;
-    buffer.open(QIODevice::ReadWrite);
-    MapWriter writer;
-    writer.writeMap(&map, &buffer);
-
-    buffer.seek(0);
-    MapReader reader;
-    auto loaded = reader.readMap(&buffer, QString());
-    QVERIFY(loaded.get());
-    QCOMPARE(loaded->properties(), properties);
-
-    Object::setPropertyTypes(SharedPropertyTypes(new PropertyTypes()));
 }
 
 QTEST_MAIN(test_MapReader)

--- a/tests/mapreader/test_mapreader.cpp
+++ b/tests/mapreader/test_mapreader.cpp
@@ -1,9 +1,12 @@
 #include "map.h"
 #include "mapobject.h"
+#include "mapwriter.h"
 #include "objectgroup.h"
+#include "propertytype.h"
 #include "tilelayer.h"
 #include "mapreader.h"
 
+#include <QBuffer>
 #include <QtTest/QtTest>
 
 using namespace Tiled;
@@ -14,6 +17,7 @@ class test_MapReader : public QObject
 
 private slots:
     void loadMap();
+    void roundTripListProperties();
 };
 
 void test_MapReader::loadMap()
@@ -51,6 +55,43 @@ void test_MapReader::loadMap()
     QCOMPARE(mapObject->y(), qreal(200));
     QCOMPARE(mapObject->width(), qreal(128));
     QCOMPARE(mapObject->height(), qreal(64));
+}
+
+void test_MapReader::roundTripListProperties()
+{
+    auto classWithList = SharedPropertyType(new ClassPropertyType(QStringLiteral("ClassWithList")));
+    classWithList->id = 1;
+    static_cast<ClassPropertyType&>(*classWithList).members
+        .insert(QStringLiteral("items"), QVariantList());
+
+    SharedPropertyTypes types(new PropertyTypes());
+    types->add(classWithList);
+    Object::setPropertyTypes(types);
+
+    Map map(Map::Parameters{});
+    Properties properties;
+    properties.insert(QStringLiteral("ParallaxLayers"),
+                      QVariantList { QStringLiteral("layer1"), QStringLiteral("layer2") });
+
+    QVariantMap classValue;
+    classValue.insert(QStringLiteral("items"),
+                      QVariantList { QStringLiteral("x"), QStringLiteral("y") });
+    properties.insert(QStringLiteral("Container"), classWithList->wrap(classValue));
+
+    map.setProperties(properties);
+
+    QBuffer buffer;
+    buffer.open(QIODevice::ReadWrite);
+    MapWriter writer;
+    writer.writeMap(&map, &buffer);
+
+    buffer.seek(0);
+    MapReader reader;
+    auto loaded = reader.readMap(&buffer, QString());
+    QVERIFY(loaded.get());
+    QCOMPARE(loaded->properties(), properties);
+
+    Object::setPropertyTypes(SharedPropertyTypes(new PropertyTypes()));
 }
 
 QTEST_MAIN(test_MapReader)

--- a/tests/properties/test_properties.cpp
+++ b/tests/properties/test_properties.cpp
@@ -542,6 +542,7 @@ void test_Properties::roundTripListProperty()
     static_cast<ClassPropertyType&>(*classWithList).members
         .insert(QStringLiteral("items"), QVariantList());
     types->add(classWithList);
+    Object::setPropertyTypes(types);
 
     Properties properties;
     properties.insert(QStringLiteral("ParallaxLayers"),
@@ -559,15 +560,12 @@ void test_Properties::roundTripListProperty()
 
     // Round-trip through the JSON helpers (clipboard / project / world path).
     {
-        const ExportContext context(*types, QString());
-        const QJsonArray json = propertiesToJson(properties, context);
-        QCOMPARE(propertiesFromJson(json, context), properties);
+        const QJsonArray json = propertiesToJson(properties);
+        QCOMPARE(propertiesFromJson(json), properties);
     }
 
     // Round-trip through the TMX XML reader and writer.
     {
-        Object::setPropertyTypes(types);
-
         Map map(Map::Parameters{});
         map.setProperties(properties);
 
@@ -581,9 +579,9 @@ void test_Properties::roundTripListProperty()
         auto loaded = reader.readMap(&buffer, QString());
         QVERIFY(loaded.get());
         QCOMPARE(loaded->properties(), properties);
-
-        Object::setPropertyTypes(SharedPropertyTypes(new PropertyTypes()));
     }
+
+    Object::setPropertyTypes(SharedPropertyTypes(new PropertyTypes()));
 }
 
 /**

--- a/tests/properties/test_properties.cpp
+++ b/tests/properties/test_properties.cpp
@@ -252,6 +252,7 @@ private slots:
 
     void loadProperties();
     void saveProperties();
+    void roundTripListProperty();
     void mergeProperties();
 
     void cleanupTestCase();
@@ -524,6 +525,38 @@ void test_Properties::saveProperties()
     QCOMPARE(classExportValue.propertyTypeName, classType->name);
 
     // todo: test saving a class with nested class
+}
+
+void test_Properties::roundTripListProperty()
+{
+    PropertyTypes types;
+    int nextId = 0;
+
+    auto &classWithList = static_cast<ClassPropertyType&>(
+        types.add(SharedPropertyType(new ClassPropertyType(QStringLiteral("ClassWithList")))));
+    classWithList.id = ++nextId;
+    classWithList.members.insert(QStringLiteral("items"), QVariantList());
+
+    ExportContext context(types, QString());
+
+    Properties properties;
+    properties.insert(QStringLiteral("ParallaxLayers"),
+                      QVariantList { QStringLiteral("layer1"), QStringLiteral("layer2") });
+
+    QVariantList nested;
+    nested.append(QVariant::fromValue(QVariantList { QStringLiteral("a"), QStringLiteral("b") }));
+    nested.append(QVariant::fromValue(QVariantList { QStringLiteral("c") }));
+    properties.insert(QStringLiteral("Nested"), nested);
+
+    QVariantMap classValue;
+    classValue.insert(QStringLiteral("items"),
+                      QVariantList { QStringLiteral("x"), QStringLiteral("y") });
+    properties.insert(QStringLiteral("Container"), classWithList.wrap(classValue));
+
+    const QJsonArray json = propertiesToJson(properties, context);
+    const Properties roundTripped = propertiesFromJson(json, context);
+
+    QCOMPARE(roundTripped, properties);
 }
 
 void test_Properties::mergeProperties()

--- a/tests/properties/test_properties.cpp
+++ b/tests/properties/test_properties.cpp
@@ -562,7 +562,7 @@ void test_Properties::roundTripListProperty()
 
 /**
  * The XML reader builds an ExportValue whose value is already a QVariantList
- * of typed values (not the JsonReady wrapper form), and then calls
+ * of typed values (not the TypedListValues wrapper form), and then calls
  * context.toPropertyValue with the default ExportContext. Verify that this
  * still works and does not mangle the items.
  */

--- a/tests/properties/test_properties.cpp
+++ b/tests/properties/test_properties.cpp
@@ -562,9 +562,9 @@ void test_Properties::roundTripListProperty()
 
 /**
  * The XML reader builds an ExportValue whose value is already a QVariantList
- * of typed values (not the TypedListValues wrapper form), and then calls
- * context.toPropertyValue with the default ExportContext. Verify that this
- * still works and does not mangle the items.
+ * of typed values (not the TypedListValues wrapper form). Verify that under
+ * the default NoRecursion behavior toPropertyValue passes such a list through
+ * untouched.
  */
 void test_Properties::typedListPassesThroughDefaultMode()
 {

--- a/tests/properties/test_properties.cpp
+++ b/tests/properties/test_properties.cpp
@@ -253,6 +253,7 @@ private slots:
     void loadProperties();
     void saveProperties();
     void roundTripListProperty();
+    void typedListPassesThroughDefaultMode();
     void mergeProperties();
 
     void cleanupTestCase();
@@ -557,6 +558,25 @@ void test_Properties::roundTripListProperty()
     const Properties roundTripped = propertiesFromJson(json, context);
 
     QCOMPARE(roundTripped, properties);
+}
+
+/**
+ * The XML reader builds an ExportValue whose value is already a QVariantList
+ * of typed values (not the JsonReady wrapper form), and then calls
+ * context.toPropertyValue with the default ExportContext. Verify that this
+ * still works and does not mangle the items.
+ */
+void test_Properties::typedListPassesThroughDefaultMode()
+{
+    ExportContext context(mTypes, QString());
+
+    ExportValue exportValue;
+    exportValue.typeName = QStringLiteral("list");
+    exportValue.value = QVariantList { QStringLiteral("a"), QStringLiteral("b") };
+
+    const QVariant result = context.toPropertyValue(exportValue);
+    QCOMPARE(result.toList(),
+             (QVariantList { QStringLiteral("a"), QStringLiteral("b") }));
 }
 
 void test_Properties::mergeProperties()

--- a/tests/properties/test_properties.cpp
+++ b/tests/properties/test_properties.cpp
@@ -1,5 +1,11 @@
+#include "map.h"
+#include "mapreader.h"
+#include "mapwriter.h"
+#include "object.h"
 #include "properties.h"
+#include "propertytype.h"
 
+#include <QBuffer>
 #include <QtTest/QtTest>
 
 using namespace Tiled;
@@ -530,15 +536,12 @@ void test_Properties::saveProperties()
 
 void test_Properties::roundTripListProperty()
 {
-    PropertyTypes types;
-    int nextId = 0;
-
-    auto &classWithList = static_cast<ClassPropertyType&>(
-        types.add(SharedPropertyType(new ClassPropertyType(QStringLiteral("ClassWithList")))));
-    classWithList.id = ++nextId;
-    classWithList.members.insert(QStringLiteral("items"), QVariantList());
-
-    ExportContext context(types, QString());
+    SharedPropertyTypes types(new PropertyTypes());
+    auto classWithList = SharedPropertyType(new ClassPropertyType(QStringLiteral("ClassWithList")));
+    classWithList->id = 1;
+    static_cast<ClassPropertyType&>(*classWithList).members
+        .insert(QStringLiteral("items"), QVariantList());
+    types->add(classWithList);
 
     Properties properties;
     properties.insert(QStringLiteral("ParallaxLayers"),
@@ -552,12 +555,35 @@ void test_Properties::roundTripListProperty()
     QVariantMap classValue;
     classValue.insert(QStringLiteral("items"),
                       QVariantList { QStringLiteral("x"), QStringLiteral("y") });
-    properties.insert(QStringLiteral("Container"), classWithList.wrap(classValue));
+    properties.insert(QStringLiteral("Container"), classWithList->wrap(classValue));
 
-    const QJsonArray json = propertiesToJson(properties, context);
-    const Properties roundTripped = propertiesFromJson(json, context);
+    // Round-trip through the JSON helpers (clipboard / project / world path).
+    {
+        const ExportContext context(*types, QString());
+        const QJsonArray json = propertiesToJson(properties, context);
+        QCOMPARE(propertiesFromJson(json, context), properties);
+    }
 
-    QCOMPARE(roundTripped, properties);
+    // Round-trip through the TMX XML reader and writer.
+    {
+        Object::setPropertyTypes(types);
+
+        Map map(Map::Parameters{});
+        map.setProperties(properties);
+
+        QBuffer buffer;
+        buffer.open(QIODevice::ReadWrite);
+        MapWriter writer;
+        writer.writeMap(&map, &buffer);
+
+        buffer.seek(0);
+        MapReader reader;
+        auto loaded = reader.readMap(&buffer, QString());
+        QVERIFY(loaded.get());
+        QCOMPARE(loaded->properties(), properties);
+
+        Object::setPropertyTypes(SharedPropertyTypes(new PropertyTypes()));
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #4514: copying a list custom property and pasting it onto another object dropped the items, leaving them saved as `type="std::nullptr_t"` in TMX. The same bug applied to lists nested inside class properties.

The clipboard, project files, and world files serialize through `propertiesToJson` / `propertiesFromJson`, which fed `QJsonValue::fromVariant` a tree containing `ExportValue` wrappers it could not encode. They now use a new `TypedListValues` `RecursiveBehavior` that produces `{type, propertytype, value}` maps for each list element (matching the existing JSON2 map format on disk) and decodes the same shape on read.

A few cleanups while in the area:

- Folded the JSON2 map converter helpers (`exportValuesToVariantMap`, `convertListValues`) into `ExportContext` so the same recursion logic is shared.
- Replaced the half-baked `ListsAsExportValues` default with an explicit `NoRecursion` default. Callers that walk compound values themselves (the XML reader and writer, `PropertyTypes::toJson`) now use the default; the JSON helpers and the JSON2 converter opt in to `TypedListValues`.
- Made the XML writer mirror the XML reader: it drives recursion through lists and class members itself, so `ExportValuesOnly` was no longer needed and was removed.

## Test plan
- [x] `test_Properties::roundTripListProperty` covers list, list-of-lists, and class-with-list through both the JSON helpers and the TMX writer/reader.
- [x] `test_properties`, `test_mapreader`, `test_automapping`, and `test_staggeredrenderer` show the same totals as on master (pre-existing failures only).