### PR TITLE
Fix resolve class members in lists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Fixed ability to change properties after deselecting the current object (#4440)
 * Fixed Properties view getting stuck with updates disabled (#4506)
 * Fixed copy/paste of list properties losing item types (#4514)
+* Fixed resolving of class members values in lists on export (#4525)
 * Fixed locale-aware parsing of numbers in expression-capable spin boxes
 * Fixed Tile Animation Editor update after tileset image reload (#3923)
 * Fixed runtime language switching in many editor widgets and models (by SIDDHAARTHAA, #4411)

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -365,9 +365,9 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
 QVariant MapToVariantConverter::toVariant(const Properties &properties) const
 {
     QVariantMap variantMap;
+
+    // In the JSON1 format, none of the export values retain their type, we use the values only.
     ExportContext context(mDir.path());
-    // The JSON1 format can't represent typed lists, but classes still need
-    // their members converted to scalars.
     context.setRecursiveBehavior(ExportContext::RecursiveBehavior::ValuesOnly);
 
     Properties::const_iterator it = properties.constBegin();
@@ -818,7 +818,7 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
     ExportContext context(mDir.path());
 
     if (mVersion == 1) {
-        // The JSON1 format can't support typed lists
+        // The JSON1 format doesn't include type information for list values or class members
         context.setRecursiveBehavior(ExportContext::RecursiveBehavior::ValuesOnly);
 
         QVariantMap propertiesMap;

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -308,8 +308,16 @@ static const struct  {
     { ClassPropertyType::ProjectClass,          QLatin1String("project") },
 };
 
+/*
+ * Walks the value tree ourselves rather than relying on
+ * RecursiveBehavior::TypedListValues, because the property types JSON format
+ * spells the key "propertyType" while TypedListValues emits "propertytype".
+ * Hence the context is expected to be in NoRecursion mode.
+ */
 QJsonValue exportValueToJson(const QVariant &value, const ExportContext &context)
 {
+    Q_ASSERT(context.recursiveBehavior() == ExportContext::RecursiveBehavior::NoRecursion);
+
     const ExportValue exportValue = context.toExportValue(value);
 
     if (exportValue.typeName == QLatin1String("list")) {

--- a/src/tiled/exporthelper.cpp
+++ b/src/tiled/exporthelper.cpp
@@ -143,6 +143,17 @@ const Map *ExportHelper::prepareExportMap(const Map *map, std::unique_ptr<Map> &
 
 static bool resolveClassPropertyMembers(QVariant &value)
 {
+    // Recurse into list values
+    if (value.userType() == QMetaType::QVariantList) {
+        bool changed = false;
+        auto list = value.value<QVariantList>();
+        for (auto &item : list)
+            changed |= resolveClassPropertyMembers(item);
+        if (changed)
+            value = list;
+        return changed;
+    }
+
     if (value.userType() != propertyValueId())
         return false;
 


### PR DESCRIPTION
The `ExportHelper` forgot to recurse into list values.