### PR TITLE
Avoid crash from dangling action pointers in ActionManager

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
 * Fixed crash when the selection becomes empty while starting a move (#4536)
+* Fixed crash when opening the Preferences dialog due to a dangling action (#4551)
 * snap: Updated to Qt 6
 * Raised the minimum Qt version to 6.2 (drops Qt 5 support)
 

--- a/src/tiled/actionmanager.cpp
+++ b/src/tiled/actionmanager.cpp
@@ -78,6 +78,15 @@ void ActionManager::registerAction(QAction *action, Id id)
         emit d->actionChanged(id);
     });
 
+    // Make sure an action that gets destroyed doesn't leave a dangling pointer behind
+    connect(action, &QObject::destroyed, d, [=] {
+        d->mIdToActions.remove(id, action);
+        if (!d->mIdToActions.contains(id)) {
+            d->mDefaultShortcuts.remove(id);
+            d->mLastKnownShortcuts.remove(id);
+        }
+    });
+
     if (d->hasCustomShortcut(id)) {
         d->mDefaultShortcuts.insert(id, action->shortcuts());
         d->applyShortcut(action, d->mCustomShortcuts.value(id));
@@ -85,18 +94,6 @@ void ActionManager::registerAction(QAction *action, Id id)
 
     d->updateToolTipWithShortcut(action);
 
-    emit d->actionsChanged();
-}
-
-void ActionManager::unregisterAction(QAction *action, Id id)
-{
-    auto d = instance();
-
-    Q_ASSERT_X(d->mIdToActions.contains(id, action), "ActionManager::unregisterAction", "unknown action");
-    d->mIdToActions.remove(id, action);
-    action->disconnect(d);
-    d->mDefaultShortcuts.remove(id);
-    d->mLastKnownShortcuts.remove(id);
     emit d->actionsChanged();
 }
 

--- a/src/tiled/actionmanager.h
+++ b/src/tiled/actionmanager.h
@@ -69,7 +69,6 @@ public:
     static ActionManager *instance();
 
     static void registerAction(QAction *action, Id id);
-    static void unregisterAction(QAction *action, Id id);
 
     static void registerMenu(QMenu *menu, Id id);
     static void unregisterMenu(Id id);

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -416,10 +416,7 @@ ScriptedAction *ScriptModule::registerAction(const QByteArray &idName, QJSValue 
     Id id { idName };
     auto &action = mRegisteredActions[id];
 
-    // Remove any previously registered action with the same name
-    if (action) {
-        action.reset();
-    } else if (ActionManager::findAction(id)) {
+    if (!action && ActionManager::findAction(id)) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Reserved ID"));
         return nullptr;
     }

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -77,9 +77,6 @@ ScriptModule::ScriptModule(QObject *parent)
 
 ScriptModule::~ScriptModule()
 {
-    for (const auto &[id, action] : mRegisteredActions)
-        ActionManager::unregisterAction(action.get(), id);
-
     ActionManager::clearMenuExtensions();
 
     IssuesModel::instance().removeIssuesWithContext(this);
@@ -421,7 +418,7 @@ ScriptedAction *ScriptModule::registerAction(const QByteArray &idName, QJSValue 
 
     // Remove any previously registered action with the same name
     if (action) {
-        ActionManager::unregisterAction(action.get(), id);
+        action.reset();
     } else if (ActionManager::findAction(id)) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Reserved ID"));
         return nullptr;

--- a/src/tiled/toolmanager.cpp
+++ b/src/tiled/toolmanager.cpp
@@ -133,9 +133,6 @@ void ToolManager::unregisterTool(AbstractTool *tool)
     auto action = findAction(tool);
     Q_ASSERT(action);
 
-    if (mRegisterActions)
-        ActionManager::unregisterAction(action, tool->id());
-
     delete action;
 
     tool->disconnect(this);


### PR DESCRIPTION
`ActionManager` stores raw `QAction` pointers in `mIdToActions` and only removed them when `unregisterAction()` was called explicitly. An action destroyed without being unregistered therefore left a dangling pointer behind, which `ActionsModel::refreshConflicts()` would later dereference (via `findAction()`), crashing when opening the Preferences dialog.

The exact trigger of the reported crashes is unknown. All built-in actions should live until the application exits and scripted actions should already have been calling `unregisterAction` as appropriate. Tracking destruction of the `QAction` instance makes the code less fragile and will hopefully avoid this kind of crash.

This fixes a crash that was reported on Sentry.