### PR TITLE
Fixed Properties view not updating on Reset Template Instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
 * Fixed crash when the selection becomes empty while starting a move (#4536)
+* Fixed Properties view update on 'Reset Template Instance' and 'Replace With Template' actions
 * Linux: Added file associations for .tmj, .tsj, .tiled-project and .world files (by miffe, #4550)
 * macOS: Declared UTIs and file associations for all supported Tiled formats (with Jyotish, #4469)
 * snap: Updated to Qt 6

--- a/src/tiled/changemapobject.cpp
+++ b/src/tiled/changemapobject.cpp
@@ -256,7 +256,8 @@ void ResetInstances::redo()
 
     for (auto object : mMapObjects) {
         // Template instances initially don't hold any custom properties
-        object->clearProperties();
+        if (!object->properties().isEmpty())
+            mDocument->setProperties(object, Properties());
 
         affectedProperties |= object->changedProperties();
 
@@ -266,9 +267,6 @@ void ResetInstances::redo()
     }
 
     emit mDocument->changed(MapObjectsChangeEvent(mMapObjects, affectedProperties));
-
-    // This signal forces updating custom properties in the properties dock
-//    emit mMapDocument->selectedObjectsChanged();
 }
 
 void ResetInstances::undo()
@@ -276,8 +274,14 @@ void ResetInstances::undo()
     MapObject::ChangedProperties affectedProperties = MapObject::CustomProperties;
 
     for (int i = 0; i < mMapObjects.size(); ++i) {
-        mMapObjects.at(i)->copyPropertiesFrom(mOldMapObjects.at(i));
-        affectedProperties |= mOldMapObjects.at(i)->changedProperties();
+        MapObject *object = mMapObjects.at(i);
+        const MapObject *oldObject = mOldMapObjects.at(i);
+
+        object->copyPropertiesFrom(oldObject);
+        affectedProperties |= oldObject->changedProperties();
+
+        if (!oldObject->properties().isEmpty())
+            emit mDocument->propertiesChanged(object);
     }
 
     emit mDocument->changed(MapObjectsChangeEvent(mMapObjects, affectedProperties));
@@ -314,6 +318,9 @@ void ReplaceObjectsWithTemplate::redo()
     }
 
     emit mDocument->changed(MapObjectsChangeEvent(mMapObjects, MapObject::AllProperties));
+
+    for (MapObject *object : std::as_const(mMapObjects))
+        emit mDocument->propertiesChanged(object);
 }
 
 void ReplaceObjectsWithTemplate::undo()
@@ -322,4 +329,7 @@ void ReplaceObjectsWithTemplate::undo()
         mMapObjects.at(i)->copyPropertiesFrom(mOldMapObjects.at(i));
 
     emit mDocument->changed(MapObjectsChangeEvent(mMapObjects, MapObject::AllProperties));
+
+    for (MapObject *object : std::as_const(mMapObjects))
+        emit mDocument->propertiesChanged(object);
 }


### PR DESCRIPTION
`ResetInstances` and `ReplaceObjectsWithTemplate` changed the custom properties of the affected objects without going through the Document's property API, only emitting a `MapObjectsChangeEvent` whose `CustomProperties` flag isn't handled anywhere. The Properties view and the object reference arrows rely on the `propertiesChanged` signal, so make sure this signal is emitted.

`ReplaceObjectsWithTemplate` emits `propertiesChanged` unconditionally, since the properties suggested based on the template may change even for instances without any overrides.