### PR TITLE
Set desktop file name for the application

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Fixed crash when the selection becomes empty while starting a move (#4536)
 * Fixed Properties view update on 'Reset Template Instance' and 'Replace With Template' actions
 * Linux: Added file associations for .tmj, .tsj, .tiled-project and .world files (by miffe, #4550)
+* Linux: Fixed the window icon on some Wayland compositors (by Balló György, #4567)
 * macOS: Declared UTIs and file associations for all supported Tiled formats (with Jyotish, #4469)
 * snap: Updated to Qt 6
 * Raised the minimum Qt version to 6.2 (drops Qt 5 support)

--- a/src/tiled/tiledapplication.cpp
+++ b/src/tiled/tiledapplication.cpp
@@ -51,6 +51,7 @@ TiledApplication::TiledApplication(int &argc, char **argv)
 #endif
     setApplicationDisplayName(QLatin1String("Tiled"));
     setApplicationVersion(QLatin1String(AS_STRING(TILED_VERSION)));
+    setDesktopFileName(QLatin1String("org.mapeditor.Tiled"));
 
     LanguageManager::instance()->installTranslators();
 


### PR DESCRIPTION
This ensures that the XDG toplevel app ID matches with the desktop file name, so Wayland compositors could match the window with the application and show the appropriate icon for them.

Without this change, the app ID is `org.mapeditor.tiled`, but the desktop file is called as [`org.mapeditor.Tiled`](https://github.com/mapeditor/tiled/blob/8bd35d5100f8f87ade0ad24c9e011a95e5f4c5a2/org.mapeditor.Tiled.desktop).

References:
- https://github.com/qt/qtbase/blob/bf1ae5862807ec2b9a411506d59ccd566937a4c7/src/plugins/platforms/wayland/qwaylandwindow.cpp#L152C20-L177
- https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id