### PR TITLE
add preference for repeated shortcuts toggling to previous tool

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added 'Collapse All' action and 'Only Expand to Current' mode to Project view (with rhythmcache, #4346)
 * Added command variables %exportfile and %exportpath (#4476)
+* Made switching to the previously selected tool when pressing its shortcut again optional and off by default (by dogboydog, #4540)
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
 

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -691,6 +691,17 @@ void Preferences::setNaturalSorting(bool enabled)
     emit naturalSortingChanged(enabled);
 }
 
+bool Preferences::repeatShortcutForPreviousTool() const
+{
+    return get("Project/RepeatShortcutForPreviousTool", false);
+}
+
+void Preferences::setRepeatShortcutForPreviousTool(bool enabled)
+{
+    setValue(QLatin1String("Project/RepeatShortcutForPreviousTool"), enabled);
+    emit naturalSortingChanged(enabled);
+}
+
 void Preferences::addToRecentFileList(const QString &fileName, QStringList& files)
 {
     // Remember the file by its absolute file path (not the canonical one,

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -693,13 +693,12 @@ void Preferences::setNaturalSorting(bool enabled)
 
 bool Preferences::repeatShortcutForPreviousTool() const
 {
-    return get("Project/RepeatShortcutForPreviousTool", false);
+    return get("Interface/RepeatShortcutForPreviousTool", false);
 }
 
 void Preferences::setRepeatShortcutForPreviousTool(bool enabled)
 {
-    setValue(QLatin1String("Project/RepeatShortcutForPreviousTool"), enabled);
-    emit naturalSortingChanged(enabled);
+    setValue(QLatin1String("Interface/RepeatShortcutForPreviousTool"), enabled);
 }
 
 void Preferences::addToRecentFileList(const QString &fileName, QStringList& files)

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -172,6 +172,9 @@ public:
     bool naturalSorting() const;
     void setNaturalSorting(bool enabled);
 
+    bool repeatShortcutForPreviousTool() const;
+    void setRepeatShortcutForPreviousTool(bool enabled);
+
     bool checkForUpdates() const;
     void setCheckForUpdates(bool on);
 

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -95,6 +95,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
             preferences, &Preferences::setExportOnSave);
     connect(mUi->naturalSorting, &QCheckBox::toggled,
             preferences, &Preferences::setNaturalSorting);
+    connect(mUi->repeatShortcutForPreviousTool, &QCheckBox::toggled,
+            preferences, &Preferences::setRepeatShortcutForPreviousTool);
 
     connect(mUi->embedTilesets, &QCheckBox::toggled, preferences, [preferences] (bool value) {
         preferences->setExportOption(Preferences::EmbedTilesets, value);

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -273,16 +273,16 @@
             </property>
            </widget>
           </item>
-            <item row="8" column="0" colspan="2">
-             <widget class="QCheckBox" name="repeatShortcutForPreviousTool">
-              <property name="toolTip">
-               <string>Pressing the shortcut of the currently selected tool changes back to the previously selected tool, rather than keeping the current tool selected.</string>
-              </property>
-              <property name="text">
-               <string>Press a tool shortcut twice to switch to the previous tool</string>
-              </property>
-             </widget>
-            </item>
+          <item row="8" column="0" colspan="2">
+           <widget class="QCheckBox" name="repeatShortcutForPreviousTool">
+            <property name="toolTip">
+             <string>Pressing the shortcut of the currently selected tool changes back to the previously selected tool, rather than keeping the current tool selected.</string>
+            </property>
+            <property name="text">
+             <string>Pressing a tool shortcut again toggles to the previous tool</string>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="1" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -273,6 +273,16 @@
             </property>
            </widget>
           </item>
+            <item row="8" column="0" colspan="2">
+             <widget class="QCheckBox" name="repeatShortcutForPreviousTool">
+              <property name="toolTip">
+               <string>Pressing the shortcut of the currently selected tool changes back to the previously selected tool, rather than keeping the current tool selected.</string>
+              </property>
+              <property name="text">
+               <string>Press a tool shortcut twice to switch to the previous tool</string>
+              </property>
+             </widget>
+            </item>
           <item row="4" column="1" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>

--- a/src/tiled/toolmanager.cpp
+++ b/src/tiled/toolmanager.cpp
@@ -237,7 +237,7 @@ void ToolManager::retranslateTools()
  * This is done to make sure the shortcuts can still be used even when the
  * actions are only added to a tool bar and this tool bar is hidden.
  *
- * In addition, this allows us to optionally implement a toggle behavior: if the tool is
+ * In addition, this allows us to implement the optional toggle behavior: if the tool is
  * already selected, pressing the shortcut again will switch to the previously
  * selected tool.
  */
@@ -262,7 +262,7 @@ void ToolManager::createShortcuts(QWidget *parent)
                 if (!action->isChecked()) {
                     // Select the tool associated with this shortcut
                     action->trigger();
-                } else if ( Preferences::instance()->repeatShortcutForPreviousTool() ) {
+                } else if (Preferences::instance()->repeatShortcutForPreviousTool()) {
                     // The tool is already selected, switch to the previously selected tool
                     auto tool = mPreviousSelectedTool;
                     if (tool && tool->isVisible())

--- a/src/tiled/toolmanager.cpp
+++ b/src/tiled/toolmanager.cpp
@@ -237,7 +237,7 @@ void ToolManager::retranslateTools()
  * This is done to make sure the shortcuts can still be used even when the
  * actions are only added to a tool bar and this tool bar is hidden.
  *
- * In addition, this allows us to implement a toggle behavior: if the tool is
+ * In addition, this allows us to optionally implement a toggle behavior: if the tool is
  * already selected, pressing the shortcut again will switch to the previously
  * selected tool.
  */
@@ -262,7 +262,7 @@ void ToolManager::createShortcuts(QWidget *parent)
                 if (!action->isChecked()) {
                     // Select the tool associated with this shortcut
                     action->trigger();
-                } else {
+                } else if ( Preferences::instance()->repeatShortcutForPreviousTool() ) {
                     // The tool is already selected, switch to the previously selected tool
                     auto tool = mPreviousSelectedTool;
                     if (tool && tool->isVisible())


### PR DESCRIPTION
Fix  #4490

 I defaulted it to false  because I don't personally prefer this behavior either and we had a few users complain, so I thought most  users familiar with the app might expect it to be off . I can change it to default to true if desired 