### PR TITLE
CI: build snap without snapcore/action-build

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -170,12 +170,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set Tiled version
-      id: version
-      run: |
-        if [[ "$TILED_RELEASE" == 'true' ]]; then echo "snap_channel=candidate" >> $GITHUB_OUTPUT ; fi
-        if [[ "$TILED_RELEASE" != 'true' ]]; then echo "snap_channel=beta" >> $GITHUB_OUTPUT ; fi
-
     - name: Install snapcraft
       run: sudo snap install --classic snapcraft
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -158,7 +158,7 @@ jobs:
 
   snap:
     name: Linux (snap)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: version
 
     env:
@@ -176,9 +176,15 @@ jobs:
         if [[ "$TILED_RELEASE" == 'true' ]]; then echo "snap_channel=candidate" >> $GITHUB_OUTPUT ; fi
         if [[ "$TILED_RELEASE" != 'true' ]]; then echo "snap_channel=beta" >> $GITHUB_OUTPUT ; fi
 
+    - name: Install snapcraft
+      run: sudo snap install --classic snapcraft
+
     - name: Build snap
       id: build
-      uses: snapcore/action-build@v1
+      env:
+        SNAPCRAFT_BUILD_INFO: "1"
+        SNAPCRAFT_IMAGE_INFO: '{"build_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+      run: sudo snapcraft --destructive-mode
 
     - name: Upload snap artifact
       uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

[snapcore/action-build](https://github.com/snapcore/action-build) appears effectively unmaintained: [snapcore/action-build#1](https://github.com/snapcore/action-build/pull/1) (updating the action's Node.js runtime to node24) has been open since April with no maintainer response. As GitHub's node20 deprecation rolls in, this action becomes a liability.

Replace it with two inline steps:

1. `sudo snap install --classic snapcraft`
2. `sudo snapcraft --destructive-mode`, with the same `SNAPCRAFT_BUILD_INFO` and `SNAPCRAFT_IMAGE_INFO` env vars the action used to set.

`--destructive-mode` builds directly on the runner (no LXD), which is faster and simpler. The job is pinned to `ubuntu-24.04` so the host always matches the snap's `base: core24`.

## Test plan

- [ ] CI runs the `Linux (snap)` job and produces `tiled_*_amd64.snap`
- [ ] Resulting snap contains `snap/manifest.yaml` (from `SNAPCRAFT_BUILD_INFO=1`)