### PR TITLE
Add manual section for resizing maps and the world grid

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,7 @@ gettext_compact = True
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = [
     '.DS_Store',
+    '.venv',
     'README.md',
     'Thumbs.db',
     '_build',

--- a/docs/manual/worlds.rst
+++ b/docs/manual/worlds.rst
@@ -94,21 +94,26 @@ Moving Maps
 
 Resizing Maps
     Hover over a map with the World Tool to show resize handles on its corners
-    and edges, then drag a handle to resize the map within the world. The size
-    snaps to the world grid; hold 'Ctrl' while dragging to resize freely. You
-    can abort a resize by hitting 'Escape' or by right-clicking.
-
-Using the World Grid
-    A grid can be shown across the world to help align maps. Toggle it with
-    *View > Show World Grid*, and toggle snapping with *View > Snapping > Snap
-    Maps to World Grid*. When snapping is enabled, maps snap to the grid while
-    being moved or resized (hold 'Ctrl' to override). The grid size is set per
-    world in the *World > World Properties* dialog.
+    and edges, then drag a handle to resize the map within the world. The map's
+    existing content keeps its position within the world, with the map's world
+    position adjusted when necessary to achieve this. You can abort a resize
+    by hitting 'Escape' or by right-clicking.
 
 Saving World files
     You can save manipulated world files by using the *World > Save World*
     menu. Worlds will also automatically be saved if you launch any external
     tool that has the 'Save Map Before Executing' option enabled.
+
+The World Grid
+--------------
+
+A grid can be shown across the world to help align maps. Toggle it with
+*View > Show World Grid*, and toggle snapping with *View > Snapping > Snap Maps
+to World Grid*. While snapping is enabled, maps snap to the grid as they are
+moved or resized. Hold 'Ctrl' during the drag to temporarily turn off snapping,
+letting you position the map freely.
+
+The grid size is set per world in the *World > World Properties* dialog.
 
 Using Pattern Matching
 ----------------------

--- a/docs/manual/worlds.rst
+++ b/docs/manual/worlds.rst
@@ -92,6 +92,19 @@ Moving Maps
     Alternatively you can use the arrow keys to move the current selected map
     - holding Shift will perform bigger steps.
 
+Resizing Maps
+    Hover over a map with the World Tool to show resize handles on its corners
+    and edges, then drag a handle to resize the map within the world. The size
+    snaps to the world grid; hold 'Ctrl' while dragging to resize freely. You
+    can abort a resize by hitting 'Escape' or by right-clicking.
+
+Using the World Grid
+    A grid can be shown across the world to help align maps. Toggle it with
+    *View > Show World Grid*, and toggle snapping with *View > Snapping > Snap
+    Maps to World Grid*. When snapping is enabled, maps snap to the grid while
+    being moved or resized (hold 'Ctrl' to override). The grid size is set per
+    world in the *World > World Properties* dialog.
+
 Saving World files
     You can save manipulated world files by using the *World > Save World*
     menu. Worlds will also automatically be saved if you launch any external

--- a/docs/manual/worlds.rst
+++ b/docs/manual/worlds.rst
@@ -81,7 +81,7 @@ Adding Maps
     can be accessed by right-clicking in the map editor.
 
 Removing Maps
-    Hit the 'Remove the current map from the current world' button on the 
+    Hit the 'Remove the current map from the current world' button on the
     toolbar. Alternatively, right-click a map in the map editor and select the
     'Remove ... from World ...' action from the context menu.
 
@@ -91,6 +91,10 @@ Moving Maps
 
     Alternatively you can use the arrow keys to move the current selected map
     - holding Shift will perform bigger steps.
+
+.. raw:: html
+
+    <div class="new">New in Tiled 1.13</div>
 
 Resizing Maps
     Hover over a map with the World Tool to show resize handles on its corners
@@ -103,6 +107,10 @@ Saving World files
     You can save manipulated world files by using the *World > Save World*
     menu. Worlds will also automatically be saved if you launch any external
     tool that has the 'Save Map Before Executing' option enabled.
+
+.. raw:: html
+
+    <div class="new">New in Tiled 1.13</div>
 
 The World Grid
 --------------


### PR DESCRIPTION
This is the PR for the manual update from #4545 . Adds short sections under "Editing Worlds" for resizing maps and the world grid.