### PR TITLE
CI: Install Qbs from official nupkg instead of Chocolatey feed

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -241,17 +241,19 @@ jobs:
       with:
         cmake-version: '${{ env.CMAKE_VERSION }}'
 
+    - name: Install Qbs
+      run: |
+        tarball=qbs-macos-$(uname -m)-${{ env.QBS_VERSION }}.tar.gz
+        curl -fLO "https://download.qt.io/official_releases/qbs/${{ env.QBS_VERSION }}/${tarball}"
+        mkdir -p "${HOME}/qbs"
+        tar xzf "${tarball}" -C "${HOME}/qbs"
+        dirname "$(find "${HOME}/qbs" -name qbs -type f | head -n1)" >> "$GITHUB_PATH"
+
     - name: Setup Qbs
       run: |
-        brew update
-        brew install qbs
-        export PATH="$(brew --prefix qbs)/bin:$PATH"
-        echo "$(brew --prefix qbs)/bin" >> "$GITHUB_PATH"
         qbs --version
         qbs setup-toolchains --detect
-        qbs setup-qt --detect
-        qbs config profiles.qt-6-9-3.baseProfile xcode
-        qbs config defaultProfile qt-6-9-3
+        qbs config defaultProfile xcode
 
     - name: Build Zstandard
       run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -385,7 +385,8 @@ jobs:
 
     - name: Install Qbs
       run: |
-        choco install -y qbs --version ${{ env.QBS_VERSION }}
+        curl -fLO https://download.qt.io/official_releases/qbs/${{ env.QBS_VERSION }}/qbs.${{ env.QBS_VERSION }}.nupkg
+        choco install -y qbs --version ${{ env.QBS_VERSION }} --source .
 
     - name: Setup Qbs
       run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -19,7 +19,7 @@ on:
     - '.travis.yml'
 
 env:
-  QBS_VERSION: 3.1.1
+  QBS_VERSION: 3.2.0
   CMAKE_VERSION: 3.31
   SENTRY_VERSION: 0.12.8
   SENTRY_ORG: mapeditor


### PR DESCRIPTION
The 'choco install qbs' step frequently fails when the Chocolatey community feed returns errors (such as 406 Not Acceptable), even though the package itself just downloads Qbs from download.qt.io.

Fetch the official .nupkg from download.qt.io and install it from a local source, so Chocolatey no longer contacts the community feed while still unzipping Qbs and putting it on PATH.