### PR TITLE
Scripting: Added cell creation and editing API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added 'Collapse All' action and 'Only Expand to Current' mode to Project view (with rhythmcache, #4346)
 * Added command variables %exportfile and %exportpath (#4476)
+* Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 
 ### Tiled 1.12.2 (27 May 2026)
 

--- a/docs/scripting-doc/index.d.ts
+++ b/docs/scripting-doc/index.d.ts
@@ -3590,6 +3590,17 @@ interface cell {
   empty: boolean;
 
   /**
+   * The flags used for the tile.
+   *
+   * This is a combination of {@link Tile.FlippedHorizontally},
+   * {@link Tile.FlippedVertically}, {@link Tile.FlippedAntiDiagonally} and
+   * {@link Tile.RotatedHexagonal120}.
+   *
+   * @since 1.13
+   */
+  flags: number;
+
+  /**
    * Whether the tile is flipped horizontally.
    */
   flippedHorizontally: boolean;
@@ -3717,6 +3728,24 @@ interface TileLayerEdit {
    * (since Tiled 1.10.2).
    */
   setTile(x: number, y: number, tile: Tile | null, flags?: number): void;
+
+  /**
+   * Sets the cell at the given location. This is an alternative to
+   * {@link setTile} that takes a {@link cell} value, which is convenient for
+   * copying cells along with their flags (for example a value returned by
+   * {@link TileLayer.cellAt}).
+   *
+   * New cells can be created with {@link tiled.cell}. To remove a tile, set an
+   * empty cell (`tiled.cell()`).
+   *
+   * As with {@link setTile}, all locations which have been set retain a special
+   * flag that is taken into account by {@link TileMap.merge} and
+   * {@link Tool.preview}, to enable erasing tiles and highlighting the erased
+   * area, respectively.
+   *
+   * @since 1.13
+   */
+  setCell(x: number, y: number, cell: cell): void;
 
   /**
    * Applies the changes made through this object to the target layer. This
@@ -5219,6 +5248,19 @@ declare namespace tiled {
    * @since 1.11
    */
   export function color(r: number, g: number, b: number, a?: number): color;
+
+  /**
+   * Creates a {@link cell} referring to the given tile, optionally with the
+   * given flags (any combination of {@link Tile.FlippedHorizontally},
+   * {@link Tile.FlippedVertically}, {@link Tile.FlippedAntiDiagonally} and
+   * {@link Tile.RotatedHexagonal120}).
+   *
+   * Pass no tile (or `null`) to create an empty cell, which can be used with
+   * {@link TileLayerEdit.setCell} to erase a tile.
+   *
+   * @since 1.13
+   */
+  export function cell(tile?: Tile | null, flags?: number): cell;
 
   /**
    * Creates a {@link FilePath} object with the given URL.

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -32,8 +32,8 @@
 #include "tiled_global.h"
 
 #include "layer.h"
-#include "tiled.h"
 #include "tile.h"
+#include "tiled.h"
 #include "tileset.h"
 
 #include <QHash>
@@ -67,6 +67,7 @@ class TILEDSHARED_EXPORT Cell
 
     Q_PROPERTY(int tileId READ tileId)
     Q_PROPERTY(bool empty READ isEmpty)
+    Q_PROPERTY(int flags READ flags WRITE setFlags)
     Q_PROPERTY(bool flippedHorizontally READ flippedHorizontally WRITE setFlippedHorizontally)
     Q_PROPERTY(bool flippedVertically READ flippedVertically WRITE setFlippedVertically)
     Q_PROPERTY(bool flippedAntiDiagonally READ flippedAntiDiagonally WRITE setFlippedAntiDiagonally)
@@ -116,6 +117,8 @@ public:
     bool flippedVertically() const { return _flags & FlippedVertically; }
     bool flippedAntiDiagonally() const { return _flags & FlippedAntiDiagonally; }
     bool rotatedHexagonal120() const { return _flags & RotatedHexagonal120; }
+
+    void setFlags(int flags) { _flags = (_flags & ~VisualFlags) | (flags & VisualFlags); }
 
     void setFlippedHorizontally(bool v) { v ? _flags |= FlippedHorizontally : _flags &= ~FlippedHorizontally; }
     void setFlippedVertically(bool v) { v ? _flags |= FlippedVertically : _flags &= ~FlippedVertically; }

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -24,6 +24,7 @@
 #include "commandmanager.h"
 #include "compression.h"
 #include "documentmanager.h"
+#include "editabletile.h"
 #include "editabletileset.h"
 #include "issuesmodel.h"
 #include "logginginterface.h"
@@ -259,6 +260,13 @@ QColor ScriptModule::color(const QString &name) const
 QColor ScriptModule::color(float r, float g, float b, float a) const
 {
     return QColor::fromRgbF(r, g, b, a);
+}
+
+Cell ScriptModule::cell(EditableTile *tile, int flags) const
+{
+    Cell cell(tile ? tile->tile() : nullptr);
+    cell.setFlags(flags);
+    return cell;
 }
 
 FilePath ScriptModule::filePath(const QUrl &path) const

--- a/src/tiled/scriptmodule.h
+++ b/src/tiled/scriptmodule.h
@@ -23,6 +23,7 @@
 #include "id.h"
 #include "issuesdock.h"
 #include "properties.h"
+#include "tilelayer.h"
 
 #include <QJSValue>
 #include <QObject>
@@ -36,6 +37,7 @@ namespace Tiled {
 
 class Document;
 class EditableAsset;
+class EditableTile;
 class MapEditor;
 class ScriptImage;
 class ScriptMapFormatWrapper;
@@ -111,6 +113,7 @@ public:
 
     Q_INVOKABLE QColor color(const QString &name) const;
     Q_INVOKABLE QColor color(float r, float g, float b, float a = 1.0f) const;
+    Q_INVOKABLE Tiled::Cell cell(Tiled::EditableTile *tile = nullptr, int flags = 0) const;
     Q_INVOKABLE Tiled::FilePath filePath(const QUrl &path) const;
     Q_INVOKABLE Tiled::ObjectRef objectRef(int id) const;
     Q_INVOKABLE QVariant propertyValue(const QString &typeName, const QJSValue &value) const;

--- a/src/tiled/tilelayeredit.cpp
+++ b/src/tiled/tilelayeredit.cpp
@@ -40,18 +40,16 @@ TileLayerEdit::~TileLayerEdit()
 void TileLayerEdit::setTile(int x, int y, EditableTile *tile, int flags)
 {
     Cell cell(tile ? tile->tile() : nullptr);
-    cell.setChecked(true);  // Used to find painted region later (allows erasing)
+    cell.setFlags(flags);
+    setCell(x, y, cell);
+}
 
-    if (flags & EditableTile::FlippedHorizontally)
-        cell.setFlippedHorizontally(true);
-    if (flags & EditableTile::FlippedVertically)
-        cell.setFlippedVertically(true);
-    if (flags & EditableTile::FlippedAntiDiagonally)
-        cell.setFlippedAntiDiagonally(true);
-    if (flags & EditableTile::RotatedHexagonal120)
-        cell.setRotatedHexagonal120(true);
+void TileLayerEdit::setCell(int x, int y, const Cell &cell)
+{
+    Cell changedCell = cell;
+    changedCell.setChecked(true);   // Used to find painted region later (allows erasing)
 
-    mChanges.setCell(x, y, cell);
+    mChanges.setCell(x, y, changedCell);
 }
 
 void TileLayerEdit::apply()

--- a/src/tiled/tilelayeredit.h
+++ b/src/tiled/tilelayeredit.h
@@ -54,6 +54,7 @@ public:
 
 public slots:
     void setTile(int x, int y, EditableTile *tile, int flags = 0);
+    void setCell(int x, int y, const Tiled::Cell &cell);
     void apply();
 
 private:


### PR DESCRIPTION
Added a `flags` property to `cell`, exposing the combined flip and rotate flags directly instead of requiring each flag to be queried and assembled separately.

Added `tiled.cell(tile, flags)` for creating cells from scripts, including empty cells (used to erase tiles), and `TileLayerEdit.setCell` for placing a whole cell at once. Together these make it convenient to copy cells along with their flags, for example a value returned by `TileLayer.cellAt`.

`TileLayerEdit.setTile` now delegates to `setCell` and uses the new `Cell::setFlags` function.

Triggered by https://github.com/mapeditor/tiled-extensions/pull/28.