### PR TITLE
Require Qbs 1.23 for MSVC to drop the explicit /permissive- flag

### DIFF
--- a/qbs/imports/TiledPlugin.qbs
+++ b/qbs/imports/TiledPlugin.qbs
@@ -6,14 +6,6 @@ DynamicLibrary {
     Depends { name: "Qt"; submodules: "gui" }
 
     cpp.cxxLanguageVersion: "c++17"
-    cpp.cxxFlags: {
-        var flags = base;
-        if (qbs.toolchain.contains("msvc")) {
-            if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
-                flags.push("/permissive-");
-        }
-        return flags;
-    }
     cpp.visibility: "minimal"
     cpp.useRPaths: project.useRPaths
     cpp.rpaths: {

--- a/qbs/imports/TiledQtGuiApplication.qbs
+++ b/qbs/imports/TiledQtGuiApplication.qbs
@@ -7,14 +7,6 @@ QtGuiApplication {
             return ["$ORIGIN/../" + project.libDir];
     }
     cpp.cxxLanguageVersion: "c++17"
-    cpp.cxxFlags: {
-        var flags = base;
-        if (qbs.toolchain.contains("msvc")) {
-            if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
-                flags.push("/permissive-");
-        }
-        return flags;
-    }
     cpp.defines: [
         "QT_DISABLE_DEPRECATED_BEFORE=0x050F00",
         "QT_NO_DEPRECATED_WARNINGS",

--- a/qbs/imports/TiledTest.qbs
+++ b/qbs/imports/TiledTest.qbs
@@ -9,14 +9,6 @@ CppApplication {
     Depends { name: "autotest" }
 
     cpp.cxxLanguageVersion: "c++17"
-    cpp.cxxFlags: {
-        var flags = base;
-        if (qbs.toolchain.contains("msvc")) {
-            if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
-                flags.push("/permissive-");
-        }
-        return flags;
-    }
     cpp.rpaths: FileInfo.joinPaths(cpp.rpathOrigin, "../install-root/usr/local", project.libDir)
     autotest.workingDir: sourceDirectory
 }

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -17,11 +17,6 @@ DynamicLibrary {
     cpp.cxxFlags: {
         var flags = base;
 
-        if (qbs.toolchain.contains("msvc")) {
-            if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
-                flags.push("/permissive-");
-        }
-
         if (pkgConfigZstd.found)
             flags = flags.concat(pkgConfigZstd.cflags);
 

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -10,14 +10,6 @@ DynamicLibrary {
     Depends { name: "Qt"; submodules: ["quick","shadertools"]; versionAtLeast: "6.5" }
 
     cpp.cxxLanguageVersion: "c++17"
-    cpp.cxxFlags: {
-        var flags = base;
-        if (qbs.toolchain.contains("msvc")) {
-            if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
-                flags.push("/permissive-");
-        }
-        return flags;
-    }
     cpp.visibility: "minimal"
     cpp.defines: [
         "TILED_QUICK_LIBRARY",

--- a/src/qtsingleapplication/qtsingleapplication.qbs
+++ b/src/qtsingleapplication/qtsingleapplication.qbs
@@ -8,14 +8,6 @@ StaticLibrary {
 
     cpp.includePaths: ["src"]
     cpp.cxxLanguageVersion: "c++17"
-    cpp.cxxFlags: {
-        var flags = base;
-        if (qbs.toolchain.contains("msvc")) {
-            if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
-                flags.push("/permissive-");
-        }
-        return flags;
-    }
     cpp.visibility: "minimal"
 
     // Avoid wrapping this in a static framework, whose code signing breaks

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -25,14 +25,6 @@ DynamicLibrary {
 
     cpp.useCxxPrecompiledHeader: qbs.buildVariant != "debug"
     cpp.cxxLanguageVersion: "c++17"
-    cpp.cxxFlags: {
-        var flags = base;
-        if (qbs.toolchain.contains("msvc")) {
-            if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
-                flags.push("/permissive-");
-        }
-        return flags;
-    }
     cpp.visibility: "minimal"
 
     cpp.defines: {

--- a/src/tiledquick/tiledquick.qbs
+++ b/src/tiledquick/tiledquick.qbs
@@ -23,12 +23,6 @@ QtGuiApplication {
     cpp.includePaths: ["."]
     cpp.rpaths: qbs.targetOS.contains("darwin") ? ["@loader_path/../Frameworks"] : ["$ORIGIN/../" + project.libDir]
     cpp.cxxLanguageVersion: "c++17"
-    cpp.cxxFlags: {
-        var flags = base;
-        if (qbs.toolchain.contains("msvc"))
-            flags.push("/permissive-");
-        return flags;
-    }
     cpp.defines: [
         "QT_DISABLE_DEPRECATED_BEFORE=QT_VERSION_CHECK(6,5,0)",
         "QT_NO_DEPRECATED_WARNINGS",

--- a/src/tiledquickplugin/tiledquickplugin.qbs
+++ b/src/tiledquickplugin/tiledquickplugin.qbs
@@ -13,14 +13,6 @@ DynamicLibrary {
     }
 
     cpp.cxxLanguageVersion: "c++17"
-    cpp.cxxFlags: {
-        var flags = base;
-        if (qbs.toolchain.contains("msvc")) {
-            if (Qt.core.versionMajor >= 6 && Qt.core.versionMinor >= 3)
-                flags.push("/permissive-");
-        }
-        return flags;
-    }
     cpp.defines: [
         "QT_DISABLE_DEPRECATED_BEFORE=0x060500",
         "QT_NO_DEPRECATED_WARNINGS",

--- a/tiled.qbs
+++ b/tiled.qbs
@@ -4,7 +4,8 @@ Project {
     name: "Tiled"
 
     qbsSearchPaths: "qbs"
-    minimumQbsVersion: "1.18"
+    // Qbs 1.23 adds the required /permissive- flag for MSVC automatically.
+    minimumQbsVersion: qbs.toolchain.contains("msvc") ? "1.23" : "1.18"
 
     property string version: Environment.getEnv("TILED_VERSION") || "1.12.2";
     property bool snapshot: Environment.getEnv("TILED_SNAPSHOT") == "true"


### PR DESCRIPTION
Qbs 1.23 adds the required `/permissive-` flag for MSVC automatically, so the explicit additions across the `.qbs` files are no longer needed.

The minimum Qbs version is raised to 1.23 only for the MSVC toolchain, keeping 1.18 as the minimum for other toolchains.

(split off from https://github.com/mapeditor/tiled/pull/4526 to keep that change more focused)