### PR TITLE
Tiled Quick: Adjusted grid.frag to use more precise numbers when calculating grid

### DIFF
--- a/src/libtiledquick/grid.frag
+++ b/src/libtiledquick/grid.frag
@@ -14,21 +14,31 @@ layout(std140, binding = 0) uniform buf {
     vec4 color;
 } ubuf;
 
-void main()
+const float thickness = 1;
+const float dashLength = thickness * 2;
+const float spaceLength = dashLength;
+
+bool posInGrid(vec2 pixelPos)
 {
-    float thickness = 1;
-    float dashLength = thickness * 2;
-    float spaceLength = dashLength;
-
-    vec2 pixelPos = vTexCoord * vec2(ubuf.pixelWidth, ubuf.pixelHeight) * ubuf.scale + thickness * 0.5;
-
     if ((mod(pixelPos.x, ubuf.tileWidth * ubuf.scale) < thickness &&
          mod(pixelPos.y, dashLength + spaceLength) < dashLength) ||
         (mod(pixelPos.y, ubuf.tileHeight * ubuf.scale) < thickness &&
          mod(pixelPos.x, dashLength + spaceLength) < dashLength))
     {
-        fragColor = ubuf.color * ubuf.qt_Opacity;
-    } else {
-        discard;
+        return true;
     }
+    return false;
+}
+
+void main()
+{
+    vec2 pixelPos = vTexCoord * vec2(ubuf.pixelWidth, ubuf.pixelHeight) * ubuf.scale + ceil(thickness * 0.5);
+
+    if (posInGrid(floor(pixelPos)))
+    {
+        fragColor = ubuf.color * ubuf.qt_Opacity;
+        return;
+    }
+
+    discard;
 }


### PR DESCRIPTION
Though uncommon at most scales/zooms, the current libtiledquick/grid.frag shader can have floating-point precision errors when determining whether or not a pixel should be filled by the grid.

This PR fixes the precision error by floor()-ing the pixelPos used for the position in grid calculation and ceil()-ing the thickness/2 offset, which allows the calculation to work with numbers much closer to integers.

Additionally, the 'position in grid' boolean calculation is moved to its own function for better clarity and to make it easier to work with in the future.