### PR TITLE
Add direct swap for tileset tile order

### DIFF
--- a/src/libtiled/tileset.cpp
+++ b/src/libtiled/tileset.cpp
@@ -503,6 +503,17 @@ QList<int> Tileset::relocateTiles(const QList<Tile *> &tiles, int location)
     return prevLocations;
 }
 
+void Tileset::swapTiles(Tile *tileA, Tile *tileB)
+{
+    const int indexA = mTiles.indexOf(tileA);
+    const int indexB = mTiles.indexOf(tileB);
+
+    Q_ASSERT(indexA != -1);
+    Q_ASSERT(indexB != -1);
+
+    mTiles.swapItemsAt(indexA, indexB);
+}
+
 bool Tileset::anyTileOutOfOrder() const
 {
     int tileId = 0;

--- a/src/libtiled/tileset.h
+++ b/src/libtiled/tileset.h
@@ -227,6 +227,7 @@ public:
     void removeTiles(const QList<Tile *> &tiles);
     void deleteTile(int id);
     QList<int> relocateTiles(const QList<Tile *> &tiles, int location);
+    void swapTiles(Tile *tileA, Tile *tileB);
 
     bool anyTileOutOfOrder() const;
     void resetTileOrder();

--- a/src/tiled/relocatetiles.cpp
+++ b/src/tiled/relocatetiles.cpp
@@ -53,4 +53,20 @@ void RelocateTiles::redo()
     mPrevLocations = mTilesetDocument->relocateTiles(mTiles, mLocation);
 }
 
+SwapTilesetTiles::SwapTilesetTiles(TilesetDocument *tilesetDocument,
+                                   Tile *tileA,
+                                   Tile *tileB)
+    : QUndoCommand(QCoreApplication::translate("Undo Commands",
+                                               "Swap Tiles"))
+    , mTilesetDocument(tilesetDocument)
+    , mTileA(tileA)
+    , mTileB(tileB)
+{
+}
+
+void SwapTilesetTiles::swap()
+{
+    mTilesetDocument->swapTiles(mTileA, mTileB);
+}
+
 } // namespace Tiled

--- a/src/tiled/relocatetiles.h
+++ b/src/tiled/relocatetiles.h
@@ -57,4 +57,25 @@ private:
     QList<int> mPrevLocations;
 };
 
+/**
+ * A command that swaps the display order of two tiles in a tileset.
+ */
+class SwapTilesetTiles : public QUndoCommand
+{
+public:
+    SwapTilesetTiles(TilesetDocument *tilesetDocument,
+                     Tile *tileA,
+                     Tile *tileB);
+
+    void undo() override { swap(); }
+    void redo() override { swap(); }
+
+private:
+    void swap();
+
+    TilesetDocument * const mTilesetDocument;
+    Tile * const mTileA;
+    Tile * const mTileB;
+};
+
 } // namespace Tiled

--- a/src/tiled/tilesetdocument.cpp
+++ b/src/tiled/tilesetdocument.cpp
@@ -367,6 +367,12 @@ QList<int> TilesetDocument::relocateTiles(const QList<Tile *> &tiles, int locati
     return prevLocations;
 }
 
+void TilesetDocument::swapTiles(Tile *tileA, Tile *tileB)
+{
+    mTileset->swapTiles(tileA, tileB);
+    emit tilesetChanged(mTileset.data());
+}
+
 void TilesetDocument::setSelectedTiles(const QList<Tile*> &selectedTiles)
 {
     mSelectedTiles = selectedTiles;

--- a/src/tiled/tilesetdocument.h
+++ b/src/tiled/tilesetdocument.h
@@ -101,6 +101,7 @@ public:
     void addTiles(const QList<Tile*> &tiles);
     void removeTiles(const QList<Tile*> &tiles);
     QList<int> relocateTiles(const QList<Tile *> &tiles, int location);
+    void swapTiles(Tile *tileA, Tile *tileB);
 
     const QList<Tile*> &selectedTiles() const;
     void setSelectedTiles(const QList<Tile*> &selectedTiles);

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -40,6 +40,7 @@
 #endif
 #include "preferences.h"
 #include "propertiesdock.h"
+#include "relocatetiles.h"
 #include "scriptmanager.h"
 #include "session.h"
 #include "templatesdock.h"
@@ -306,6 +307,7 @@ void TilesetEditor::addDocument(Document *document)
     connect(view, &TilesetView::wangColorImageSelected, this, &TilesetEditor::setWangColorImage);
     connect(view, &TilesetView::wangIdUsedChanged, mWangDock, &WangDock::onWangIdUsedChanged);
     connect(view, &TilesetView::currentWangIdChanged, mWangDock, &WangDock::onCurrentWangIdChanged);
+    connect(view, &TilesetView::swapTilesRequested, this, &TilesetEditor::swapTiles);
 
     QItemSelectionModel *s = view->selectionModel();
     connect(s, &QItemSelectionModel::selectionChanged, this, &TilesetEditor::selectionChanged);
@@ -836,6 +838,19 @@ void TilesetEditor::addTiles(const QList<QUrl> &urls)
     }
 
     mCurrentTilesetDocument->undoStack()->push(new AddTiles(mCurrentTilesetDocument, tiles));
+}
+
+void TilesetEditor::swapTiles(Tile *tileA, Tile *tileB)
+{
+    if (!mCurrentTilesetDocument || !tileA || !tileB || tileA == tileB)
+        return;
+
+    Tileset *tileset = mCurrentTilesetDocument->tileset().data();
+    if (tileA->tileset() != tileset || tileB->tileset() != tileset)
+        return;
+
+    mCurrentTilesetDocument->undoStack()->push(
+            new SwapTilesetTiles(mCurrentTilesetDocument, tileA, tileB));
 }
 
 static bool hasTileReferences(MapDocument *mapDocument,

--- a/src/tiled/tileseteditor.h
+++ b/src/tiled/tileseteditor.h
@@ -131,6 +131,7 @@ private:
     void openAddTilesDialog();
     void addTiles(const QList<QUrl> &urls);
     void removeTiles();
+    void swapTiles(Tile *tileA, Tile *tileB);
 
     void setRelocateTiles(bool relocateTiles);
     void setEditCollision(bool editCollision);

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -802,6 +802,13 @@ void TilesetView::contextMenuEvent(QContextMenuEvent *event)
         }
 
         if (mTilesetDocument) {
+            const bool exactlyTwoTilesSelected =
+                    (selectionModel()->selectedIndexes().size() == 2);
+
+            QAction *swapTilesAction = menu.addAction(tr("&Swap Tiles"));
+            swapTilesAction->setEnabled(exactlyTwoTilesSelected);
+            connect(swapTilesAction, &QAction::triggered, this, &TilesetView::swapTiles);
+
             const QIcon propIcon(QStringLiteral(":images/16/document-properties.png"));
             QAction *tileProperties = menu.addAction(propIcon,
                                                      tr("Tile &Properties..."));


### PR DESCRIPTION
## Summary
- add a direct tileset-order swap path for two selected tiles in the tileset editor
- keep it undoable with a dedicated `SwapTilesetTiles` command
- leave the existing map tile-reference swap behavior separate from tileset display-order rearranging

Fixes #3112.

## Behavior
In the tileset editor, select exactly two tiles and use the context menu action `Swap Tiles`. Their display order is exchanged without changing tile IDs, map references, or the source tileset image.

## Testing
- `git diff --check`
- verified issue #3112 is still open and no related PR exists
- statically checked the signal path from `TilesetView` to `TilesetEditor`, undo command, `TilesetDocument`, and `Tileset`

Not run locally: full Tiled build/runtime. This Windows environment has no `qbs`, `cmake`, `ninja`, `g++`, `clang++`, or `cl` available.