### PR TITLE
docs: Document list properties in the TMX and JSON format references

### DIFF
--- a/docs/reference/json-map-format.rst
+++ b/docs/reference/json-map-format.rst
@@ -753,9 +753,43 @@ Property
     :widths: 1, 1, 4
 
     name,             string,           "Name of the property"
-    type,             string,           "Type of the property (``string`` (default), ``int``, ``float``, ``bool``, ``color``, ``file``, ``object`` or ``class`` (since 0.16, with ``color`` and ``file`` added in 0.17, ``object`` added in 1.4 and ``class`` added in 1.8))"
+    type,             string,           "Type of the property (``string`` (default), ``int``, ``float``, ``bool``, ``color``, ``file``, ``object``, ``class`` or ``list`` (since 0.16, with ``color`` and ``file`` added in 0.17, ``object`` added in 1.4, ``class`` added in 1.8 and ``list`` added in 1.12))"
     propertytype,     string,           "Name of the :ref:`custom property type <custom-property-types>`, when applicable (since 1.8)"
     value,            value,            "Value of the property"
+
+When the type is ``list``, the ``value`` is an array storing each item of the
+list as an object with ``type``, ``value`` and (when applicable)
+``propertytype`` fields, like a property without a name. Class items store
+their set members as a JSON object, and list items store their values as a
+nested array.
+
+Example of a list property with a nested list:
+
+.. code:: json
+
+   {
+       "name":"list property",
+       "type":"list",
+       "value":[
+           {
+               "type":"int",
+               "value":10
+           },
+           {
+               "type":"string",
+               "value":"text"
+           },
+           {
+               "type":"list",
+               "value":[
+                   {
+                       "type":"bool",
+                       "value":true
+                   }
+               ]
+           }
+       ]
+   }
 
 .. _json-point:
 
@@ -783,6 +817,10 @@ Tiled 1.12
 * Added ``capsule`` property to :ref:`json-object`.
 
 * Added ``opacity`` property to :ref:`json-object`.
+
+* Added ``list`` as a possible type of :ref:`json-property`. The ``value`` of
+  a list property is an array storing each item as an object with ``type``,
+  ``propertytype`` and ``value`` fields.
 
 Tiled 1.11.1
 ~~~~~~~~~~~~

--- a/docs/reference/tmx-changelog.rst
+++ b/docs/reference/tmx-changelog.rst
@@ -7,7 +7,7 @@ Below are described the changes/additions that were made to the
 Tiled 1.12
 ----------
 
--  Added ``mode`` attribute on :ref:`tmx-layer` to specific its blend mode.
+-  Added ``mode`` attribute on :ref:`tmx-layer` to specify its blend mode.
 
 -  Added ``oblique`` to the supported values for the ``orientation`` attribute
    on the :ref:`tmx-map` element, along with the ``skewx`` and ``skewy``
@@ -22,7 +22,11 @@ Tiled 1.12
         <capsule/>
       </object>
 
--  Added ``opacity`` attribute to :ref:`tmx-object` to specificy its opacity.
+-  Added ``opacity`` attribute to :ref:`tmx-object` to specify its opacity.
+
+-  Added ``list`` to the supported values for the ``type`` attribute on the
+   :ref:`tmx-property` element. Each value of a list property is stored in a
+   nested :ref:`item <tmx-item>` element.
 
 
 Tiled 1.10

--- a/docs/reference/tmx-map-format.rst
+++ b/docs/reference/tmx-map-format.rst
@@ -755,9 +755,9 @@ Can contain any number: :ref:`tmx-property`
 
 -  **name:** The name of the property.
 -  **type:** The type of the property. Can be ``string`` (default), ``int``,
-   ``float``, ``bool``, ``color``, ``file``, ``object`` or ``class`` (since
-   0.16, with ``color`` and ``file`` added in 0.17, ``object`` added in 1.4 and
-   ``class`` added in 1.8).
+   ``float``, ``bool``, ``color``, ``file``, ``object``, ``class`` or ``list``
+   (since 0.16, with ``color`` and ``file`` added in 0.17, ``object`` added in
+   1.4, ``class`` added in 1.8 and ``list`` added in 1.12).
 -  **propertytype:** The name of the
    :ref:`custom property type <custom-property-types>`, when applicable
    (since 1.8).
@@ -781,6 +781,9 @@ Class properties will have their member values stored in a nested
 :ref:`tmx-properties` element. Only the actually set members are saved. When no
 members have been set the ``properties`` element is left out entirely.
 
+List properties store each of their values in a nested :ref:`tmx-item`
+element and have no ``value`` attribute of their own.
+
 When a string property contains newlines, the current version of Tiled
 will write out the value as characters contained inside the ``property``
 element rather than as the ``value`` attribute. It is possible that a
@@ -788,6 +791,41 @@ future version of the TMX format will switch to always saving property
 values inside the element rather than as an attribute.
 
 Can contain at most one: :ref:`tmx-properties` (since 1.8)
+
+Can contain any number: :ref:`tmx-item` (since 1.12)
+
+.. _tmx-item:
+
+<item>
+~~~~~~
+
+-  **type:** The type of the value. Same as the ``type`` attribute on the
+   :ref:`tmx-property` element (default ``string``).
+-  **propertytype:** The name of the
+   :ref:`custom property type <custom-property-types>`, when applicable.
+-  **value:** The value of this item.
+
+Stores one value of a ``list`` property (since 1.12). Apart from having no
+``name`` attribute, an item is structured like a :ref:`tmx-property` element:
+``class`` items store their set members in a nested :ref:`tmx-properties`
+element, ``list`` items contain their own ``item`` elements and multiline
+strings are written as characters contained inside the ``item`` element.
+
+Example of a list property with a nested list:
+
+.. code:: xml
+
+   <property name="list property" type="list">
+    <item type="int" value="10"/>
+    <item value="text"/>
+    <item type="list">
+     <item type="bool" value="true"/>
+    </item>
+   </property>
+
+Can contain at most one: :ref:`tmx-properties`
+
+Can contain any number: :ref:`tmx-item`
 
 .. _tmx-template-files:
 


### PR DESCRIPTION
List properties were added in Tiled 1.12 but were never documented. Documents the new 'list' property type and the `<item>` element for the TMX format, the array of typed items used by the JSON format, and adds the corresponding entries to both format changelogs.

Also fixes two 'specificy'/'specific' typos in the changelog entries for the blend mode and object opacity.