### PR TITLE
Fix empty `className` for template-instantiated objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Added 'Collapse All' action and 'Only Expand to Current' mode to Project view (with rhythmcache, #4346)
 * Added command variables %exportfile and %exportpath (#4476)
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
+* Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
 
 ### Tiled 1.12.2 (27 May 2026)
 

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -1827,6 +1827,15 @@ declare class MapObject extends TiledObject {
   layer: ObjectGroup | null;
 
   /**
+   * Returns the resolved class name of this object.
+   * This may be the class name of the object's template or the class name of its tile,
+   * in the case of the object not having an explicitly set class name.
+   *
+   * @since 1.13
+   */
+  resolvedClassName(): string;
+
+  /**
    * Map this object is part of (or `null` in case of a
    * standalone object).
    */

--- a/src/tiled/editablemapobject.h
+++ b/src/tiled/editablemapobject.h
@@ -133,6 +133,8 @@ public:
 
     MapObject *mapObject() const;
 
+    Q_INVOKABLE QString resolvedClassName() const;
+
     void detach();
     MapObject *attach(EditableAsset *asset);
     void hold(std::unique_ptr<MapObject> mapObject);
@@ -271,6 +273,11 @@ inline bool EditableMapObject::tileFlippedVertically() const
 inline MapObject *EditableMapObject::mapObject() const
 {
     return static_cast<MapObject*>(object());
+}
+
+inline QString EditableMapObject::resolvedClassName() const
+{
+    return mapObject()->effectiveClassName();
 }
 
 inline bool EditableMapObject::isOwning() const


### PR DESCRIPTION
This adds a new method to `MapObject`, `resolvedClassName`. It falls back to the template classname in case the object classname is empty.

Fixes #4528

However, the new method is missing documentation.