### PR TITLE
snap: Declared target platforms, skipped qaseprite on s390x/ppc64el

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,6 +6,12 @@ base: core24
 grade: stable
 confinement: strict
 
+platforms:
+  amd64:
+  arm64:
+  s390x:
+  ppc64el:
+
 apps:
   tiled:
     command-chain: &command-chain
@@ -82,6 +88,28 @@ parts:
       - -DUSE_SHARED_PIXMAN=on
       - -DUSE_SHARED_FREETYPE=on
       - -DUSE_SHARED_HARFBUZZ=on
+    # Aseprite's vendored `laf` library hardcodes the CPU-architecture
+    # whitelist (x86/x64/arm64/riscv64) and refuses to compile on s390x
+    # or ppc64el. Skip the plugin entirely on those arches so the rest
+    # of Tiled still builds; users there lose .ase/.aseprite import.
+    override-pull: |
+      case "$CRAFT_ARCH_BUILD_FOR" in
+        s390x|ppc64el)
+          echo "Skipping qaseprite pull on $CRAFT_ARCH_BUILD_FOR"
+          ;;
+        *)
+          craftctl default
+          ;;
+      esac
+    override-build: |
+      case "$CRAFT_ARCH_BUILD_FOR" in
+        s390x|ppc64el)
+          echo "Skipping qaseprite build on $CRAFT_ARCH_BUILD_FOR"
+          ;;
+        *)
+          craftctl default
+          ;;
+      esac
     build-packages:
       - libfreetype-dev
       - libgl1-mesa-dev


### PR DESCRIPTION
The snap-store auto-build was attempting all five Launchpad architectures (amd64, arm64, s390x, ppc64el, armhf) and silently failing on the latter three. Declared `platforms:` explicitly to limit the target set to amd64, arm64, s390x, and ppc64el (armhf is excluded because libqt5gui5 is no longer built for that arch in noble).

The qaseprite plugin bundles Aseprite's laf library, which static- asserts the CPU architecture against a hardcoded whitelist (x86/x64/arm64/riscv64). Skip the plugin's pull and build steps on s390x and ppc64el so the rest of the snap still builds; users on those arches lose .ase/.aseprite import.