### PR TITLE
Add support for declarative QML extensions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,11 @@ jobs:
         sudo apt update
         sudo apt install qt6-base-dev libqt6svg6-dev qt6-tools-dev-tools qt6-l10n-tools qt6-declarative-dev qt6-declarative-dev-tools libgl-dev zlib1g-dev qbs python3-dev
         sudo update-alternatives --install /usr/bin/qmake qmake /usr/bin/qmake6 100
+        # Qbs 1.21 looks for qmltyperegistrar in Qt's bin directory, whereas
+        # the Ubuntu packages install it under libexec
+        if [ ! -e /usr/lib/qt6/bin/qmltyperegistrar ]; then
+            sudo ln -s ../libexec/qmltyperegistrar /usr/lib/qt6/bin/qmltyperegistrar
+        fi
 
     - name: Setup qbs
       run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,8 +39,13 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install qt6-base-dev libqt6svg6-dev qt6-tools-dev-tools qt6-l10n-tools qt6-declarative-dev libgl-dev zlib1g-dev qbs python3-dev
+        sudo apt install qt6-base-dev libqt6svg6-dev qt6-tools-dev-tools qt6-l10n-tools qt6-declarative-dev qt6-declarative-dev-tools libgl-dev zlib1g-dev qbs python3-dev
         sudo update-alternatives --install /usr/bin/qmake qmake /usr/bin/qmake6 100
+        # Qbs 1.21 looks for qmltyperegistrar in Qt's bin directory, whereas
+        # the Ubuntu packages install it under libexec
+        if [ ! -e /usr/lib/qt6/bin/qmltyperegistrar ]; then
+            sudo ln -s ../libexec/qmltyperegistrar /usr/lib/qt6/bin/qmltyperegistrar
+        fi
 
     - name: Setup qbs
       run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install qt6-base-dev libqt6svg6-dev qt6-tools-dev-tools qt6-l10n-tools qt6-declarative-dev libgl-dev zlib1g-dev qbs python3-dev
+        sudo apt install qt6-base-dev libqt6svg6-dev qt6-tools-dev-tools qt6-l10n-tools qt6-declarative-dev qt6-declarative-dev-tools libgl-dev zlib1g-dev qbs python3-dev
         sudo update-alternatives --install /usr/bin/qmake qmake /usr/bin/qmake6 100
 
     - name: Setup qbs

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         export TILED_VERSION=$(git describe | cut -c 2-)
         qbs install --install-root install config:release
-        macdeployqt install/Tiled.app -verbose=2
+        macdeployqt install/Tiled.app -verbose=2 -qmldir=dist/qml
         pushd install
         ruby ../dist/macos/fixup-install-names.rb
         ditto -c -k --sequesterRsrc --keepParent Tiled.app ../Tiled-$TILED_VERSION-macos.zip

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -144,6 +144,7 @@ jobs:
         wget --no-verbose "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
         chmod +x linuxdeploy*.AppImage
         export EXTRA_QT_PLUGINS=svg
+        export QML_SOURCES_PATHS=$PWD/dist/qml
         export LD_LIBRARY_PATH=${QT_ROOT_DIR}/lib:$PWD/AppDir/usr/lib
         export OUTPUT=Tiled-${{ needs.version.outputs.version }}_Linux_x86_64.AppImage
         # Avoid shipping the debug information
@@ -287,7 +288,7 @@ jobs:
 
     - name: Deploy Qt
       run: |
-        macdeployqt install/Tiled.app -verbose=2
+        macdeployqt install/Tiled.app -verbose=2 -qmldir=dist/qml
         rm -f install/Tiled.app/Contents/PlugIns/tls/libqopensslbackend.dylib
         pushd install
         ruby ../dist/macos/fixup-install-names.rb

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install qt6-base-dev libqt6svg6 libqt6test6 qt6-l10n-tools qt6-declarative-dev zlib1g-dev qbs python3-dev
+        sudo apt install qt6-base-dev libqt6svg6 libqt6test6 qt6-l10n-tools qt6-declarative-dev qt6-declarative-dev-tools zlib1g-dev qbs python3-dev
         sudo update-alternatives --install /usr/bin/qmake qmake /usr/bin/qmake6 100
 
     - name: Setup qbs

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Compiling Tiled
 Before you can compile Tiled, you must ensure the Qt (>= 6.2) development
 libraries have been installed as well as the Qbs build tool:
 
-* On Ubuntu/Debian: `sudo apt install qt6-base-dev libqt6svg6 libqt6test6 qt6-l10n-tools qt6-declarative-dev zlib1g-dev qbs`
+* On Ubuntu/Debian: `sudo apt install qt6-base-dev libqt6svg6 libqt6test6 qt6-l10n-tools qt6-declarative-dev qt6-declarative-dev-tools zlib1g-dev qbs`
 * On Fedora:        `sudo dnf builddep tiled`
 * On Arch Linux:    `sudo pacman -S qt6-declarative qt6-svg qt6-tools qbs`
 * On macOS with [Homebrew](https://brew.sh/):

--- a/dist/distribute.qbs
+++ b/dist/distribute.qbs
@@ -76,6 +76,14 @@ Product {
                     "Qt" + major + "Svg" + postfix,
                     "Qt" + major + "Widgets" + postfix
                 );
+
+                // Qt Quick libraries, needed by QML extensions. Their
+                // existence depends on the Qt version.
+                for (i = 0; i < project.qtQuickLibraries.length; ++i) {
+                    var lib = "Qt" + major + project.qtQuickLibraries[i] + postfix;
+                    if (File.exists(prefix + lib))
+                        list.push(lib);
+                }
             }
 
             if (qbs.targetOS.contains("linux")) {
@@ -122,6 +130,50 @@ Product {
             files.push("*d.dll");
         }
         return files;
+    }
+
+    property string qtQmlDir: FileInfo.joinPaths(Qt.core.binPath, "../qml")
+
+    Probe {
+        id: qmlModuleFiles
+        property string qmlDir: qtQmlDir
+        property stringList importDirs: project.qmlImportDirs
+        property stringList files
+        configure: {
+            var list = [];
+
+            for (var i = 0; i < importDirs.length; ++i) {
+                var dir = importDirs[i];
+                var absDir = qmlDir + "/" + dir;
+                if (!File.exists(absDir))
+                    continue;
+
+                var entries = File.directoryEntries(absDir, File.Files);
+                for (var j = 0; j < entries.length; ++j) {
+                    var entry = entries[j];
+                    if (entry.endsWith(".qmltypes") || entry.endsWith(".pdb"))
+                        continue;
+
+                    // Skip debug variants of the QML plugins
+                    if (entry.endsWith("d.dll") && File.exists(absDir + "/" + entry.slice(0, -5) + ".dll"))
+                        continue;
+
+                    list.push(dir + "/" + entry);
+                }
+            }
+
+            files = list;
+            found = true;
+        }
+    }
+
+    Group {
+        name: "Qt QML Modules"
+        prefix: qtQmlDir + "/"
+        files: qmlModuleFiles.files
+        qbs.install: true
+        qbs.installDir: "qml"
+        qbs.installSourceBase: prefix
     }
 
     Group {

--- a/dist/distribute.qbs
+++ b/dist/distribute.qbs
@@ -6,6 +6,8 @@
 import qbs.File
 import qbs.FileInfo
 
+import "qmlmodules.js" as QmlModules
+
 Product {
     name: "distribute"
     type: "installable"
@@ -77,13 +79,10 @@ Product {
                     "Qt" + major + "Widgets" + postfix
                 );
 
-                // Qt Quick libraries, needed by QML extensions. Their
-                // existence depends on the Qt version.
-                for (i = 0; i < project.qtQuickLibraries.length; ++i) {
-                    var lib = "Qt" + major + project.qtQuickLibraries[i] + postfix;
-                    if (File.exists(prefix + lib))
-                        list.push(lib);
-                }
+                // Qt Quick libraries, needed by QML extensions
+                list = list.concat(QmlModules.existingLibraries(prefix, major,
+                                                               project.qtQuickLibraries,
+                                                               postfix));
             }
 
             if (qbs.targetOS.contains("linux")) {
@@ -140,29 +139,7 @@ Product {
         property stringList importDirs: project.qmlImportDirs
         property stringList files
         configure: {
-            var list = [];
-
-            for (var i = 0; i < importDirs.length; ++i) {
-                var dir = importDirs[i];
-                var absDir = qmlDir + "/" + dir;
-                if (!File.exists(absDir))
-                    continue;
-
-                var entries = File.directoryEntries(absDir, File.Files);
-                for (var j = 0; j < entries.length; ++j) {
-                    var entry = entries[j];
-                    if (entry.endsWith(".qmltypes") || entry.endsWith(".pdb"))
-                        continue;
-
-                    // Skip debug variants of the QML plugins
-                    if (entry.endsWith("d.dll") && File.exists(absDir + "/" + entry.slice(0, -5) + ".dll"))
-                        continue;
-
-                    list.push(dir + "/" + entry);
-                }
-            }
-
-            files = list;
+            files = QmlModules.moduleFiles(qmlDir, importDirs);
             found = true;
         }
     }

--- a/dist/linux/qt.conf
+++ b/dist/linux/qt.conf
@@ -1,4 +1,6 @@
 [Paths]
 Libraries = lib
 Plugins = plugins
+QmlImports = qml
+Qml2Imports = qml
 Translations = translations

--- a/dist/qml/imports.qml
+++ b/dist/qml/imports.qml
@@ -1,0 +1,21 @@
+// This file declares the QML modules that are shipped with Tiled for use by
+// QML extensions. It is scanned by macdeployqt (through the -qmldir option)
+// and by linuxdeploy-plugin-qt (through QML_SOURCES_PATHS) to determine
+// which QML modules to deploy.
+//
+// The Windows packages derive the list of shipped files from the
+// qmlImportDirs and qtQuickLibraries properties in tiled.qbs instead, so
+// these should be kept in sync.
+
+import QtQml
+import QtQml.Models
+import QtQml.WorkerScript
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls.Basic
+import QtQuick.Controls.Fusion
+import QtQuick.Layouts
+import QtQuick.Templates
+import QtQuick.Window
+
+QtObject {}

--- a/dist/qmlmodules.js
+++ b/dist/qmlmodules.js
@@ -1,0 +1,82 @@
+/*
+  Determines which files of the QML modules shipped with Tiled and which of
+  the Qt Quick libraries they need are available in the Qt installation.
+
+  Shared between the "distribute" product, which puts these files in the
+  archive, and the Windows installer, which ships them in the MSI. Both are
+  based on the qmlImportDirs and qtQuickLibraries properties in tiled.qbs.
+*/
+
+var File = require("qbs.File");
+var FileInfo = require("qbs.FileInfo");
+
+/**
+ * Returns an entry for each of the given import directories that exists below
+ * qmlDir, providing the directory (both relative and absolute) along with the
+ * names of the files to ship from it.
+ */
+function moduleDirs(qmlDir, importDirs)
+{
+    var result = [];
+
+    for (var i = 0; i < importDirs.length; ++i) {
+        var dir = importDirs[i];
+        var absDir = FileInfo.joinPaths(qmlDir, dir);
+        if (!File.exists(absDir))
+            continue;
+
+        var files = [];
+        var entries = File.directoryEntries(absDir, File.Files);
+        for (var j = 0; j < entries.length; ++j) {
+            var entry = entries[j];
+            if (entry.endsWith(".qmltypes") || entry.endsWith(".pdb"))
+                continue;
+
+            // Skip debug variants of the QML plugins
+            if (entry.endsWith("d.dll") && File.exists(FileInfo.joinPaths(absDir, entry.slice(0, -5) + ".dll")))
+                continue;
+
+            files.push(entry);
+        }
+
+        result.push({ dir: dir, absDir: absDir, files: files });
+    }
+
+    return result;
+}
+
+/**
+ * Returns the files to ship for the given import directories, as paths
+ * relative to qmlDir.
+ */
+function moduleFiles(qmlDir, importDirs)
+{
+    var result = [];
+    var dirs = moduleDirs(qmlDir, importDirs);
+
+    for (var i = 0; i < dirs.length; ++i) {
+        var files = dirs[i].files;
+        for (var j = 0; j < files.length; ++j)
+            result.push(dirs[i].dir + "/" + files[j]);
+    }
+
+    return result;
+}
+
+/**
+ * Returns the file names of the given Qt Quick libraries which exist in the
+ * directory referred to by prefix (which is expected to include the trailing
+ * separator). Their existence depends on the Qt version.
+ */
+function existingLibraries(prefix, versionMajor, libraries, suffix)
+{
+    var result = [];
+
+    for (var i = 0; i < libraries.length; ++i) {
+        var lib = "Qt" + versionMajor + libraries[i] + suffix;
+        if (File.exists(prefix + lib))
+            result.push(lib);
+    }
+
+    return result;
+}

--- a/dist/win/installer.qbs
+++ b/dist/win/installer.qbs
@@ -2,6 +2,7 @@ import qbs.FileInfo
 import qbs.File
 import qbs.TextFile
 import qbs.Environment
+import qbs.Utilities
 
 WindowsInstallerPackage {
     builtByDefault: project.windowsInstaller
@@ -75,6 +76,120 @@ WindowsInstallerPackage {
         "Custom_InstallDirDlg.wxs",
         "installer.wxs"
     ]
+
+    // Generates a WiX fragment that ships the QML modules usable by QML
+    // extensions, along with the Qt libraries they need. The fragment is
+    // generated based on the actual contents of the Qt installation, since
+    // the set of files differs between Qt versions.
+    Rule {
+        multiplex: true
+        inputsFromDependencies: ["installable"]
+
+        Artifact {
+            filePath: "qml-modules.wxs"
+            fileTags: ["wxs"]
+        }
+
+        prepare: {
+            var binPath = product.moduleProperty("Qt.core", "binPath");
+
+            var cmd = new JavaScriptCommand();
+            cmd.description = "generating qml-modules.wxs";
+            cmd.qmlDir = FileInfo.joinPaths(binPath, "../qml");
+            cmd.binDir = binPath;
+            cmd.qmlImportDirs = project.qmlImportDirs;
+            cmd.qtQuickLibraries = project.qtQuickLibraries;
+            cmd.versionMajor = product.moduleProperty("Qt.core", "versionMajor");
+            cmd.sourceCode = function() {
+                // WiX identifiers are limited to 72 characters
+                function idFor(prefix, path) {
+                    var id = prefix + path.replace(/[^A-Za-z0-9_.]/g, "_");
+                    if (id.length > 72)
+                        id = id.slice(0, 30) + "_" + Utilities.getHash(path);
+                    return id;
+                }
+
+                var tf;
+                try {
+                    tf = new TextFile(output.filePath, TextFile.WriteOnly);
+                    tf.writeLine("<?xml version='1.0' encoding='windows-1252'?>");
+                    tf.writeLine("<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>");
+                    tf.writeLine("  <Fragment>");
+
+                    // Directory tree below INSTALLDIR/qml
+                    var tree = {};
+                    var i, j;
+                    for (i = 0; i < qmlImportDirs.length; ++i) {
+                        var parts = qmlImportDirs[i].split("/");
+                        var node = tree;
+                        for (j = 0; j < parts.length; ++j)
+                            node = node[parts[j]] = node[parts[j]] || {};
+                    }
+
+                    function writeDirs(node, relPath, indent) {
+                        for (var name in node) {
+                            var rel = relPath ? relPath + "/" + name : name;
+                            tf.writeLine(indent + "<Directory Id='" + idFor("qmldir_", rel) + "' Name='" + name + "'>");
+                            writeDirs(node[name], rel, indent + "  ");
+                            tf.writeLine(indent + "</Directory>");
+                        }
+                    }
+
+                    tf.writeLine("    <DirectoryRef Id='INSTALLDIR'>");
+                    tf.writeLine("      <Directory Id='qmldir' Name='qml'>");
+                    writeDirs(tree, "", "        ");
+                    tf.writeLine("      </Directory>");
+                    tf.writeLine("    </DirectoryRef>");
+
+                    tf.writeLine("    <ComponentGroup Id='QmlModules'>");
+
+                    for (i = 0; i < qmlImportDirs.length; ++i) {
+                        var dir = qmlImportDirs[i];
+                        var absDir = FileInfo.joinPaths(qmlDir, dir);
+                        if (!File.exists(absDir))
+                            continue;
+
+                        var entries = File.directoryEntries(absDir, File.Files);
+                        for (j = 0; j < entries.length; ++j) {
+                            var entry = entries[j];
+                            if (entry.endsWith(".qmltypes") || entry.endsWith(".pdb"))
+                                continue;
+
+                            // Skip debug variants of the QML plugins
+                            if (entry.endsWith("d.dll") && File.exists(FileInfo.joinPaths(absDir, entry.slice(0, -5) + ".dll")))
+                                continue;
+
+                            var rel = dir + "/" + entry;
+                            tf.writeLine("      <Component Id='" + idFor("cmp_", rel) + "' Directory='" + idFor("qmldir_", dir) + "' Guid='*'>");
+                            tf.writeLine("        <File Id='" + idFor("qml_", rel) + "' Source='" + FileInfo.toWindowsSeparators(FileInfo.joinPaths(absDir, entry)) + "' KeyPath='yes' />");
+                            tf.writeLine("      </Component>");
+                        }
+                    }
+
+                    // Qt libraries needed by the QML modules. Their existence
+                    // depends on the Qt version.
+                    for (i = 0; i < qtQuickLibraries.length; ++i) {
+                        var dll = "Qt" + versionMajor + qtQuickLibraries[i] + ".dll";
+                        var absFile = FileInfo.joinPaths(binDir, dll);
+                        if (!File.exists(absFile))
+                            continue;
+
+                        tf.writeLine("      <Component Id='" + idFor("cmp_", dll) + "' Directory='INSTALLDIR' Guid='*'>");
+                        tf.writeLine("        <File Id='" + idFor("", dll) + "' Source='" + FileInfo.toWindowsSeparators(absFile) + "' KeyPath='yes' />");
+                        tf.writeLine("      </Component>");
+                    }
+
+                    tf.writeLine("    </ComponentGroup>");
+                    tf.writeLine("  </Fragment>");
+                    tf.writeLine("</Wix>");
+                } finally {
+                    if (tf)
+                        tf.close();
+                }
+            };
+            return [cmd];
+        }
+    }
 
     // This is a clever hack to make the rule that compiles the installer
     // depend on all installables, since that rule implicitly depends on

--- a/dist/win/installer.qbs
+++ b/dist/win/installer.qbs
@@ -112,7 +112,7 @@ WindowsInstallerPackage {
                 var tf;
                 try {
                     tf = new TextFile(output.filePath, TextFile.WriteOnly);
-                    tf.writeLine("<?xml version='1.0' encoding='windows-1252'?>");
+                    tf.writeLine("<?xml version='1.0' encoding='utf-8'?>");
                     tf.writeLine("<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>");
                     tf.writeLine("  <Fragment>");
 

--- a/dist/win/installer.qbs
+++ b/dist/win/installer.qbs
@@ -4,6 +4,8 @@ import qbs.TextFile
 import qbs.Environment
 import qbs.Utilities
 
+import "../qmlmodules.js" as QmlModules
+
 WindowsInstallerPackage {
     builtByDefault: project.windowsInstaller
     condition: {
@@ -143,36 +145,24 @@ WindowsInstallerPackage {
 
                     tf.writeLine("    <ComponentGroup Id='QmlModules'>");
 
-                    for (i = 0; i < qmlImportDirs.length; ++i) {
-                        var dir = qmlImportDirs[i];
-                        var absDir = FileInfo.joinPaths(qmlDir, dir);
-                        if (!File.exists(absDir))
-                            continue;
-
-                        var entries = File.directoryEntries(absDir, File.Files);
-                        for (j = 0; j < entries.length; ++j) {
-                            var entry = entries[j];
-                            if (entry.endsWith(".qmltypes") || entry.endsWith(".pdb"))
-                                continue;
-
-                            // Skip debug variants of the QML plugins
-                            if (entry.endsWith("d.dll") && File.exists(FileInfo.joinPaths(absDir, entry.slice(0, -5) + ".dll")))
-                                continue;
-
-                            var rel = dir + "/" + entry;
-                            tf.writeLine("      <Component Id='" + idFor("cmp_", rel) + "' Directory='" + idFor("qmldir_", dir) + "' Guid='*'>");
-                            tf.writeLine("        <File Id='" + idFor("qml_", rel) + "' Source='" + FileInfo.toWindowsSeparators(FileInfo.joinPaths(absDir, entry)) + "' KeyPath='yes' />");
+                    var moduleDirs = QmlModules.moduleDirs(qmlDir, qmlImportDirs);
+                    for (i = 0; i < moduleDirs.length; ++i) {
+                        var moduleDir = moduleDirs[i];
+                        for (j = 0; j < moduleDir.files.length; ++j) {
+                            var entry = moduleDir.files[j];
+                            var rel = moduleDir.dir + "/" + entry;
+                            tf.writeLine("      <Component Id='" + idFor("cmp_", rel) + "' Directory='" + idFor("qmldir_", moduleDir.dir) + "' Guid='*'>");
+                            tf.writeLine("        <File Id='" + idFor("qml_", rel) + "' Source='" + FileInfo.toWindowsSeparators(FileInfo.joinPaths(moduleDir.absDir, entry)) + "' KeyPath='yes' />");
                             tf.writeLine("      </Component>");
                         }
                     }
 
-                    // Qt libraries needed by the QML modules. Their existence
-                    // depends on the Qt version.
-                    for (i = 0; i < qtQuickLibraries.length; ++i) {
-                        var dll = "Qt" + versionMajor + qtQuickLibraries[i] + ".dll";
+                    // Qt libraries needed by the QML modules
+                    var libraries = QmlModules.existingLibraries(binDir + "/", versionMajor,
+                                                                qtQuickLibraries, ".dll");
+                    for (i = 0; i < libraries.length; ++i) {
+                        var dll = libraries[i];
                         var absFile = FileInfo.joinPaths(binDir, dll);
-                        if (!File.exists(absFile))
-                            continue;
 
                         tf.writeLine("      <Component Id='" + idFor("cmp_", dll) + "' Directory='INSTALLDIR' Guid='*'>");
                         tf.writeLine("        <File Id='" + idFor("", dll) + "' Source='" + FileInfo.toWindowsSeparators(absFile) + "' KeyPath='yes' />");

--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -429,6 +429,7 @@
         <ComponentRef Id='StylePlugins' />
       <?endif?>
       <ComponentRef Id='TlsPlugins' />
+      <ComponentGroupRef Id='QmlModules' />
       <ComponentRef Id='ProgramMenuDir' />
     </Feature>
 

--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -409,6 +409,18 @@
       </Directory>
     </Directory>
 
+    <!-- The Tiled QML module, providing the type description used by tooling
+         like qmllint and qmlls. The "qml" directory is created by the
+         generated qml-modules.wxs fragment. -->
+    <DirectoryRef Id="qmldir">
+      <Directory Id="qmlTiledDir" Name="Tiled">
+        <Component Id="QmlTiledModule" Guid="{1AE516C3-5BB5-4A9B-AEA9-6957A3F21E12}">
+          <File Id="TiledQmldir" Source="$(var.InstallRoot)\qml\Tiled\qmldir" KeyPath="yes" />
+          <File Id="TiledPluginsQmltypes" Source="$(var.InstallRoot)\qml\Tiled\plugins.qmltypes" />
+        </Component>
+      </Directory>
+    </DirectoryRef>
+
     <Feature Id='Complete' Level='1' Title="Tiled" Description="The complete package." ConfigurableDirectory='INSTALLDIR' AllowAdvertise='no' Absent='disallow'>
       <ComponentRef Id='MainExecutable' />
       <ComponentRef Id='DesktopShortcut' />
@@ -430,6 +442,7 @@
       <?endif?>
       <ComponentRef Id='TlsPlugins' />
       <ComponentGroupRef Id='QmlModules' />
+      <ComponentRef Id='QmlTiledModule' />
       <ComponentRef Id='ProgramMenuDir' />
     </Feature>
 

--- a/dist/win/qt.conf
+++ b/dist/win/qt.conf
@@ -1,3 +1,5 @@
 [Paths]
 Plugins = plugins
+QmlImports = qml
+Qml2Imports = qml
 Translations = translations

--- a/docs/manual/scripting.rst
+++ b/docs/manual/scripting.rst
@@ -188,6 +188,12 @@ instantiated as an extension. Reusable components should be placed in a
 sub-directory, from where they can be used through a relative directory
 import (for example, ``import "./components"``).
 
+The following QML modules are shipped with Tiled and can be used by
+extensions: ``QtQml``, ``QtQuick``, ``QtQuick.Controls``, ``QtQuick.Layouts``,
+``QtQuick.Templates`` and ``QtQuick.Window``. For Qt Quick Controls, the
+Fusion and Basic styles are available, with Fusion being used by default (can
+be overridden using the ``QT_QUICK_CONTROLS_STYLE`` environment variable).
+
 .. _script-console:
 
 Console View

--- a/docs/manual/scripting.rst
+++ b/docs/manual/scripting.rst
@@ -97,6 +97,97 @@ works as intended.
 Apart from scripts, extensions can include images that can be used as the icon
 for scripted actions or tools.
 
+.. _qml-extensions:
+
+QML Extensions
+^^^^^^^^^^^^^^
+
+.. raw:: html
+
+   <div class="new">Since Tiled 1.13</div>
+
+Extensions can also be written as declarative QML documents (``.qml`` files
+placed in an extensions directory). These are loaded by the same script engine
+and can coexist with JavaScript extensions. The ``Tiled`` import provides the
+following types:
+
+============== =============================================================
+Type           Description
+============== =============================================================
+Action         Registers an action, like ``tiled.registerAction``
+MenuExtension  Adds items to a menu, like ``tiled.extendMenu``
+Tool           Registers a tool, like ``tiled.registerTool``
+MapFormat      Registers a map format, like ``tiled.registerMapFormat``
+TilesetFormat  Registers a tileset format, like ``tiled.registerTilesetFormat``
+Dock           Adds a dock widget with Qt Quick based contents
+Extension      Groups any number of the above types
+============== =============================================================
+
+The main advantage of the declarative approach is that property bindings can
+be used to keep dynamic property values up to date. This applies to live
+properties like the ``enabled``, ``text`` or ``checked`` state of an action
+and anything inside the contents of a dock. Properties that describe a
+registration (like the ``name`` of an action or the ``items`` of a menu
+extension) are read once when the extension is loaded. The following example
+registers an action that is only enabled when a map is active, and adds it to
+the Map menu:
+
+.. code:: qml
+
+    import Tiled
+
+    Extension {
+        Action {
+            id: countLayers
+            name: "CountLayers"
+            text: "Count Layers"
+            enabled: tiled.activeAsset && tiled.activeAsset.isTileMap
+            onTriggered: tiled.alert("The map has " + tiled.activeAsset.layerCount + " layers.")
+        }
+
+        MenuExtension {
+            menu: "Map"
+            items: [
+                { separator: true },
+                { action: countLayers },
+            ]
+        }
+    }
+
+A ``Dock`` declares custom UI using Qt Quick, which is shown in a dock widget
+that can be moved, floated and tabbed like the built-in views. Its ``name``
+identifies the dock when saving and restoring the window layout, so it should
+be unique and stable:
+
+.. code:: qml
+
+    import QtQuick
+    import Tiled
+
+    Dock {
+        name: "activeAssetDock"
+        title: "Active Asset"
+
+        Text {
+            text: tiled.activeAsset ? tiled.activeAsset.fileName : "No asset active"
+        }
+    }
+
+By default a dock is added to Tiled's main window. Set the ``window`` property
+to ``Dock.MapEditor`` or ``Dock.TilesetEditor`` to add it to the window of the
+respective editor instead, in which case it is only visible while that editor
+is active.
+
+The registered types generally support the same properties and functions as
+their JavaScript counterparts. For example, a ``Tool`` can declare functions
+like ``mousePressed`` or ``tilePositionChanged``, and a ``MapFormat`` is
+expected to provide ``read`` and/or ``write`` functions.
+
+Note that every ``.qml`` file found directly in an extension directory is
+instantiated as an extension. Reusable components should be placed in a
+sub-directory, from where they can be used through a relative directory
+import (for example, ``import "./components"``).
+
 .. _script-console:
 
 Console View

--- a/docs/manual/scripting.rst
+++ b/docs/manual/scripting.rst
@@ -183,6 +183,12 @@ The action that shows and hides a dock is registered with the ID
 given a custom keyboard shortcut in *Preferences > Keyboard*. A default
 shortcut can be suggested using the ``shortcut`` property.
 
+The ``visible`` property tells whether the dock is currently shown and can
+also be used to show or hide it. For a dock in an editor window it is also
+``false`` while that editor is not the active one. Setting it to ``false``
+only has an effect the first time the dock is created, since after that the
+dock is restored to the state the user left it in.
+
 The registered types generally support the same properties and functions as
 their JavaScript counterparts. For example, a ``Tool`` can declare functions
 like ``mousePressed`` or ``tilePositionChanged``, and a ``MapFormat`` is

--- a/docs/manual/scripting.rst
+++ b/docs/manual/scripting.rst
@@ -178,6 +178,11 @@ to ``Dock.MapEditor`` or ``Dock.TilesetEditor`` to add it to the window of the
 respective editor instead, in which case it is only visible while that editor
 is active.
 
+The action that shows and hides a dock is registered with the ID
+``Dock.<name>``, so that it can be triggered from the action search and can be
+given a custom keyboard shortcut in *Preferences > Keyboard*. A default
+shortcut can be suggested using the ``shortcut`` property.
+
 The registered types generally support the same properties and functions as
 their JavaScript counterparts. For example, a ``Tool`` can declare functions
 like ``mousePressed`` or ``tilePositionChanged``, and a ``MapFormat`` is

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -7,6 +7,10 @@ DynamicLibrary {
     Depends { name: "cpp" }
     Depends { name: "Qt"; submodules: "gui"; versionAtLeast: "6.2.0" }
 
+    // Needed by libtilededitor to resolve the base classes of the types it
+    // registers to QML (see Qt.qml.importName)
+    Qt.core.generateMetaTypesFile: true
+
     Probes.PkgConfigProbe {
         id: pkgConfigZstd
         name: "libzstd"

--- a/src/tiled/abstracttool.h
+++ b/src/tiled/abstracttool.h
@@ -207,8 +207,9 @@ protected:
 
     /**
      * Allows setting the ID after construction, for tools that only know
-     * their ID once their declared properties have been set (see QmlTool).
-     * Should not be called after the tool has been registered.
+     * their ID once their declared properties have been set (see
+     * ScriptedTool::componentComplete). Should not be called after the tool
+     * has been registered.
      */
     void setId(Id id) { mId = id; }
 

--- a/src/tiled/abstracttool.h
+++ b/src/tiled/abstracttool.h
@@ -205,6 +205,13 @@ protected:
     MapDocument *mapDocument() const { return mMapDocument; }
     MapScene *mapScene() const { return mMapScene; }
 
+    /**
+     * Allows setting the ID after construction, for tools that only know
+     * their ID once their declared properties have been set (see QmlTool).
+     * Should not be called after the tool has been registered.
+     */
+    void setId(Id id) { mId = id; }
+
     Layer *currentLayer() const;
 
     /**

--- a/src/tiled/abstracttool.h
+++ b/src/tiled/abstracttool.h
@@ -205,6 +205,14 @@ protected:
     MapDocument *mapDocument() const { return mMapDocument; }
     MapScene *mapScene() const { return mMapScene; }
 
+    /**
+     * Allows setting the ID after construction, for tools that only know
+     * their ID once their declared properties have been set (see
+     * ScriptedTool::componentComplete). Should not be called after the tool
+     * has been registered.
+     */
+    void setId(Id id) { mId = id; }
+
     Layer *currentLayer() const;
 
     /**

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -14,6 +14,49 @@ DynamicLibrary {
     Depends { name: "Qt.dbus"; condition: qbs.targetOS.contains("linux") && project.dbus; required: false }
     Depends { name: "Qt.gui-private"; condition: qbs.targetOS.contains("windows") }
 
+    // Generates the registration of the QML types provided for use by QML
+    // extensions (see QML_NAMED_ELEMENT), along with a "plugins.qmltypes"
+    // file describing them for use by tooling like qmllint and qmlls.
+    Qt.qml.importName: "Tiled"
+    Qt.qml.importVersion: "1.0"
+    Qt.qml.typesInstallDir: "qml/Tiled"
+    Qt.qml.extraMetaTypesFiles: qtMetaTypes.files
+
+    // Locates the metatypes files of the used Qt modules, needed to resolve
+    // the Qt base classes of the QML registered types. Their location
+    // differs between Qt builds.
+    Probe {
+        id: qtMetaTypes
+        property string libPath: Qt.core.libPath
+        property string libExecPath: Qt.core.libExecPath
+        property stringList files
+        configure: {
+            var candidates = [
+                FileInfo.joinPaths(libPath, "metatypes"),
+                FileInfo.joinPaths(libExecPath, "..", "metatypes"),
+            ];
+            var list = [];
+            for (var i = 0; i < candidates.length && list.length === 0; ++i) {
+                if (!File.exists(candidates[i]))
+                    continue;
+                var entries = File.directoryEntries(candidates[i], File.Files);
+                for (var j = 0; j < entries.length; ++j) {
+                    if (entries[j].endsWith("_metatypes.json"))
+                        list.push(FileInfo.joinPaths(candidates[i], entries[j]));
+                }
+            }
+            files = list;
+            found = list.length > 0;
+        }
+    }
+
+    Group {
+        name: "QML type description"
+        files: ["qml/Tiled/qmldir"]
+        qbs.install: true
+        qbs.installDir: "qml/Tiled"
+    }
+
     cpp.includePaths: {
         var paths = ["."];
 

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -8,7 +8,7 @@ DynamicLibrary {
     Depends { name: "libtiled" }
     Depends { name: "translations" }
     Depends { name: "qtsingleapplication" }
-    Depends { name: "Qt"; submodules: ["core", "widgets", "concurrent", "qml"]; versionAtLeast: "6.2.0" }
+    Depends { name: "Qt"; submodules: ["core", "widgets", "concurrent", "qml", "quick", "quickwidgets"]; versionAtLeast: "6.2.0" }
     Depends { name: "Qt.svg"; condition: qbs.targetOS.contains("macos") }
     Depends { name: "Qt.openglwidgets"; required: false }
     Depends { name: "Qt.dbus"; condition: qbs.targetOS.contains("linux") && project.dbus; required: false }
@@ -406,6 +406,10 @@ DynamicLibrary {
         "propertytypeseditor.ui",
         "propertytypesmodel.cpp",
         "propertytypesmodel.h",
+        "qmldock.cpp",
+        "qmldock.h",
+        "qmlextension.cpp",
+        "qmlextension.h",
         "raiselowerhelper.cpp",
         "raiselowerhelper.h",
         "randompicker.h",

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -23,30 +23,56 @@ DynamicLibrary {
     Qt.qml.extraMetaTypesFiles: qtMetaTypes.files
 
     // Locates the metatypes files of the used Qt modules, needed to resolve
-    // the Qt base classes of the QML registered types. Their location
-    // differs between Qt builds.
+    // the Qt base classes of the QML registered types. Qbs passes these
+    // files automatically when they are in the archdata directory, which is
+    // the case since Qt 6.5 (qtbase commit 4234ce12dc819). Older Qt builds
+    // place them under lib/metatypes instead, a location Qbs does not
+    // currently check, so this Probe supplies them in that case. It can be
+    // removed entirely once the minimum Qbs version includes the upstream
+    // fix "Qt support: Look for metatypes files in the libraries directory
+    // too".
     Probe {
         id: qtMetaTypes
         property string libPath: Qt.core.libPath
-        property string libExecPath: Qt.core.libExecPath
+        property string mkspecPath: Qt.core.mkspecPath
         property stringList files
         configure: {
-            var candidates = [
-                FileInfo.joinPaths(libPath, "metatypes"),
-                FileInfo.joinPaths(libExecPath, "..", "metatypes"),
-            ];
             var list = [];
-            for (var i = 0; i < candidates.length && list.length === 0; ++i) {
-                if (!File.exists(candidates[i]))
-                    continue;
-                var entries = File.directoryEntries(candidates[i], File.Files);
-                for (var j = 0; j < entries.length; ++j) {
-                    if (entries[j].endsWith("_metatypes.json"))
-                        list.push(FileInfo.joinPaths(candidates[i], entries[j]));
+
+            // The used mkspec lives at <archdata>/mkspecs/<spec>, so the
+            // archdata directory is two levels up from it.
+            var archDataPath = FileInfo.path(FileInfo.path(mkspecPath));
+            var archDataMetaTypesDir = FileInfo.joinPaths(archDataPath,
+                                                          "metatypes");
+
+            var handledByQbs = false;
+            if (File.exists(archDataMetaTypesDir)) {
+                var entries = File.directoryEntries(archDataMetaTypesDir,
+                                                    File.Files);
+                for (var i = 0; i < entries.length; ++i) {
+                    if (entries[i].endsWith("_metatypes.json")) {
+                        handledByQbs = true;
+                        break;
+                    }
                 }
             }
+
+            if (!handledByQbs) {
+                var libMetaTypesDir = FileInfo.joinPaths(libPath, "metatypes");
+                if (File.exists(libMetaTypesDir)) {
+                    var libEntries = File.directoryEntries(libMetaTypesDir,
+                                                           File.Files);
+                    for (var j = 0; j < libEntries.length; ++j) {
+                        if (libEntries[j].endsWith("_metatypes.json")) {
+                            list.push(FileInfo.joinPaths(libMetaTypesDir,
+                                                         libEntries[j]));
+                        }
+                    }
+                }
+            }
+
             files = list;
-            found = list.length > 0;
+            found = true;
         }
     }
 

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -14,12 +14,21 @@ DynamicLibrary {
     Depends { name: "Qt.dbus"; condition: qbs.targetOS.contains("linux") && project.dbus; required: false }
     Depends { name: "Qt.gui-private"; condition: qbs.targetOS.contains("windows") }
 
+    // When the build multiplexes over multiple architectures, the QML type
+    // description only needs to be installed once, since its contents do not
+    // depend on the architecture.
+    readonly property bool installQmlTypeDescription: {
+        return !qbs.architectures
+                || qbs.architectures.length < 2
+                || qbs.architecture === qbs.architectures[0];
+    }
+
     // Generates the registration of the QML types provided for use by QML
     // extensions (see QML_NAMED_ELEMENT), along with a "plugins.qmltypes"
     // file describing them for use by tooling like qmllint and qmlls.
     Qt.qml.importName: "Tiled"
     Qt.qml.importVersion: "1.0"
-    Qt.qml.typesInstallDir: "qml/Tiled"
+    Qt.qml.typesInstallDir: installQmlTypeDescription ? "qml/Tiled" : undefined
     Qt.qml.extraMetaTypesFiles: qtMetaTypes.files
 
     // Locates the metatypes files of the used Qt modules, needed to resolve
@@ -79,7 +88,7 @@ DynamicLibrary {
     Group {
         name: "QML type description"
         files: ["qml/Tiled/qmldir"]
-        qbs.install: true
+        qbs.install: installQmlTypeDescription
         qbs.installDir: "qml/Tiled"
     }
 

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -8,7 +8,7 @@ DynamicLibrary {
     Depends { name: "libtiled" }
     Depends { name: "translations" }
     Depends { name: "qtsingleapplication" }
-    Depends { name: "Qt"; submodules: ["core", "widgets", "concurrent", "qml", "quick", "quickwidgets"]; versionAtLeast: "6.2.0" }
+    Depends { name: "Qt"; submodules: ["core", "widgets", "concurrent", "qml", "quick", "quickcontrols2", "quickwidgets"]; versionAtLeast: "6.2.0" }
     Depends { name: "Qt.svg"; condition: qbs.targetOS.contains("macos") }
     Depends { name: "Qt.openglwidgets"; required: false }
     Depends { name: "Qt.dbus"; condition: qbs.targetOS.contains("linux") && project.dbus; required: false }

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -38,8 +38,7 @@ DynamicLibrary {
     // place them under lib/metatypes instead, a location Qbs does not
     // currently check, so this Probe supplies them in that case. It can be
     // removed entirely once the minimum Qbs version includes the upstream
-    // fix "Qt support: Look for metatypes files in the libraries directory
-    // too".
+    // fix (https://codereview.qt-project.org/c/qbs/qbs/+/753486).
     Probe {
         id: qtMetaTypes
         property string libPath: Qt.core.libPath

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -14,6 +14,83 @@ DynamicLibrary {
     Depends { name: "Qt.dbus"; condition: qbs.targetOS.contains("linux") && project.dbus; required: false }
     Depends { name: "Qt.gui-private"; condition: qbs.targetOS.contains("windows") }
 
+    // When the build multiplexes over multiple architectures, the QML type
+    // description only needs to be installed once, since its contents do not
+    // depend on the architecture.
+    readonly property bool installQmlTypeDescription: {
+        return !qbs.architectures
+                || qbs.architectures.length < 2
+                || qbs.architecture === qbs.architectures[0];
+    }
+
+    // Generates the registration of the QML types provided for use by QML
+    // extensions (see QML_NAMED_ELEMENT), along with a "plugins.qmltypes"
+    // file describing them for use by tooling like qmllint and qmlls.
+    Qt.qml.importName: "Tiled"
+    Qt.qml.importVersion: "1.0"
+    Qt.qml.typesInstallDir: installQmlTypeDescription ? "qml/Tiled" : undefined
+    Qt.qml.extraMetaTypesFiles: qtMetaTypes.files
+
+    // Locates the metatypes files of the used Qt modules, needed to resolve
+    // the Qt base classes of the QML registered types. Qbs passes these
+    // files automatically when they are in the archdata directory, which is
+    // the case since Qt 6.5 (qtbase commit 4234ce12dc819). Older Qt builds
+    // place them under lib/metatypes instead, a location Qbs does not
+    // currently check, so this Probe supplies them in that case. It can be
+    // removed entirely once the minimum Qbs version includes the upstream
+    // fix (https://codereview.qt-project.org/c/qbs/qbs/+/753486).
+    Probe {
+        id: qtMetaTypes
+        property string libPath: Qt.core.libPath
+        property string mkspecPath: Qt.core.mkspecPath
+        property stringList files
+        configure: {
+            var list = [];
+
+            // The used mkspec lives at <archdata>/mkspecs/<spec>, so the
+            // archdata directory is two levels up from it.
+            var archDataPath = FileInfo.path(FileInfo.path(mkspecPath));
+            var archDataMetaTypesDir = FileInfo.joinPaths(archDataPath,
+                                                          "metatypes");
+
+            var handledByQbs = false;
+            if (File.exists(archDataMetaTypesDir)) {
+                var entries = File.directoryEntries(archDataMetaTypesDir,
+                                                    File.Files);
+                for (var i = 0; i < entries.length; ++i) {
+                    if (entries[i].endsWith("_metatypes.json")) {
+                        handledByQbs = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!handledByQbs) {
+                var libMetaTypesDir = FileInfo.joinPaths(libPath, "metatypes");
+                if (File.exists(libMetaTypesDir)) {
+                    var libEntries = File.directoryEntries(libMetaTypesDir,
+                                                           File.Files);
+                    for (var j = 0; j < libEntries.length; ++j) {
+                        if (libEntries[j].endsWith("_metatypes.json")) {
+                            list.push(FileInfo.joinPaths(libMetaTypesDir,
+                                                         libEntries[j]));
+                        }
+                    }
+                }
+            }
+
+            files = list;
+            found = true;
+        }
+    }
+
+    Group {
+        name: "QML type description"
+        files: ["qml/Tiled/qmldir"]
+        qbs.install: installQmlTypeDescription
+        qbs.installDir: "qml/Tiled"
+    }
+
     cpp.includePaths: {
         var paths = ["."];
 

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -2165,9 +2165,26 @@ void MainWindow::updateViewsAndToolbarsMenu()
     mViewsAndToolbarsMenu->addAction(mConsoleDock->toggleViewAction());
     mViewsAndToolbarsMenu->addAction(mIssuesDock->toggleViewAction());
 
+    // Docks contributed by extensions
+    const auto extensionDocks = findChildren<QDockWidget*>(QString(), Qt::FindDirectChildrenOnly);
+    for (auto dockWidget : extensionDocks) {
+        if (dockWidget == mProjectDock || dockWidget == mConsoleDock || dockWidget == mIssuesDock)
+            continue;
+        mViewsAndToolbarsMenu->addAction(dockWidget->toggleViewAction());
+    }
+
     if (Editor *editor = mDocumentManager->currentEditor()) {
         mViewsAndToolbarsMenu->addSeparator();
-        const auto dockWidgets = editor->dockWidgets();
+        auto dockWidgets = editor->dockWidgets();
+
+        // Include docks contributed by extensions
+        if (auto editorWindow = qobject_cast<QMainWindow*>(editor->editorWidget())) {
+            const auto editorDocks = editorWindow->findChildren<QDockWidget*>(QString(), Qt::FindDirectChildrenOnly);
+            for (auto dockWidget : editorDocks)
+                if (!dockWidgets.contains(dockWidget))
+                    dockWidgets.append(dockWidget);
+        }
+
         for (auto dockWidget : dockWidgets)
             mViewsAndToolbarsMenu->addAction(dockWidget->toggleViewAction());
 

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -2202,9 +2202,26 @@ void MainWindow::updateViewsAndToolbarsMenu()
     mViewsAndToolbarsMenu->addAction(mConsoleDock->toggleViewAction());
     mViewsAndToolbarsMenu->addAction(mIssuesDock->toggleViewAction());
 
+    // Docks contributed by extensions
+    const auto extensionDocks = findChildren<QDockWidget*>(QString(), Qt::FindDirectChildrenOnly);
+    for (auto dockWidget : extensionDocks) {
+        if (dockWidget == mProjectDock || dockWidget == mConsoleDock || dockWidget == mIssuesDock)
+            continue;
+        mViewsAndToolbarsMenu->addAction(dockWidget->toggleViewAction());
+    }
+
     if (Editor *editor = mDocumentManager->currentEditor()) {
         mViewsAndToolbarsMenu->addSeparator();
-        const auto dockWidgets = editor->dockWidgets();
+        auto dockWidgets = editor->dockWidgets();
+
+        // Include docks contributed by extensions
+        if (auto editorWindow = qobject_cast<QMainWindow*>(editor->editorWidget())) {
+            const auto editorDocks = editorWindow->findChildren<QDockWidget*>(QString(), Qt::FindDirectChildrenOnly);
+            for (auto dockWidget : editorDocks)
+                if (!dockWidgets.contains(dockWidget))
+                    dockWidgets.append(dockWidget);
+        }
+
         for (auto dockWidget : dockWidgets)
             mViewsAndToolbarsMenu->addAction(dockWidget->toggleViewAction());
 

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -2194,6 +2194,30 @@ void MainWindow::resetToDefaultLayout()
         editor->resetLayout();
 }
 
+/**
+ * Docks contributed by extensions are identified by their object name, which
+ * is set by QmlDock.
+ */
+static bool isExtensionDock(const QDockWidget *dockWidget)
+{
+    return dockWidget->objectName().startsWith(QLatin1String("qml."));
+}
+
+/**
+ * Returns the docks contributed by extensions to the given \a mainWindow.
+ */
+static QList<QDockWidget*> extensionDockWidgets(const QMainWindow *mainWindow)
+{
+    QList<QDockWidget*> extensionDocks;
+
+    const auto dockWidgets = mainWindow->findChildren<QDockWidget*>(QString(), Qt::FindDirectChildrenOnly);
+    for (auto dockWidget : dockWidgets)
+        if (isExtensionDock(dockWidget))
+            extensionDocks.append(dockWidget);
+
+    return extensionDocks;
+}
+
 void MainWindow::updateViewsAndToolbarsMenu()
 {
     mViewsAndToolbarsMenu->clear();
@@ -2203,24 +2227,17 @@ void MainWindow::updateViewsAndToolbarsMenu()
     mViewsAndToolbarsMenu->addAction(mIssuesDock->toggleViewAction());
 
     // Docks contributed by extensions
-    const auto extensionDocks = findChildren<QDockWidget*>(QString(), Qt::FindDirectChildrenOnly);
-    for (auto dockWidget : extensionDocks) {
-        if (dockWidget == mProjectDock || dockWidget == mConsoleDock || dockWidget == mIssuesDock)
-            continue;
+    const auto extensionDocks = extensionDockWidgets(this);
+    for (auto dockWidget : extensionDocks)
         mViewsAndToolbarsMenu->addAction(dockWidget->toggleViewAction());
-    }
 
     if (Editor *editor = mDocumentManager->currentEditor()) {
         mViewsAndToolbarsMenu->addSeparator();
         auto dockWidgets = editor->dockWidgets();
 
         // Include docks contributed by extensions
-        if (auto editorWindow = qobject_cast<QMainWindow*>(editor->editorWidget())) {
-            const auto editorDocks = editorWindow->findChildren<QDockWidget*>(QString(), Qt::FindDirectChildrenOnly);
-            for (auto dockWidget : editorDocks)
-                if (!dockWidgets.contains(dockWidget))
-                    dockWidgets.append(dockWidget);
-        }
+        if (auto editorWindow = qobject_cast<QMainWindow*>(editor->editorWidget()))
+            dockWidgets += extensionDockWidgets(editorWindow);
 
         for (auto dockWidget : dockWidgets)
             mViewsAndToolbarsMenu->addAction(dockWidget->toggleViewAction());
@@ -2621,8 +2638,13 @@ QList<QDockWidget *> MainWindow::allDockWidgets() const
     QList<QDockWidget*> docks = findChildren<QDockWidget*>(QString(), Qt::FindDirectChildrenOnly);
 
     const auto editors = mDocumentManager->editors();
-    for (Editor *editor : editors)
+    for (Editor *editor : editors) {
         docks += editor->dockWidgets();
+
+        // Include docks contributed by extensions
+        if (auto editorWindow = qobject_cast<QMainWindow*>(editor->editorWidget()))
+            docks += extensionDockWidgets(editorWindow);
+    }
 
     return docks;
 }

--- a/src/tiled/qml/Tiled/qmldir
+++ b/src/tiled/qml/Tiled/qmldir
@@ -1,0 +1,2 @@
+module Tiled
+typeinfo plugins.qmltypes

--- a/src/tiled/qmldock.cpp
+++ b/src/tiled/qmldock.cpp
@@ -133,12 +133,13 @@ void QmlDock::componentComplete()
     dock->setWidget(quickWidget);
     mDockWidget = dock;
 
-    mainWindow->addDockWidget(static_cast<Qt::DockWidgetArea>(mArea), dock);
-
     // Apply any previously saved placement, relevant when the dock is
     // created after the main window layout was restored (which is the common
-    // case, and always the case after a script engine reset).
-    mainWindow->restoreDockWidget(dock);
+    // case, and always the case after a script engine reset). Restoring
+    // before adding also avoids a crash with Qt 6.10.0 to 6.10.2 (see
+    // QTBUG-143708).
+    if (!mainWindow->restoreDockWidget(dock))
+        mainWindow->addDockWidget(static_cast<Qt::DockWidgetArea>(mArea), dock);
 }
 
 } // namespace Tiled

--- a/src/tiled/qmldock.cpp
+++ b/src/tiled/qmldock.cpp
@@ -1,0 +1,147 @@
+/*
+ * qmldock.cpp
+ * Copyright 2026, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qmldock.h"
+
+#include "documentmanager.h"
+#include "editor.h"
+#include "logginginterface.h"
+#include "mainwindow.h"
+#include "scriptmanager.h"
+
+#include <QCoreApplication>
+#include <QDockWidget>
+#include <QMainWindow>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QQuickItem>
+#include <QQuickWidget>
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+#include <QQuickWindow>
+#endif
+
+namespace Tiled {
+
+QmlDock::QmlDock(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QmlDock::~QmlDock()
+{
+    delete mDockWidget;
+}
+
+void QmlDock::setTitle(const QString &title)
+{
+    if (mTitle == title)
+        return;
+
+    mTitle = title;
+
+    if (mDockWidget)
+        mDockWidget->setWindowTitle(title);
+
+    emit titleChanged();
+}
+
+static QMainWindow *targetWindow(QmlDock::Window window)
+{
+    switch (window) {
+    case QmlDock::MainWindow:
+        return Tiled::MainWindow::maybeInstance();
+    case QmlDock::MapEditor:
+    case QmlDock::TilesetEditor: {
+        const auto documentType = window == QmlDock::MapEditor ? Document::MapDocumentType
+                                                               : Document::TilesetDocumentType;
+        if (auto documentManager = DocumentManager::maybeInstance())
+            if (auto editor = documentManager->editor(documentType))
+                return qobject_cast<QMainWindow*>(editor->editorWidget());
+        break;
+    }
+    }
+    return nullptr;
+}
+
+void QmlDock::componentComplete()
+{
+    // Docks are not supported when running without GUI
+    auto mainWindow = targetWindow(mWindow);
+    if (!mainWindow)
+        return;
+
+    if (mName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Dock without name"));
+        return;
+    }
+
+    if (!mContentItem) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Dock '%1' without content item").arg(mName));
+        return;
+    }
+
+    // The object name identifies the dock when saving/restoring the window
+    // layout, so duplicates would corrupt each other's placement.
+    const QString objectName = QLatin1String("qml.") + mName;
+    if (mainWindow->findChild<QDockWidget*>(objectName)) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Duplicate dock name: '%1'").arg(mName));
+        return;
+    }
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+    // Before Qt 6.4, QQuickWidget only works with the OpenGL backend
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+#endif
+
+    std::unique_ptr<QObject> content { mContentItem->create() };
+    if (!content) {
+        for (const QQmlError &error : mContentItem->errors())
+            Tiled::ERROR(error.toString());
+        return;
+    }
+
+    if (!qobject_cast<QQuickItem*>(content.get())) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Dock '%1' content is not an Item").arg(mName));
+        return;
+    }
+
+    auto dock = new QDockWidget(mTitle.isEmpty() ? mName : mTitle, mainWindow);
+    dock->setObjectName(objectName);
+
+    auto quickWidget = new QQuickWidget(ScriptManager::instance().engine(), dock);
+    quickWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+    quickWidget->setContent(mContentItem->url(), mContentItem, content.release());
+
+    dock->setWidget(quickWidget);
+    mDockWidget = dock;
+
+    // Apply any previously saved placement, relevant when the dock is
+    // created after the main window layout was restored (which is the common
+    // case, and always the case after a script engine reset). Restoring
+    // before adding also avoids a crash with Qt 6.10.0 to 6.10.2 (see
+    // QTBUG-143708).
+    if (!mainWindow->restoreDockWidget(dock))
+        mainWindow->addDockWidget(static_cast<Qt::DockWidgetArea>(mArea), dock);
+}
+
+} // namespace Tiled
+
+#include "moc_qmldock.cpp"

--- a/src/tiled/qmldock.cpp
+++ b/src/tiled/qmldock.cpp
@@ -1,0 +1,146 @@
+/*
+ * qmldock.cpp
+ * Copyright 2026, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qmldock.h"
+
+#include "documentmanager.h"
+#include "editor.h"
+#include "logginginterface.h"
+#include "mainwindow.h"
+#include "scriptmanager.h"
+
+#include <QCoreApplication>
+#include <QDockWidget>
+#include <QMainWindow>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QQuickItem>
+#include <QQuickWidget>
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+#include <QQuickWindow>
+#endif
+
+namespace Tiled {
+
+QmlDock::QmlDock(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QmlDock::~QmlDock()
+{
+    delete mDockWidget;
+}
+
+void QmlDock::setTitle(const QString &title)
+{
+    if (mTitle == title)
+        return;
+
+    mTitle = title;
+
+    if (mDockWidget)
+        mDockWidget->setWindowTitle(title);
+
+    emit titleChanged();
+}
+
+static QMainWindow *targetWindow(QmlDock::Window window)
+{
+    switch (window) {
+    case QmlDock::MainWindow:
+        return Tiled::MainWindow::maybeInstance();
+    case QmlDock::MapEditor:
+    case QmlDock::TilesetEditor: {
+        const auto documentType = window == QmlDock::MapEditor ? Document::MapDocumentType
+                                                               : Document::TilesetDocumentType;
+        if (auto documentManager = DocumentManager::maybeInstance())
+            if (auto editor = documentManager->editor(documentType))
+                return qobject_cast<QMainWindow*>(editor->editorWidget());
+        break;
+    }
+    }
+    return nullptr;
+}
+
+void QmlDock::componentComplete()
+{
+    // Docks are not supported when running without GUI
+    auto mainWindow = targetWindow(mWindow);
+    if (!mainWindow)
+        return;
+
+    if (mName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Dock without name"));
+        return;
+    }
+
+    if (!mContentItem) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Dock '%1' without content item").arg(mName));
+        return;
+    }
+
+    // The object name identifies the dock when saving/restoring the window
+    // layout, so duplicates would corrupt each other's placement.
+    const QString objectName = QLatin1String("qml.") + mName;
+    if (mainWindow->findChild<QDockWidget*>(objectName)) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Duplicate dock name: '%1'").arg(mName));
+        return;
+    }
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+    // Before Qt 6.4, QQuickWidget only works with the OpenGL backend
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+#endif
+
+    std::unique_ptr<QObject> content { mContentItem->create() };
+    if (!content) {
+        for (const QQmlError &error : mContentItem->errors())
+            Tiled::ERROR(error.toString());
+        return;
+    }
+
+    if (!qobject_cast<QQuickItem*>(content.get())) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Dock '%1' content is not an Item").arg(mName));
+        return;
+    }
+
+    auto dock = new QDockWidget(mTitle.isEmpty() ? mName : mTitle, mainWindow);
+    dock->setObjectName(objectName);
+
+    auto quickWidget = new QQuickWidget(ScriptManager::instance().engine(), dock);
+    quickWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+    quickWidget->setContent(mContentItem->url(), mContentItem, content.release());
+
+    dock->setWidget(quickWidget);
+    mDockWidget = dock;
+
+    mainWindow->addDockWidget(static_cast<Qt::DockWidgetArea>(mArea), dock);
+
+    // Apply any previously saved placement, relevant when the dock is
+    // created after the main window layout was restored (which is the common
+    // case, and always the case after a script engine reset).
+    mainWindow->restoreDockWidget(dock);
+}
+
+} // namespace Tiled
+
+#include "moc_qmldock.cpp"

--- a/src/tiled/qmldock.cpp
+++ b/src/tiled/qmldock.cpp
@@ -82,6 +82,30 @@ static QMainWindow *targetWindow(QmlDock::Window window)
     return nullptr;
 }
 
+/**
+ * Returns whether \a mainWindow already has a dock widget called
+ * \a objectName.
+ *
+ * Dock widgets can be reparented into a floating group window, so the search
+ * is recursive and each match is attributed to its first QMainWindow ancestor.
+ * Docks in other main windows are ignored, since each main window saves and
+ * restores its layout separately.
+ */
+static bool hasDockWidget(QMainWindow *mainWindow, const QString &objectName)
+{
+    const auto dockWidgets = mainWindow->findChildren<QDockWidget*>(objectName);
+    for (QDockWidget *dockWidget : dockWidgets) {
+        for (QWidget *w = dockWidget->parentWidget(); w; w = w->parentWidget()) {
+            if (auto window = qobject_cast<QMainWindow*>(w)) {
+                if (window == mainWindow)
+                    return true;
+                break;
+            }
+        }
+    }
+    return false;
+}
+
 void QmlDock::componentComplete()
 {
     // Docks are not supported when running without GUI
@@ -102,7 +126,7 @@ void QmlDock::componentComplete()
     // The object name identifies the dock when saving/restoring the window
     // layout, so duplicates would corrupt each other's placement.
     const QString objectName = QLatin1String("qml.") + mName;
-    if (mainWindow->findChild<QDockWidget*>(objectName)) {
+    if (hasDockWidget(mainWindow, objectName)) {
         Tiled::ERROR(QCoreApplication::translate("Script Errors", "Duplicate dock name: '%1'").arg(mName));
         return;
     }

--- a/src/tiled/qmldock.cpp
+++ b/src/tiled/qmldock.cpp
@@ -30,6 +30,7 @@
 #include <QDockWidget>
 #include <QMainWindow>
 #include <QQmlComponent>
+#include <QQmlContext>
 #include <QQmlEngine>
 #include <QQuickItem>
 #include <QQuickWidget>
@@ -111,7 +112,13 @@ void QmlDock::componentComplete()
     QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
 #endif
 
-    std::unique_ptr<QObject> content { mContentItem->create() };
+    // Create the content in the component's creation context, so that it can
+    // refer to the scope of the file it was declared in.
+    auto context = mContentItem->creationContext();
+    if (!context)
+        context = qmlContext(this);
+
+    std::unique_ptr<QObject> content { mContentItem->create(context) };
     if (!content) {
         for (const QQmlError &error : mContentItem->errors())
             Tiled::ERROR(error.toString());

--- a/src/tiled/qmldock.cpp
+++ b/src/tiled/qmldock.cpp
@@ -20,12 +20,14 @@
 
 #include "qmldock.h"
 
+#include "actionmanager.h"
 #include "documentmanager.h"
 #include "editor.h"
 #include "logginginterface.h"
 #include "mainwindow.h"
 #include "scriptmanager.h"
 
+#include <QAction>
 #include <QCoreApplication>
 #include <QDockWidget>
 #include <QMainWindow>
@@ -48,7 +50,10 @@ QmlDock::QmlDock(QObject *parent)
 
 QmlDock::~QmlDock()
 {
-    delete mDockWidget;
+    if (mDockWidget) {
+        ActionManager::unregisterAction(mDockWidget->toggleViewAction(), mActionId);
+        delete mDockWidget;
+    }
 }
 
 void QmlDock::setTitle(const QString &title)
@@ -62,6 +67,14 @@ void QmlDock::setTitle(const QString &title)
         mDockWidget->setWindowTitle(title);
 
     emit titleChanged();
+}
+
+void QmlDock::setShortcut(const QString &shortcut)
+{
+    mShortcut = shortcut;
+
+    if (mDockWidget)
+        mDockWidget->toggleViewAction()->setShortcut(QKeySequence(shortcut));
 }
 
 static QMainWindow *targetWindow(QmlDock::Window window)
@@ -163,6 +176,18 @@ void QmlDock::componentComplete()
 
     dock->setWidget(quickWidget);
     mDockWidget = dock;
+    mActionId = Id { QByteArray("Dock.") + mName.toUtf8() };
+
+    // Registering the action makes it possible to assign a custom shortcut to
+    // it and to find it through the action search. Adding it to the window is
+    // what makes its shortcut work, since it is not permanently part of any
+    // menu. Docks with the same name in different windows share the action ID
+    // and therefore also their shortcut.
+    auto toggleViewAction = dock->toggleViewAction();
+    if (!mShortcut.isEmpty())
+        toggleViewAction->setShortcut(QKeySequence(mShortcut));
+    ActionManager::registerAction(toggleViewAction, mActionId);
+    mainWindow->addAction(toggleViewAction);
 
     // Apply any previously saved placement, relevant when the dock is
     // created after the main window layout was restored (which is the common

--- a/src/tiled/qmldock.cpp
+++ b/src/tiled/qmldock.cpp
@@ -77,6 +77,19 @@ void QmlDock::setShortcut(const QString &shortcut)
         mDockWidget->toggleViewAction()->setShortcut(QKeySequence(shortcut));
 }
 
+void QmlDock::setVisible(bool visible)
+{
+    if (mVisible == visible)
+        return;
+
+    mVisible = visible;
+
+    if (mDockWidget)
+        mDockWidget->setVisible(visible);
+
+    emit visibleChanged();
+}
+
 static QMainWindow *targetWindow(QmlDock::Window window)
 {
     switch (window) {
@@ -189,11 +202,28 @@ void QmlDock::componentComplete()
     ActionManager::registerAction(toggleViewAction, mActionId);
     mainWindow->addAction(toggleViewAction);
 
+    // The action is checked exactly when the dock is shown, so it also serves
+    // to keep the 'visible' property up to date when the dock is closed by
+    // the user or restored to a saved state.
+    connect(toggleViewAction, &QAction::toggled, this, [this] (bool checked) {
+        if (mVisible == checked)
+            return;
+
+        mVisible = checked;
+        emit visibleChanged();
+    });
+
+    // Adding a dock to a window that is already visible shows it, so starting
+    // out closed requires hiding it explicitly.
+    if (!mVisible)
+        dock->hide();
+
     // Apply any previously saved placement, relevant when the dock is
     // created after the main window layout was restored (which is the common
     // case, and always the case after a script engine reset). Restoring
     // before adding also avoids a crash with Qt 6.10.0 to 6.10.2 (see
-    // QTBUG-143708).
+    // QTBUG-143708). It also restores the visibility, which takes precedence
+    // over the initial value of the 'visible' property.
     if (!mainWindow->restoreDockWidget(dock))
         mainWindow->addDockWidget(static_cast<Qt::DockWidgetArea>(mArea), dock);
 }

--- a/src/tiled/qmldock.h
+++ b/src/tiled/qmldock.h
@@ -23,6 +23,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QQmlParserStatus>
+#include <QtQml/qqmlregistration.h>
 
 class QDockWidget;
 class QQmlComponent;
@@ -41,6 +42,7 @@ class QmlDock : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
+    QML_NAMED_ELEMENT(Dock)
 
     Q_PROPERTY(QString name READ name WRITE setName)
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged)

--- a/src/tiled/qmldock.h
+++ b/src/tiled/qmldock.h
@@ -1,0 +1,105 @@
+/*
+ * qmldock.h
+ * Copyright 2026, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+#include <QQmlParserStatus>
+
+class QDockWidget;
+class QQmlComponent;
+
+namespace Tiled {
+
+/**
+ * A dock widget with Qt Quick based contents, declared by a QML extension.
+ *
+ * The contents are rendered by a QQuickWidget that shares the script engine,
+ * so expressions in the contents can refer to the 'tiled' API. The dock is
+ * added to the main window and its placement is persisted based on its
+ * mandatory 'name' property, which needs to be unique and stable.
+ */
+class QmlDock : public QObject, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(QString name READ name WRITE setName)
+    Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged)
+    Q_PROPERTY(DockArea area READ area WRITE setArea)
+    Q_PROPERTY(Window window READ window WRITE setWindow)
+    Q_PROPERTY(QQmlComponent *contentItem READ contentItem WRITE setContentItem)
+    Q_CLASSINFO("DefaultProperty", "contentItem")
+
+public:
+    enum DockArea {
+        LeftDockArea = 1,   // synchronized with Qt::DockWidgetArea
+        RightDockArea = 2,
+        TopDockArea = 4,
+        BottomDockArea = 8,
+    };
+    Q_ENUM(DockArea)
+
+    /**
+     * The main window the dock should be added to: either the top-level
+     * window (default), or the window of the map or tileset editor.
+     */
+    enum Window {
+        MainWindow,
+        MapEditor,
+        TilesetEditor,
+    };
+    Q_ENUM(Window)
+
+    explicit QmlDock(QObject *parent = nullptr);
+    ~QmlDock() override;
+
+    QString name() const { return mName; }
+    void setName(const QString &name) { mName = name; }
+
+    QString title() const { return mTitle; }
+    void setTitle(const QString &title);
+
+    DockArea area() const { return mArea; }
+    void setArea(DockArea area) { mArea = area; }
+
+    Window window() const { return mWindow; }
+    void setWindow(Window window) { mWindow = window; }
+
+    QQmlComponent *contentItem() const { return mContentItem; }
+    void setContentItem(QQmlComponent *component) { mContentItem = component; }
+
+    void classBegin() override {}
+    void componentComplete() override;
+
+signals:
+    void titleChanged();
+
+private:
+    QString mName;
+    QString mTitle;
+    DockArea mArea = RightDockArea;
+    Window mWindow = MainWindow;
+    QQmlComponent *mContentItem = nullptr;
+    QPointer<QDockWidget> mDockWidget;
+};
+
+} // namespace Tiled

--- a/src/tiled/qmldock.h
+++ b/src/tiled/qmldock.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "id.h"
+
 #include <QObject>
 #include <QPointer>
 #include <QQmlParserStatus>
@@ -37,6 +39,10 @@ namespace Tiled {
  * so expressions in the contents can refer to the 'tiled' API. The dock is
  * added to the main window and its placement is persisted based on its
  * mandatory 'name' property, which needs to be unique and stable.
+ *
+ * The action that shows and hides the dock is registered with the
+ * ActionManager as "Dock.<name>", so that it shows up in the action search
+ * and can be assigned a custom keyboard shortcut.
  */
 class QmlDock : public QObject, public QQmlParserStatus
 {
@@ -48,6 +54,7 @@ class QmlDock : public QObject, public QQmlParserStatus
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged)
     Q_PROPERTY(DockArea area READ area WRITE setArea)
     Q_PROPERTY(Window window READ window WRITE setWindow)
+    Q_PROPERTY(QString shortcut READ shortcut WRITE setShortcut)
     Q_PROPERTY(QQmlComponent *contentItem READ contentItem WRITE setContentItem)
     Q_CLASSINFO("DefaultProperty", "contentItem")
 
@@ -86,6 +93,9 @@ public:
     Window window() const { return mWindow; }
     void setWindow(Window window) { mWindow = window; }
 
+    QString shortcut() const { return mShortcut; }
+    void setShortcut(const QString &shortcut);
+
     QQmlComponent *contentItem() const { return mContentItem; }
     void setContentItem(QQmlComponent *component) { mContentItem = component; }
 
@@ -98,6 +108,8 @@ signals:
 private:
     QString mName;
     QString mTitle;
+    QString mShortcut;
+    Id mActionId;
     DockArea mArea = RightDockArea;
     Window mWindow = MainWindow;
     QQmlComponent *mContentItem = nullptr;

--- a/src/tiled/qmldock.h
+++ b/src/tiled/qmldock.h
@@ -43,6 +43,10 @@ namespace Tiled {
  * The action that shows and hides the dock is registered with the
  * ActionManager as "Dock.<name>", so that it shows up in the action search
  * and can be assigned a custom keyboard shortcut.
+ *
+ * The 'visible' property tracks whether the dock is shown. Its initial value
+ * only applies when there is no saved placement yet, since otherwise the dock
+ * is restored to the state the user left it in.
  */
 class QmlDock : public QObject, public QQmlParserStatus
 {
@@ -55,6 +59,7 @@ class QmlDock : public QObject, public QQmlParserStatus
     Q_PROPERTY(DockArea area READ area WRITE setArea)
     Q_PROPERTY(Window window READ window WRITE setWindow)
     Q_PROPERTY(QString shortcut READ shortcut WRITE setShortcut)
+    Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibleChanged)
     Q_PROPERTY(QQmlComponent *contentItem READ contentItem WRITE setContentItem)
     Q_CLASSINFO("DefaultProperty", "contentItem")
 
@@ -96,6 +101,9 @@ public:
     QString shortcut() const { return mShortcut; }
     void setShortcut(const QString &shortcut);
 
+    bool isVisible() const { return mVisible; }
+    void setVisible(bool visible);
+
     QQmlComponent *contentItem() const { return mContentItem; }
     void setContentItem(QQmlComponent *component) { mContentItem = component; }
 
@@ -104,6 +112,7 @@ public:
 
 signals:
     void titleChanged();
+    void visibleChanged();
 
 private:
     QString mName;
@@ -112,6 +121,7 @@ private:
     Id mActionId;
     DockArea mArea = RightDockArea;
     Window mWindow = MainWindow;
+    bool mVisible = true;
     QQmlComponent *mContentItem = nullptr;
     QPointer<QDockWidget> mDockWidget;
 };

--- a/src/tiled/qmlextension.cpp
+++ b/src/tiled/qmlextension.cpp
@@ -22,13 +22,9 @@
 
 #include "actionmanager.h"
 #include "logginginterface.h"
-#include "qmldock.h"
 #include "scriptedaction.h"
-#include "scriptedfileformat.h"
-#include "scriptedtool.h"
 
 #include <QCoreApplication>
-#include <QQmlEngine>
 #include <QTimer>
 
 namespace Tiled {
@@ -113,23 +109,6 @@ void QmlMenuExtension::apply()
     }
 
     ActionManager::registerMenuExtension(menuId, extension);
-}
-
-
-void registerQmlExtensionTypes()
-{
-    static bool registered = false;
-    if (registered)
-        return;
-    registered = true;
-
-    qmlRegisterType<ScriptedAction>("Tiled", 1, 0, "Action");
-    qmlRegisterType<QmlDock>("Tiled", 1, 0, "Dock");
-    qmlRegisterType<QmlExtension>("Tiled", 1, 0, "Extension");
-    qmlRegisterType<ScriptedMapFormat>("Tiled", 1, 0, "MapFormat");
-    qmlRegisterType<QmlMenuExtension>("Tiled", 1, 0, "MenuExtension");
-    qmlRegisterType<ScriptedTilesetFormat>("Tiled", 1, 0, "TilesetFormat");
-    qmlRegisterType<ScriptedTool>("Tiled", 1, 0, "Tool");
 }
 
 } // namespace Tiled

--- a/src/tiled/qmlextension.cpp
+++ b/src/tiled/qmlextension.cpp
@@ -22,13 +22,12 @@
 
 #include "actionmanager.h"
 #include "logginginterface.h"
-#include "pluginmanager.h"
 #include "qmldock.h"
+#include "scriptedaction.h"
 #include "scriptedfileformat.h"
-#include "scriptmanager.h"
+#include "scriptedtool.h"
 
 #include <QCoreApplication>
-#include <QJSEngine>
 #include <QQmlEngine>
 #include <QTimer>
 
@@ -51,87 +50,6 @@ void QmlExtension::setName(const QString &name)
 QQmlListProperty<QObject> QmlExtension::data()
 {
     return QQmlListProperty<QObject>(this, &mData);
-}
-
-
-QmlAction::QmlAction(QObject *parent)
-    : QAction(parent)
-{
-    static QIcon scriptIcon = [] {
-        QIcon icon(QStringLiteral("://images/32/plugin.png"));
-        icon.addFile(QStringLiteral("://images/22/plugin.png"));
-        icon.addFile(QStringLiteral("://images/16/plugin.png"));
-        return icon;
-    }();
-
-    setIcon(scriptIcon);
-}
-
-QmlAction::~QmlAction()
-{
-    if (mRegistered)
-        ActionManager::unregisterAction(this, mId);
-}
-
-QString QmlAction::name() const
-{
-    return mName;
-}
-
-void QmlAction::setName(const QString &name)
-{
-    mName = name;
-}
-
-void QmlAction::setIconFileName(const QString &fileName)
-{
-    if (mIconFileName == fileName)
-        return;
-
-    mIconFileName = fileName;
-
-    QString iconFile = fileName;
-
-    const QString ext = QStringLiteral("ext:");
-    if (!iconFile.startsWith(ext) && !iconFile.startsWith(QLatin1Char(':')))
-        iconFile.prepend(ext);
-
-    setIcon(QIcon { iconFile });
-}
-
-QString QmlAction::shortcutString() const
-{
-    return shortcut().toString();
-}
-
-void QmlAction::setShortcutString(const QString &shortcut)
-{
-    setShortcut(QKeySequence(shortcut));
-}
-
-void QmlAction::componentComplete()
-{
-    // May be called earlier by a QmlMenuExtension referencing this action
-    if (mCompleted)
-        return;
-
-    mCompleted = true;
-
-    if (mName.isEmpty()) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Action without name"));
-        return;
-    }
-
-    const Id id { mName.toUtf8() };
-
-    if (ActionManager::findAction(id)) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved ID: '%1'").arg(mName));
-        return;
-    }
-
-    mId = id;
-    ActionManager::registerAction(this, id);
-    mRegistered = true;
 }
 
 
@@ -166,8 +84,8 @@ void QmlMenuExtension::apply()
         const QVariant action = map.value(QStringLiteral("action"));
 
         // An action can be referenced either by its ID or directly
-        if (auto qmlAction = qobject_cast<QmlAction*>(action.value<QObject*>())) {
-            menuItem.action = qmlAction->id();
+        if (auto scriptedAction = qobject_cast<ScriptedAction*>(action.value<QObject*>())) {
+            menuItem.action = scriptedAction->id();
         } else if (action.userType() == QMetaType::QString) {
             menuItem.action = Id(action.toString().toUtf8());
         }
@@ -198,123 +116,6 @@ void QmlMenuExtension::apply()
 }
 
 
-QmlMapFormat::QmlMapFormat(QObject *parent)
-    : QObject(parent)
-{
-}
-
-QmlMapFormat::~QmlMapFormat()
-{
-}
-
-void QmlMapFormat::componentComplete()
-{
-    if (mShortName.isEmpty()) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "MapFormat without shortName"));
-        return;
-    }
-
-    const auto formats = PluginManager::objects<MapFormat>();
-    for (auto format : formats) {
-        if (format->shortName() == mShortName) {
-            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(mShortName));
-            return;
-        }
-    }
-
-    if (mName.isEmpty() || mExtension.isEmpty()) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires 'name' and 'extension' properties)"));
-        return;
-    }
-
-    // This object is owned by the loaded extension, the garbage collector
-    // should leave it alone.
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-
-    const QJSValue self = ScriptManager::instance().engine()->newQObject(this);
-
-    if (!self.property(QStringLiteral("read")).isCallable() &&
-            !self.property(QStringLiteral("write")).isCallable()) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires a 'write' and/or 'read' function property)"));
-        return;
-    }
-
-    mFormat = std::make_unique<ScriptedMapFormat>(mShortName, self, nullptr);
-}
-
-
-QmlTilesetFormat::QmlTilesetFormat(QObject *parent)
-    : QObject(parent)
-{
-}
-
-QmlTilesetFormat::~QmlTilesetFormat()
-{
-}
-
-void QmlTilesetFormat::componentComplete()
-{
-    if (mShortName.isEmpty()) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "TilesetFormat without shortName"));
-        return;
-    }
-
-    const auto formats = PluginManager::objects<TilesetFormat>();
-    for (auto format : formats) {
-        if (format->shortName() == mShortName) {
-            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(mShortName));
-            return;
-        }
-    }
-
-    if (mName.isEmpty() || mExtension.isEmpty()) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires 'name' and 'extension' properties)"));
-        return;
-    }
-
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-
-    const QJSValue self = ScriptManager::instance().engine()->newQObject(this);
-
-    if (!self.property(QStringLiteral("read")).isCallable() &&
-            !self.property(QStringLiteral("write")).isCallable()) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires a 'write' and/or 'read' function property)"));
-        return;
-    }
-
-    mFormat = std::make_unique<ScriptedTilesetFormat>(mShortName, self, nullptr);
-}
-
-
-QmlTool::QmlTool(QObject *parent)
-    : ScriptedTool(parent)
-{
-}
-
-void QmlTool::componentComplete()
-{
-    if (mShortName.isEmpty()) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Tool without shortName"));
-        return;
-    }
-
-    const Id id { mShortName.toUtf8() };
-    const auto tools = PluginManager::objects<AbstractTool>();
-    for (auto tool : tools) {
-        if (tool->id() == id) {
-            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(mShortName));
-            return;
-        }
-    }
-
-    setId(id);
-
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-    setScriptObject(ScriptManager::instance().engine()->newQObject(this));
-    addToPluginManager();
-}
-
-
 void registerQmlExtensionTypes()
 {
     static bool registered = false;
@@ -322,13 +123,13 @@ void registerQmlExtensionTypes()
         return;
     registered = true;
 
-    qmlRegisterType<QmlAction>("Tiled", 1, 0, "Action");
+    qmlRegisterType<ScriptedAction>("Tiled", 1, 0, "Action");
     qmlRegisterType<QmlDock>("Tiled", 1, 0, "Dock");
     qmlRegisterType<QmlExtension>("Tiled", 1, 0, "Extension");
-    qmlRegisterType<QmlMapFormat>("Tiled", 1, 0, "MapFormat");
+    qmlRegisterType<ScriptedMapFormat>("Tiled", 1, 0, "MapFormat");
     qmlRegisterType<QmlMenuExtension>("Tiled", 1, 0, "MenuExtension");
-    qmlRegisterType<QmlTilesetFormat>("Tiled", 1, 0, "TilesetFormat");
-    qmlRegisterType<QmlTool>("Tiled", 1, 0, "Tool");
+    qmlRegisterType<ScriptedTilesetFormat>("Tiled", 1, 0, "TilesetFormat");
+    qmlRegisterType<ScriptedTool>("Tiled", 1, 0, "Tool");
 }
 
 } // namespace Tiled

--- a/src/tiled/qmlextension.cpp
+++ b/src/tiled/qmlextension.cpp
@@ -1,0 +1,336 @@
+/*
+ * qmlextension.cpp
+ * Copyright 2026, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qmlextension.h"
+
+#include "actionmanager.h"
+#include "logginginterface.h"
+#include "pluginmanager.h"
+#include "qmldock.h"
+#include "scriptedfileformat.h"
+#include "scriptmanager.h"
+
+#include <QCoreApplication>
+#include <QJSEngine>
+#include <QQmlEngine>
+#include <QTimer>
+
+namespace Tiled {
+
+QmlExtension::QmlExtension(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void QmlExtension::setName(const QString &name)
+{
+    if (mName == name)
+        return;
+
+    mName = name;
+    emit nameChanged();
+}
+
+QQmlListProperty<QObject> QmlExtension::data()
+{
+    return QQmlListProperty<QObject>(this, &mData);
+}
+
+
+QmlAction::QmlAction(QObject *parent)
+    : QAction(parent)
+{
+    static QIcon scriptIcon = [] {
+        QIcon icon(QStringLiteral("://images/32/plugin.png"));
+        icon.addFile(QStringLiteral("://images/22/plugin.png"));
+        icon.addFile(QStringLiteral("://images/16/plugin.png"));
+        return icon;
+    }();
+
+    setIcon(scriptIcon);
+}
+
+QmlAction::~QmlAction()
+{
+    if (mRegistered)
+        ActionManager::unregisterAction(this, mId);
+}
+
+QString QmlAction::name() const
+{
+    return mName;
+}
+
+void QmlAction::setName(const QString &name)
+{
+    mName = name;
+}
+
+void QmlAction::setIconFileName(const QString &fileName)
+{
+    if (mIconFileName == fileName)
+        return;
+
+    mIconFileName = fileName;
+
+    QString iconFile = fileName;
+
+    const QString ext = QStringLiteral("ext:");
+    if (!iconFile.startsWith(ext) && !iconFile.startsWith(QLatin1Char(':')))
+        iconFile.prepend(ext);
+
+    setIcon(QIcon { iconFile });
+}
+
+QString QmlAction::shortcutString() const
+{
+    return shortcut().toString();
+}
+
+void QmlAction::setShortcutString(const QString &shortcut)
+{
+    setShortcut(QKeySequence(shortcut));
+}
+
+void QmlAction::componentComplete()
+{
+    // May be called earlier by a QmlMenuExtension referencing this action
+    if (mCompleted)
+        return;
+
+    mCompleted = true;
+
+    if (mName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Action without name"));
+        return;
+    }
+
+    const Id id { mName.toUtf8() };
+
+    if (ActionManager::findAction(id)) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved ID: '%1'").arg(mName));
+        return;
+    }
+
+    mId = id;
+    ActionManager::registerAction(this, id);
+    mRegistered = true;
+}
+
+
+QmlMenuExtension::QmlMenuExtension(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void QmlMenuExtension::componentComplete()
+{
+    // Defer the registration, since the order in which objects are completed
+    // is not defined and the referenced actions may even be declared in
+    // extension files that have not been loaded yet.
+    QTimer::singleShot(0, this, &QmlMenuExtension::apply);
+}
+
+void QmlMenuExtension::apply()
+{
+    const Id menuId { mMenu.toUtf8() };
+
+    if (mMenu.isEmpty() || !ActionManager::hasMenu(menuId)) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Unknown menu: '%1'").arg(mMenu));
+        return;
+    }
+
+    ActionManager::MenuExtension extension;
+
+    for (const QVariant &value : std::as_const(mItems)) {
+        const QVariantMap map = value.toMap();
+        ActionManager::MenuItem menuItem {};
+
+        const QVariant action = map.value(QStringLiteral("action"));
+
+        // An action can be referenced either by its ID or directly
+        if (auto qmlAction = qobject_cast<QmlAction*>(action.value<QObject*>())) {
+            menuItem.action = qmlAction->id();
+        } else if (action.userType() == QMetaType::QString) {
+            menuItem.action = Id(action.toString().toUtf8());
+        }
+
+        menuItem.beforeAction = Id(map.value(QStringLiteral("before")).toString().toUtf8());
+        menuItem.isSeparator = map.value(QStringLiteral("separator")).toBool();
+
+        if (!menuItem.action.isNull()) {
+            if (menuItem.isSeparator) {
+                Tiled::ERROR(QCoreApplication::translate("Script Errors", "Separators can't have actions"));
+                return;
+            }
+
+            if (!ActionManager::findAction(menuItem.action)) {
+                Tiled::ERROR(QCoreApplication::translate("Script Errors", "Unknown action: '%1'").arg(
+                                 QString::fromUtf8(menuItem.action.name())));
+                return;
+            }
+        } else if (!menuItem.isSeparator) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Non-separator item without action"));
+            return;
+        }
+
+        extension.items.append(menuItem);
+    }
+
+    ActionManager::registerMenuExtension(menuId, extension);
+}
+
+
+QmlMapFormat::QmlMapFormat(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QmlMapFormat::~QmlMapFormat()
+{
+}
+
+void QmlMapFormat::componentComplete()
+{
+    if (mShortName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "MapFormat without shortName"));
+        return;
+    }
+
+    const auto formats = PluginManager::objects<MapFormat>();
+    for (auto format : formats) {
+        if (format->shortName() == mShortName) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(mShortName));
+            return;
+        }
+    }
+
+    if (mName.isEmpty() || mExtension.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires 'name' and 'extension' properties)"));
+        return;
+    }
+
+    // This object is owned by the loaded extension, the garbage collector
+    // should leave it alone.
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
+
+    const QJSValue self = ScriptManager::instance().engine()->newQObject(this);
+
+    if (!self.property(QStringLiteral("read")).isCallable() &&
+            !self.property(QStringLiteral("write")).isCallable()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires a 'write' and/or 'read' function property)"));
+        return;
+    }
+
+    mFormat = std::make_unique<ScriptedMapFormat>(mShortName, self, nullptr);
+}
+
+
+QmlTilesetFormat::QmlTilesetFormat(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QmlTilesetFormat::~QmlTilesetFormat()
+{
+}
+
+void QmlTilesetFormat::componentComplete()
+{
+    if (mShortName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "TilesetFormat without shortName"));
+        return;
+    }
+
+    const auto formats = PluginManager::objects<TilesetFormat>();
+    for (auto format : formats) {
+        if (format->shortName() == mShortName) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(mShortName));
+            return;
+        }
+    }
+
+    if (mName.isEmpty() || mExtension.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires 'name' and 'extension' properties)"));
+        return;
+    }
+
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
+
+    const QJSValue self = ScriptManager::instance().engine()->newQObject(this);
+
+    if (!self.property(QStringLiteral("read")).isCallable() &&
+            !self.property(QStringLiteral("write")).isCallable()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires a 'write' and/or 'read' function property)"));
+        return;
+    }
+
+    mFormat = std::make_unique<ScriptedTilesetFormat>(mShortName, self, nullptr);
+}
+
+
+QmlTool::QmlTool(QObject *parent)
+    : ScriptedTool(parent)
+{
+}
+
+void QmlTool::componentComplete()
+{
+    if (mShortName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Tool without shortName"));
+        return;
+    }
+
+    const Id id { mShortName.toUtf8() };
+    const auto tools = PluginManager::objects<AbstractTool>();
+    for (auto tool : tools) {
+        if (tool->id() == id) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(mShortName));
+            return;
+        }
+    }
+
+    setId(id);
+
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
+    setScriptObject(ScriptManager::instance().engine()->newQObject(this));
+    addToPluginManager();
+}
+
+
+void registerQmlExtensionTypes()
+{
+    static bool registered = false;
+    if (registered)
+        return;
+    registered = true;
+
+    qmlRegisterType<QmlAction>("Tiled", 1, 0, "Action");
+    qmlRegisterType<QmlDock>("Tiled", 1, 0, "Dock");
+    qmlRegisterType<QmlExtension>("Tiled", 1, 0, "Extension");
+    qmlRegisterType<QmlMapFormat>("Tiled", 1, 0, "MapFormat");
+    qmlRegisterType<QmlMenuExtension>("Tiled", 1, 0, "MenuExtension");
+    qmlRegisterType<QmlTilesetFormat>("Tiled", 1, 0, "TilesetFormat");
+    qmlRegisterType<QmlTool>("Tiled", 1, 0, "Tool");
+}
+
+} // namespace Tiled
+
+#include "moc_qmlextension.cpp"

--- a/src/tiled/qmlextension.cpp
+++ b/src/tiled/qmlextension.cpp
@@ -84,6 +84,11 @@ void QmlMenuExtension::apply()
             menuItem.action = scriptedAction->id();
         } else if (action.userType() == QMetaType::QString) {
             menuItem.action = Id(action.toString().toUtf8());
+        } else if (action.userType() == QMetaType::QByteArray) {
+            menuItem.action = Id(action.toByteArray());
+        } else if (action.isValid() && !action.isNull()) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid action reference"));
+            return;
         }
 
         menuItem.beforeAction = Id(map.value(QStringLiteral("before")).toString().toUtf8());

--- a/src/tiled/qmlextension.cpp
+++ b/src/tiled/qmlextension.cpp
@@ -1,0 +1,137 @@
+/*
+ * qmlextension.cpp
+ * Copyright 2026, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qmlextension.h"
+
+#include "actionmanager.h"
+#include "logginginterface.h"
+#include "qmldock.h"
+#include "scriptedaction.h"
+#include "scriptedfileformat.h"
+#include "scriptedtool.h"
+
+#include <QCoreApplication>
+#include <QQmlEngine>
+#include <QTimer>
+
+namespace Tiled {
+
+QmlExtension::QmlExtension(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void QmlExtension::setName(const QString &name)
+{
+    if (mName == name)
+        return;
+
+    mName = name;
+    emit nameChanged();
+}
+
+QQmlListProperty<QObject> QmlExtension::data()
+{
+    return QQmlListProperty<QObject>(this, &mData);
+}
+
+
+QmlMenuExtension::QmlMenuExtension(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void QmlMenuExtension::componentComplete()
+{
+    // Defer the registration, since the order in which objects are completed
+    // is not defined and the referenced actions may even be declared in
+    // extension files that have not been loaded yet.
+    QTimer::singleShot(0, this, &QmlMenuExtension::apply);
+}
+
+void QmlMenuExtension::apply()
+{
+    const Id menuId { mMenu.toUtf8() };
+
+    if (mMenu.isEmpty() || !ActionManager::hasMenu(menuId)) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Unknown menu: '%1'").arg(mMenu));
+        return;
+    }
+
+    ActionManager::MenuExtension extension;
+
+    for (const QVariant &value : std::as_const(mItems)) {
+        const QVariantMap map = value.toMap();
+        ActionManager::MenuItem menuItem {};
+
+        const QVariant action = map.value(QStringLiteral("action"));
+
+        // An action can be referenced either by its ID or directly
+        if (auto scriptedAction = qobject_cast<ScriptedAction*>(action.value<QObject*>())) {
+            menuItem.action = scriptedAction->id();
+        } else if (action.userType() == QMetaType::QString) {
+            menuItem.action = Id(action.toString().toUtf8());
+        }
+
+        menuItem.beforeAction = Id(map.value(QStringLiteral("before")).toString().toUtf8());
+        menuItem.isSeparator = map.value(QStringLiteral("separator")).toBool();
+
+        if (!menuItem.action.isNull()) {
+            if (menuItem.isSeparator) {
+                Tiled::ERROR(QCoreApplication::translate("Script Errors", "Separators can't have actions"));
+                return;
+            }
+
+            if (!ActionManager::findAction(menuItem.action)) {
+                Tiled::ERROR(QCoreApplication::translate("Script Errors", "Unknown action: '%1'").arg(
+                                 QString::fromUtf8(menuItem.action.name())));
+                return;
+            }
+        } else if (!menuItem.isSeparator) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Non-separator item without action"));
+            return;
+        }
+
+        extension.items.append(menuItem);
+    }
+
+    ActionManager::registerMenuExtension(menuId, extension);
+}
+
+
+void registerQmlExtensionTypes()
+{
+    static bool registered = false;
+    if (registered)
+        return;
+    registered = true;
+
+    qmlRegisterType<ScriptedAction>("Tiled", 1, 0, "Action");
+    qmlRegisterType<QmlDock>("Tiled", 1, 0, "Dock");
+    qmlRegisterType<QmlExtension>("Tiled", 1, 0, "Extension");
+    qmlRegisterType<ScriptedMapFormat>("Tiled", 1, 0, "MapFormat");
+    qmlRegisterType<QmlMenuExtension>("Tiled", 1, 0, "MenuExtension");
+    qmlRegisterType<ScriptedTilesetFormat>("Tiled", 1, 0, "TilesetFormat");
+    qmlRegisterType<ScriptedTool>("Tiled", 1, 0, "Tool");
+}
+
+} // namespace Tiled
+
+#include "moc_qmlextension.cpp"

--- a/src/tiled/qmlextension.h
+++ b/src/tiled/qmlextension.h
@@ -24,6 +24,7 @@
 #include <QQmlListProperty>
 #include <QQmlParserStatus>
 #include <QVariantList>
+#include <QtQml/qqmlregistration.h>
 
 namespace Tiled {
 
@@ -36,6 +37,7 @@ namespace Tiled {
 class QmlExtension : public QObject
 {
     Q_OBJECT
+    QML_NAMED_ELEMENT(Extension)
 
     Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
     Q_PROPERTY(QQmlListProperty<QObject> data READ data)
@@ -71,6 +73,7 @@ class QmlMenuExtension : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
+    QML_NAMED_ELEMENT(MenuExtension)
 
     Q_PROPERTY(QString menu READ menu WRITE setMenu)
     Q_PROPERTY(QVariantList items READ items WRITE setItems)
@@ -93,11 +96,5 @@ private:
     QString mMenu;
     QVariantList mItems;
 };
-
-/**
- * Registers the QML types provided by the "Tiled" import. Safe to call
- * multiple times; registration only happens once per process.
- */
-void registerQmlExtensionTypes();
 
 } // namespace Tiled

--- a/src/tiled/qmlextension.h
+++ b/src/tiled/qmlextension.h
@@ -1,0 +1,251 @@
+/*
+ * qmlextension.h
+ * Copyright 2026, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "id.h"
+#include "scriptedtool.h"
+
+#include <QAction>
+#include <QObject>
+#include <QQmlListProperty>
+#include <QQmlParserStatus>
+#include <QVariantList>
+
+#include <memory>
+
+namespace Tiled {
+
+class ScriptedMapFormat;
+class ScriptedTilesetFormat;
+
+/**
+ * Groups any number of extension objects, giving the extension a name.
+ *
+ * Purely a container for now, but reserved to enable dynamically
+ * enabling/disabling extensions in the UI later on.
+ */
+class QmlExtension : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
+    Q_PROPERTY(QQmlListProperty<QObject> data READ data)
+    Q_CLASSINFO("DefaultProperty", "data")
+
+public:
+    explicit QmlExtension(QObject *parent = nullptr);
+
+    QString name() const { return mName; }
+    void setName(const QString &name);
+
+    QQmlListProperty<QObject> data();
+
+signals:
+    void nameChanged();
+
+private:
+    QString mName;
+    QList<QObject*> mData;
+};
+
+/**
+ * A declaratively registered action, which registers itself with the
+ * ActionManager once its declared properties are set and unregisters on
+ * destruction (when the extension is unloaded or the engine is reset).
+ */
+class QmlAction : public QAction, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(QString name READ name WRITE setName)
+    Q_PROPERTY(QString icon READ iconFileName WRITE setIconFileName)
+    Q_PROPERTY(QString shortcut READ shortcutString WRITE setShortcutString)
+
+public:
+    explicit QmlAction(QObject *parent = nullptr);
+    ~QmlAction() override;
+
+    QString name() const;
+    void setName(const QString &name);
+
+    Id id() const { return mId; }
+
+    QString iconFileName() const { return mIconFileName; }
+    void setIconFileName(const QString &fileName);
+
+    // Shadows QAction::shortcut to support assigning a string in QML
+    QString shortcutString() const;
+    void setShortcutString(const QString &shortcut);
+
+    void classBegin() override {}
+    void componentComplete() override;
+
+private:
+    QString mName;
+    QString mIconFileName;
+    Id mId;
+    bool mCompleted = false;
+    bool mRegistered = false;
+};
+
+/**
+ * Extends a registered menu with additional items, mirroring
+ * tiled.extendMenu from the JavaScript API.
+ *
+ * Each entry in \a items is an object with the following properties:
+ *
+ * - action: the ID of a registered action, or a reference to an Action
+ * - before: the ID of an action before which to insert this item
+ * - separator: whether this item is a separator
+ */
+class QmlMenuExtension : public QObject, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(QString menu READ menu WRITE setMenu)
+    Q_PROPERTY(QVariantList items READ items WRITE setItems)
+
+public:
+    explicit QmlMenuExtension(QObject *parent = nullptr);
+
+    QString menu() const { return mMenu; }
+    void setMenu(const QString &menu) { mMenu = menu; }
+
+    QVariantList items() const { return mItems; }
+    void setItems(const QVariantList &items) { mItems = items; }
+
+    void classBegin() override {}
+    void componentComplete() override;
+
+private:
+    void apply();
+
+    QString mMenu;
+    QVariantList mItems;
+};
+
+/**
+ * A declaratively registered map format. The 'read', 'write' and
+ * 'outputFiles' functions can be declared as QML functions on this object.
+ */
+class QmlMapFormat : public QObject, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
+    Q_PROPERTY(QString name READ name WRITE setName)
+    Q_PROPERTY(QString extension READ extension WRITE setExtension)
+
+public:
+    explicit QmlMapFormat(QObject *parent = nullptr);
+    ~QmlMapFormat() override;
+
+    QString shortName() const { return mShortName; }
+    void setShortName(const QString &shortName) { mShortName = shortName; }
+
+    QString name() const { return mName; }
+    void setName(const QString &name) { mName = name; }
+
+    QString extension() const { return mExtension; }
+    void setExtension(const QString &extension) { mExtension = extension; }
+
+    void classBegin() override {}
+    void componentComplete() override;
+
+private:
+    QString mShortName;
+    QString mName;
+    QString mExtension;
+    std::unique_ptr<ScriptedMapFormat> mFormat;
+};
+
+/**
+ * A declaratively registered tileset format. The 'read' and 'write'
+ * functions can be declared as QML functions on this object.
+ */
+class QmlTilesetFormat : public QObject, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
+    Q_PROPERTY(QString name READ name WRITE setName)
+    Q_PROPERTY(QString extension READ extension WRITE setExtension)
+
+public:
+    explicit QmlTilesetFormat(QObject *parent = nullptr);
+    ~QmlTilesetFormat() override;
+
+    QString shortName() const { return mShortName; }
+    void setShortName(const QString &shortName) { mShortName = shortName; }
+
+    QString name() const { return mName; }
+    void setName(const QString &name) { mName = name; }
+
+    QString extension() const { return mExtension; }
+    void setExtension(const QString &extension) { mExtension = extension; }
+
+    void classBegin() override {}
+    void componentComplete() override;
+
+private:
+    QString mShortName;
+    QString mName;
+    QString mExtension;
+    std::unique_ptr<ScriptedTilesetFormat> mFormat;
+};
+
+/**
+ * A declaratively registered tool. Event handlers like 'activated',
+ * 'mousePressed' or 'tilePositionChanged' can be declared as QML functions
+ * on this object, like they are declared on the object passed to
+ * tiled.registerTool in the JavaScript API.
+ */
+class QmlTool : public ScriptedTool, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
+
+public:
+    explicit QmlTool(QObject *parent = nullptr);
+
+    QString shortName() const { return mShortName; }
+    void setShortName(const QString &shortName) { mShortName = shortName; }
+
+    void classBegin() override {}
+    void componentComplete() override;
+
+private:
+    QString mShortName;
+};
+
+/**
+ * Registers the QML types provided by the "Tiled" import. Safe to call
+ * multiple times; registration only happens once per process.
+ */
+void registerQmlExtensionTypes();
+
+} // namespace Tiled

--- a/src/tiled/qmlextension.h
+++ b/src/tiled/qmlextension.h
@@ -20,21 +20,12 @@
 
 #pragma once
 
-#include "id.h"
-#include "scriptedtool.h"
-
-#include <QAction>
 #include <QObject>
 #include <QQmlListProperty>
 #include <QQmlParserStatus>
 #include <QVariantList>
 
-#include <memory>
-
 namespace Tiled {
-
-class ScriptedMapFormat;
-class ScriptedTilesetFormat;
 
 /**
  * Groups any number of extension objects, giving the extension a name.
@@ -64,47 +55,6 @@ signals:
 private:
     QString mName;
     QList<QObject*> mData;
-};
-
-/**
- * A declaratively registered action, which registers itself with the
- * ActionManager once its declared properties are set and unregisters on
- * destruction (when the extension is unloaded or the engine is reset).
- */
-class QmlAction : public QAction, public QQmlParserStatus
-{
-    Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
-
-    Q_PROPERTY(QString name READ name WRITE setName)
-    Q_PROPERTY(QString icon READ iconFileName WRITE setIconFileName)
-    Q_PROPERTY(QString shortcut READ shortcutString WRITE setShortcutString)
-
-public:
-    explicit QmlAction(QObject *parent = nullptr);
-    ~QmlAction() override;
-
-    QString name() const;
-    void setName(const QString &name);
-
-    Id id() const { return mId; }
-
-    QString iconFileName() const { return mIconFileName; }
-    void setIconFileName(const QString &fileName);
-
-    // Shadows QAction::shortcut to support assigning a string in QML
-    QString shortcutString() const;
-    void setShortcutString(const QString &shortcut);
-
-    void classBegin() override {}
-    void componentComplete() override;
-
-private:
-    QString mName;
-    QString mIconFileName;
-    Id mId;
-    bool mCompleted = false;
-    bool mRegistered = false;
 };
 
 /**
@@ -142,104 +92,6 @@ private:
 
     QString mMenu;
     QVariantList mItems;
-};
-
-/**
- * A declaratively registered map format. The 'read', 'write' and
- * 'outputFiles' functions can be declared as QML functions on this object.
- */
-class QmlMapFormat : public QObject, public QQmlParserStatus
-{
-    Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
-
-    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
-    Q_PROPERTY(QString name READ name WRITE setName)
-    Q_PROPERTY(QString extension READ extension WRITE setExtension)
-
-public:
-    explicit QmlMapFormat(QObject *parent = nullptr);
-    ~QmlMapFormat() override;
-
-    QString shortName() const { return mShortName; }
-    void setShortName(const QString &shortName) { mShortName = shortName; }
-
-    QString name() const { return mName; }
-    void setName(const QString &name) { mName = name; }
-
-    QString extension() const { return mExtension; }
-    void setExtension(const QString &extension) { mExtension = extension; }
-
-    void classBegin() override {}
-    void componentComplete() override;
-
-private:
-    QString mShortName;
-    QString mName;
-    QString mExtension;
-    std::unique_ptr<ScriptedMapFormat> mFormat;
-};
-
-/**
- * A declaratively registered tileset format. The 'read' and 'write'
- * functions can be declared as QML functions on this object.
- */
-class QmlTilesetFormat : public QObject, public QQmlParserStatus
-{
-    Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
-
-    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
-    Q_PROPERTY(QString name READ name WRITE setName)
-    Q_PROPERTY(QString extension READ extension WRITE setExtension)
-
-public:
-    explicit QmlTilesetFormat(QObject *parent = nullptr);
-    ~QmlTilesetFormat() override;
-
-    QString shortName() const { return mShortName; }
-    void setShortName(const QString &shortName) { mShortName = shortName; }
-
-    QString name() const { return mName; }
-    void setName(const QString &name) { mName = name; }
-
-    QString extension() const { return mExtension; }
-    void setExtension(const QString &extension) { mExtension = extension; }
-
-    void classBegin() override {}
-    void componentComplete() override;
-
-private:
-    QString mShortName;
-    QString mName;
-    QString mExtension;
-    std::unique_ptr<ScriptedTilesetFormat> mFormat;
-};
-
-/**
- * A declaratively registered tool. Event handlers like 'activated',
- * 'mousePressed' or 'tilePositionChanged' can be declared as QML functions
- * on this object, like they are declared on the object passed to
- * tiled.registerTool in the JavaScript API.
- */
-class QmlTool : public ScriptedTool, public QQmlParserStatus
-{
-    Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
-
-    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
-
-public:
-    explicit QmlTool(QObject *parent = nullptr);
-
-    QString shortName() const { return mShortName; }
-    void setShortName(const QString &shortName) { mShortName = shortName; }
-
-    void classBegin() override {}
-    void componentComplete() override;
-
-private:
-    QString mShortName;
 };
 
 /**

--- a/src/tiled/qmlextension.h
+++ b/src/tiled/qmlextension.h
@@ -1,0 +1,103 @@
+/*
+ * qmlextension.h
+ * Copyright 2026, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QQmlListProperty>
+#include <QQmlParserStatus>
+#include <QVariantList>
+
+namespace Tiled {
+
+/**
+ * Groups any number of extension objects, giving the extension a name.
+ *
+ * Purely a container for now, but reserved to enable dynamically
+ * enabling/disabling extensions in the UI later on.
+ */
+class QmlExtension : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
+    Q_PROPERTY(QQmlListProperty<QObject> data READ data)
+    Q_CLASSINFO("DefaultProperty", "data")
+
+public:
+    explicit QmlExtension(QObject *parent = nullptr);
+
+    QString name() const { return mName; }
+    void setName(const QString &name);
+
+    QQmlListProperty<QObject> data();
+
+signals:
+    void nameChanged();
+
+private:
+    QString mName;
+    QList<QObject*> mData;
+};
+
+/**
+ * Extends a registered menu with additional items, mirroring
+ * tiled.extendMenu from the JavaScript API.
+ *
+ * Each entry in \a items is an object with the following properties:
+ *
+ * - action: the ID of a registered action, or a reference to an Action
+ * - before: the ID of an action before which to insert this item
+ * - separator: whether this item is a separator
+ */
+class QmlMenuExtension : public QObject, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(QString menu READ menu WRITE setMenu)
+    Q_PROPERTY(QVariantList items READ items WRITE setItems)
+
+public:
+    explicit QmlMenuExtension(QObject *parent = nullptr);
+
+    QString menu() const { return mMenu; }
+    void setMenu(const QString &menu) { mMenu = menu; }
+
+    QVariantList items() const { return mItems; }
+    void setItems(const QVariantList &items) { mItems = items; }
+
+    void classBegin() override {}
+    void componentComplete() override;
+
+private:
+    void apply();
+
+    QString mMenu;
+    QVariantList mItems;
+};
+
+/**
+ * Registers the QML types provided by the "Tiled" import. Safe to call
+ * multiple times; registration only happens once per process.
+ */
+void registerQmlExtensionTypes();
+
+} // namespace Tiled

--- a/src/tiled/scriptedaction.cpp
+++ b/src/tiled/scriptedaction.cpp
@@ -22,7 +22,7 @@
 
 #include "scriptmanager.h"
 
-#include <QJSEngine>
+#include <QQmlEngine>
 
 namespace Tiled {
 

--- a/src/tiled/scriptedaction.cpp
+++ b/src/tiled/scriptedaction.cpp
@@ -20,18 +20,17 @@
 
 #include "scriptedaction.h"
 
+#include "actionmanager.h"
+#include "logginginterface.h"
 #include "scriptmanager.h"
 
+#include <QCoreApplication>
 #include <QQmlEngine>
 
 namespace Tiled {
 
-ScriptedAction::ScriptedAction(Id id,
-                               const QJSValue &callback,
-                               QObject *parent)
+ScriptedAction::ScriptedAction(QObject *parent)
     : QAction(parent)
-    , mId(id)
-    , mCallback(callback)
 {
     static QIcon scriptIcon = [] {
         QIcon icon(QStringLiteral("://images/32/plugin.png"));
@@ -41,6 +40,16 @@ ScriptedAction::ScriptedAction(Id id,
     }();
 
     setIcon(scriptIcon);
+}
+
+ScriptedAction::ScriptedAction(Id id,
+                               const QJSValue &callback,
+                               QObject *parent)
+    : ScriptedAction(parent)
+{
+    mId = id;
+    mName = QString::fromUtf8(id.name());
+    mCallback = callback;
 
     connect(this, &QAction::triggered, this, [this] {
         QJSValueList arguments;
@@ -49,6 +58,15 @@ ScriptedAction::ScriptedAction(Id id,
         QJSValue result = mCallback.call(arguments);
         ScriptManager::instance().checkError(result);
     });
+
+    ActionManager::registerAction(this, id);
+    mRegistered = true;
+}
+
+ScriptedAction::~ScriptedAction()
+{
+    if (mRegistered)
+        ActionManager::unregisterAction(this, mId);
 }
 
 void ScriptedAction::setIconFileName(const QString &fileName)
@@ -65,6 +83,35 @@ void ScriptedAction::setIconFileName(const QString &fileName)
         iconFile.prepend(ext);
 
     setIcon(QIcon { iconFile });
+}
+
+QString ScriptedAction::shortcutString() const
+{
+    return shortcut().toString();
+}
+
+void ScriptedAction::setShortcutString(const QString &shortcut)
+{
+    setShortcut(QKeySequence(shortcut));
+}
+
+void ScriptedAction::componentComplete()
+{
+    if (mName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Action without name"));
+        return;
+    }
+
+    const Id id { mName.toUtf8() };
+
+    if (ActionManager::findAction(id)) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved ID: '%1'").arg(mName));
+        return;
+    }
+
+    mId = id;
+    ActionManager::registerAction(this, id);
+    mRegistered = true;
 }
 
 } // namespace Tiled

--- a/src/tiled/scriptedaction.cpp
+++ b/src/tiled/scriptedaction.cpp
@@ -20,18 +20,17 @@
 
 #include "scriptedaction.h"
 
+#include "actionmanager.h"
+#include "logginginterface.h"
 #include "scriptmanager.h"
 
-#include <QJSEngine>
+#include <QCoreApplication>
+#include <QQmlEngine>
 
 namespace Tiled {
 
-ScriptedAction::ScriptedAction(Id id,
-                               const QJSValue &callback,
-                               QObject *parent)
+ScriptedAction::ScriptedAction(QObject *parent)
     : QAction(parent)
-    , mId(id)
-    , mCallback(callback)
 {
     static QIcon scriptIcon = [] {
         QIcon icon(QStringLiteral("://images/32/plugin.png"));
@@ -41,6 +40,16 @@ ScriptedAction::ScriptedAction(Id id,
     }();
 
     setIcon(scriptIcon);
+}
+
+ScriptedAction::ScriptedAction(Id id,
+                               const QJSValue &callback,
+                               QObject *parent)
+    : ScriptedAction(parent)
+{
+    mId = id;
+    mName = QString::fromUtf8(id.name());
+    mCallback = callback;
 
     connect(this, &QAction::triggered, this, [this] {
         QJSValueList arguments;
@@ -49,6 +58,15 @@ ScriptedAction::ScriptedAction(Id id,
         QJSValue result = mCallback.call(arguments);
         ScriptManager::instance().checkError(result);
     });
+
+    ActionManager::registerAction(this, id);
+    mRegistered = true;
+}
+
+ScriptedAction::~ScriptedAction()
+{
+    if (mRegistered)
+        ActionManager::unregisterAction(this, mId);
 }
 
 void ScriptedAction::setIconFileName(const QString &fileName)
@@ -65,6 +83,35 @@ void ScriptedAction::setIconFileName(const QString &fileName)
         iconFile.prepend(ext);
 
     setIcon(QIcon { iconFile });
+}
+
+QString ScriptedAction::shortcutString() const
+{
+    return shortcut().toString();
+}
+
+void ScriptedAction::setShortcutString(const QString &shortcut)
+{
+    setShortcut(QKeySequence(shortcut));
+}
+
+void ScriptedAction::componentComplete()
+{
+    if (mName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Action without name"));
+        return;
+    }
+
+    const Id id { mName.toUtf8() };
+
+    if (ActionManager::findAction(id)) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved ID: '%1'").arg(mName));
+        return;
+    }
+
+    mId = id;
+    ActionManager::registerAction(this, id);
+    mRegistered = true;
 }
 
 } // namespace Tiled

--- a/src/tiled/scriptedaction.h
+++ b/src/tiled/scriptedaction.h
@@ -25,6 +25,7 @@
 #include <QAction>
 #include <QJSValue>
 #include <QQmlParserStatus>
+#include <QtQml/qqmlregistration.h>
 
 namespace Tiled {
 
@@ -37,6 +38,7 @@ class ScriptedAction : public QAction, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
+    QML_NAMED_ELEMENT(Action)
 
     Q_PROPERTY(QByteArray id READ idName CONSTANT)
     Q_PROPERTY(QString name READ name WRITE setName)

--- a/src/tiled/scriptedaction.h
+++ b/src/tiled/scriptedaction.h
@@ -24,31 +24,54 @@
 
 #include <QAction>
 #include <QJSValue>
+#include <QQmlParserStatus>
 
 namespace Tiled {
 
-class ScriptedAction : public QAction
+/**
+ * An action registered by an extension, either through
+ * tiled.registerAction or declared as a QML component. It registers itself
+ * with the ActionManager and unregisters on destruction.
+ */
+class ScriptedAction : public QAction, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
 
     Q_PROPERTY(QByteArray id READ idName CONSTANT)
+    Q_PROPERTY(QString name READ name WRITE setName)
     Q_PROPERTY(QString icon READ iconFileName WRITE setIconFileName)
+    Q_PROPERTY(QString shortcut READ shortcutString WRITE setShortcutString)
 
 public:
+    explicit ScriptedAction(QObject *parent = nullptr);
     ScriptedAction(Id id,
                    const QJSValue &callback,
                    QObject *parent = nullptr);
+    ~ScriptedAction() override;
 
     Id id() const;
     QByteArray idName() const;
 
+    QString name() const;
+    void setName(const QString &name);
+
     QString iconFileName() const;
     void setIconFileName(const QString &fileName);
 
+    // Shadows QAction::shortcut to support assigning a string in QML
+    QString shortcutString() const;
+    void setShortcutString(const QString &shortcut);
+
+    void classBegin() override {}
+    void componentComplete() override;
+
 private:
     Id mId;
+    QString mName;
     QJSValue mCallback;
     QString mIconFileName;
+    bool mRegistered = false;
 };
 
 
@@ -60,6 +83,16 @@ inline Id ScriptedAction::id() const
 inline QByteArray ScriptedAction::idName() const
 {
     return mId.name();
+}
+
+inline QString ScriptedAction::name() const
+{
+    return mName;
+}
+
+inline void ScriptedAction::setName(const QString &name)
+{
+    mName = name;
 }
 
 inline QString ScriptedAction::iconFileName() const

--- a/src/tiled/scriptedfileformat.cpp
+++ b/src/tiled/scriptedfileformat.cpp
@@ -25,13 +25,52 @@
 #include "savefile.h"
 #include "scriptmanager.h"
 
+#include "logginginterface.h"
+
 #include <QCoreApplication>
 #include <QFile>
-#include <QJSEngine>
+#include <QQmlEngine>
 #include <QJSValueIterator>
 #include <QTextStream>
 
 namespace Tiled {
+
+/**
+ * Validates the declared properties of a QML declared file format, reporting
+ * errors to the Console view.
+ */
+template<typename FormatList>
+static bool validateQmlFileFormat(const QString &shortName,
+                                  const QString &name,
+                                  const QString &extension,
+                                  const QJSValue &object,
+                                  const FormatList &existingFormats)
+{
+    if (shortName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "File format without shortName"));
+        return false;
+    }
+
+    if (name.isEmpty() || extension.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires 'name' and 'extension' properties)"));
+        return false;
+    }
+
+    if (!object.property(QStringLiteral("read")).isCallable() &&
+            !object.property(QStringLiteral("write")).isCallable()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires a 'write' and/or 'read' function property)"));
+        return false;
+    }
+
+    for (auto format : existingFormats) {
+        if (format->shortName() == shortName) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(shortName));
+            return false;
+        }
+    }
+
+    return true;
+}
 
 ScriptedFileFormat::ScriptedFileFormat(const QJSValue &object)
     : mObject(object)
@@ -157,6 +196,11 @@ bool ScriptedFileFormat::validateFileFormatObject(const QJSValue &value)
 }
 
 
+ScriptedMapFormat::ScriptedMapFormat(QObject *parent)
+    : MapFormat(parent)
+{
+}
+
 ScriptedMapFormat::ScriptedMapFormat(const QString &shortName,
                                      const QJSValue &object,
                                      QObject *parent)
@@ -165,11 +209,26 @@ ScriptedMapFormat::ScriptedMapFormat(const QString &shortName,
     , mFormat(object)
 {
     PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 ScriptedMapFormat::~ScriptedMapFormat()
 {
-    PluginManager::removeObject(this);
+    if (mAddedToPluginManager)
+        PluginManager::removeObject(this);
+}
+
+void ScriptedMapFormat::componentComplete()
+{
+    const QJSValue self = ScriptManager::instance().engine()->newQObject(this);
+
+    if (!validateQmlFileFormat(mShortName, mName, mExtension, self,
+                               PluginManager::objects<MapFormat>()))
+        return;
+
+    mFormat.setObject(self);
+    PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 QStringList ScriptedMapFormat::outputFiles(const Map *map, const QString &fileName) const
@@ -208,6 +267,11 @@ bool ScriptedMapFormat::write(const Map *map, const QString &fileName, Options o
 }
 
 
+ScriptedTilesetFormat::ScriptedTilesetFormat(QObject *parent)
+    : TilesetFormat(parent)
+{
+}
+
 ScriptedTilesetFormat::ScriptedTilesetFormat(const QString &shortName,
                                              const QJSValue &object,
                                              QObject *parent)
@@ -216,11 +280,26 @@ ScriptedTilesetFormat::ScriptedTilesetFormat(const QString &shortName,
     , mFormat(object)
 {
     PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 ScriptedTilesetFormat::~ScriptedTilesetFormat()
 {
-    PluginManager::removeObject(this);
+    if (mAddedToPluginManager)
+        PluginManager::removeObject(this);
+}
+
+void ScriptedTilesetFormat::componentComplete()
+{
+    const QJSValue self = ScriptManager::instance().engine()->newQObject(this);
+
+    if (!validateQmlFileFormat(mShortName, mName, mExtension, self,
+                               PluginManager::objects<TilesetFormat>()))
+        return;
+
+    mFormat.setObject(self);
+    PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 SharedTileset ScriptedTilesetFormat::read(const QString &fileName)

--- a/src/tiled/scriptedfileformat.cpp
+++ b/src/tiled/scriptedfileformat.cpp
@@ -25,6 +25,8 @@
 #include "savefile.h"
 #include "scriptmanager.h"
 
+#include "logginginterface.h"
+
 #include <QCoreApplication>
 #include <QFile>
 #include <QQmlEngine>
@@ -32,6 +34,43 @@
 #include <QTextStream>
 
 namespace Tiled {
+
+/**
+ * Validates the declared properties of a QML declared file format, reporting
+ * errors to the Console view.
+ */
+template<typename FormatList>
+static bool validateQmlFileFormat(const QString &shortName,
+                                  const QString &name,
+                                  const QString &extension,
+                                  const QJSValue &object,
+                                  const FormatList &existingFormats)
+{
+    if (shortName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "File format without shortName"));
+        return false;
+    }
+
+    if (name.isEmpty() || extension.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires 'name' and 'extension' properties)"));
+        return false;
+    }
+
+    if (!object.property(QStringLiteral("read")).isCallable() &&
+            !object.property(QStringLiteral("write")).isCallable()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires a 'write' and/or 'read' function property)"));
+        return false;
+    }
+
+    for (auto format : existingFormats) {
+        if (format->shortName() == shortName) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(shortName));
+            return false;
+        }
+    }
+
+    return true;
+}
 
 ScriptedFileFormat::ScriptedFileFormat(const QJSValue &object)
     : mObject(object)
@@ -157,6 +196,11 @@ bool ScriptedFileFormat::validateFileFormatObject(const QJSValue &value)
 }
 
 
+ScriptedMapFormat::ScriptedMapFormat(QObject *parent)
+    : MapFormat(parent)
+{
+}
+
 ScriptedMapFormat::ScriptedMapFormat(const QString &shortName,
                                      const QJSValue &object,
                                      QObject *parent)
@@ -165,11 +209,26 @@ ScriptedMapFormat::ScriptedMapFormat(const QString &shortName,
     , mFormat(object)
 {
     PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 ScriptedMapFormat::~ScriptedMapFormat()
 {
-    PluginManager::removeObject(this);
+    if (mAddedToPluginManager)
+        PluginManager::removeObject(this);
+}
+
+void ScriptedMapFormat::componentComplete()
+{
+    const QJSValue self = ScriptManager::instance().engine()->newQObject(this);
+
+    if (!validateQmlFileFormat(mShortName, mName, mExtension, self,
+                               PluginManager::objects<MapFormat>()))
+        return;
+
+    mFormat.setObject(self);
+    PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 QStringList ScriptedMapFormat::outputFiles(const Map *map, const QString &fileName) const
@@ -208,6 +267,11 @@ bool ScriptedMapFormat::write(const Map *map, const QString &fileName, Options o
 }
 
 
+ScriptedTilesetFormat::ScriptedTilesetFormat(QObject *parent)
+    : TilesetFormat(parent)
+{
+}
+
 ScriptedTilesetFormat::ScriptedTilesetFormat(const QString &shortName,
                                              const QJSValue &object,
                                              QObject *parent)
@@ -216,11 +280,26 @@ ScriptedTilesetFormat::ScriptedTilesetFormat(const QString &shortName,
     , mFormat(object)
 {
     PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 ScriptedTilesetFormat::~ScriptedTilesetFormat()
 {
-    PluginManager::removeObject(this);
+    if (mAddedToPluginManager)
+        PluginManager::removeObject(this);
+}
+
+void ScriptedTilesetFormat::componentComplete()
+{
+    const QJSValue self = ScriptManager::instance().engine()->newQObject(this);
+
+    if (!validateQmlFileFormat(mShortName, mName, mExtension, self,
+                               PluginManager::objects<TilesetFormat>()))
+        return;
+
+    mFormat.setObject(self);
+    PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 SharedTileset ScriptedTilesetFormat::read(const QString &fileName)

--- a/src/tiled/scriptedfileformat.cpp
+++ b/src/tiled/scriptedfileformat.cpp
@@ -27,7 +27,7 @@
 
 #include <QCoreApplication>
 #include <QFile>
-#include <QJSEngine>
+#include <QQmlEngine>
 #include <QJSValueIterator>
 #include <QTextStream>
 

--- a/src/tiled/scriptedfileformat.cpp
+++ b/src/tiled/scriptedfileformat.cpp
@@ -36,6 +36,19 @@
 namespace Tiled {
 
 /**
+ * Returns an error message when the given object provides neither a 'read'
+ * nor a 'write' function, or an empty string when it is fine.
+ */
+static QString checkReadWriteFunctions(const QJSValue &object)
+{
+    if (!object.property(QStringLiteral("read")).isCallable() &&
+            !object.property(QStringLiteral("write")).isCallable())
+        return QCoreApplication::translate("Script Errors", "Invalid file format object (requires a 'write' and/or 'read' function property)");
+
+    return QString();
+}
+
+/**
  * Validates the declared properties of a QML declared file format, reporting
  * errors to the Console view.
  */
@@ -56,9 +69,9 @@ static bool validateQmlFileFormat(const QString &shortName,
         return false;
     }
 
-    if (!object.property(QStringLiteral("read")).isCallable() &&
-            !object.property(QStringLiteral("write")).isCallable()) {
-        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Invalid file format object (requires a 'write' and/or 'read' function property)"));
+    const QString error = checkReadWriteFunctions(object);
+    if (!error.isEmpty()) {
+        Tiled::ERROR(error);
         return false;
     }
 
@@ -174,8 +187,6 @@ bool ScriptedFileFormat::validateFileFormatObject(const QJSValue &value)
 {
     const QJSValue nameProperty = value.property(QStringLiteral("name"));
     const QJSValue extensionProperty = value.property(QStringLiteral("extension"));
-    const QJSValue writeProperty = value.property(QStringLiteral("write"));
-    const QJSValue readProperty = value.property(QStringLiteral("read"));
 
     if (!nameProperty.isString()) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid file format object (requires string 'name' property)"));
@@ -187,8 +198,9 @@ bool ScriptedFileFormat::validateFileFormatObject(const QJSValue &value)
         return false;
     }
 
-    if (!writeProperty.isCallable() && !readProperty.isCallable()) {
-        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid file format object (requires a 'write' and/or 'read' function property)"));
+    const QString error = checkReadWriteFunctions(value);
+    if (!error.isEmpty()) {
+        ScriptManager::instance().throwError(error);
         return false;
     }
 

--- a/src/tiled/scriptedfileformat.h
+++ b/src/tiled/scriptedfileformat.h
@@ -24,6 +24,7 @@
 #include "tilesetformat.h"
 
 #include <QJSValue>
+#include <QQmlParserStatus>
 
 namespace Tiled {
 
@@ -32,7 +33,10 @@ class EditableAsset;
 class ScriptedFileFormat
 {
 public:
+    ScriptedFileFormat() = default;
     explicit ScriptedFileFormat(const QJSValue &object);
+
+    void setObject(const QJSValue &object) { mObject = object; }
 
     FileFormat::Capabilities capabilities() const;
     QString nameFilter() const;
@@ -50,15 +54,37 @@ private:
     QJSValue mObject;
 };
 
-class ScriptedMapFormat final : public MapFormat
+/**
+ * A map format registered by an extension, either through
+ * tiled.registerMapFormat or declared as a QML component. The 'read',
+ * 'write' and 'outputFiles' functions are looked up on the script object,
+ * which for QML declared formats is the format object itself.
+ */
+class ScriptedMapFormat : public MapFormat, public QQmlParserStatus
 {
     Q_OBJECT
-    Q_INTERFACES(Tiled::MapFormat)
+    Q_INTERFACES(Tiled::MapFormat QQmlParserStatus)
+
+    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
+    Q_PROPERTY(QString name READ name WRITE setName)
+    Q_PROPERTY(QString extension READ extension WRITE setExtension)
 
 public:
+    explicit ScriptedMapFormat(QObject *parent = nullptr);
     ScriptedMapFormat(const QString &shortName, const QJSValue &object,
                       QObject *parent = nullptr);
     ~ScriptedMapFormat() override;
+
+    QString name() const { return mName; }
+    void setName(const QString &name) { mName = name; }
+
+    QString extension() const { return mExtension; }
+    void setExtension(const QString &extension) { mExtension = extension; }
+
+    void setShortName(const QString &shortName) { mShortName = shortName; }
+
+    void classBegin() override {}
+    void componentComplete() override;
 
     // FileFormat interface
     Capabilities capabilities() const override { return mFormat.capabilities(); }
@@ -74,19 +100,42 @@ public:
 
 private:
     QString mShortName;
+    QString mName;
+    QString mExtension;
     QString mError;
     ScriptedFileFormat mFormat;
+    bool mAddedToPluginManager = false;
 };
 
-class ScriptedTilesetFormat final : public TilesetFormat
+/**
+ * A tileset format registered by an extension, either through
+ * tiled.registerTilesetFormat or declared as a QML component.
+ */
+class ScriptedTilesetFormat : public TilesetFormat, public QQmlParserStatus
 {
     Q_OBJECT
-    Q_INTERFACES(Tiled::TilesetFormat)
+    Q_INTERFACES(Tiled::TilesetFormat QQmlParserStatus)
+
+    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
+    Q_PROPERTY(QString name READ name WRITE setName)
+    Q_PROPERTY(QString extension READ extension WRITE setExtension)
 
 public:
+    explicit ScriptedTilesetFormat(QObject *parent = nullptr);
     ScriptedTilesetFormat(const QString &shortName, const QJSValue &object,
                           QObject *parent = nullptr);
     ~ScriptedTilesetFormat() override;
+
+    QString name() const { return mName; }
+    void setName(const QString &name) { mName = name; }
+
+    QString extension() const { return mExtension; }
+    void setExtension(const QString &extension) { mExtension = extension; }
+
+    void setShortName(const QString &shortName) { mShortName = shortName; }
+
+    void classBegin() override {}
+    void componentComplete() override;
 
     // FileFormat interface
     Capabilities capabilities() const override { return mFormat.capabilities(); }
@@ -101,8 +150,11 @@ public:
 
 private:
     QString mShortName;
+    QString mName;
+    QString mExtension;
     QString mError;
     ScriptedFileFormat mFormat;
+    bool mAddedToPluginManager = false;
 };
 
 } // namespace Tiled

--- a/src/tiled/scriptedfileformat.h
+++ b/src/tiled/scriptedfileformat.h
@@ -25,6 +25,7 @@
 
 #include <QJSValue>
 #include <QQmlParserStatus>
+#include <QtQml/qqmlregistration.h>
 
 namespace Tiled {
 
@@ -64,6 +65,7 @@ class ScriptedMapFormat : public MapFormat, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(Tiled::MapFormat QQmlParserStatus)
+    QML_NAMED_ELEMENT(MapFormat)
 
     Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
     Q_PROPERTY(QString name READ name WRITE setName)
@@ -115,6 +117,7 @@ class ScriptedTilesetFormat : public TilesetFormat, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(Tiled::TilesetFormat QQmlParserStatus)
+    QML_NAMED_ELEMENT(TilesetFormat)
 
     Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
     Q_PROPERTY(QString name READ name WRITE setName)

--- a/src/tiled/scriptedtool.cpp
+++ b/src/tiled/scriptedtool.cpp
@@ -39,9 +39,16 @@
 
 namespace Tiled {
 
+ScriptedTool::ScriptedTool(QObject *parent)
+    : AbstractTileTool(Id(), QStringLiteral("<unnamed tool>"), QIcon(), QKeySequence(), nullptr, parent)
+{
+    setTargetLayerType(0);  // default behavior is not to disable based on current layer
+}
+
 ScriptedTool::ScriptedTool(Id id, QJSValue object, QObject *parent)
     : AbstractTileTool(id, QStringLiteral("<unnamed tool>"), QIcon(), QKeySequence(), nullptr, parent)
     , mScriptObject(std::move(object))
+    , mShortName(QString::fromUtf8(id.name()))
 {
     // Read out the properties from the script object before setting its prototype
     const QJSValue nameProperty = mScriptObject.property(QStringLiteral("name"));
@@ -82,11 +89,35 @@ ScriptedTool::ScriptedTool(Id id, QJSValue object, QObject *parent)
         setTargetLayerType(0);  // default behavior is not to disable based on current layer
 
     PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 ScriptedTool::~ScriptedTool()
 {
-    PluginManager::removeObject(this);
+    if (mAddedToPluginManager)
+        PluginManager::removeObject(this);
+}
+
+void ScriptedTool::componentComplete()
+{
+    if (mShortName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Tool without shortName"));
+        return;
+    }
+
+    const Id id { mShortName.toUtf8() };
+    const auto tools = PluginManager::objects<AbstractTool>();
+    for (auto tool : tools) {
+        if (tool->id() == id) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(mShortName));
+            return;
+        }
+    }
+
+    setId(id);
+    mScriptObject = ScriptManager::instance().engine()->newQObject(this);
+    PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 EditableMap *ScriptedTool::editableMap() const

--- a/src/tiled/scriptedtool.cpp
+++ b/src/tiled/scriptedtool.cpp
@@ -39,9 +39,16 @@
 
 namespace Tiled {
 
+ScriptedTool::ScriptedTool(QObject *parent)
+    : AbstractTileTool(Id(), QStringLiteral("<unnamed tool>"), QIcon(), QKeySequence(), nullptr, parent)
+{
+    setTargetLayerType(0);  // default behavior is not to disable based on current layer
+}
+
 ScriptedTool::ScriptedTool(Id id, QJSValue object, QObject *parent)
     : AbstractTileTool(id, QStringLiteral("<unnamed tool>"), QIcon(), QKeySequence(), nullptr, parent)
     , mScriptObject(std::move(object))
+    , mShortName(QString::fromUtf8(id.name()))
 {
     // Read out the properties from the script object before setting its prototype
     const QJSValue nameProperty = mScriptObject.property(QStringLiteral("name"));
@@ -81,13 +88,8 @@ ScriptedTool::ScriptedTool(Id id, QJSValue object, QObject *parent)
     else
         setTargetLayerType(0);  // default behavior is not to disable based on current layer
 
-    addToPluginManager();
-}
-
-ScriptedTool::ScriptedTool(QObject *parent)
-    : AbstractTileTool(Id(), QStringLiteral("<unnamed tool>"), QIcon(), QKeySequence(), nullptr, parent)
-{
-    setTargetLayerType(0);  // default behavior is not to disable based on current layer
+    PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 ScriptedTool::~ScriptedTool()
@@ -96,13 +98,24 @@ ScriptedTool::~ScriptedTool()
         PluginManager::removeObject(this);
 }
 
-void ScriptedTool::setScriptObject(QJSValue object)
+void ScriptedTool::componentComplete()
 {
-    mScriptObject = std::move(object);
-}
+    if (mShortName.isEmpty()) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Tool without shortName"));
+        return;
+    }
 
-void ScriptedTool::addToPluginManager()
-{
+    const Id id { mShortName.toUtf8() };
+    const auto tools = PluginManager::objects<AbstractTool>();
+    for (auto tool : tools) {
+        if (tool->id() == id) {
+            Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(mShortName));
+            return;
+        }
+    }
+
+    setId(id);
+    mScriptObject = ScriptManager::instance().engine()->newQObject(this);
     PluginManager::addObject(this);
     mAddedToPluginManager = true;
 }

--- a/src/tiled/scriptedtool.cpp
+++ b/src/tiled/scriptedtool.cpp
@@ -81,12 +81,30 @@ ScriptedTool::ScriptedTool(Id id, QJSValue object, QObject *parent)
     else
         setTargetLayerType(0);  // default behavior is not to disable based on current layer
 
-    PluginManager::addObject(this);
+    addToPluginManager();
+}
+
+ScriptedTool::ScriptedTool(QObject *parent)
+    : AbstractTileTool(Id(), QStringLiteral("<unnamed tool>"), QIcon(), QKeySequence(), nullptr, parent)
+{
+    setTargetLayerType(0);  // default behavior is not to disable based on current layer
 }
 
 ScriptedTool::~ScriptedTool()
 {
-    PluginManager::removeObject(this);
+    if (mAddedToPluginManager)
+        PluginManager::removeObject(this);
+}
+
+void ScriptedTool::setScriptObject(QJSValue object)
+{
+    mScriptObject = std::move(object);
+}
+
+void ScriptedTool::addToPluginManager()
+{
+    PluginManager::addObject(this);
+    mAddedToPluginManager = true;
 }
 
 EditableMap *ScriptedTool::editableMap() const

--- a/src/tiled/scriptedtool.cpp
+++ b/src/tiled/scriptedtool.cpp
@@ -106,6 +106,14 @@ void ScriptedTool::componentComplete()
     }
 
     const Id id { mShortName.toUtf8() };
+
+    // Built-in tools don't get added to the PluginManager, but their actions
+    // are registered with the ActionManager by the ToolManager.
+    if (ActionManager::findAction(id)) {
+        Tiled::ERROR(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(mShortName));
+        return;
+    }
+
     const auto tools = PluginManager::objects<AbstractTool>();
     for (auto tool : tools) {
         if (tool->id() == id) {

--- a/src/tiled/scriptedtool.h
+++ b/src/tiled/scriptedtool.h
@@ -24,6 +24,7 @@
 
 #include <QJSValue>
 #include <QQmlParserStatus>
+#include <QtQml/qqmlregistration.h>
 
 namespace Tiled {
 
@@ -41,6 +42,7 @@ class ScriptedTool : public AbstractTileTool, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
+    QML_NAMED_ELEMENT(Tool)
 
     Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
     Q_PROPERTY(QString icon READ iconFileName WRITE setIconFileName)

--- a/src/tiled/scriptedtool.h
+++ b/src/tiled/scriptedtool.h
@@ -72,6 +72,16 @@ public:
     void setToolBarActions(const QStringList &actionNames);
 
 protected:
+    /**
+     * Constructs a scripted tool that does not have a script object yet and
+     * is not added to the PluginManager. Used by QmlTool, which sets its
+     * script object and adds itself once its declared properties are set.
+     */
+    explicit ScriptedTool(QObject *parent = nullptr);
+
+    void setScriptObject(QJSValue object);
+    void addToPluginManager();
+
     void mapDocumentChanged(MapDocument *oldDocument, MapDocument *newDocument) override;
 
     void tilePositionChanged(QPoint tilePos) override;
@@ -85,6 +95,7 @@ private:
     QJSValue mScriptObject;
     QString mIconFileName;
     QList<Id> mToolBarActions;
+    bool mAddedToPluginManager = false;
 };
 
 

--- a/src/tiled/scriptedtool.h
+++ b/src/tiled/scriptedtool.h
@@ -23,6 +23,7 @@
 #include "abstracttiletool.h"
 
 #include <QJSValue>
+#include <QQmlParserStatus>
 
 namespace Tiled {
 
@@ -30,10 +31,18 @@ class BrushItem;
 class EditableMap;
 class EditableTile;
 
-class ScriptedTool : public AbstractTileTool
+/**
+ * A tool registered by an extension, either through tiled.registerTool or
+ * declared as a QML component. Its behavior functions (like 'activated' or
+ * 'mousePressed') are looked up on the script object, which for QML declared
+ * tools is the tool object itself.
+ */
+class ScriptedTool : public AbstractTileTool, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
 
+    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
     Q_PROPERTY(QString icon READ iconFileName WRITE setIconFileName)
     Q_PROPERTY(Tiled::EditableMap *map READ editableMap)
     Q_PROPERTY(Tiled::EditableTile *selectedTile READ editableTile)
@@ -41,8 +50,15 @@ class ScriptedTool : public AbstractTileTool
     Q_PROPERTY(QStringList toolBarActions READ toolBarActions WRITE setToolBarActions)
 
 public:
+    explicit ScriptedTool(QObject *parent = nullptr);
     explicit ScriptedTool(Id id, QJSValue object, QObject *parent = nullptr);
     ~ScriptedTool() override;
+
+    QString shortName() const { return mShortName; }
+    void setShortName(const QString &shortName) { mShortName = shortName; }
+
+    void classBegin() override {}
+    void componentComplete() override;
 
     EditableMap *editableMap() const;
     EditableTile *editableTile() const;
@@ -72,16 +88,6 @@ public:
     void setToolBarActions(const QStringList &actionNames);
 
 protected:
-    /**
-     * Constructs a scripted tool that does not have a script object yet and
-     * is not added to the PluginManager. Used by QmlTool, which sets its
-     * script object and adds itself once its declared properties are set.
-     */
-    explicit ScriptedTool(QObject *parent = nullptr);
-
-    void setScriptObject(QJSValue object);
-    void addToPluginManager();
-
     void mapDocumentChanged(MapDocument *oldDocument, MapDocument *newDocument) override;
 
     void tilePositionChanged(QPoint tilePos) override;
@@ -93,6 +99,7 @@ private:
     bool call(const QString &methodName, const QJSValueList &args = QJSValueList());
 
     QJSValue mScriptObject;
+    QString mShortName;
     QString mIconFileName;
     QList<Id> mToolBarActions;
     bool mAddedToPluginManager = false;

--- a/src/tiled/scriptedtool.h
+++ b/src/tiled/scriptedtool.h
@@ -23,6 +23,7 @@
 #include "abstracttiletool.h"
 
 #include <QJSValue>
+#include <QQmlParserStatus>
 
 namespace Tiled {
 
@@ -30,10 +31,18 @@ class BrushItem;
 class EditableMap;
 class EditableTile;
 
-class ScriptedTool : public AbstractTileTool
+/**
+ * A tool registered by an extension, either through tiled.registerTool or
+ * declared as a QML component. Its behavior functions (like 'activated' or
+ * 'mousePressed') are looked up on the script object, which for QML declared
+ * tools is the tool object itself.
+ */
+class ScriptedTool : public AbstractTileTool, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
 
+    Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
     Q_PROPERTY(QString icon READ iconFileName WRITE setIconFileName)
     Q_PROPERTY(Tiled::EditableMap *map READ editableMap)
     Q_PROPERTY(Tiled::EditableTile *selectedTile READ editableTile)
@@ -41,8 +50,15 @@ class ScriptedTool : public AbstractTileTool
     Q_PROPERTY(QStringList toolBarActions READ toolBarActions WRITE setToolBarActions)
 
 public:
+    explicit ScriptedTool(QObject *parent = nullptr);
     explicit ScriptedTool(Id id, QJSValue object, QObject *parent = nullptr);
     ~ScriptedTool() override;
+
+    QString shortName() const { return mShortName; }
+    void setShortName(const QString &shortName) { mShortName = shortName; }
+
+    void classBegin() override {}
+    void componentComplete() override;
 
     EditableMap *editableMap() const;
     EditableTile *editableTile() const;
@@ -83,8 +99,10 @@ private:
     bool call(const QString &methodName, const QJSValueList &args = QJSValueList());
 
     QJSValue mScriptObject;
+    QString mShortName;
     QString mIconFileName;
     QList<Id> mToolBarActions;
+    bool mAddedToPluginManager = false;
 };
 
 

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -315,9 +315,6 @@ void ScriptManager::loadQmlExtension(const QString &fileName)
         return;
     }
 
-    // The engine should not delete the object tree we own
-    QQmlEngine::setObjectOwnership(rootObject.get(), QQmlEngine::CppOwnership);
-
     mQmlExtensions.push_back({ std::move(component), std::move(rootObject) });
 }
 

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -294,8 +294,14 @@ void ScriptManager::loadQmlExtension(const QString &fileName)
     // with Tiled, make sure a deterministic style is used. Can be overridden
     // using the QT_QUICK_CONTROLS_STYLE environment variable. Needs to be
     // set up before the first extension using Qt Quick Controls is loaded.
-    if (QQuickStyle::name().isEmpty() && qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE"))
-        QQuickStyle::setStyle(QStringLiteral("Fusion"));
+    // Note that QQuickStyle::name can't be used as a guard here, since it
+    // resolves and locks in the platform default style.
+    static bool styleInitialized = false;
+    if (!styleInitialized) {
+        styleInitialized = true;
+        if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE"))
+            QQuickStyle::setStyle(QStringLiteral("Fusion"));
+    }
 
     Tiled::INFO(tr("Loading '%1'").arg(fileName));
 

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -37,7 +37,6 @@
 #include "preferences.h"
 #include "project.h"
 #include "projectmanager.h"
-#include "qmlextension.h"
 #include "regionvaluetype.h"
 #include "scriptbase64.h"
 #include "scriptdialog.h"
@@ -136,8 +135,6 @@ ScriptManager::ScriptManager(QObject *parent)
     qRegisterMetaType<ScriptTilesetFormatWrapper*>();
     qRegisterMetaType<ScriptImage*>();
     qRegisterMetaType<WangIndex::Value>("WangIndex");
-
-    registerQmlExtensionTypes();
 
     connect(&mWatcher, &FileSystemWatcher::pathsChanged,
             this, &ScriptManager::scriptFilesChanged);

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -37,6 +37,7 @@
 #include "preferences.h"
 #include "project.h"
 #include "projectmanager.h"
+#include "qmlextension.h"
 #include "regionvaluetype.h"
 #include "scriptbase64.h"
 #include "scriptdialog.h"
@@ -61,6 +62,8 @@
 #include <QDesktopServices>
 #include <QDir>
 #include <QFile>
+#include <QQmlComponent>
+#include <QQmlContext>
 #include <QQmlEngine>
 #include <QStandardPaths>
 #include <QStringDecoder>
@@ -133,6 +136,8 @@ ScriptManager::ScriptManager(QObject *parent)
     qRegisterMetaType<ScriptImage*>();
     qRegisterMetaType<WangIndex::Value>("WangIndex");
 
+    registerQmlExtensionTypes();
+
     connect(&mWatcher, &FileSystemWatcher::pathsChanged,
             this, &ScriptManager::scriptFilesChanged);
 
@@ -146,6 +151,14 @@ ScriptManager::ScriptManager(QObject *parent)
         if (!QFile::exists(mExtensionsPath))
             QDir().mkpath(mExtensionsPath);
     }
+}
+
+ScriptManager::~ScriptManager()
+{
+    // Make sure any loaded QML extensions (which may reference the engine,
+    // for example through a QQuickWidget) are destroyed before the engine is
+    // deleted along with the other children.
+    mQmlExtensions.clear();
 }
 
 void ScriptManager::ensureInitialized()
@@ -258,17 +271,46 @@ void ScriptManager::loadExtension(const QString &path)
 
     const QStringList nameFilters = {
         QLatin1String("*.js"),
-        QLatin1String("*.mjs")
+        QLatin1String("*.mjs"),
+        QLatin1String("*.qml")
     };
     const QDir dir(path);
-    const QStringList jsFiles = dir.entryList(nameFilters,
-                                              QDir::Files | QDir::Readable);
+    const QStringList scriptFiles = dir.entryList(nameFilters,
+                                                  QDir::Files | QDir::Readable);
 
-    for (const QString &jsFile : jsFiles) {
-        const QString absolutePath = dir.filePath(jsFile);
-        evaluateFileOrLoadModule(absolutePath);
+    for (const QString &scriptFile : scriptFiles) {
+        const QString absolutePath = dir.filePath(scriptFile);
+
+        if (scriptFile.endsWith(QLatin1String(".qml"), Qt::CaseInsensitive))
+            loadQmlExtension(absolutePath);
+        else
+            evaluateFileOrLoadModule(absolutePath);
+
         mWatcher.addPath(absolutePath);
     }
+}
+
+void ScriptManager::loadQmlExtension(const QString &fileName)
+{
+    Tiled::INFO(tr("Loading '%1'").arg(fileName));
+
+    auto component = std::make_unique<QQmlComponent>(mEngine,
+                                                     QUrl::fromLocalFile(fileName));
+    if (component->isError()) {
+        onScriptWarnings(component->errors());
+        return;
+    }
+
+    std::unique_ptr<QObject> rootObject { component->create() };
+    if (!rootObject) {
+        onScriptWarnings(component->errors());
+        return;
+    }
+
+    // The engine should not delete the object tree we own
+    QQmlEngine::setObjectOwnership(rootObject.get(), QQmlEngine::CppOwnership);
+
+    mQmlExtensions.push_back({ std::move(component), std::move(rootObject) });
 }
 
 bool ScriptManager::checkError(QJSValue value, const QString &program)
@@ -328,6 +370,10 @@ void ScriptManager::reset()
 
     mWatcher.clear();
 
+    // QML extensions may reference the engine, for example through a
+    // QQuickWidget, so they need to be destroyed before the engine.
+    mQmlExtensions.clear();
+
     delete mEngine;
     delete mModule;
 
@@ -348,6 +394,11 @@ void ScriptManager::initialize()
 
     mEngine = engine;
     mModule = new ScriptModule(this);
+
+    // Make the 'tiled' object available to expressions in QML extensions
+    // (the global object properties set below are not resolved by the QML
+    // context chain).
+    engine->rootContext()->setContextProperty(QStringLiteral("tiled"), mModule);
 
     QJSValue globalObject = engine->globalObject();
 

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -65,6 +65,7 @@
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QQuickStyle>
 #include <QStandardPaths>
 #include <QStringDecoder>
 #include <QtDebug>
@@ -292,6 +293,13 @@ void ScriptManager::loadExtension(const QString &path)
 
 void ScriptManager::loadQmlExtension(const QString &fileName)
 {
+    // Since the platform-native Qt Quick Controls styles are not shipped
+    // with Tiled, make sure a deterministic style is used. Can be overridden
+    // using the QT_QUICK_CONTROLS_STYLE environment variable. Needs to be
+    // set up before the first extension using Qt Quick Controls is loaded.
+    if (QQuickStyle::name().isEmpty() && qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE"))
+        QQuickStyle::setStyle(QStringLiteral("Fusion"));
+
     Tiled::INFO(tr("Loading '%1'").arg(fileName));
 
     auto component = std::make_unique<QQmlComponent>(mEngine,

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -501,7 +501,13 @@ void ScriptManager::refreshExtensionsPaths()
 
     if (mEngine) {
         Tiled::INFO(tr("Extensions paths changed: %1").arg(mExtensionsPaths.join(QLatin1String(", "))));
-        reset();
+
+        // Never reset immediately, since this function can be reached from
+        // script or QML code. It is called when the project changes, which
+        // can be triggered by a script calling tiled.trigger("CloseProject")
+        // or by a button in a QML extension. Deleting the engine while it is
+        // still executing that code would crash.
+        mResetTimer.start();
     }
 }
 

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -37,6 +37,7 @@
 #include "preferences.h"
 #include "project.h"
 #include "projectmanager.h"
+#include "qmlextension.h"
 #include "regionvaluetype.h"
 #include "scriptbase64.h"
 #include "scriptdialog.h"
@@ -61,6 +62,8 @@
 #include <QDesktopServices>
 #include <QDir>
 #include <QFile>
+#include <QQmlComponent>
+#include <QQmlContext>
 #include <QQmlEngine>
 #include <QStandardPaths>
 #include <QStringDecoder>
@@ -133,6 +136,8 @@ ScriptManager::ScriptManager(QObject *parent)
     qRegisterMetaType<ScriptImage*>();
     qRegisterMetaType<WangIndex::Value>("WangIndex");
 
+    registerQmlExtensionTypes();
+
     connect(&mWatcher, &FileSystemWatcher::pathsChanged,
             this, &ScriptManager::scriptFilesChanged);
 
@@ -146,6 +151,14 @@ ScriptManager::ScriptManager(QObject *parent)
         if (!QFile::exists(mExtensionsPath))
             QDir().mkpath(mExtensionsPath);
     }
+}
+
+ScriptManager::~ScriptManager()
+{
+    // Make sure any loaded QML extensions (which may reference the engine,
+    // for example through a QQuickWidget) are destroyed before the engine is
+    // deleted along with the other children.
+    mQmlExtensions.clear();
 }
 
 void ScriptManager::ensureInitialized()
@@ -258,17 +271,43 @@ void ScriptManager::loadExtension(const QString &path)
 
     const QStringList nameFilters = {
         QLatin1String("*.js"),
-        QLatin1String("*.mjs")
+        QLatin1String("*.mjs"),
+        QLatin1String("*.qml")
     };
     const QDir dir(path);
-    const QStringList jsFiles = dir.entryList(nameFilters,
-                                              QDir::Files | QDir::Readable);
+    const QStringList scriptFiles = dir.entryList(nameFilters,
+                                                  QDir::Files | QDir::Readable);
 
-    for (const QString &jsFile : jsFiles) {
-        const QString absolutePath = dir.filePath(jsFile);
-        evaluateFileOrLoadModule(absolutePath);
+    for (const QString &scriptFile : scriptFiles) {
+        const QString absolutePath = dir.filePath(scriptFile);
+
+        if (scriptFile.endsWith(QLatin1String(".qml"), Qt::CaseInsensitive))
+            loadQmlExtension(absolutePath);
+        else
+            evaluateFileOrLoadModule(absolutePath);
+
         mWatcher.addPath(absolutePath);
     }
+}
+
+void ScriptManager::loadQmlExtension(const QString &fileName)
+{
+    Tiled::INFO(tr("Loading '%1'").arg(fileName));
+
+    auto component = std::make_unique<QQmlComponent>(mEngine,
+                                                     QUrl::fromLocalFile(fileName));
+    if (component->isError()) {
+        onScriptWarnings(component->errors());
+        return;
+    }
+
+    std::unique_ptr<QObject> rootObject { component->create() };
+    if (!rootObject) {
+        onScriptWarnings(component->errors());
+        return;
+    }
+
+    mQmlExtensions.push_back({ std::move(component), std::move(rootObject) });
 }
 
 bool ScriptManager::checkError(QJSValue value, const QString &program)
@@ -328,6 +367,10 @@ void ScriptManager::reset()
 
     mWatcher.clear();
 
+    // QML extensions may reference the engine, for example through a
+    // QQuickWidget, so they need to be destroyed before the engine.
+    mQmlExtensions.clear();
+
     delete mEngine;
     delete mModule;
 
@@ -348,6 +391,11 @@ void ScriptManager::initialize()
 
     mEngine = engine;
     mModule = new ScriptModule(this);
+
+    // Make the 'tiled' object available to expressions in QML extensions
+    // (the global object properties set below are not resolved by the QML
+    // context chain).
+    engine->rootContext()->setContextProperty(QStringLiteral("tiled"), mModule);
 
     QJSValue globalObject = engine->globalObject();
 

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -65,6 +65,7 @@
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QQuickStyle>
 #include <QStandardPaths>
 #include <QStringDecoder>
 #include <QtDebug>
@@ -292,6 +293,19 @@ void ScriptManager::loadExtension(const QString &path)
 
 void ScriptManager::loadQmlExtension(const QString &fileName)
 {
+    // Since the platform-native Qt Quick Controls styles are not shipped
+    // with Tiled, make sure a deterministic style is used. Can be overridden
+    // using the QT_QUICK_CONTROLS_STYLE environment variable. Needs to be
+    // set up before the first extension using Qt Quick Controls is loaded.
+    // Note that QQuickStyle::name can't be used as a guard here, since it
+    // resolves and locks in the platform default style.
+    static bool styleInitialized = false;
+    if (!styleInitialized) {
+        styleInitialized = true;
+        if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE"))
+            QQuickStyle::setStyle(QStringLiteral("Fusion"));
+    }
+
     Tiled::INFO(tr("Loading '%1'").arg(fileName));
 
     auto component = std::make_unique<QQmlComponent>(mEngine,

--- a/src/tiled/scriptmanager.h
+++ b/src/tiled/scriptmanager.h
@@ -29,7 +29,11 @@
 #include <QScopedValueRollback>
 #include <QStringList>
 
-class QJSEngine;
+#include <memory>
+#include <vector>
+
+class QQmlComponent;
+class QQmlEngine;
 
 namespace Tiled {
 
@@ -68,7 +72,7 @@ public:
     const QString &extensionsPath() const;
 
     ScriptModule *module() const;
-    QJSEngine *engine() const;
+    QQmlEngine *engine() const;
 
     QJSValue evaluate(const QString &program,
                       const QString &fileName = QString(), int lineNumber = 1);
@@ -95,7 +99,7 @@ signals:
 
 private:
     explicit ScriptManager(QObject *parent = nullptr);
-    ~ScriptManager() override = default;
+    ~ScriptManager() override;
 
     void reset();
     void initialize();
@@ -106,11 +110,23 @@ private:
 
     void loadExtensions();
     void loadExtension(const QString &path);
+    void loadQmlExtension(const QString &fileName);
 
     QJSValue evaluateFile(const QString &fileName);
 
-    QJSEngine *mEngine = nullptr;
+    /**
+     * The object tree instantiated for a loaded QML extension file. The root
+     * object is destroyed before the component and both are destroyed before
+     * the engine.
+     */
+    struct QmlExtensionFile {
+        std::unique_ptr<QQmlComponent> component;
+        std::unique_ptr<QObject> rootObject;
+    };
+
+    QQmlEngine *mEngine = nullptr;
     ScriptModule *mModule = nullptr;
+    std::vector<QmlExtensionFile> mQmlExtensions;
     FileSystemWatcher mWatcher;
     QString mExtensionsPath;
     QStringList mExtensionsPaths;
@@ -135,7 +151,7 @@ inline ScriptModule *ScriptManager::module() const
     return mModule;
 }
 
-inline QJSEngine *ScriptManager::engine() const
+inline QQmlEngine *ScriptManager::engine() const
 {
     return mEngine;
 }

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -77,9 +77,6 @@ ScriptModule::ScriptModule(QObject *parent)
 
 ScriptModule::~ScriptModule()
 {
-    for (const auto &[id, action] : mRegisteredActions)
-        ActionManager::unregisterAction(action.get(), id);
-
     ActionManager::clearMenuExtensions();
 
     IssuesModel::instance().removeIssuesWithContext(this);
@@ -421,16 +418,14 @@ ScriptedAction *ScriptModule::registerAction(const QByteArray &idName, QJSValue 
 
     if (it != mRegisteredActions.end()) {
         // Remove any previously registered action with the same name
-        ActionManager::unregisterAction(it->second.get(), id);
+        it->second.reset();
     } else if (ActionManager::findAction(id)) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Reserved ID"));
         return nullptr;
     }
 
     auto &action = mRegisteredActions[id];
-
     action = std::make_unique<ScriptedAction>(id, callback, this);
-    ActionManager::registerAction(action.get(), id);
     return action.get();
 }
 

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -77,9 +77,6 @@ ScriptModule::ScriptModule(QObject *parent)
 
 ScriptModule::~ScriptModule()
 {
-    for (const auto &[id, action] : mRegisteredActions)
-        ActionManager::unregisterAction(action.get(), id);
-
     ActionManager::clearMenuExtensions();
 
     IssuesModel::instance().removeIssuesWithContext(this);
@@ -417,18 +414,18 @@ ScriptedAction *ScriptModule::registerAction(const QByteArray &idName, QJSValue 
     }
 
     Id id { idName };
-    auto &action = mRegisteredActions[id];
+    auto it = mRegisteredActions.find(id);
 
-    // Remove any previously registered action with the same name
-    if (action) {
-        ActionManager::unregisterAction(action.get(), id);
+    if (it != mRegisteredActions.end()) {
+        // Remove any previously registered action with the same name
+        it->second.reset();
     } else if (ActionManager::findAction(id)) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Reserved ID"));
         return nullptr;
     }
 
+    auto &action = mRegisteredActions[id];
     action = std::make_unique<ScriptedAction>(id, callback, this);
-    ActionManager::registerAction(action.get(), id);
     return action.get();
 }
 

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -417,15 +417,17 @@ ScriptedAction *ScriptModule::registerAction(const QByteArray &idName, QJSValue 
     }
 
     Id id { idName };
-    auto &action = mRegisteredActions[id];
+    auto it = mRegisteredActions.find(id);
 
-    // Remove any previously registered action with the same name
-    if (action) {
-        ActionManager::unregisterAction(action.get(), id);
+    if (it != mRegisteredActions.end()) {
+        // Remove any previously registered action with the same name
+        ActionManager::unregisterAction(it->second.get(), id);
     } else if (ActionManager::findAction(id)) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Reserved ID"));
         return nullptr;
     }
+
+    auto &action = mRegisteredActions[id];
 
     action = std::make_unique<ScriptedAction>(id, callback, this);
     ActionManager::registerAction(action.get(), id);

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -429,6 +429,39 @@ ScriptedAction *ScriptModule::registerAction(const QByteArray &idName, QJSValue 
     return action.get();
 }
 
+/**
+ * Checks whether the given shortName is still available, reporting an error
+ * when it is already used by another file format.
+ *
+ * The format that is about to be replaced by a re-registration is excluded
+ * from this check, since it is still registered at this point.
+ */
+template<typename Format>
+static bool checkShortNameAvailable(const QString &shortName,
+                                    const Format *replacedFormat)
+{
+    const auto formats = PluginManager::objects<Format>();
+    for (auto format : formats) {
+        if (format != replacedFormat && format->shortName() == shortName) {
+            ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Reserved shortName: '%1'").arg(shortName));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Returns the format currently registered for the given shortName, or nullptr
+ * when there is none.
+ */
+template<typename Container>
+static auto registeredFormat(const Container &formats, const QString &shortName)
+{
+    const auto it = formats.find(shortName);
+    return it != formats.end() ? it->second.get() : nullptr;
+}
+
 void ScriptModule::registerMapFormat(const QString &shortName, QJSValue mapFormatObject)
 {
     if (shortName.isEmpty()) {
@@ -437,6 +470,9 @@ void ScriptModule::registerMapFormat(const QString &shortName, QJSValue mapForma
     }
 
     if (!ScriptedFileFormat::validateFileFormatObject(mapFormatObject))
+        return;
+
+    if (!checkShortNameAvailable<MapFormat>(shortName, registeredFormat(mRegisteredMapFormats, shortName)))
         return;
 
     auto &format = mRegisteredMapFormats[shortName];
@@ -451,6 +487,9 @@ void ScriptModule::registerTilesetFormat(const QString &shortName, QJSValue tile
     }
 
     if (!ScriptedFileFormat::validateFileFormatObject(tilesetFormatObject))
+        return;
+
+    if (!checkShortNameAvailable<TilesetFormat>(shortName, registeredFormat(mRegisteredTilesetFormats, shortName)))
         return;
 
     auto &format = mRegisteredTilesetFormats[shortName];

--- a/tiled.qbs
+++ b/tiled.qbs
@@ -21,6 +21,43 @@ Project {
     property string openSslPath: Environment.getEnv("OPENSSL_PATH")
     property string pythonPkgConfigName: "python3-embed"
 
+    // The QML modules shipped with Tiled for use by QML extensions, along
+    // with the Qt libraries they need at runtime. Used by the "distribute"
+    // and "installer" products (on Linux and macOS, the deployment tools
+    // derive this from dist/qml/imports.qml instead). Only the files directly
+    // in each listed directory are shipped.
+    property stringList qmlImportDirs: [
+        "QML",
+        "QtQml",
+        "QtQml/Models",
+        "QtQml/WorkerScript",
+        "QtQuick",
+        "QtQuick/Controls",
+        "QtQuick/Controls/Basic",
+        "QtQuick/Controls/Basic/impl",
+        "QtQuick/Controls/Fusion",
+        "QtQuick/Controls/Fusion/impl",
+        "QtQuick/Controls/impl",
+        "QtQuick/Layouts",
+        "QtQuick/Templates",
+        "QtQuick/Window",
+    ]
+    property stringList qtQuickLibraries: [
+        "QmlMeta",
+        "QmlModels",
+        "QmlWorkerScript",
+        "Quick",
+        "QuickControls2",
+        "QuickControls2Basic",
+        "QuickControls2BasicStyleImpl",
+        "QuickControls2Fusion",
+        "QuickControls2FusionStyleImpl",
+        "QuickControls2Impl",
+        "QuickLayouts",
+        "QuickTemplates2",
+        "QuickWidgets",
+    ]
+
     references: [
         "dist/archive.qbs",
         "dist/distribute.qbs",


### PR DESCRIPTION
This adds support for writing extensions as declarative QML documents, implementing the idea described in [Next-generation Tiled extensions](https://github.com/mapeditor/tiled/wiki/Next-generation-Tiled-extensions). QML extensions are loaded by the same engine as the JavaScript extensions, which remain fully supported.

The Tiled QML module provides `Action`, `MenuExtension`, `Tool`, `MapFormat`, `TilesetFormat` and `Dock` types, plus an `Extension` type for grouping them. The main advantage is that property bindings can be used to keep dynamic values up to date:
```qml
import Tiled

Action {
    name: "CountLayers"
    text: "Count Layers"
    enabled: tiled.activeAsset && tiled.activeAsset.isTileMap
    onTriggered: tiled.alert("The map has " + tiled.activeAsset.layerCount + " layers.")
}
```
`Dock` elements define custom UI using Qt Quick, shown in a dock widget on the main window or the map/tileset editor windows, with persistent placement. The packages now ship the necessary QML modules (QtQuick, Qt Quick Controls with the Fusion and Basic styles, Layouts, Templates and Window).

The build also generates a QML type description installed to `qml/Tiled`, so `qmllint` and `qmlls` can check extensions and provide completion.

For examples, see the [`qml` branch of tiled-extensions](https://github.com/mapeditor/tiled-extensions/tree/qml), where all extensions have been ported to QML.