### PR TITLE
Show resize handles on maps in the world view

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Added 'Collapse All' action and 'Only Expand to Current' mode to Project view (with rhythmcache, #4346)
 * Added command variables %exportfile and %exportpath (#4476)
 * Added a configurable world grid with snapping for maps (by Kanishka, #4534)
+* Added drag-to-resize for maps in the world view (by Kanishka, #4545)
 * Made switching to the previously selected tool when pressing its shortcut again optional and off by default (by dogboydog, #4540)
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -87,7 +87,7 @@ AbstractWorldTool::AbstractWorldTool(Id id,
 {
     mSelectionRectangle->setVisible(false);
 
-    for (auto &handle : mResizeHandles){
+    for (auto &handle : mResizeHandles) {
         handle = std::make_unique<MapResizeHandle>();
         handle->setVisible(false);
     }
@@ -426,12 +426,12 @@ void AbstractWorldTool::updateSelectionRectangle()
         mSelectionRectangle->setRectangle(rect);
         mSelectionRectangle->setVisible(true);
 
-        // Place the eight handles on the corners andedge midpoints
+        // Place the eight handles on the corners and edge midpoints
         const QPoint center = rect.center();
-        const QPoint handlePos[] = {
-            rect.topLeft(),QPoint(center.x(),rect.top()),rect.topRight(),
-            QPoint(rect.left(),center.y()),QPoint(rect.right(),center.y()),
-            rect.bottomLeft(),QPoint(center.x(),rect.bottom()),rect.bottomRight(),
+        const QPoint handlePos[HandleCount] = {
+            rect.topLeft(),    QPoint(center.x(), rect.top()),    rect.topRight(),
+            QPoint(rect.left(), center.y()),                      QPoint(rect.right(), center.y()),
+            rect.bottomLeft(), QPoint(center.x(), rect.bottom()), rect.bottomRight(),
         };
         for (int i = 0; i < 8; ++i) {
             mResizeHandles[i]->setPos(handlePos[i]);

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -59,6 +59,7 @@ public:
     MapResizeHandle()
     {
         setAcceptedMouseButtons(Qt::MouseButtons());
+        setAcceptHoverEvents(true);
         setFlag(QGraphicsItem::ItemIgnoresTransformations);
         setZValue(10000 + 1);
     }
@@ -76,6 +77,18 @@ public:
     }
 };
 
+// The eight resize handle positions for bounds, in ResizeHandlePosition order,
+// using a QRectF so right() and bottom() are not off by one like QRect
+std::array<QPointF, 8> resizeHandlePositions(const QRectF &bounds)
+{
+    const QPointF center = bounds.center();
+    return {{
+        bounds.topLeft(),    QPointF(center.x(), bounds.top()),    bounds.topRight(),
+        QPointF(bounds.left(), center.y()),                        QPointF(bounds.right(), center.y()),
+        bounds.bottomLeft(), QPointF(center.x(), bounds.bottom()), bounds.bottomRight(),
+    }};
+}
+
 } // namespace
 
 AbstractWorldTool::AbstractWorldTool(Id id,
@@ -88,9 +101,16 @@ AbstractWorldTool::AbstractWorldTool(Id id,
 {
     mSelectionRectangle->setVisible(false);
 
-    for (auto &handle : mResizeHandles) {
-        handle = std::make_unique<MapResizeHandle>();
-        handle->setVisible(false);
+    // Each handle owns its resize cursor, so it shows above a map's own cursor
+    static constexpr Qt::CursorShape handleCursors[HandleCount] = {
+        Qt::SizeFDiagCursor, Qt::SizeVerCursor, Qt::SizeBDiagCursor,
+        Qt::SizeHorCursor,                      Qt::SizeHorCursor,
+        Qt::SizeBDiagCursor, Qt::SizeVerCursor, Qt::SizeFDiagCursor,
+    };
+    for (int i = 0; i < HandleCount; ++i) {
+        mResizeHandles[i] = std::make_unique<MapResizeHandle>();
+        mResizeHandles[i]->setVisible(false);
+        mResizeHandles[i]->setCursor(handleCursors[i]);
     }
 
     WorldManager &worldManager = WorldManager::instance();
@@ -206,6 +226,37 @@ MapDocument *AbstractWorldTool::mapAt(const QPointF &pos) const
             return mapItem->mapDocument();
     }
     return nullptr;
+}
+
+// Finds a resize handle near the cursor on any map, hit-tested in view
+// coordinates so the hit area matches the on-screen handle size at any zoom,
+// returning its index and setting mapDocument to the owning map, or -1 if none
+int AbstractWorldTool::resizeHandleNear(const QPointF &scenePos, MapDocument *&mapDocument) const
+{
+    const auto views = mapScene()->views();
+    if (views.isEmpty())
+        return -1;
+
+    const QTransform viewTransform = views.first()->viewportTransform();
+    const QPointF viewPos = viewTransform.map(scenePos);
+    const qreal radius = Utils::dpiScaled(10.0);
+
+    const auto items = mapScene()->items();
+    for (QGraphicsItem *item : items) {
+        auto mapItem = qgraphicsitem_cast<MapItem*>(item);
+        if (!mapItem || !mapItem->isEnabled())
+            continue;
+
+        const auto handlePos = resizeHandlePositions(mapRect(mapItem->mapDocument()));
+        for (int i = 0; i < HandleCount; ++i) {
+            const QPointF delta = viewPos - viewTransform.map(handlePos[i]);
+            if (qAbs(delta.x()) <= radius && qAbs(delta.y()) <= radius) {
+                mapDocument = mapItem->mapDocument();
+                return i;
+            }
+        }
+    }
+    return -1;
 }
 
 bool AbstractWorldTool::mapCanBeMoved(MapDocument *mapDocument) const
@@ -432,33 +483,12 @@ void AbstractWorldTool::setSelectionScreenRect(const QRect &rect)
     mSelectionRectangle->setRectangle(rect);
     mSelectionRectangle->setVisible(true);
 
-    // Place the eight handles on the corners and edge midpoints, using QRectF
-    // to avoid the off-by-one of QRect::right() and bottom()
-    const QRectF bounds = rect;
-    const QPointF center = bounds.center();
-    const QPointF handlePos[HandleCount] = {
-        bounds.topLeft(),    QPointF(center.x(), bounds.top()),    bounds.topRight(),
-        QPointF(bounds.left(), center.y()),                        QPointF(bounds.right(), center.y()),
-        bounds.bottomLeft(), QPointF(center.x(), bounds.bottom()), bounds.bottomRight(),
-    };
+    // Place the eight handles on the corners and edge midpoints
+    const auto handlePos = resizeHandlePositions(rect);
     for (int i = 0; i < HandleCount; ++i) {
         mResizeHandles[i]->setPos(handlePos[i]);
         mResizeHandles[i]->setVisible(true);
     }
-}
-
-int AbstractWorldTool::resizeHandleAt(const QPointF &scenePos) const
-{
-    // The handles ignore transformations, so itemAt needs the view transform
-    const auto views = mapScene()->views();
-    const QTransform viewTransform = views.isEmpty() ? QTransform()
-                                                     : views.first()->transform();
-    QGraphicsItem *item = mapScene()->itemAt(scenePos, viewTransform);
-    for (int i = 0; i < HandleCount; ++i) {
-        if (mResizeHandles[i].get() == item)
-            return i;
-    }
-    return -1;
 }
 
 // The scene rect currently visible in the active map's view

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -436,12 +436,14 @@ void AbstractWorldTool::setSelectionScreenRect(const QRect &rect)
     mSelectionRectangle->setRectangle(rect);
     mSelectionRectangle->setVisible(true);
 
-    // Place the eight handles on the corners and edge midpoints
-    const QPoint center = rect.center();
-    const QPoint handlePos[HandleCount] = {
-        rect.topLeft(),    QPoint(center.x(), rect.top()),    rect.topRight(),
-        QPoint(rect.left(), center.y()),                      QPoint(rect.right(), center.y()),
-        rect.bottomLeft(), QPoint(center.x(), rect.bottom()), rect.bottomRight(),
+    // Place the eight handles on the corners and edge midpoints, using QRectf
+    // to avoid the off by-one of QRect::right() and bottom()
+    const QRectF bounds = rect;
+    const QPointF center = bounds.center();
+    const QPointF handlePos[HandleCount] = {
+        bounds.topLeft(),    QPointF(center.x(), bounds.top()),    bounds.topRight(),
+        QPointF(bounds.left(), center.y()),                        QPointF(bounds.right(), center.y()),
+        bounds.bottomLeft(), QPointF(center.x(), bounds.bottom()), bounds.bottomRight(),
     };
     for (int i = 0; i < HandleCount; ++i) {
         mResizeHandles[i]->setPos(handlePos[i]);

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -79,7 +79,7 @@ public:
 
 // The eight resize handle positions for bounds, in ResizeHandlePosition order,
 // using a QRectF so right() and bottom() are not off by one like QRect
-std::array<QPointF, 8> resizeHandlePositions(const QRectF &bounds)
+std::array<QPointF, HandleCount> resizeHandlePositions(const QRectF &bounds)
 {
     const QPointF center = bounds.center();
     return {{
@@ -332,7 +332,8 @@ void AbstractWorldTool::populateAddToWorldMenu(QMenu &menu)
 
 void AbstractWorldTool::addAnotherMapToWorldAtCenter()
 {
-    addAnotherMapToWorld(sceneViewRect().center().toPoint());
+    MapView *view = DocumentManager::instance()->viewForDocument(mapDocument());
+    addAnotherMapToWorld(view->viewCenter().toPoint());
 }
 
 void AbstractWorldTool::addAnotherMapToWorld(QPoint insertPos)
@@ -491,20 +492,14 @@ void AbstractWorldTool::setSelectionScreenRect(const QRect &rect)
     }
 }
 
-// The scene rect currently visible in the active map's view
-QRectF AbstractWorldTool::sceneViewRect() const
-{
-    MapView *view = DocumentManager::instance()->viewForDocument(mapDocument());
-    return view->viewportTransform().inverted().mapRect(QRectF(view->viewport()->rect()));
-}
-
 // Move the camera back by offset, to keep the active map steady after it shifts
 void AbstractWorldTool::recenterView(const QPoint &offset)
 {
+    if (offset.isNull())
+        return;
+
     MapView *view = DocumentManager::instance()->viewForDocument(mapDocument());
-    const QRectF viewRect { view->viewport()->rect() };
-    const QRectF sceneViewRect = view->viewportTransform().inverted().mapRect(viewRect);
-    view->forceCenterOn(sceneViewRect.center() - offset);
+    view->forceCenterOn(view->viewCenter() - offset);
 }
 
 } // namespace Tiled

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -30,21 +30,52 @@
 #include "mapview.h"
 #include "preferences.h"
 #include "selectionrectangle.h"
+#include "utils.h"
 #include "world.h"
 #include "worlddocument.h"
 #include "worldmanager.h"
 
 #include <QAction>
 #include <QFileDialog>
+#include <QGraphicsItem>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPainter>
 #include <QToolBar>
 #include <QToolButton>
 #include <QUndoStack>
 #include <QtMath>
 
 namespace Tiled {
+
+namespace {
+
+// A small square handle shown on a map's corners and edges for resizing
+class MapResizeHandle : public QGraphicsItem
+{
+public:
+    MapResizeHandle()
+    {
+        setAcceptedMouseButtons(Qt::MouseButtons());
+        setFlag(QGraphicsItem::ItemIgnoresTransformations);
+        setZValue(10000);
+    }
+
+    QRectF boundingRect() const override
+    {
+        return Utils::dpiScaled(QRectF(-5, -5, 10, 10));
+    }
+
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) override
+    {
+        painter->setPen(QPen(Qt::black, 1));
+        painter->setBrush(Qt::white);
+        painter->drawRect(Utils::dpiScaled(QRectF(-4, -4, 8, 8)));
+    }
+};
+
+} // namespace
 
 AbstractWorldTool::AbstractWorldTool(Id id,
                                      const QString &name,
@@ -55,6 +86,11 @@ AbstractWorldTool::AbstractWorldTool(Id id,
     , mSelectionRectangle(new SelectionRectangle)
 {
     mSelectionRectangle->setVisible(false);
+
+    for (auto &handle : mResizeHandles){
+        handle = std::make_unique<MapResizeHandle>();
+        handle->setVisible(false);
+    }
 
     WorldManager &worldManager = WorldManager::instance();
     connect(&worldManager, &WorldManager::worldsChanged, this, &AbstractWorldTool::updateEnabledState);
@@ -87,6 +123,8 @@ AbstractWorldTool::~AbstractWorldTool() = default;
 void AbstractWorldTool::activate(MapScene *scene)
 {
     scene->addItem(mSelectionRectangle.get());
+    for (auto &handle : mResizeHandles)
+        scene->addItem(handle.get());
     connect(scene, &MapScene::sceneRefreshed, this, &AbstractWorldTool::updateSelectionRectangle);
     AbstractTool::activate(scene);
 }
@@ -94,6 +132,8 @@ void AbstractWorldTool::activate(MapScene *scene)
 void AbstractWorldTool::deactivate(MapScene *scene)
 {
     scene->removeItem(mSelectionRectangle.get());
+    for (auto &handle : mResizeHandles)
+        scene->removeItem(handle.get());
     disconnect(scene, &MapScene::sceneRefreshed, this, &AbstractWorldTool::updateSelectionRectangle);
     AbstractTool::deactivate(scene);
 }
@@ -382,11 +422,25 @@ void AbstractWorldTool::setTargetMap(MapDocument *mapDocument)
 void AbstractWorldTool::updateSelectionRectangle()
 {
     if (mTargetMap) {
-        const auto rect = mapRect(mTargetMap);
+        const QRect rect = mapRect(mTargetMap);
         mSelectionRectangle->setRectangle(rect);
         mSelectionRectangle->setVisible(true);
+
+        // Place the eight handles on the corners andedge midpoints
+        const QPoint center = rect.center();
+        const QPoint handlePos[] = {
+            rect.topLeft(),QPoint(center.x(),rect.top()),rect.topRight(),
+            QPoint(rect.left(),center.y()),QPoint(rect.right(),center.y()),
+            rect.bottomLeft(),QPoint(center.x(),rect.bottom()),rect.bottomRight(),
+        };
+        for (int i = 0; i < 8; ++i) {
+            mResizeHandles[i]->setPos(handlePos[i]);
+            mResizeHandles[i]->setVisible(true);
+        }
     } else {
         mSelectionRectangle->setVisible(false);
+        for (auto &handle : mResizeHandles)
+            handle->setVisible(false);
     }
 }
 

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -59,7 +59,7 @@ public:
     {
         setAcceptedMouseButtons(Qt::MouseButtons());
         setFlag(QGraphicsItem::ItemIgnoresTransformations);
-        setZValue(10000);
+        setZValue(10000 + 1);
     }
 
     QRectF boundingRect() const override
@@ -422,26 +422,42 @@ void AbstractWorldTool::setTargetMap(MapDocument *mapDocument)
 void AbstractWorldTool::updateSelectionRectangle()
 {
     if (mTargetMap) {
-        const QRect rect = mapRect(mTargetMap);
-        mSelectionRectangle->setRectangle(rect);
-        mSelectionRectangle->setVisible(true);
-
-        // Place the eight handles on the corners and edge midpoints
-        const QPoint center = rect.center();
-        const QPoint handlePos[HandleCount] = {
-            rect.topLeft(),    QPoint(center.x(), rect.top()),    rect.topRight(),
-            QPoint(rect.left(), center.y()),                      QPoint(rect.right(), center.y()),
-            rect.bottomLeft(), QPoint(center.x(), rect.bottom()), rect.bottomRight(),
-        };
-        for (int i = 0; i < 8; ++i) {
-            mResizeHandles[i]->setPos(handlePos[i]);
-            mResizeHandles[i]->setVisible(true);
-        }
+        setSelectionScreenRect(mapRect(mTargetMap));
     } else {
         mSelectionRectangle->setVisible(false);
         for (auto &handle : mResizeHandles)
             handle->setVisible(false);
     }
+}
+
+void AbstractWorldTool::setSelectionScreenRect(const QRect &rect)
+{
+    mSelectionRectangle->setRectangle(rect);
+    mSelectionRectangle->setVisible(true);
+
+    // Place the eight handles on the corners and edge midpoints
+    const QPoint center = rect.center();
+    const QPoint handlePos[HandleCount] = {
+        rect.topLeft(),    QPoint(center.x(), rect.top()),    rect.topRight(),
+        QPoint(rect.left(), center.y()),                      QPoint(rect.right(), center.y()),
+        rect.bottomLeft(), QPoint(center.x(), rect.bottom()), rect.bottomRight(),
+    };
+    for (int i = 0; i < HandleCount; ++i) {
+        mResizeHandles[i]->setPos(handlePos[i]);
+        mResizeHandles[i]->setVisible(true);
+    }
+}
+
+int AbstractWorldTool::resizeHandleAt(const QPointF &scenePos,
+                                      const QTransform &viewTransform) const
+{
+    // The handles ignore transformations, so pass the view transform to hit-test them
+    QGraphicsItem *item = mapScene()->itemAt(scenePos, viewTransform);
+    for (int i = 0; i < HandleCount; ++i) {
+        if (mResizeHandles[i].get() == item)
+            return i;
+    }
+    return -1;
 }
 
 } // namespace Tiled

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -281,11 +281,7 @@ void AbstractWorldTool::populateAddToWorldMenu(QMenu &menu)
 
 void AbstractWorldTool::addAnotherMapToWorldAtCenter()
 {
-    DocumentManager *manager = DocumentManager::instance();
-    MapView *view = manager->viewForDocument(mapDocument());
-    const QRectF viewRect { view->viewport()->rect() };
-    const QRectF sceneViewRect = view->viewportTransform().inverted().mapRect(viewRect);
-    addAnotherMapToWorld(sceneViewRect.center().toPoint());
+    addAnotherMapToWorld(sceneViewRect().center().toPoint());
 }
 
 void AbstractWorldTool::addAnotherMapToWorld(QPoint insertPos)
@@ -436,8 +432,8 @@ void AbstractWorldTool::setSelectionScreenRect(const QRect &rect)
     mSelectionRectangle->setRectangle(rect);
     mSelectionRectangle->setVisible(true);
 
-    // Place the eight handles on the corners and edge midpoints, using QRectf
-    // to avoid the off by-one of QRect::right() and bottom()
+    // Place the eight handles on the corners and edge midpoints, using QRectF
+    // to avoid the off-by-one of QRect::right() and bottom()
     const QRectF bounds = rect;
     const QPointF center = bounds.center();
     const QPointF handlePos[HandleCount] = {
@@ -463,6 +459,22 @@ int AbstractWorldTool::resizeHandleAt(const QPointF &scenePos) const
             return i;
     }
     return -1;
+}
+
+// The scene rect currently visible in the active map's view
+QRectF AbstractWorldTool::sceneViewRect() const
+{
+    MapView *view = DocumentManager::instance()->viewForDocument(mapDocument());
+    return view->viewportTransform().inverted().mapRect(QRectF(view->viewport()->rect()));
+}
+
+// Move the camera back by offset, to keep the active map steady after it shifts
+void AbstractWorldTool::recenterView(const QPoint &offset)
+{
+    MapView *view = DocumentManager::instance()->viewForDocument(mapDocument());
+    const QRectF viewRect { view->viewport()->rect() };
+    const QRectF sceneViewRect = view->viewportTransform().inverted().mapRect(viewRect);
+    view->forceCenterOn(sceneViewRect.center() - offset);
 }
 
 } // namespace Tiled

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -38,6 +38,7 @@
 #include <QAction>
 #include <QFileDialog>
 #include <QGraphicsItem>
+#include <QGraphicsView>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QMessageBox>
@@ -448,10 +449,12 @@ void AbstractWorldTool::setSelectionScreenRect(const QRect &rect)
     }
 }
 
-int AbstractWorldTool::resizeHandleAt(const QPointF &scenePos,
-                                      const QTransform &viewTransform) const
+int AbstractWorldTool::resizeHandleAt(const QPointF &scenePos) const
 {
-    // The handles ignore transformations, so pass the view transform to hit-test them
+    // The handles ignore transformations, so itemAt needs the view transform
+    const auto views = mapScene()->views();
+    const QTransform viewTransform = views.isEmpty() ? QTransform()
+                                                     : views.first()->transform();
     QGraphicsItem *item = mapScene()->itemAt(scenePos, viewTransform);
     for (int i = 0; i < HandleCount; ++i) {
         if (mResizeHandles[i].get() == item)

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -91,6 +91,17 @@ std::array<QPointF, HandleCount> resizeHandlePositions(const QRectF &bounds)
 
 } // namespace
 
+Qt::CursorShape cursorForHandle(int handle)
+{
+    switch (handle) {
+    case TopLeftHandle: case BottomRightHandle: return Qt::SizeFDiagCursor;
+    case TopRightHandle: case BottomLeftHandle: return Qt::SizeBDiagCursor;
+    case TopHandle: case BottomHandle:          return Qt::SizeVerCursor;
+    case LeftHandle: case RightHandle:          return Qt::SizeHorCursor;
+    default:                                    return Qt::ArrowCursor;
+    }
+}
+
 AbstractWorldTool::AbstractWorldTool(Id id,
                                      const QString &name,
                                      const QIcon &icon,
@@ -102,15 +113,10 @@ AbstractWorldTool::AbstractWorldTool(Id id,
     mSelectionRectangle->setVisible(false);
 
     // Each handle owns its resize cursor, so it shows above a map's own cursor
-    static constexpr Qt::CursorShape handleCursors[HandleCount] = {
-        Qt::SizeFDiagCursor, Qt::SizeVerCursor, Qt::SizeBDiagCursor,
-        Qt::SizeHorCursor,                      Qt::SizeHorCursor,
-        Qt::SizeBDiagCursor, Qt::SizeVerCursor, Qt::SizeFDiagCursor,
-    };
     for (int i = 0; i < HandleCount; ++i) {
         mResizeHandles[i] = std::make_unique<MapResizeHandle>();
         mResizeHandles[i]->setVisible(false);
-        mResizeHandles[i]->setCursor(handleCursors[i]);
+        mResizeHandles[i]->setCursor(cursorForHandle(i));
     }
 
     WorldManager &worldManager = WorldManager::instance();

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -102,7 +102,7 @@ protected:
     MapDocument *targetMap() const { return mTargetMap; }
     void updateSelectionRectangle();
     void setSelectionScreenRect(const QRect &rect);
-    int resizeHandleAt(const QPointF &scenePos) const;
+    int resizeHandleNear(const QPointF &scenePos, MapDocument *&mapDocument) const;
 
     QRectF sceneViewRect() const;
     void recenterView(const QPoint &offset);

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -28,6 +28,7 @@
 class QAction;
 class QGraphicsItem;
 class QMenu;
+class QTransform;
 
 namespace Tiled {
 
@@ -88,6 +89,8 @@ protected:
     void setTargetMap(MapDocument *mapDocument);
     MapDocument *targetMap() const { return mTargetMap; }
     void updateSelectionRectangle();
+    void setSelectionScreenRect(const QRect &rect);
+    int resizeHandleAt(const QPointF &scenePos, const QTransform &viewTransform) const;
 
     bool mapCanBeMoved(MapDocument *mapDocument) const;
     QRect mapRect(MapDocument *mapDocument) const;

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -47,6 +47,7 @@ enum ResizeHandlePosition {
     BottomLeftHandle,
     BottomHandle,
     BottomRightHandle,
+    HandleCount,
 };
 
 /**
@@ -125,8 +126,6 @@ private:
     QAction *mRemoveMapFromWorldAction;
 
     std::unique_ptr<SelectionRectangle> mSelectionRectangle;
-
-    static constexpr int HandleCount = 8;
     std::array<std::unique_ptr<QGraphicsItem>, HandleCount> mResizeHandles;
 };
 

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -105,7 +105,6 @@ protected:
     void setSelectionScreenRect(const QRect &rect);
     int resizeHandleNear(const QPointF &scenePos, MapDocument *&mapDocument) const;
 
-    QRectF sceneViewRect() const;
     void recenterView(const QPoint &offset);
 
     bool mapCanBeMoved(MapDocument *mapDocument) const;

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -50,6 +50,9 @@ enum ResizeHandlePosition {
     HandleCount,
 };
 
+// The resize cursor shape for a given resize handle.
+Qt::CursorShape cursorForHandle(int handle);
+
 /**
  * A convenient base class for tools that work on object layers. Implements
  * the standard context menu.

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -107,7 +107,9 @@ private:
     QAction *mRemoveMapFromWorldAction;
 
     std::unique_ptr<SelectionRectangle> mSelectionRectangle;
-    std::array<std::unique_ptr<QGraphicsItem>, 8> mResizeHandles;
+
+    static constexpr int HandleCount = 8;
+    std::array<std::unique_ptr<QGraphicsItem>, HandleCount> mResizeHandles;
 };
 
 } // namespace Tiled

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -22,7 +22,11 @@
 
 #include "abstracttool.h"
 
+#include <array>
+#include <memory>
+
 class QAction;
+class QGraphicsItem;
 class QMenu;
 
 namespace Tiled {
@@ -103,6 +107,7 @@ private:
     QAction *mRemoveMapFromWorldAction;
 
     std::unique_ptr<SelectionRectangle> mSelectionRectangle;
+    std::array<std::unique_ptr<QGraphicsItem>, 8> mResizeHandles;
 };
 
 } // namespace Tiled

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -28,7 +28,6 @@
 class QAction;
 class QGraphicsItem;
 class QMenu;
-class QTransform;
 
 namespace Tiled {
 
@@ -36,6 +35,19 @@ class World;
 
 class SelectionRectangle;
 class WorldDocument;
+
+// The eight resize handles, in the order they are placed by
+// AbstractWorldTool::setSelectionScreenRect.
+enum ResizeHandlePosition {
+    TopLeftHandle,
+    TopHandle,
+    TopRightHandle,
+    LeftHandle,
+    RightHandle,
+    BottomLeftHandle,
+    BottomHandle,
+    BottomRightHandle,
+};
 
 /**
  * A convenient base class for tools that work on object layers. Implements
@@ -90,7 +102,7 @@ protected:
     MapDocument *targetMap() const { return mTargetMap; }
     void updateSelectionRectangle();
     void setSelectionScreenRect(const QRect &rect);
-    int resizeHandleAt(const QPointF &scenePos, const QTransform &viewTransform) const;
+    int resizeHandleAt(const QPointF &scenePos) const;
 
     bool mapCanBeMoved(MapDocument *mapDocument) const;
     QRect mapRect(MapDocument *mapDocument) const;

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -104,6 +104,9 @@ protected:
     void setSelectionScreenRect(const QRect &rect);
     int resizeHandleAt(const QPointF &scenePos) const;
 
+    QRectF sceneViewRect() const;
+    void recenterView(const QPoint &offset);
+
     bool mapCanBeMoved(MapDocument *mapDocument) const;
     QRect mapRect(MapDocument *mapDocument) const;
     WorldDocument *worldForMap(MapDocument *mapDocument) const;

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -333,10 +333,8 @@ void MapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (mDisplayMode == ReadOnly && event->button() == Qt::LeftButton && isUnderMouse()) {
         MapView *view = static_cast<MapView*>(event->widget()->parent());
-        QRectF viewRect { view->viewport()->rect() };
-        QRectF sceneViewRect = view->viewportTransform().inverted().mapRect(viewRect);
         DocumentManager::instance()->switchToDocumentAndHandleSimiliarTileset(mMapDocument.data(),
-                                                                              sceneViewRect.center() - pos(),
+                                                                              view->viewCenter() - pos(),
                                                                               view->zoomable()->scale());
         return;
     }

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -35,6 +35,7 @@
 #include "zoomable.h"
 
 #include <QApplication>
+#include <QGraphicsView>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QToolBar>
@@ -47,6 +48,36 @@
 using namespace Tiled;
 
 namespace Tiled {
+
+namespace {
+
+// which edges each resize handle moves, in the same order as
+// setSelectionScreenRect (corners and edge midpoints)
+struct HandleEdges { bool left, right, top, bottom; };
+
+const HandleEdges handleEdges[] = {
+    { true,  false, true,  false },     // top-left
+    { false, false, true,  false },     // top
+    { false, true,  true,  false },     // top-right
+    { true,  false, false, false },     // left
+    { false, true,  false, false },     // right
+    { true,  false, false, true  },     // bottom-left
+    { false, false, false, true  },     // bottom
+    { false, true,  false, true  },     // bottom-right
+};
+
+Qt::CursorShape cursorForHandle(int handle)
+{
+    switch (handle) {
+    case 0: case 7: return Qt::SizeFDiagCursor;     // top-left / bottom-right
+    case 2: case 5: return Qt::SizeBDiagCursor;     // top-right / bottom-left
+    case 1: case 6: return Qt::SizeVerCursor;       // top / bottom
+    case 3: case 4: return Qt::SizeHorCursor;       // left / right
+    default:        return Qt::ArrowCursor;
+    }
+}
+
+} // namespace
 
 WorldMoveMapTool::WorldMoveMapTool(QObject *parent)
     : AbstractWorldTool("WorldMoveMapTool",
@@ -72,6 +103,7 @@ void WorldMoveMapTool::keyPressed(QKeyEvent *event)
     case Qt::Key_Right: moveBy = QPointF(1, 0); break;
     case Qt::Key_Escape:
         abortMoving();
+        abortResizing();
         return;
     default:
         AbstractWorldTool::keyPressed(event);
@@ -131,17 +163,89 @@ void WorldMoveMapTool::moveMap(MapDocument *document, QPoint moveBy)
     }
 }
 
+void WorldMoveMapTool::updateResizingMap(const QPointF &pos,
+                                         Qt::KeyboardModifiers modifiers)
+{
+    const Map *map = mResizingMap->map();
+    const int tileWidth = map->tileWidth();
+    const int tileHeight = map->tileHeight();
+    const QSize step = snapSize(mResizingMap);
+    const HandleEdges edges = handleEdges[mResizeHandle];
+
+    int left = mResizeStartWorldRect.left();
+    int top = mResizeStartWorldRect.top();
+    int right = mResizeStartWorldRect.left() + mResizeStartWorldRect.width();
+    int bottom = mResizeStartWorldRect.top() + mResizeStartWorldRect.height();
+
+    const QPoint delta = (pos - mDragStartScenePos).toPoint();
+    const bool snapToGrid = !(modifiers & Qt::ControlModifier);
+
+    const auto snap = [&](int value, int gridStep) {
+        return (snapToGrid && gridStep > 0) ? qRound(qreal(value) / gridStep) * gridStep
+                                            : value;
+    };
+
+    if (edges.left)
+        left = snap(left + delta.x(), step.width());
+    if (edges.right)
+        right = snap(right + delta.x(), step.width());
+    if (edges.top)
+        top = snap(top + delta.y(), step.height());
+    if (edges.bottom)
+        bottom = snap(bottom + delta.y(), step.height());
+
+    // a map is always a whole number of tiles, so round to the nearest tile
+    const int newWidth = qMax(1, qRound(qreal(right - left) / tileWidth));
+    const int newHeight = qMax(1, qRound(qreal(bottom - top) / tileHeight));
+
+    // the content only shifts when the left or top edge is the one being moved
+    mResizeOffset = QPoint(edges.left ? newWidth - map->width() : 0,
+                           edges.top ? newHeight - map->height() : 0);
+    mResizeNewSize = QSize(newWidth, newHeight);
+
+    // preview the result, matching what resizeMap() will produce
+    const QPoint topLeft(mResizeStartWorldRect.left() - mResizeOffset.x() * tileWidth,
+                         mResizeStartWorldRect.top() - mResizeOffset.y() * tileHeight);
+    const QRect previewRect(topLeft, QSize(newWidth * tileWidth, newHeight * tileHeight));
+    setSelectionScreenRect(previewRect.translated(mResizeSceneOffset));
+
+    setStatusInfo(tr("Resize map to %1 x %2").arg(newWidth).arg(newHeight));
+}
+
 void WorldMoveMapTool::mouseEntered()
 {
 }
 
 void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
 {
-    if (mDraggingMap)
+    if (mDraggingMap || mResizingMap)
         return;
 
     if (event->button() == Qt::LeftButton && mapCanBeMoved(targetMap())) {
-        // initiate drag action
+        // initiate a resize when one of the handles is pressed
+        QTransform viewTransform;
+        if (QWidget *viewport = event->widget())
+            if (auto view = qobject_cast<QGraphicsView*>(viewport->parent()))
+                viewTransform = view->transform();
+
+        const int handle = resizeHandleAt(event->scenePos(), viewTransform);
+        if (handle != -1) {
+            mResizingMap = targetMap();
+            mResizeHandle = handle;
+            mDragStartScenePos = event->scenePos();
+
+            auto world = worldForMap(mResizingMap)->world();
+            const QPoint worldPos = world->mapRect(mResizingMap->fileName()).topLeft();
+            const QSize sizePixels = mResizingMap->renderer()->mapBoundingRect().size();
+            mResizeStartWorldRect = QRect(worldPos, sizePixels);
+            mResizeSceneOffset = mapScene()->mapItem(mResizingMap)->pos().toPoint() - worldPos;
+            mResizeNewSize = mResizingMap->map()->size();
+            mResizeOffset = QPoint(0, 0);
+            refreshCursor();
+            return;
+        }
+
+        // otherwise initiate a move
         mDraggingMap = targetMap();
         mDraggingMapItem = mapScene()->mapItem(mDraggingMap);
         mDragStartScenePos = event->scenePos();
@@ -157,8 +261,23 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
 void WorldMoveMapTool::mouseMoved(const QPointF &pos,
                                   Qt::KeyboardModifiers modifiers)
 {    
+    if (mResizingMap) {
+        updateResizingMap(pos, modifiers);
+        return;
+    }
+
     if (!worldForMap(mDraggingMap) || !mDraggingMap) {
         AbstractWorldTool::mouseMoved(pos, modifiers);
+
+        // show a resize cursor while hovering one of the handles
+        const auto views = mapScene()->views();
+        const QTransform viewTransform = views.isEmpty() ? QTransform()
+                                                         : views.first()->transform();
+        const int handle = resizeHandleAt(pos, viewTransform);
+        const Qt::CursorShape shape = (handle != -1) ? cursorForHandle(handle)
+                                                     : Qt::ArrowCursor;
+        if (cursor().shape() != shape)
+            setCursor(shape);
         return;
     }
 
@@ -186,6 +305,40 @@ void WorldMoveMapTool::mouseMoved(const QPointF &pos,
 
 void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
 {
+    if (mResizingMap) {
+        if (event->button() == Qt::LeftButton) {
+            auto resizedMap = std::exchange(mResizingMap, nullptr);
+            mResizeHandle = -1;
+
+            if (mResizeNewSize != resizedMap->map()->size() || !mResizeOffset.isNull()) {
+                const QPoint prevPos = mResizeStartWorldRect.topLeft();
+                resizedMap->resizeMap(mResizeNewSize, mResizeOffset, false);
+
+                // keep the view steady when the active map's position shifted
+                if (resizedMap == mapDocument()) {
+                    if (auto worldDocument = worldForMap(resizedMap)) {
+                        const QPoint newPos = worldDocument->world()->mapRect(resizedMap->fileName()).topLeft();
+                        const QPoint actualOffset = newPos - prevPos;
+                        if (!actualOffset.isNull()) {
+                            DocumentManager *manager = DocumentManager::instance();
+                            MapView *view = manager->viewForDocument(mapDocument());
+                            const QRectF viewRect { view->viewport()->rect() };
+                            const QRectF sceneViewRect = view->viewportTransform().inverted().mapRect(viewRect);
+                            view->forceCenterOn(sceneViewRect.center() - actualOffset);
+                        }
+                    }
+                }
+            }
+
+            updateSelectionRectangle();
+            refreshCursor();
+            setStatusInfo(QString());
+        } else if (event->button() == Qt::RightButton) {
+            abortResizing();
+        }
+        return;
+    }
+
     if (!mDraggingMap)
         return;
 
@@ -243,6 +396,8 @@ void WorldMoveMapTool::refreshCursor()
 
     if (mDraggingMap)
         cursorShape = Qt::SizeAllCursor;
+    else if (mResizingMap)
+        cursorShape = cursorForHandle(mResizeHandle);
 
     if (cursor().shape() != cursorShape)
         setCursor(cursorShape);
@@ -256,6 +411,19 @@ void WorldMoveMapTool::abortMoving()
     mDraggingMapItem->setPos(mDraggedMapStartPos);
     mDraggingMapItem = nullptr;
     mDraggingMap = nullptr;
+    updateSelectionRectangle();
+
+    refreshCursor();
+    setStatusInfo(QString());
+}
+
+void WorldMoveMapTool::abortResizing()
+{
+    if (!mResizingMap)
+        return;
+
+    mResizingMap = nullptr;
+    mResizeHandle = -1;
     updateSelectionRectangle();
 
     refreshCursor();

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -54,7 +54,7 @@ namespace {
 // setSelectionScreenRect (corners and edge midpoints)
 struct HandleEdges { bool left, right, top, bottom; };
 
-const HandleEdges handleEdges[] = {
+static constexpr HandleEdges handleEdges[HandleCount] = {
     { true,  false, true,  false },     // top-left
     { false, false, true,  false },     // top
     { false, true,  true,  false },     // top-right
@@ -267,7 +267,7 @@ void WorldMoveMapTool::startMoving(QGraphicsSceneMouseEvent *event)
 
 void WorldMoveMapTool::mouseMoved(const QPointF &pos,
                                   Qt::KeyboardModifiers modifiers)
-{    
+{
     if (mResizingMap) {
         updateResizingMap(pos, modifiers);
         return;

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -35,7 +35,6 @@
 #include "zoomable.h"
 
 #include <QApplication>
-#include <QGraphicsView>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QToolBar>
@@ -69,11 +68,11 @@ const HandleEdges handleEdges[] = {
 Qt::CursorShape cursorForHandle(int handle)
 {
     switch (handle) {
-    case 0: case 7: return Qt::SizeFDiagCursor;     // top-left / bottom-right
-    case 2: case 5: return Qt::SizeBDiagCursor;     // top-right / bottom-left
-    case 1: case 6: return Qt::SizeVerCursor;       // top / bottom
-    case 3: case 4: return Qt::SizeHorCursor;       // left / right
-    default:        return Qt::ArrowCursor;
+    case TopLeftHandle: case BottomRightHandle: return Qt::SizeFDiagCursor;
+    case TopRightHandle: case BottomLeftHandle: return Qt::SizeBDiagCursor;
+    case TopHandle: case BottomHandle:          return Qt::SizeVerCursor;
+    case LeftHandle: case RightHandle:          return Qt::SizeHorCursor;
+    default:                                    return Qt::ArrowCursor;
     }
 }
 
@@ -203,11 +202,14 @@ void WorldMoveMapTool::updateResizingMap(const QPointF &pos,
                            edges.top ? newHeight - map->height() : 0);
     mResizeNewSize = QSize(newWidth, newHeight);
 
-    // preview the result, matching what resizeMap() will produce
-    const QPoint topLeft(mResizeStartWorldRect.left() - mResizeOffset.x() * tileWidth,
-                         mResizeStartWorldRect.top() - mResizeOffset.y() * tileHeight);
-    const QRect previewRect(topLeft, QSize(newWidth * tileWidth, newHeight * tileHeight));
-    setSelectionScreenRect(previewRect.translated(mResizeSceneOffset));
+    // preview the result, matching what resizeMap() will produce, using the
+    // renderer so the size is correct for isometric and other orientations
+    const MapRenderer *renderer = mResizingMap->renderer();
+    const QPointF pixelOffset = renderer->tileToPixelCoords(QPointF())
+                              - renderer->tileToPixelCoords(-mResizeOffset);
+    const QPoint topLeft = mResizeStartWorldRect.topLeft() - pixelOffset.toPoint();
+    const QSize previewSize = renderer->boundingRect(QRect(QPoint(), mResizeNewSize)).size();
+    setSelectionScreenRect(QRect(topLeft, previewSize).translated(mResizeSceneOffset));
 
     setStatusInfo(tr("Resize map to %1 x %2").arg(newWidth).arg(newHeight));
 }
@@ -223,12 +225,7 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
 
     if (event->button() == Qt::LeftButton && mapCanBeMoved(targetMap())) {
         // initiate a resize when one of the handles is pressed
-        QTransform viewTransform;
-        if (QWidget *viewport = event->widget())
-            if (auto view = qobject_cast<QGraphicsView*>(viewport->parent()))
-                viewTransform = view->transform();
-
-        const int handle = resizeHandleAt(event->scenePos(), viewTransform);
+        const int handle = resizeHandleAt(event->scenePos());
         if (handle != -1) {
             mResizingMap = targetMap();
             mResizeHandle = handle;
@@ -269,15 +266,9 @@ void WorldMoveMapTool::mouseMoved(const QPointF &pos,
     if (!worldForMap(mDraggingMap) || !mDraggingMap) {
         AbstractWorldTool::mouseMoved(pos, modifiers);
 
-        // show a resize cursor while hovering one of the handles
-        const auto views = mapScene()->views();
-        const QTransform viewTransform = views.isEmpty() ? QTransform()
-                                                         : views.first()->transform();
-        const int handle = resizeHandleAt(pos, viewTransform);
-        const Qt::CursorShape shape = (handle != -1) ? cursorForHandle(handle)
-                                                     : Qt::ArrowCursor;
-        if (cursor().shape() != shape)
-            setCursor(shape);
+        // update the hovered handle so refreshCursor can show a resize cursor
+        mHoveredHandle = resizeHandleAt(pos);
+        refreshCursor();
         return;
     }
 
@@ -398,6 +389,8 @@ void WorldMoveMapTool::refreshCursor()
         cursorShape = Qt::SizeAllCursor;
     else if (mResizingMap)
         cursorShape = cursorForHandle(mResizeHandle);
+    else if (mHoveredHandle != -1)
+        cursorShape = cursorForHandle(mHoveredHandle);
 
     if (cursor().shape() != cursorShape)
         setCursor(cursorShape);

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -153,8 +153,7 @@ void WorldMoveMapTool::moveMap(MapDocument *document, QPoint moveBy)
 
     if (document == mapDocument()) {
         // undo camera movement, by the actual snapped offset
-        const QPoint actualOffset = rect.topLeft() - prevRect.topLeft();
-        recenterView(actualOffset);
+        recenterView(rect.topLeft() - prevRect.topLeft());
     }
 }
 
@@ -343,9 +342,7 @@ void WorldMoveMapTool::finishResizing()
         if (resizedMap == mapDocument()) {
             if (auto worldDocument = worldForMap(resizedMap)) {
                 const QPoint newPos = worldDocument->world()->mapRect(resizedMap->fileName()).topLeft();
-                const QPoint actualOffset = newPos - prevPos;
-                if (!actualOffset.isNull())
-                    recenterView(actualOffset);
+                recenterView(newPos - prevPos);
             }
         }
     }
@@ -359,7 +356,6 @@ void WorldMoveMapTool::finishMoving()
 {
     DocumentManager *manager = DocumentManager::instance();
     MapView *view = manager->viewForDocument(mapDocument());
-    const QPointF viewCenter = sceneViewRect().center();
 
     auto draggedMap = std::exchange(mDraggingMap, nullptr);
     mDraggingMapItem = nullptr;
@@ -377,13 +373,13 @@ void WorldMoveMapTool::finishMoving()
 
             if (draggedMap == mapDocument()) {
                 // undo camera movement
-                view->forceCenterOn(viewCenter - mDragOffset);
+                view->forceCenterOn(view->viewCenter() - mDragOffset);
             }
         }
     } else {
         // switch to the document
         manager->switchToDocumentAndHandleSimiliarTileset(draggedMap,
-                                                          viewCenter - mDraggedMapStartPos,
+                                                          view->viewCenter() - mDraggedMapStartPos,
                                                           view->zoomable()->scale());
     }
 

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -154,11 +154,7 @@ void WorldMoveMapTool::moveMap(MapDocument *document, QPoint moveBy)
     if (document == mapDocument()) {
         // undo camera movement, by the actual snapped offset
         const QPoint actualOffset = rect.topLeft() - prevRect.topLeft();
-        DocumentManager *manager = DocumentManager::instance();
-        MapView *view = manager->viewForDocument(mapDocument());
-        QRectF viewRect { view->viewport()->rect() };
-        QRectF sceneViewRect = view->viewportTransform().inverted().mapRect(viewRect);
-        view->forceCenterOn(sceneViewRect.center() - actualOffset);
+        recenterView(actualOffset);
     }
 }
 
@@ -310,13 +306,8 @@ void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
                     if (auto worldDocument = worldForMap(resizedMap)) {
                         const QPoint newPos = worldDocument->world()->mapRect(resizedMap->fileName()).topLeft();
                         const QPoint actualOffset = newPos - prevPos;
-                        if (!actualOffset.isNull()) {
-                            DocumentManager *manager = DocumentManager::instance();
-                            MapView *view = manager->viewForDocument(mapDocument());
-                            const QRectF viewRect { view->viewport()->rect() };
-                            const QRectF sceneViewRect = view->viewportTransform().inverted().mapRect(viewRect);
-                            view->forceCenterOn(sceneViewRect.center() - actualOffset);
-                        }
+                        if (!actualOffset.isNull())
+                            recenterView(actualOffset);
                     }
                 }
             }
@@ -336,8 +327,7 @@ void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
     if (event->button() == Qt::LeftButton) {
         DocumentManager *manager = DocumentManager::instance();
         MapView *view = manager->viewForDocument(mapDocument());
-        const QRectF viewRect { view->viewport()->rect() };
-        const QRectF sceneViewRect = view->viewportTransform().inverted().mapRect(viewRect);
+        const QPointF viewCenter = sceneViewRect().center();
 
         auto draggedMap = std::exchange(mDraggingMap, nullptr);
         mDraggingMapItem = nullptr;
@@ -355,13 +345,13 @@ void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
 
                 if (draggedMap == mapDocument()) {
                     // undo camera movement
-                    view->forceCenterOn(sceneViewRect.center() - mDragOffset);
+                    view->forceCenterOn(viewCenter - mDragOffset);
                 }
             }
         } else {
             // switch to the document
             manager->switchToDocumentAndHandleSimiliarTileset(draggedMap,
-                                                              sceneViewRect.center() - mDraggedMapStartPos,
+                                                              viewCenter - mDraggedMapStartPos,
                                                               view->zoomable()->scale());
         }
 

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -219,12 +219,14 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
     if (mDraggingMap || mResizingMap)
         return;
 
-    if (event->button() == Qt::LeftButton && mapCanBeMoved(targetMap())) {
+    if (event->button() == Qt::LeftButton) {
         if (startResizing(event))
             return;
 
-        startMoving(event);
-        return;
+        if (mapCanBeMoved(targetMap())) {
+            startMoving(event);
+            return;
+        }
     }
 
     AbstractWorldTool::mousePressed(event);
@@ -233,11 +235,12 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
 // returns false when no handle was pressed, so the caller can start a move
 bool WorldMoveMapTool::startResizing(QGraphicsSceneMouseEvent *event)
 {
-    const int handle = resizeHandleAt(event->scenePos());
-    if (handle == -1)
+    MapDocument *map = nullptr;
+    const int handle = resizeHandleNear(event->scenePos(), map);
+    if (handle == -1 || !mapCanBeMoved(map))
         return false;
 
-    mResizingMap = targetMap();
+    mResizingMap = map;
     mResizeHandle = handle;
     mDragStartScenePos = event->scenePos();
 
@@ -271,10 +274,14 @@ void WorldMoveMapTool::mouseMoved(const QPointF &pos,
     }
 
     if (!worldForMap(mDraggingMap) || !mDraggingMap) {
-        AbstractWorldTool::mouseMoved(pos, modifiers);
+        // target the map whose handle is under the cursor, else hover normally
+        MapDocument *map = nullptr;
+        const int hoveredHandle = resizeHandleNear(pos, map);
+        if (hoveredHandle != -1 && mapCanBeMoved(map))
+            setTargetMap(map);
+        else
+            AbstractWorldTool::mouseMoved(pos, modifiers);
 
-        // update the hovered handle so refreshCursor can show a resize cursor
-        mHoveredHandle = resizeHandleAt(pos);
         refreshCursor();
         return;
     }
@@ -399,8 +406,6 @@ void WorldMoveMapTool::refreshCursor()
         cursorShape = Qt::SizeAllCursor;
     else if (mResizingMap)
         cursorShape = cursorForHandle(mResizeHandle);
-    else if (mHoveredHandle != -1)
-        cursorShape = cursorForHandle(mHoveredHandle);
 
     if (cursor().shape() != cursorShape)
         setCursor(cursorShape);

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -208,11 +208,15 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
         return;
 
     if (event->button() == Qt::LeftButton) {
-        if (startResizing(event))
+        MapDocument *map = nullptr;
+        const int handle = resizeHandleNear(event->scenePos(), map);
+        if (handle != -1 && mapCanBeMoved(map)) {
+            startResizing(map, handle, event->scenePos());
             return;
+        }
 
         if (mapCanBeMoved(targetMap())) {
-            startMoving(event);
+            startMoving(targetMap(), event->scenePos());
             return;
         }
     }
@@ -220,17 +224,12 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
     AbstractWorldTool::mousePressed(event);
 }
 
-// returns false when no handle was pressed, so the caller can start a move
-bool WorldMoveMapTool::startResizing(QGraphicsSceneMouseEvent *event)
+void WorldMoveMapTool::startResizing(MapDocument *map, int handle,
+                                     const QPointF &scenePos)
 {
-    MapDocument *map = nullptr;
-    const int handle = resizeHandleNear(event->scenePos(), map);
-    if (handle == -1 || !mapCanBeMoved(map))
-        return false;
-
     mResizingMap = map;
     mResizeHandle = handle;
-    mDragStartScenePos = event->scenePos();
+    mDragStartScenePos = scenePos;
 
     auto world = worldForMap(mResizingMap)->world();
     const QPoint worldPos = world->mapRect(mResizingMap->fileName()).topLeft();
@@ -240,14 +239,13 @@ bool WorldMoveMapTool::startResizing(QGraphicsSceneMouseEvent *event)
     mResizeNewSize = mResizingMap->map()->size();
     mResizeOffset = QPoint(0, 0);
     refreshCursor();
-    return true;
 }
 
-void WorldMoveMapTool::startMoving(QGraphicsSceneMouseEvent *event)
+void WorldMoveMapTool::startMoving(MapDocument *map, const QPointF &scenePos)
 {
-    mDraggingMap = targetMap();
+    mDraggingMap = map;
     mDraggingMapItem = mapScene()->mapItem(mDraggingMap);
-    mDragStartScenePos = event->scenePos();
+    mDragStartScenePos = scenePos;
     mDraggedMapStartPos = mDraggingMapItem->pos();
     mDragOffset = QPoint(0, 0);
     refreshCursor();

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -220,35 +220,46 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
         return;
 
     if (event->button() == Qt::LeftButton && mapCanBeMoved(targetMap())) {
-        // initiate a resize when one of the handles is pressed
-        const int handle = resizeHandleAt(event->scenePos());
-        if (handle != -1) {
-            mResizingMap = targetMap();
-            mResizeHandle = handle;
-            mDragStartScenePos = event->scenePos();
-
-            auto world = worldForMap(mResizingMap)->world();
-            const QPoint worldPos = world->mapRect(mResizingMap->fileName()).topLeft();
-            const QSize sizePixels = mResizingMap->renderer()->mapBoundingRect().size();
-            mResizeStartWorldRect = QRect(worldPos, sizePixels);
-            mResizeSceneOffset = mapScene()->mapItem(mResizingMap)->pos().toPoint() - worldPos;
-            mResizeNewSize = mResizingMap->map()->size();
-            mResizeOffset = QPoint(0, 0);
-            refreshCursor();
+        if (startResizing(event))
             return;
-        }
 
-        // otherwise initiate a move
-        mDraggingMap = targetMap();
-        mDraggingMapItem = mapScene()->mapItem(mDraggingMap);
-        mDragStartScenePos = event->scenePos();
-        mDraggedMapStartPos = mDraggingMapItem->pos();
-        mDragOffset = QPoint(0, 0);
-        refreshCursor();
+        startMoving(event);
         return;
     }
 
     AbstractWorldTool::mousePressed(event);
+}
+
+// returns false when no handle was pressed, so the caller can start a move
+bool WorldMoveMapTool::startResizing(QGraphicsSceneMouseEvent *event)
+{
+    const int handle = resizeHandleAt(event->scenePos());
+    if (handle == -1)
+        return false;
+
+    mResizingMap = targetMap();
+    mResizeHandle = handle;
+    mDragStartScenePos = event->scenePos();
+
+    auto world = worldForMap(mResizingMap)->world();
+    const QPoint worldPos = world->mapRect(mResizingMap->fileName()).topLeft();
+    const QSize sizePixels = mResizingMap->renderer()->mapBoundingRect().size();
+    mResizeStartWorldRect = QRect(worldPos, sizePixels);
+    mResizeSceneOffset = mapScene()->mapItem(mResizingMap)->pos().toPoint() - worldPos;
+    mResizeNewSize = mResizingMap->map()->size();
+    mResizeOffset = QPoint(0, 0);
+    refreshCursor();
+    return true;
+}
+
+void WorldMoveMapTool::startMoving(QGraphicsSceneMouseEvent *event)
+{
+    mDraggingMap = targetMap();
+    mDraggingMapItem = mapScene()->mapItem(mDraggingMap);
+    mDragStartScenePos = event->scenePos();
+    mDraggedMapStartPos = mDraggingMapItem->pos();
+    mDragOffset = QPoint(0, 0);
+    refreshCursor();
 }
 
 void WorldMoveMapTool::mouseMoved(const QPointF &pos,
@@ -293,31 +304,10 @@ void WorldMoveMapTool::mouseMoved(const QPointF &pos,
 void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
 {
     if (mResizingMap) {
-        if (event->button() == Qt::LeftButton) {
-            auto resizedMap = std::exchange(mResizingMap, nullptr);
-            mResizeHandle = -1;
-
-            if (mResizeNewSize != resizedMap->map()->size() || !mResizeOffset.isNull()) {
-                const QPoint prevPos = mResizeStartWorldRect.topLeft();
-                resizedMap->resizeMap(mResizeNewSize, mResizeOffset, false);
-
-                // keep the view steady when the active map's position shifted
-                if (resizedMap == mapDocument()) {
-                    if (auto worldDocument = worldForMap(resizedMap)) {
-                        const QPoint newPos = worldDocument->world()->mapRect(resizedMap->fileName()).topLeft();
-                        const QPoint actualOffset = newPos - prevPos;
-                        if (!actualOffset.isNull())
-                            recenterView(actualOffset);
-                    }
-                }
-            }
-
-            updateSelectionRectangle();
-            refreshCursor();
-            setStatusInfo(QString());
-        } else if (event->button() == Qt::RightButton) {
+        if (event->button() == Qt::LeftButton)
+            finishResizing();
+        else if (event->button() == Qt::RightButton)
             abortResizing();
-        }
         return;
     }
 
@@ -325,43 +315,73 @@ void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
         return;
 
     if (event->button() == Qt::LeftButton) {
-        DocumentManager *manager = DocumentManager::instance();
-        MapView *view = manager->viewForDocument(mapDocument());
-        const QPointF viewCenter = sceneViewRect().center();
-
-        auto draggedMap = std::exchange(mDraggingMap, nullptr);
-        mDraggingMapItem = nullptr;
-
-        if (!mDragOffset.isNull()) {
-            if (auto worldDocument = worldForMap(draggedMap)) {
-                QRect rect = draggedMap->renderer()->mapBoundingRect();
-
-                auto world = worldDocument->world();
-                rect.moveTo(world->mapRect(draggedMap->fileName()).topLeft());
-                rect.translate(mDragOffset);
-
-                auto undoStack = worldDocument->undoStack();
-                undoStack->push(new SetMapRectCommand(worldDocument, draggedMap->fileName(), rect));
-
-                if (draggedMap == mapDocument()) {
-                    // undo camera movement
-                    view->forceCenterOn(viewCenter - mDragOffset);
-                }
-            }
-        } else {
-            // switch to the document
-            manager->switchToDocumentAndHandleSimiliarTileset(draggedMap,
-                                                              viewCenter - mDraggedMapStartPos,
-                                                              view->zoomable()->scale());
-        }
-
-        refreshCursor();
-        setStatusInfo(QString());
+        finishMoving();
         return;
     }
 
     if (event->button() == Qt::RightButton)
         abortMoving();
+}
+
+void WorldMoveMapTool::finishResizing()
+{
+    auto resizedMap = std::exchange(mResizingMap, nullptr);
+    mResizeHandle = -1;
+
+    if (mResizeNewSize != resizedMap->map()->size() || !mResizeOffset.isNull()) {
+        const QPoint prevPos = mResizeStartWorldRect.topLeft();
+        resizedMap->resizeMap(mResizeNewSize, mResizeOffset, false);
+
+        // keep the view steady when the active map's position shifted
+        if (resizedMap == mapDocument()) {
+            if (auto worldDocument = worldForMap(resizedMap)) {
+                const QPoint newPos = worldDocument->world()->mapRect(resizedMap->fileName()).topLeft();
+                const QPoint actualOffset = newPos - prevPos;
+                if (!actualOffset.isNull())
+                    recenterView(actualOffset);
+            }
+        }
+    }
+
+    updateSelectionRectangle();
+    refreshCursor();
+    setStatusInfo(QString());
+}
+
+void WorldMoveMapTool::finishMoving()
+{
+    DocumentManager *manager = DocumentManager::instance();
+    MapView *view = manager->viewForDocument(mapDocument());
+    const QPointF viewCenter = sceneViewRect().center();
+
+    auto draggedMap = std::exchange(mDraggingMap, nullptr);
+    mDraggingMapItem = nullptr;
+
+    if (!mDragOffset.isNull()) {
+        if (auto worldDocument = worldForMap(draggedMap)) {
+            QRect rect = draggedMap->renderer()->mapBoundingRect();
+
+            auto world = worldDocument->world();
+            rect.moveTo(world->mapRect(draggedMap->fileName()).topLeft());
+            rect.translate(mDragOffset);
+
+            auto undoStack = worldDocument->undoStack();
+            undoStack->push(new SetMapRectCommand(worldDocument, draggedMap->fileName(), rect));
+
+            if (draggedMap == mapDocument()) {
+                // undo camera movement
+                view->forceCenterOn(viewCenter - mDragOffset);
+            }
+        }
+    } else {
+        // switch to the document
+        manager->switchToDocumentAndHandleSimiliarTileset(draggedMap,
+                                                          viewCenter - mDraggedMapStartPos,
+                                                          view->zoomable()->scale());
+    }
+
+    refreshCursor();
+    setStatusInfo(QString());
 }
 
 void WorldMoveMapTool::languageChanged()

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -65,17 +65,6 @@ static constexpr HandleEdges handleEdges[HandleCount] = {
     { false, true,  false, true  },     // bottom-right
 };
 
-Qt::CursorShape cursorForHandle(int handle)
-{
-    switch (handle) {
-    case TopLeftHandle: case BottomRightHandle: return Qt::SizeFDiagCursor;
-    case TopRightHandle: case BottomLeftHandle: return Qt::SizeBDiagCursor;
-    case TopHandle: case BottomHandle:          return Qt::SizeVerCursor;
-    case LeftHandle: case RightHandle:          return Qt::SizeHorCursor;
-    default:                                    return Qt::ArrowCursor;
-    }
-}
-
 } // namespace
 
 WorldMoveMapTool::WorldMoveMapTool(QObject *parent)

--- a/src/tiled/worldmovemaptool.h
+++ b/src/tiled/worldmovemaptool.h
@@ -44,6 +44,10 @@ public:
     void languageChanged() override;
 
 protected:
+    bool startResizing(QGraphicsSceneMouseEvent *event);
+    void startMoving(QGraphicsSceneMouseEvent *event);
+    void finishResizing();
+    void finishMoving();
     void abortMoving();
     void abortResizing();
     void refreshCursor();

--- a/src/tiled/worldmovemaptool.h
+++ b/src/tiled/worldmovemaptool.h
@@ -61,6 +61,7 @@ protected:
     // resize drag state
     MapDocument *mResizingMap = nullptr;
     int mResizeHandle = -1;
+    int mHoveredHandle = -1;
     QRect mResizeStartWorldRect;
     QPoint mResizeSceneOffset;
     QSize mResizeNewSize;

--- a/src/tiled/worldmovemaptool.h
+++ b/src/tiled/worldmovemaptool.h
@@ -65,7 +65,6 @@ protected:
     // resize drag state
     MapDocument *mResizingMap = nullptr;
     int mResizeHandle = -1;
-    int mHoveredHandle = -1;
     QRect mResizeStartWorldRect;
     QPoint mResizeSceneOffset;
     QSize mResizeNewSize;

--- a/src/tiled/worldmovemaptool.h
+++ b/src/tiled/worldmovemaptool.h
@@ -44,8 +44,8 @@ public:
     void languageChanged() override;
 
 protected:
-    bool startResizing(QGraphicsSceneMouseEvent *event);
-    void startMoving(QGraphicsSceneMouseEvent *event);
+    void startResizing(MapDocument *map, int handle, const QPointF &scenePos);
+    void startMoving(MapDocument *map, const QPointF &scenePos);
     void finishResizing();
     void finishMoving();
     void abortMoving();

--- a/src/tiled/worldmovemaptool.h
+++ b/src/tiled/worldmovemaptool.h
@@ -45,9 +45,11 @@ public:
 
 protected:
     void abortMoving();
+    void abortResizing();
     void refreshCursor();
 
     void moveMap(MapDocument *document, QPoint moveBy);
+    void updateResizingMap(const QPointF &pos, Qt::KeyboardModifiers modifiers);
 
     // drag state
     MapDocument *mDraggingMap = nullptr;
@@ -55,6 +57,14 @@ protected:
     QPointF mDragStartScenePos;
     QPointF mDraggedMapStartPos;
     QPoint mDragOffset;
+
+    // resize drag state
+    MapDocument *mResizingMap = nullptr;
+    int mResizeHandle = -1;
+    QRect mResizeStartWorldRect;
+    QPoint mResizeSceneOffset;
+    QSize mResizeNewSize;
+    QPoint mResizeOffset;
 };
 
 } // namespace Tiled


### PR DESCRIPTION
First piece of the drag-handle map resize feature.For now this just shows the 8 resize handles on the active map's corners and edges (no resize yet)