### PR TITLE
Update the mime types to support more of the Tiled extensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
 * Fixed crash when the selection becomes empty while starting a move (#4536)
+* Linux: Added file associations for .tmj, .tsj, .tiled-project and .world files (by miffe, #4550)
 * snap: Updated to Qt 6
 * Raised the minimum Qt version to 6.2 (drops Qt 5 support)
 

--- a/mime/org.mapeditor.Tiled.xml
+++ b/mime/org.mapeditor.Tiled.xml
@@ -12,4 +12,28 @@
     <glob pattern="*.tsx"/>
     <sub-class-of type="application/xml"/>
   </mime-type>
+  <mime-type type="application/x-tiled-tmj">
+    <comment>Tiled map</comment>
+    <generic-icon name="application-x-tiled"/>
+    <glob pattern="*.tmj"/>
+    <sub-class-of type="application/json"/>
+  </mime-type>
+  <mime-type type="application/x-tiled-tsj">
+    <comment>Tiled tileset</comment>
+    <generic-icon name="application-x-tiled"/>
+    <glob pattern="*.tsj"/>
+    <sub-class-of type="application/json"/>
+  </mime-type>
+  <mime-type type="application/x-tiled-project">
+    <comment>Tiled project</comment>
+    <generic-icon name="application-x-tiled"/>
+    <glob pattern="*.tiled-project"/>
+    <sub-class-of type="application/json"/>
+  </mime-type>
+  <mime-type type="application/x-tiled-world">
+    <comment>Tiled world</comment>
+    <generic-icon name="application-x-tiled"/>
+    <glob pattern="*.world"/>
+    <sub-class-of type="application/json"/>
+  </mime-type>
 </mime-info>

--- a/org.mapeditor.Tiled.desktop
+++ b/org.mapeditor.Tiled.desktop
@@ -10,4 +10,4 @@ Icon=tiled
 Categories=Graphics;2DGraphics;
 StartupNotify=true
 X-Desktop-File-Install-Version=0.1
-MimeType=application/x-tiled-tmx;application/x-tiled-tsx;
+MimeType=application/x-tiled-tmx;application/x-tiled-tsx;application/x-tiled-tmj;application/x-tiled-tsj;application/x-tiled-project;application/x-tiled-world;


### PR DESCRIPTION
This updates the mime database and the desktop file to add suport for:
 - .tmj: Tiled map json files
 - .tsj: Tiled tileset json files
 - .tiled-project: Tiled project files
 - .world: Tiled world files

Closes #4523