### PR TITLE
Persisted collapsed state of the properties groups in the session

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Added a configurable world grid with snapping for maps (by Kanishka, #4534)
 * Added drag-to-resize for maps in the world view (by Kanishka, #4545)
 * Made switching to the previously selected tool when pressing its shortcut again optional and off by default (by dogboydog, #4540)
+* Persisted collapsed state of the properties groups in the session (#4561)
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
 * Fixed crash when the selection becomes empty while starting a move (#4536)

--- a/src/tiled/propertiesview.cpp
+++ b/src/tiled/propertiesview.cpp
@@ -1549,9 +1549,11 @@ void PropertiesView::setPropertyChildrenExpanded(PropertyWidgets &widgets,
         if (widgets.children->isHidden() == expanded)
             widgets.children->setVisible(expanded);
 
-        // needed to avoid flickering when hiding the children
-        if (!expanded)
-            activateParentLayouts(widgets.children->parentWidget());
+        // Activate the affected layouts right away, to avoid flickering due to
+        // relayouting not being done before the next paint. When expanding we
+        // start at the children, so that their own layout is activated first.
+        activateParentLayouts(expanded ? widgets.children
+                                       : widgets.children->parentWidget());
     }
 }
 

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -39,6 +39,7 @@
 #include "preferences.h"
 #include "propertiesview.h"
 #include "propertyeditorwidgets.h"
+#include "session.h"
 #include "tilesetchanges.h"
 #include "tilesetdocument.h"
 #include "tilesetparametersedit.h"
@@ -66,6 +67,9 @@
 #include <algorithm>
 
 namespace Tiled {
+
+static SessionOption<QList<bool>> propertiesObjectExpandedStates { "properties.objectExpandedStates" };
+static SessionOption<bool> customPropertiesExpanded { "properties.customExpanded", true };
 
 /**
  * Suppresses widget updates for the duration of a scope. Updates are
@@ -2316,6 +2320,18 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
 
     mRootProperty->addProperty(mCustomProperties);
 
+    // The collapsed states are stored in the session. Keep them in sync with
+    // the session at runtime, so that changes are reflected in any other open
+    // properties view as well.
+    mCustomProperties->setExpanded(customPropertiesExpanded);
+    connect(mCustomProperties, &GroupProperty::expandedChanged,
+            this, [] (bool expanded) { customPropertiesExpanded = expanded; });
+
+    mObjectExpandedCallback = propertiesObjectExpandedStates.onChange(
+                [this] { applyObjectExpandedStates(); });
+    mCustomExpandedCallback = customPropertiesExpanded.onChange(
+                [this] { mCustomProperties->setExpanded(customPropertiesExpanded); });
+
     mActionAddProperty = new QAction(this);
     mActionAddProperty->setEnabled(false);
     mActionAddProperty->setIcon(mAddIcon);
@@ -2374,6 +2390,9 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
 
 PropertiesWidget::~PropertiesWidget()
 {
+    propertiesObjectExpandedStates.unregister(mObjectExpandedCallback);
+    customPropertiesExpanded.unregister(mCustomExpandedCallback);
+
     // Disconnect to avoid crashing due to signals emitted during destruction
     mPropertiesView->disconnect(this);
 }
@@ -2429,13 +2448,6 @@ void PropertiesWidget::currentObjectChanged(Object *object)
     const ScopedUpdatesDisabler updatesDisabler(mPropertiesView);
 
     if (mPropertiesObject) {
-        // Remember the expanded states
-        const auto &subProperties = mPropertiesObject->subProperties();
-        for (int i = 0; i < subProperties.size(); ++i) {
-            if (auto subGroupProperty = qobject_cast<GroupProperty*>(subProperties.at(i)))
-                mExpandedStates[i] = subGroupProperty->isExpanded();
-        }
-
         mRootProperty->deleteProperty(mPropertiesObject);
         mPropertiesObject = nullptr;
     }
@@ -2501,12 +2513,26 @@ void PropertiesWidget::currentObjectChanged(Object *object)
         }
     }
 
-    // Restore the expanded states
+    // Restore the expanded states from the session and keep the session in
+    // sync when they are changed by the user.
     if (mPropertiesObject) {
+        applyObjectExpandedStates();
+
         const auto &subProperties = mPropertiesObject->subProperties();
         for (int i = 0; i < subProperties.size(); ++i) {
-            if (auto subGroupProperty = qobject_cast<GroupProperty*>(subProperties.at(i)))
-                subGroupProperty->setExpanded(mExpandedStates.value(i, true));
+            auto subGroupProperty = qobject_cast<GroupProperty*>(subProperties.at(i));
+            if (!subGroupProperty)
+                continue;
+
+            connect(subGroupProperty, &GroupProperty::expandedChanged, this, [i] (bool expanded) {
+                // Only update the state at this index, leaving the states of
+                // any additional groups shown in another view intact.
+                auto expandedStates = propertiesObjectExpandedStates.get();
+                while (expandedStates.size() <= i)
+                    expandedStates.append(true);
+                expandedStates[i] = expanded;
+                propertiesObjectExpandedStates = expandedStates;
+            });
         }
 
         mRootProperty->insertProperty(0, mPropertiesObject);
@@ -2520,6 +2546,19 @@ void PropertiesWidget::currentObjectChanged(Object *object)
 
     mPropertiesView->setEnabled(object);
     mActionAddProperty->setEnabled(enabled);
+}
+
+void PropertiesWidget::applyObjectExpandedStates()
+{
+    if (!mPropertiesObject)
+        return;
+
+    const auto expandedStates = propertiesObjectExpandedStates.get();
+    const auto &subProperties = mPropertiesObject->subProperties();
+    for (int i = 0; i < subProperties.size(); ++i) {
+        if (auto subGroupProperty = qobject_cast<GroupProperty*>(subProperties.at(i)))
+            subGroupProperty->setExpanded(expandedStates.value(i, true));
+    }
 }
 
 

--- a/src/tiled/propertieswidget.h
+++ b/src/tiled/propertieswidget.h
@@ -20,8 +20,9 @@
 
 #pragma once
 
+#include "session.h"
+
 #include <QIcon>
-#include <QMap>
 #include <QPointer>
 #include <QWidget>
 
@@ -87,6 +88,8 @@ private:
     void currentObjectChanged(Object *object);
     void updateActions();
 
+    void applyObjectExpandedStates();
+
     void cut();
     bool copy();
     bool copyImpl(const SelectionState &state);
@@ -110,8 +113,9 @@ private:
     ObjectProperties *mPropertiesObject = nullptr;
     CustomProperties *mCustomProperties = nullptr;
     QPointer<AddValueProperty> mAddValueProperty;
-    QMap<int, bool> mExpandedStates;
     PropertiesView *mPropertiesView;
+    Session::CallbackIterator mObjectExpandedCallback;
+    Session::CallbackIterator mCustomExpandedCallback;
     QAction *mActionAddProperty;
     QAction *mActionRemoveProperty;
     QAction *mActionRenameProperty;

--- a/src/tiled/session.h
+++ b/src/tiled/session.h
@@ -70,70 +70,102 @@ inline QString FileHelper::resolve(const QString &fileName) const
 }
 
 
+/**
+ * Converts between a value of type T and the QVariant stored in the session
+ * settings. Specialize this struct to support additional types.
+ *
+ * Function templates can't be partially specialized, so this struct is used to
+ * support container types like QList<T> and QSet<T> generically.
+ */
+template<typename T>
+struct SettingsValue
+{
+    static T from(const QVariant &value) { return value.value<T>(); }
+    static QVariant to(const T &value) { return QVariant::fromValue(value); }
+};
+
+/**
+ * Stores a sequence or set as a QVariantList, converting each element through
+ * its own SettingsValue conversion. This keeps container types serializable by
+ * the JSON settings backend, which does not support arbitrary QVariant types.
+ */
+template<typename Container>
+struct SettingsValueList
+{
+    static Container from(const QVariant &value)
+    {
+        const auto variantList = value.toList();
+        Container container;
+        container.reserve(variantList.size());
+        for (const auto &variantValue : variantList)
+            container << SettingsValue<typename Container::value_type>::from(variantValue);
+        return container;
+    }
+
+    static QVariant to(const Container &container)
+    {
+        QVariantList variantList;
+        variantList.reserve(container.size());
+        for (const auto &value : container)
+            variantList.append(SettingsValue<typename Container::value_type>::to(value));
+        return variantList;
+    }
+};
+
+template<typename T>
+struct SettingsValue<QList<T>> : SettingsValueList<QList<T>> {};
+
+template<typename T>
+struct SettingsValue<QSet<T>> : SettingsValueList<QSet<T>> {};
+
+template<>
+struct SettingsValue<QSize>
+{
+    static QSize from(const QVariant &value)
+    {
+        const auto map = value.toMap();
+        return QSize(map.value(QLatin1String("width")).toInt(),
+                     map.value(QLatin1String("height")).toInt());
+    }
+
+    static QVariant to(const QSize &size)
+    {
+        return QVariantMap {
+            { QLatin1String("width"), size.width() },
+            { QLatin1String("height"), size.height() }
+        };
+    }
+};
+
+template<>
+struct SettingsValue<QPointF>
+{
+    static QPointF from(const QVariant &value)
+    {
+        const auto map = value.toMap();
+        return QPointF(map.value(QLatin1String("x")).toReal(),
+                       map.value(QLatin1String("y")).toReal());
+    }
+
+    static QVariant to(const QPointF &point)
+    {
+        return QVariantMap {
+            { QLatin1String("x"), point.x() },
+            { QLatin1String("y"), point.y() }
+        };
+    }
+};
+
 template<typename T>
 T fromSettingsValue(const QVariant &value)
 {
-    return value.value<T>();
+    return SettingsValue<T>::from(value);
 }
 
 template<typename T>
 QVariant toSettingsValue(const T &value)
 {
-    return QVariant::fromValue(value);
-}
-
-template<>
-inline QSize fromSettingsValue<QSize>(const QVariant &value)
-{
-    const auto map = value.toMap();
-    return QSize(map.value(QLatin1String("width")).toInt(),
-                 map.value(QLatin1String("height")).toInt());
-}
-
-template<>
-inline QVariant toSettingsValue<QSize>(const QSize &size)
-{
-    return QVariantMap {
-        { QLatin1String("width"), size.width() },
-        { QLatin1String("height"), size.height() }
-    };
-}
-
-template<>
-inline QPointF fromSettingsValue<QPointF>(const QVariant &value)
-{
-    const auto map = value.toMap();
-    return QPointF(map.value(QLatin1String("x")).toReal(),
-                   map.value(QLatin1String("y")).toReal());
-}
-
-template<>
-inline QVariant toSettingsValue<QPointF>(const QPointF &point)
-{
-    return QVariantMap {
-        { QLatin1String("x"), point.x() },
-        { QLatin1String("y"), point.y() }
-    };
-}
-
-template<>
-inline QSet<int> fromSettingsValue<QSet<int>>(const QVariant &value)
-{
-    const auto variantList = value.toList();
-    QSet<int> set;
-    for (const auto &variantValue : variantList)
-        set.insert(variantValue.value<int>());
-    return set;
-}
-
-template<>
-inline QVariant toSettingsValue<QSet<int>>(const QSet<int> &set)
-{
-    QVariantList variantList;
-    variantList.reserve(set.size());
-    for (const int value : set)
-        variantList.append(value);
-    return variantList;
+    return SettingsValue<T>::to(value);
 }
 
 


### PR DESCRIPTION
The expanded/collapsed state of the object properties groups and of the Custom Properties group is now stored in the session, so it survives both switching the current object and restarting the application.

The two properties docks are kept in sync at runtime through the session, so collapsing or expanding a group in one view is reflected in the other. States are stored per group index, with only the changed index being written, so a view showing fewer groups does not clobber the states of groups only shown in another view.

To support this, `toSettingsValue` and `fromSettingsValue` were generalized to handle `QList<T>` and `QSet<T>` via a `SettingsValue` trait struct, replacing the previous per-type specializations.

Also activate the affected layouts when expanding a properties group, not just when collapsing, to avoid flickering caused by repainting before the relayout is done.