### PR TITLE
Migrate the snap to Qt 6 based on kde-neon-6

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -186,7 +186,7 @@ jobs:
       env:
         SNAPCRAFT_BUILD_INFO: "1"
         SNAPCRAFT_IMAGE_INFO: '{"build_url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
-      run: sudo snapcraft --destructive-mode
+      run: sudo snapcraft pack --destructive-mode
 
     - name: Upload snap artifact
       uses: actions/upload-artifact@v6

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Added command variables %exportfile and %exportpath (#4476)
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
+* snap: Updated to Qt 6
 
 ### Tiled 1.12.2 (27 May 2026)
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,37 +12,45 @@ platforms:
   s390x:
   ppc64el:
 
+# The kde-neon-6 extension supplies the Qt 6 SDK at build time (via the
+# kde-qt6-core24-sdk content snap) and Qt 6 / KF6 runtime libraries via the
+# kf6-core24 content snap. It also auto-adds a desktop-launch command-chain
+# and the standard desktop / opengl / wayland / x11 / unity7 / network plugs
+# to every app that lists it in `extensions`.
+
+# libdrm hardcodes the path to its GPU id table at /usr/share/libdrm/amdgpu.ids,
+# which does not exist in the runtime sandbox. Stage the table via libdrm-common
+# (see the part below) and bind it into place to avoid the "amdgpu.ids: No such
+# file or directory" warning. Binding to the gpu-2404 content snap instead does
+# not work: snapd sets up the layout before that content is mounted, so the bind
+# source is still empty.
+layout:
+  /usr/share/libdrm:
+    bind: $SNAP/usr/share/libdrm
+
 apps:
   tiled:
-    command-chain: &command-chain
-      - bin/desktop-launch
+    extensions: [kde-neon-6]
     command: usr/bin/tiled
     common-id: org.mapeditor.Tiled.desktop
     plugs:
-      - desktop
-      - desktop-legacy
-      - wayland
-      - unity7
       - home
       - removable-media
-      - opengl
-      - network
+      # Let Qt query connectivity status through the NetworkMonitor portal
+      # instead of being denied it inside the sandbox.
+      - network-status
   tmxviewer:
-    command-chain: *command-chain
+    extensions: [kde-neon-6]
     command: usr/bin/tmxviewer
     plugs: &basic-plugs
-      - desktop
-      - desktop-legacy
-      - wayland
-      - unity7
       - home
       - removable-media
   tmxrasterizer:
-    command-chain: *command-chain
+    extensions: [kde-neon-6]
     command: usr/bin/tmxrasterizer
     plugs: *basic-plugs
   terraingenerator:
-    command-chain: *command-chain
+    extensions: [kde-neon-6]
     command: usr/bin/terraingenerator
     plugs: *basic-plugs
 
@@ -53,7 +61,21 @@ parts:
       craftctl default
       craftctl set version="$(git describe | sed 's/v//')"
     override-build: |
-      qbs setup-toolchains --detect
+      # Pin GCC to a fixed profile name so the Qt profile can base itself on it.
+      qbs setup-toolchains /usr/bin/g++ gcc
+      # kde-neon-6 supplies Qt 6 via the kde-qt6-core24-sdk content snap but no
+      # qmake on PATH. `find -L` follows the /snap/<name>/current symlink, and
+      # `-print -quit` exits cleanly under the scriptlet's pipefail/errexit.
+      qmake_bin="$(find -L /snap/kde-qt6-core24-sdk/current \( -name qmake6 -o -name qmake \) -type f -print -quit 2>/dev/null || true)"
+      if [ -z "$qmake_bin" ]; then
+          echo "Could not find qmake in the kde-qt6-core24-sdk" >&2
+          exit 1
+      fi
+      echo "Using qmake at: $qmake_bin"
+      # Create a Qt profile from this qmake, base it on gcc, and make it default.
+      qbs setup-qt "$qmake_bin" qt6
+      qbs config profiles.qt6.baseProfile gcc
+      qbs config defaultProfile qt6
       qbs build --jobs "${CRAFT_PARALLEL_BUILD_COUNT}" --command-echo-mode command-line config:release qbs.installPrefix:"/usr" projects.Tiled.version:$(craftctl get version) projects.Tiled.useRPaths:false
       qbs install --install-root "${CRAFT_PART_INSTALL}" config:release
     parse-info:
@@ -63,20 +85,15 @@ parts:
       - pkg-config
     # FIXME: Python plugin compiles and loads, but can't find platform libraries
     #  - python-dev
-      - qttools5-dev-tools
       - qbs
-      - libqt5svg5-dev
-      - qtdeclarative5-dev
       - zlib1g-dev
       - libzstd-dev
     stage-packages:
-      - libqt5quick5
-      - qt5-image-formats-plugins
-      - qtwayland5
     #  - libpython2.7
       - libzstd1
-      - xkb-data
-    after: [desktop-qt5]
+      # Provides /usr/share/libdrm/amdgpu.ids, bound into place via the layout
+      # above so libdrm can find its GPU id table.
+      - libdrm-common
 
   qaseprite:
     source: https://github.com/mapeditor/qaseprite/releases/download/1.0.3/qaseprite-1.0.3-source.tar.gz
@@ -125,26 +142,3 @@ parts:
       - libxcursor1
       - libxi6
       - zlib1g
-    after: [desktop-qt5]
-
-  desktop-qt5:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: qt
-    plugin: make
-    make-parameters: ["FLAVOR=qt5"]
-    build-packages:
-      - build-essential
-      - qtbase5-dev
-    stage-packages:
-      - libxkbcommon0
-      - dmz-cursor-theme
-      - light-themes
-      - adwaita-icon-theme
-      - shared-mime-info
-      - libqt5concurrent5
-      - libqt5gui5
-      - libqt5svg5 # for loading icon themes which are svg
-      - libgdk-pixbuf2.0-0
-      - locales-all
-      - xdg-user-dirs
-      - fcitx-frontend-qt5


### PR DESCRIPTION
Use the `kde-neon-6` extension to simplify the snap setup. It supplies the Qt 6 SDK at build time and the Qt 6 / KF6 runtime libraries.

The extension does not put qmake on PATH, so configure qbs with an explicit Qt profile based on a pinned gcc toolchain, set as the default profile. This no longer relies on qbs's implicit "scan PATH for qmake" provider.

Stage libdrm-common and bind /usr/share/libdrm to the snap's own copy so libdrm finds its amdgpu.ids table; binding the gpu-2404 content directory does not work because the layout is set up before that content is mounted. Add the network-status plug so Qt can query the NetworkMonitor portal instead of being denied it in the sandbox.