### PR TITLE
New Hardware Renderer: Add object layer support

### DIFF
--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -49,6 +49,8 @@ DynamicLibrary {
         "tiledquick_global.h",
         "tilelayeritem.cpp",
         "tilelayeritem.h",
+        "tilesethelper.cpp",
+        "tilesethelper.h",
         "tilesnode.cpp",
         "tilesnode.h",
     ]

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -38,6 +38,12 @@ DynamicLibrary {
         "mapitem.h",
         "maploader.cpp",
         "maploader.h",
+        "objectgroupitem.cpp",
+        "objectgroupitem.h",
+        "objectgroupmaterial.cpp",
+        "objectgroupmaterial.h",
+        "objectsnode.cpp",
+        "objectsnode.h",
         "regionoverlay.cpp",
         "regionoverlay.h",
         "tiledquick_global.h",
@@ -57,8 +63,10 @@ DynamicLibrary {
     Group {
         name: "Shaders"
         files: [
-            "grid.vert",
             "grid.frag",
+            "grid.vert",
+            "objectgroup.frag",
+            "objectgroup.vert",
         ]
     }
 

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -42,6 +42,8 @@ DynamicLibrary {
         "objectgroupitem.h",
         "objectgroupmaterial.cpp",
         "objectgroupmaterial.h",
+        "objectinteractionitem.cpp",
+        "objectinteractionitem.h",
         "objectsnode.cpp",
         "objectsnode.h",
         "regionoverlay.cpp",

--- a/src/libtiledquick/mapitem.cpp
+++ b/src/libtiledquick/mapitem.cpp
@@ -72,17 +72,17 @@ void MapItem::setVisibleArea(const QRectF &visibleArea)
     emit visibleAreaChanged();
 }
 
-void MapItem::setScale(const qreal &scale)
+void MapItem::setZoom(const qreal &zoom)
 {
-    if (mScale == scale)
+    if (mZoom == zoom)
         return;
 
-    mScale = scale;
+    mZoom = zoom;
 
     for (auto objectGroup : std::as_const(mObjectGroupItems))
-        objectGroup->setMapScale(scale);
+        objectGroup->setZoom(zoom);
 
-    emit scaleChanged();
+    emit zoomChanged();
 }
 
 QRectF MapItem::boundingRect() const
@@ -205,6 +205,7 @@ void MapItem::refresh()
         if (Tiled::ObjectGroup *og = layer->asObjectGroup()) {
             ObjectGroupItem *groupItem = new ObjectGroupItem(og, mRenderer.get(), this);
             mObjectGroupItems.append(groupItem);
+            groupItem->setZoom(mZoom);
         }
     }
 

--- a/src/libtiledquick/mapitem.cpp
+++ b/src/libtiledquick/mapitem.cpp
@@ -21,6 +21,7 @@
 #include "mapitem.h"
 
 #include "tilelayeritem.h"
+#include "objectgroupitem.h"
 
 #include "map.h"
 #include "maprenderer.h"
@@ -43,12 +44,14 @@ void MapItem::setMap(Tiled::EditableMap *editableMap)
     if (mEditableMap && mEditableMap->mapDocument()) {
         Tiled::MapDocument *oldMapDocument = mEditableMap->mapDocument();
         disconnect(oldMapDocument, &Tiled::MapDocument::regionChanged, this, &MapItem::repaintRegion);
+        disconnect(oldMapDocument, &Tiled::MapDocument::mapObjectsChanged, this, &MapItem::repaintObjects);
         disconnect(oldMapDocument, &Tiled::MapDocument::mapResized, this, &MapItem::refresh);
     }
 
     if (editableMap && editableMap->mapDocument()) {
         Tiled::MapDocument *mapDocument = editableMap->mapDocument();
         connect(mapDocument, &Tiled::MapDocument::regionChanged, this, &MapItem::repaintRegion);
+        connect(mapDocument, &Tiled::MapDocument::mapObjectsChanged, this, &MapItem::repaintObjects);
         connect(mapDocument, &Tiled::MapDocument::mapResized, this, &MapItem::refresh);
     }
 
@@ -166,6 +169,9 @@ void MapItem::refresh()
     qDeleteAll(mTileLayerItems);
     mTileLayerItems.clear();
 
+    qDeleteAll(mObjectGroupItems);
+    mObjectGroupItems.clear();
+
     mRenderer = nullptr;
 
     if (!mMap)
@@ -177,6 +183,11 @@ void MapItem::refresh()
         if (Tiled::TileLayer *tl = layer->asTileLayer()) {
             TileLayerItem *layerItem = new TileLayerItem(tl, mRenderer.get(), this);
             mTileLayerItems.append(layerItem);
+        }
+
+        if (Tiled::ObjectGroup *og = layer->asObjectGroup()) {
+            ObjectGroupItem *groupItem = new ObjectGroupItem(og, mRenderer.get(), this);
+            mObjectGroupItems.append(groupItem);
         }
     }
 
@@ -191,6 +202,22 @@ void MapItem::repaintRegion(const QRegion &, Tiled::TileLayer *tileLayer)
             // TODO: Update only the region edited
             tileLayerItem->update();
             break;
+        }
+    }
+}
+
+void MapItem::repaintObjects(const QList<Tiled::MapObject*> &objects)
+{
+    QSet<Tiled::ObjectGroup*> changedGroups;
+    for (auto *object : objects)
+        changedGroups.insert(object->objectGroup());
+
+    // TODO: Update only subgroups containing affected tiles rather than entire layers
+    for (auto *objectGroupItem : std::as_const(mObjectGroupItems)) {
+        if (changedGroups.contains(objectGroupItem->group()))
+        {
+            // objectGroupItem->syncWithObjectGroup();
+            objectGroupItem->update();
         }
     }
 }

--- a/src/libtiledquick/mapitem.cpp
+++ b/src/libtiledquick/mapitem.cpp
@@ -26,6 +26,7 @@
 #include "map.h"
 #include "maprenderer.h"
 #include "tilelayer.h"
+#include "tilesethelper.h"
 
 using namespace TiledQuick;
 
@@ -34,7 +35,10 @@ MapItem::MapItem(QQuickItem *parent)
 {
 }
 
-MapItem::~MapItem() = default;
+MapItem::~MapItem()
+{
+    TilesetHelper::deleteInstance();
+};
 
 void MapItem::setMap(Tiled::EditableMap *editableMap)
 {
@@ -66,6 +70,19 @@ void MapItem::setVisibleArea(const QRectF &visibleArea)
 {
     mVisibleArea = visibleArea;
     emit visibleAreaChanged();
+}
+
+void MapItem::setScale(const qreal &scale)
+{
+    if (mScale == scale)
+        return;
+
+    mScale = scale;
+
+    for (auto objectGroup : std::as_const(mObjectGroupItems))
+        objectGroup->setMapScale(scale);
+
+    emit scaleChanged();
 }
 
 QRectF MapItem::boundingRect() const

--- a/src/libtiledquick/mapitem.cpp
+++ b/src/libtiledquick/mapitem.cpp
@@ -230,7 +230,10 @@ void MapItem::repaintObjects(const QList<Tiled::MapObject*> &objects)
     for (auto *object : objects)
         changedGroups.insert(object->objectGroup());
 
-    // TODO: Update only subgroups containing affected tiles rather than entire layers
+    if (changedGroups.size() == 0)
+        return;
+
+    // TODO: Update only nodes containing affected objects rather than entire layers
     for (auto *objectGroupItem : std::as_const(mObjectGroupItems)) {
         if (changedGroups.contains(objectGroupItem->group()))
         {
@@ -238,4 +241,6 @@ void MapItem::repaintObjects(const QList<Tiled::MapObject*> &objects)
             objectGroupItem->update();
         }
     }
+
+    emit mapObjectsChanged();
 }

--- a/src/libtiledquick/mapitem.cpp
+++ b/src/libtiledquick/mapitem.cpp
@@ -21,17 +21,16 @@
 #include "mapitem.h"
 
 #include "tilelayeritem.h"
-#include "objectgroupitem.h"
+#include "tilesethelper.h"
 
 #include "map.h"
 #include "maprenderer.h"
-#include "tilelayer.h"
-#include "tilesethelper.h"
 
 using namespace TiledQuick;
 
 MapItem::MapItem(QQuickItem *parent)
     : QQuickItem(parent)
+    , mNewObjectsPreviewItem(nullptr, nullptr, this)
 {
 }
 
@@ -81,8 +80,28 @@ void MapItem::setZoom(const qreal &zoom)
 
     for (auto objectGroup : std::as_const(mObjectGroupItems))
         objectGroup->setZoom(zoom);
+    mNewObjectsPreviewItem.setZoom(zoom);
+
+    // Since the tool brush is always fully rendered and does not
+    // receive the visibleAreaChanged signal upon zoom changes,
+    // we need to update it here.
+    mNewObjectsPreviewItem.update();
 
     emit zoomChanged();
+}
+
+void MapItem::setNewObjectsPreview(Tiled::ObjectGroup *objects)
+{
+    if (mNewObjectsPreviewItem.group() == objects)
+        return;
+
+    mNewObjectsPreviewItem.setObjectGroup(objects);
+    emit newObjectsPreviewChanged();
+}
+
+void MapItem::repaintPreview()
+{
+    mNewObjectsPreviewItem.update();
 }
 
 QRectF MapItem::boundingRect() const
@@ -195,6 +214,8 @@ void MapItem::refresh()
         return;
 
     mRenderer = Tiled::MapRenderer::create(mMap);
+    mNewObjectsPreviewItem.setRenderer(mRenderer.get());
+    mNewObjectsPreviewItem.setZoom(mZoom);
 
     for (Tiled::Layer *layer : mMap->layers()) {
         if (Tiled::TileLayer *tl = layer->asTileLayer()) {
@@ -224,18 +245,18 @@ void MapItem::repaintRegion(const QRegion &, Tiled::TileLayer *tileLayer)
     }
 }
 
-void MapItem::repaintObjects(const QList<Tiled::MapObject*> &objects)
+void MapItem::repaintObjects(const QList<Tiled::MapObject*> &objects, ObjectGroup *group)
 {
     QSet<Tiled::ObjectGroup*> changedGroups;
-    for (auto *object : objects)
+    for (auto object : objects)
         changedGroups.insert(object->objectGroup());
 
-    if (changedGroups.size() == 0)
+    if (changedGroups.size() == 0 && !group)
         return;
 
     // TODO: Update only nodes containing affected objects rather than entire layers
-    for (auto *objectGroupItem : std::as_const(mObjectGroupItems)) {
-        if (changedGroups.contains(objectGroupItem->group()))
+    for (auto objectGroupItem : std::as_const(mObjectGroupItems)) {
+        if (objectGroupItem->group() == group || changedGroups.contains(objectGroupItem->group()))
         {
             // objectGroupItem->syncWithObjectGroup();
             objectGroupItem->update();

--- a/src/libtiledquick/mapitem.cpp
+++ b/src/libtiledquick/mapitem.cpp
@@ -46,16 +46,18 @@ void MapItem::setMap(Tiled::EditableMap *editableMap)
 
     if (mEditableMap && mEditableMap->mapDocument()) {
         Tiled::MapDocument *oldMapDocument = mEditableMap->mapDocument();
+        disconnect(oldMapDocument, &Tiled::MapDocument::mapResized, this, &MapItem::refresh);
         disconnect(oldMapDocument, &Tiled::MapDocument::regionChanged, this, &MapItem::repaintRegion);
         disconnect(oldMapDocument, &Tiled::MapDocument::mapObjectsChanged, this, &MapItem::repaintObjects);
-        disconnect(oldMapDocument, &Tiled::MapDocument::mapResized, this, &MapItem::refresh);
+        disconnect(oldMapDocument, &Tiled::MapDocument::tileLayerChanged, this, &MapItem::onTileLayerChanged);
     }
 
     if (editableMap && editableMap->mapDocument()) {
         Tiled::MapDocument *mapDocument = editableMap->mapDocument();
+        connect(mapDocument, &Tiled::MapDocument::mapResized, this, &MapItem::refresh);
         connect(mapDocument, &Tiled::MapDocument::regionChanged, this, &MapItem::repaintRegion);
         connect(mapDocument, &Tiled::MapDocument::mapObjectsChanged, this, &MapItem::repaintObjects);
-        connect(mapDocument, &Tiled::MapDocument::mapResized, this, &MapItem::refresh);
+        connect(mapDocument, &Tiled::MapDocument::tileLayerChanged, this, &MapItem::onTileLayerChanged);
     }
 
     mEditableMap = editableMap;
@@ -273,4 +275,10 @@ void MapItem::repaintObjects(const QList<Tiled::MapObject*> &objects, ObjectGrou
     }
 
     emit mapObjectsChanged();
+}
+
+void MapItem::onTileLayerChanged(Tiled::TileLayer *layer, Tiled::MapDocument::TileLayerChangeFlags) {
+    for (auto layerItem : std::as_const(mTileLayerItems))
+        if (layerItem->layer() == layer && layerItem->isVisible() != layer->isVisible())
+            layerItem->layerVisibilityChanged();
 }

--- a/src/libtiledquick/mapitem.cpp
+++ b/src/libtiledquick/mapitem.cpp
@@ -99,6 +99,15 @@ void MapItem::setNewObjectsPreview(Tiled::ObjectGroup *objects)
     emit newObjectsPreviewChanged();
 }
 
+void MapItem::setMousePos(const QPointF &pos)
+{
+    if (mNewObjectsPreviewItem.mousePos() == pos)
+        return;
+
+    mNewObjectsPreviewItem.setMousePos(pos);
+    emit mousePosChanged();
+}
+
 void MapItem::repaintPreview()
 {
     mNewObjectsPreviewItem.update();

--- a/src/libtiledquick/mapitem.h
+++ b/src/libtiledquick/mapitem.h
@@ -35,6 +35,7 @@ namespace TiledQuick {
 
 class TileItem;
 class TileLayerItem;
+class ObjectGroupItem;
 
 /**
  * A declarative item that displays a map.
@@ -81,6 +82,7 @@ private:
     void refresh();
 
     void repaintRegion(const QRegion &region, Tiled::TileLayer *tileLayer);
+    void repaintObjects(const QList<Tiled::MapObject*> &objects);
 
     Tiled::Map *mMap = nullptr;
     Tiled::EditableMap *mEditableMap = nullptr;
@@ -88,6 +90,7 @@ private:
 
     std::unique_ptr<Tiled::MapRenderer> mRenderer;
     QList<TileLayerItem*> mTileLayerItems;
+    QList<ObjectGroupItem*> mObjectGroupItems;
 };
 
 inline const QRectF &MapItem::visibleArea() const

--- a/src/libtiledquick/mapitem.h
+++ b/src/libtiledquick/mapitem.h
@@ -46,6 +46,7 @@ class TILEDQUICK_SHARED_EXPORT MapItem : public QQuickItem
 
     Q_PROPERTY(Tiled::EditableMap *map READ map WRITE setMap RESET unsetMap NOTIFY mapChanged)
     Q_PROPERTY(QRectF visibleArea READ visibleArea WRITE setVisibleArea NOTIFY visibleAreaChanged)
+    Q_PROPERTY(qreal scale READ scale WRITE setScale NOTIFY scaleChanged)
 
 public:
     explicit MapItem(QQuickItem *parent = nullptr);
@@ -57,6 +58,9 @@ public:
 
     const QRectF &visibleArea() const;
     void setVisibleArea(const QRectF &visibleArea);
+
+    const qreal &scale() const;
+    void setScale(const qreal &scale);
 
     QRectF boundingRect() const override;
 
@@ -87,6 +91,7 @@ private:
     Tiled::Map *mMap = nullptr;
     Tiled::EditableMap *mEditableMap = nullptr;
     QRectF mVisibleArea;
+    qreal mScale = 1;
 
     std::unique_ptr<Tiled::MapRenderer> mRenderer;
     QList<TileLayerItem*> mTileLayerItems;
@@ -96,6 +101,11 @@ private:
 inline const QRectF &MapItem::visibleArea() const
 {
     return mVisibleArea;
+}
+
+inline const qreal &MapItem::scale() const
+{
+    return mScale;
 }
 
 inline Tiled::EditableMap *MapItem::map() const

--- a/src/libtiledquick/mapitem.h
+++ b/src/libtiledquick/mapitem.h
@@ -46,7 +46,7 @@ class TILEDQUICK_SHARED_EXPORT MapItem : public QQuickItem
 
     Q_PROPERTY(Tiled::EditableMap *map READ map WRITE setMap RESET unsetMap NOTIFY mapChanged)
     Q_PROPERTY(QRectF visibleArea READ visibleArea WRITE setVisibleArea NOTIFY visibleAreaChanged)
-    Q_PROPERTY(qreal scale READ scale WRITE setScale NOTIFY scaleChanged)
+    Q_PROPERTY(qreal zoom READ zoom WRITE setZoom NOTIFY zoomChanged)
 
 public:
     explicit MapItem(QQuickItem *parent = nullptr);
@@ -59,8 +59,8 @@ public:
     const QRectF &visibleArea() const;
     void setVisibleArea(const QRectF &visibleArea);
 
-    const qreal &scale() const;
-    void setScale(const qreal &scale);
+    const qreal &zoom() const;
+    void setZoom(const qreal &zoom);
 
     QRectF boundingRect() const override;
 
@@ -81,6 +81,7 @@ public:
 signals:
     void mapChanged();
     void visibleAreaChanged();
+    void zoomChanged();
 
 private:
     void refresh();
@@ -91,7 +92,7 @@ private:
     Tiled::Map *mMap = nullptr;
     Tiled::EditableMap *mEditableMap = nullptr;
     QRectF mVisibleArea;
-    qreal mScale = 1;
+    qreal mZoom = 0;
 
     std::unique_ptr<Tiled::MapRenderer> mRenderer;
     QList<TileLayerItem*> mTileLayerItems;
@@ -103,9 +104,9 @@ inline const QRectF &MapItem::visibleArea() const
     return mVisibleArea;
 }
 
-inline const qreal &MapItem::scale() const
+inline const qreal &MapItem::zoom() const
 {
-    return mScale;
+    return mZoom;
 }
 
 inline Tiled::EditableMap *MapItem::map() const

--- a/src/libtiledquick/mapitem.h
+++ b/src/libtiledquick/mapitem.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "editablemap.h"
+#include "objectgroupitem.h"
 #include "tiledquick_global.h"
 
 #include <QQuickItem>
@@ -48,6 +49,13 @@ class TILEDQUICK_SHARED_EXPORT MapItem : public QQuickItem
     Q_PROPERTY(QRectF visibleArea READ visibleArea WRITE setVisibleArea NOTIFY visibleAreaChanged)
     Q_PROPERTY(qreal zoom READ zoom WRITE setZoom NOTIFY zoomChanged)
 
+    /**
+     * Holds a pointer to the selected object tool's new object preview group.
+     *
+     * This is used by mapview's toolBrush, and should remain nullptr when used for standard mapItems.
+     */
+    Q_PROPERTY(Tiled::ObjectGroup *newObjectsPreview READ newObjectsPreview WRITE setNewObjectsPreview NOTIFY newObjectsPreviewChanged)
+
 public:
     explicit MapItem(QQuickItem *parent = nullptr);
     ~MapItem() override;
@@ -61,6 +69,11 @@ public:
 
     const qreal &zoom() const;
     void setZoom(const qreal &zoom);
+
+    Tiled::ObjectGroup *newObjectsPreview() const;
+    void setNewObjectsPreview(Tiled::ObjectGroup *objects);
+
+    Q_INVOKABLE void repaintPreview();
 
     QRectF boundingRect() const override;
 
@@ -83,17 +96,19 @@ signals:
     void mapObjectsChanged();
     void visibleAreaChanged();
     void zoomChanged();
+    void newObjectsPreviewChanged();
 
 private:
     void refresh();
 
     void repaintRegion(const QRegion &region, Tiled::TileLayer *tileLayer);
-    void repaintObjects(const QList<Tiled::MapObject*> &objects);
+    void repaintObjects(const QList<Tiled::MapObject*> &objects, Tiled::ObjectGroup *group = nullptr);
 
     Tiled::Map *mMap = nullptr;
     Tiled::EditableMap *mEditableMap = nullptr;
     QRectF mVisibleArea;
     qreal mZoom = 0;
+    ObjectGroupItem mNewObjectsPreviewItem;
 
     std::unique_ptr<Tiled::MapRenderer> mRenderer;
     QList<TileLayerItem*> mTileLayerItems;
@@ -118,6 +133,11 @@ inline Tiled::EditableMap *MapItem::map() const
 inline void MapItem::unsetMap()
 {
     setMap(nullptr);
+}
+
+inline Tiled::ObjectGroup *MapItem::newObjectsPreview() const
+{
+    return mNewObjectsPreviewItem.group();
 }
 
 } // namespace TiledQuick

--- a/src/libtiledquick/mapitem.h
+++ b/src/libtiledquick/mapitem.h
@@ -105,6 +105,7 @@ private:
 
     void repaintRegion(const QRegion &region, Tiled::TileLayer *tileLayer);
     void repaintObjects(const QList<Tiled::MapObject*> &objects, Tiled::ObjectGroup *group = nullptr);
+    void onTileLayerChanged(Tiled::TileLayer *layer, Tiled::MapDocument::TileLayerChangeFlags flags);
 
     Tiled::Map *mMap = nullptr;
     Tiled::EditableMap *mEditableMap = nullptr;

--- a/src/libtiledquick/mapitem.h
+++ b/src/libtiledquick/mapitem.h
@@ -49,12 +49,9 @@ class TILEDQUICK_SHARED_EXPORT MapItem : public QQuickItem
     Q_PROPERTY(QRectF visibleArea READ visibleArea WRITE setVisibleArea NOTIFY visibleAreaChanged)
     Q_PROPERTY(qreal zoom READ zoom WRITE setZoom NOTIFY zoomChanged)
 
-    /**
-     * Holds a pointer to the selected object tool's new object preview group.
-     *
-     * This is used by mapview's toolBrush, and should remain nullptr when used for standard mapItems.
-     */
+    // MapView toolBrush only properties. Should remain nullptr for standard MapItem usage.
     Q_PROPERTY(Tiled::ObjectGroup *newObjectsPreview READ newObjectsPreview WRITE setNewObjectsPreview NOTIFY newObjectsPreviewChanged)
+    Q_PROPERTY(QPointF mousePos READ mousePos WRITE setMousePos NOTIFY mousePosChanged)
 
 public:
     explicit MapItem(QQuickItem *parent = nullptr);
@@ -72,6 +69,9 @@ public:
 
     Tiled::ObjectGroup *newObjectsPreview() const;
     void setNewObjectsPreview(Tiled::ObjectGroup *objects);
+
+    QPointF mousePos() const;
+    void setMousePos(const QPointF &pos);
 
     Q_INVOKABLE void repaintPreview();
 
@@ -96,7 +96,9 @@ signals:
     void mapObjectsChanged();
     void visibleAreaChanged();
     void zoomChanged();
+
     void newObjectsPreviewChanged();
+    void mousePosChanged();
 
 private:
     void refresh();
@@ -138,6 +140,11 @@ inline void MapItem::unsetMap()
 inline Tiled::ObjectGroup *MapItem::newObjectsPreview() const
 {
     return mNewObjectsPreviewItem.group();
+}
+
+inline QPointF MapItem::mousePos() const
+{
+    return mNewObjectsPreviewItem.mousePos();
 }
 
 } // namespace TiledQuick

--- a/src/libtiledquick/mapitem.h
+++ b/src/libtiledquick/mapitem.h
@@ -80,6 +80,7 @@ public:
 
 signals:
     void mapChanged();
+    void mapObjectsChanged();
     void visibleAreaChanged();
     void zoomChanged();
 

--- a/src/libtiledquick/objectgroup.frag
+++ b/src/libtiledquick/objectgroup.frag
@@ -10,10 +10,10 @@ const int TYPE_TEXT = 6;
 const int TYPE_POINT = 7;
 const int TYPE_TILE = 8;
 
-layout(location = 0) in vec2 in_local_pos;
-layout(location = 1) in vec2 in_tc;
-layout(location = 2) in vec4 in_tint_alpha;
-layout(location = 3) flat in uint in_object_type;
+// layout(location = 0) in vec2 in_local_pos;
+layout(location = 0) in vec2 in_tc;
+layout(location = 1) in vec4 in_tint_alpha;
+// layout(location = 3) flat in uint in_object_type;
 
 layout(location = 0) out vec4 fragColor;
 
@@ -22,23 +22,25 @@ layout(binding = 1) uniform sampler2D tex;
 vec4 tint = vec4(in_tint_alpha.rgb, 1);
 float alpha = in_tint_alpha.a;
 
-vec4 draw_tile()
-{
-    vec4 tex_color = texture(tex, in_tc);
-    return tex_color * tint * alpha;
-}
+// vec4 draw_tile()
+// {
+//     vec4 tex_color = texture(tex, in_tc);
+//     return tex_color * tint * alpha;
+// }
 
 void main()
 {
-    vec4 color = vec4(255,0,255,255);
+    vec4 tex_color = texture(tex, in_tc);
+    fragColor = tex_color * tint * alpha;
+    // vec4 color = vec4(255,0,255,255);
 
-    switch (in_object_type) {
-    case TYPE_TILE:
-        color = draw_tile();
-        break;
-    default:
-        break;
-    }
+    // switch (in_object_type) {
+    // case TYPE_TILE:
+    //     color = draw_tile();
+    //     break;
+    // default:
+    //     break;
+    // }
 
-    fragColor = color;
+    // fragColor = color;
 }

--- a/src/libtiledquick/objectgroup.frag
+++ b/src/libtiledquick/objectgroup.frag
@@ -1,17 +1,44 @@
 #version 440
 
-layout(location = 0) in vec2 in_tc;
-layout(location = 1) in vec4 in_tint_alpha;
+// This faux-enum should be identical to ObjectGroupMaterial::ObjectType
+const int TYPE_RECTANGLE = 1;
+const int TYPE_POLYGON = 2;
+const int TYPE_POLYLINE = 3;
+const int TYPE_ELLIPSE = 4;
+const int TYPE_CAPSULE = 5;
+const int TYPE_TEXT = 6;
+const int TYPE_POINT = 7;
+const int TYPE_TILE = 8;
+
+layout(location = 0) in vec2 in_local_pos;
+layout(location = 1) in vec2 in_tc;
+layout(location = 2) in vec4 in_tint_alpha;
+layout(location = 3) flat in uint in_object_type;
 
 layout(location = 0) out vec4 fragColor;
 
 layout(binding = 1) uniform sampler2D tex;
 
+vec4 tint = vec4(in_tint_alpha.rgb, 1);
+float alpha = in_tint_alpha.a;
+
+vec4 draw_tile()
+{
+    vec4 tex_color = texture(tex, in_tc);
+    return tex_color * tint * alpha;
+}
+
 void main()
 {
-    vec4 color = texture(tex, in_tc);
-    vec4 tint = vec4(in_tint_alpha.rgb, 1);
-    float alpha = in_tint_alpha.a;
+    vec4 color = vec4(255,0,255,255);
 
-    fragColor = color * tint * alpha;
+    switch (in_object_type) {
+    case TYPE_TILE:
+        color = draw_tile();
+        break;
+    default:
+        break;
+    }
+
+    fragColor = color;
 }

--- a/src/libtiledquick/objectgroup.frag
+++ b/src/libtiledquick/objectgroup.frag
@@ -1,0 +1,17 @@
+#version 440
+
+layout(location = 0) in vec2 in_tc;
+layout(location = 1) in vec4 in_tint_alpha;
+
+layout(location = 0) out vec4 fragColor;
+
+layout(binding = 1) uniform sampler2D tex;
+
+void main()
+{
+    vec4 color = texture(tex, in_tc);
+    vec4 tint = vec4(in_tint_alpha.rgb, 1);
+    float alpha = in_tint_alpha.a;
+
+    fragColor = color * tint * alpha;
+}

--- a/src/libtiledquick/objectgroup.frag
+++ b/src/libtiledquick/objectgroup.frag
@@ -1,19 +1,7 @@
 #version 440
 
-// This faux-enum should be identical to ObjectGroupMaterial::ObjectType
-const int TYPE_RECTANGLE = 1;
-const int TYPE_POLYGON = 2;
-const int TYPE_POLYLINE = 3;
-const int TYPE_ELLIPSE = 4;
-const int TYPE_CAPSULE = 5;
-const int TYPE_TEXT = 6;
-const int TYPE_POINT = 7;
-const int TYPE_TILE = 8;
-
-// layout(location = 0) in vec2 in_local_pos;
 layout(location = 0) in vec2 in_tc;
 layout(location = 1) in vec4 in_tint_alpha;
-// layout(location = 3) flat in uint in_object_type;
 
 layout(location = 0) out vec4 fragColor;
 
@@ -22,25 +10,8 @@ layout(binding = 1) uniform sampler2D tex;
 vec4 tint = vec4(in_tint_alpha.rgb, 1);
 float alpha = in_tint_alpha.a;
 
-// vec4 draw_tile()
-// {
-//     vec4 tex_color = texture(tex, in_tc);
-//     return tex_color * tint * alpha;
-// }
-
 void main()
 {
     vec4 tex_color = texture(tex, in_tc);
     fragColor = tex_color * tint * alpha;
-    // vec4 color = vec4(255,0,255,255);
-
-    // switch (in_object_type) {
-    // case TYPE_TILE:
-    //     color = draw_tile();
-    //     break;
-    // default:
-    //     break;
-    // }
-
-    // fragColor = color;
 }

--- a/src/libtiledquick/objectgroup.frag
+++ b/src/libtiledquick/objectgroup.frag
@@ -1,17 +1,17 @@
 #version 440
 
-layout(location = 0) in vec2 in_tc;
-layout(location = 1) in vec4 in_tint_alpha;
+layout(location = 0) in vec2 texCoord;
+layout(location = 1) in vec4 tintAlpha;
 
 layout(location = 0) out vec4 fragColor;
 
 layout(binding = 1) uniform sampler2D tex;
 
-vec4 tint = vec4(in_tint_alpha.rgb, 1);
-float alpha = in_tint_alpha.a;
+vec4 tint = vec4(tintAlpha.rgb, 1);
+float alpha = tintAlpha.a;
 
 void main()
 {
-    vec4 tex_color = texture(tex, in_tc);
-    fragColor = tex_color * tint * alpha;
+    vec4 texColor = texture(tex, texCoord);
+    fragColor = texColor * tint * alpha;
 }

--- a/src/libtiledquick/objectgroup.vert
+++ b/src/libtiledquick/objectgroup.vert
@@ -1,15 +1,15 @@
 #version 440
 
 layout(location = 0) in vec2 in_global_pos;
-layout(location = 1) in vec2 in_local_pos;
-layout(location = 2) in vec2 in_tc;
-layout(location = 3) in vec4 in_tint_alpha;
-layout(location = 4) in float in_object_type;
+// layout(location = 1) in vec2 in_local_pos;
+layout(location = 1) in vec2 in_tc;
+layout(location = 2) in vec4 in_tint_alpha;
+// layout(location = 4) in float in_object_type;
 
-layout(location = 0) out vec2 out_local_pos;
-layout(location = 1) out vec2 out_tc;
-layout(location = 2) out vec4 out_tint_alpha;
-layout(location = 3) flat out uint out_object_type;
+// layout(location = 0) out vec2 out_local_pos;
+layout(location = 0) out vec2 out_tc;
+layout(location = 1) out vec4 out_tint_alpha;
+// layout(location = 3) flat out uint out_object_type;
 
 layout(std140, binding = 0) uniform buf {
     mat4 matrix;
@@ -18,9 +18,9 @@ layout(std140, binding = 0) uniform buf {
 
 void main()
 {
-    out_local_pos = in_local_pos;
+    // out_local_pos = in_local_pos;
     out_tc = in_tc;
     out_tint_alpha = vec4(in_tint_alpha.rgb, in_tint_alpha.a * ubuf.opacity);
-    out_object_type = uint(in_object_type);
+    // out_object_type = uint(in_object_type);
     gl_Position = ubuf.matrix * vec4(in_global_pos, 0.0, 1.0);
 }

--- a/src/libtiledquick/objectgroup.vert
+++ b/src/libtiledquick/objectgroup.vert
@@ -1,0 +1,20 @@
+#version 440
+
+layout(location = 0) in vec2 in_pos;
+layout(location = 1) in vec2 in_tc;
+layout(location = 2) in vec4 in_tint_alpha;
+
+layout(location = 0) out vec2 out_tc;
+layout(location = 1) out vec4 out_tint_alpha;
+
+layout(std140, binding = 0) uniform buf {
+    mat4 matrix;
+    float opacity;
+} ubuf;
+
+void main()
+{
+    out_tc = in_tc;
+    out_tint_alpha = vec4(in_tint_alpha.rgb, in_tint_alpha.a * ubuf.opacity);
+    gl_Position = ubuf.matrix * vec4(in_pos, 0.0, 1.0);
+}

--- a/src/libtiledquick/objectgroup.vert
+++ b/src/libtiledquick/objectgroup.vert
@@ -1,11 +1,15 @@
 #version 440
 
-layout(location = 0) in vec2 in_pos;
-layout(location = 1) in vec2 in_tc;
-layout(location = 2) in vec4 in_tint_alpha;
+layout(location = 0) in vec2 in_global_pos;
+layout(location = 1) in vec2 in_local_pos;
+layout(location = 2) in vec2 in_tc;
+layout(location = 3) in vec4 in_tint_alpha;
+layout(location = 4) in float in_object_type;
 
-layout(location = 0) out vec2 out_tc;
-layout(location = 1) out vec4 out_tint_alpha;
+layout(location = 0) out vec2 out_local_pos;
+layout(location = 1) out vec2 out_tc;
+layout(location = 2) out vec4 out_tint_alpha;
+layout(location = 3) flat out uint out_object_type;
 
 layout(std140, binding = 0) uniform buf {
     mat4 matrix;
@@ -14,7 +18,9 @@ layout(std140, binding = 0) uniform buf {
 
 void main()
 {
+    out_local_pos = in_local_pos;
     out_tc = in_tc;
     out_tint_alpha = vec4(in_tint_alpha.rgb, in_tint_alpha.a * ubuf.opacity);
-    gl_Position = ubuf.matrix * vec4(in_pos, 0.0, 1.0);
+    out_object_type = uint(in_object_type);
+    gl_Position = ubuf.matrix * vec4(in_global_pos, 0.0, 1.0);
 }

--- a/src/libtiledquick/objectgroup.vert
+++ b/src/libtiledquick/objectgroup.vert
@@ -1,15 +1,11 @@
 #version 440
 
 layout(location = 0) in vec2 in_global_pos;
-// layout(location = 1) in vec2 in_local_pos;
 layout(location = 1) in vec2 in_tc;
 layout(location = 2) in vec4 in_tint_alpha;
-// layout(location = 4) in float in_object_type;
 
-// layout(location = 0) out vec2 out_local_pos;
 layout(location = 0) out vec2 out_tc;
 layout(location = 1) out vec4 out_tint_alpha;
-// layout(location = 3) flat out uint out_object_type;
 
 layout(std140, binding = 0) uniform buf {
     mat4 matrix;
@@ -18,9 +14,7 @@ layout(std140, binding = 0) uniform buf {
 
 void main()
 {
-    // out_local_pos = in_local_pos;
     out_tc = in_tc;
     out_tint_alpha = vec4(in_tint_alpha.rgb, in_tint_alpha.a * ubuf.opacity);
-    // out_object_type = uint(in_object_type);
     gl_Position = ubuf.matrix * vec4(in_global_pos, 0.0, 1.0);
 }

--- a/src/libtiledquick/objectgroup.vert
+++ b/src/libtiledquick/objectgroup.vert
@@ -1,11 +1,11 @@
 #version 440
 
-layout(location = 0) in vec2 in_global_pos;
-layout(location = 1) in vec2 in_tc;
-layout(location = 2) in vec4 in_tint_alpha;
+layout(location = 0) in vec2 in_globalPos;
+layout(location = 1) in vec2 in_texCoord;
+layout(location = 2) in vec4 in_tintAlpha;
 
-layout(location = 0) out vec2 out_tc;
-layout(location = 1) out vec4 out_tint_alpha;
+layout(location = 0) out vec2 texCoord;
+layout(location = 1) out vec4 tintAlpha;
 
 layout(std140, binding = 0) uniform buf {
     mat4 matrix;
@@ -14,7 +14,7 @@ layout(std140, binding = 0) uniform buf {
 
 void main()
 {
-    out_tc = in_tc;
-    out_tint_alpha = vec4(in_tint_alpha.rgb, in_tint_alpha.a * ubuf.opacity);
-    gl_Position = ubuf.matrix * vec4(in_global_pos, 0.0, 1.0);
+    texCoord = in_texCoord;
+    tintAlpha = vec4(in_tintAlpha.rgb, in_tintAlpha.a * ubuf.opacity);
+    gl_Position = ubuf.matrix * vec4(in_globalPos, 0.0, 1.0);
 }

--- a/src/libtiledquick/objectgroupitem.cpp
+++ b/src/libtiledquick/objectgroupitem.cpp
@@ -149,31 +149,68 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
                 objectData.clear();
             }
 
-            helper.setTileset(cell.tileset());
+            if (!cell.isEmpty())
+                helper.setTileset(cell.tileset());
         }
 
         ObjectData data;
+
+        switch (object->shape())
+        {
+        case MapObject::Shape::Rectangle:
+            if (object->isTileObject())
+                data.type = ObjectGroupMaterial::ObjectType::Tile;
+            else
+                data.type = ObjectGroupMaterial::ObjectType::Rectangle;
+            break;
+        case MapObject::Shape::Polygon:
+            data.type = ObjectGroupMaterial::ObjectType::Polygon;
+            break;
+        case MapObject::Shape::Polyline:
+            data.type = ObjectGroupMaterial::ObjectType::Polyline;
+            break;
+        case MapObject::Shape::Ellipse:
+            data.type = ObjectGroupMaterial::ObjectType::Ellipse;
+            break;
+        case MapObject::Shape::Capsule:
+            data.type = ObjectGroupMaterial::ObjectType::Capsule;
+            break;
+        case MapObject::Shape::Text:
+            data.type = ObjectGroupMaterial::ObjectType::Text;
+            break;
+        case MapObject::Shape::Point:
+            data.type = ObjectGroupMaterial::ObjectType::Point;
+            break;
+        }
+
         data.rotation = object->rotation();
         data.x = object->x() - x();
-        data.y = object->y() - y() - object->height();
+        data.y = object->y() - y() - ((data.type == ObjectGroupMaterial::ObjectType::Tile) ? object->height() : 0);
         data.width = object->width();
         data.height = object->height();
-        data.twidth = cell.tile()->height();
-        data.theight = cell.tile()->width();
-        data.flippedHorizontally = cell.flippedHorizontally();
-        data.flippedVertically = cell.flippedVertically();
-        data.shape = object->shape();
-        data.isTileObject = object->isTileObject();
+
+        if (!cell.isEmpty()) {
+            data.twidth = cell.tile()->height();
+            data.theight = cell.tile()->width();
+            data.flippedHorizontally = cell.flippedHorizontally();
+            data.flippedVertically = cell.flippedVertically();
+        } else {
+            data.twidth = 0;
+            data.theight = 0;
+            data.flippedHorizontally = false;
+            data.flippedVertically = false;
+        }
+
         data.alpha = object->opacity() * mGroup->opacity() * mGroup->tintColor().alpha();
 
         if (mGroup->tintColor().isValid()) {
-            data.tintR = mGroup->tintColor().red();
-            data.tintG = mGroup->tintColor().green();
-            data.tintB = mGroup->tintColor().blue();
+            data.tint_r = mGroup->tintColor().red();
+            data.tint_g = mGroup->tintColor().green();
+            data.tint_b = mGroup->tintColor().blue();
         } else {
-            data.tintR = 255;
-            data.tintG = 255;
-            data.tintB = 255;
+            data.tint_r = 255;
+            data.tint_g = 255;
+            data.tint_b = 255;
         }
 
         helper.setTextureCoordinates(data, cell);

--- a/src/libtiledquick/objectgroupitem.cpp
+++ b/src/libtiledquick/objectgroupitem.cpp
@@ -71,6 +71,7 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
 
     for (auto object : *mGroup) {
         const Cell &cell = object->cell();
+        QSGTexture *textTexture = nullptr;
 
         if (cell.tileset() != helper.tileset()) {
             if (!objectData.isEmpty()) {
@@ -106,9 +107,31 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
         case MapObject::Shape::Capsule:
             data.type = ObjectGroupMaterial::ObjectType::Capsule;
             break;
-        case MapObject::Shape::Text:
+        case MapObject::Shape::Text: {
             data.type = ObjectGroupMaterial::ObjectType::Text;
+
+            // All text objects have a unique texture, so they can be the only data in their node.
+            if (!objectData.isEmpty()) {
+                node->appendChildNode(new ObjectsNode(helper.texture(), objectData));
+                objectData.clear();
+            }
+
+            const auto& textData = object->textData();
+            QFont font = textData.font;
+            const int fontDetail = qMax(1.0, (0.5) / mZoom);
+            font.setPixelSize(font.pixelSize()*fontDetail);
+            qDebug() << fontDetail;
+            QImage textImage(object->width()*fontDetail, object->height()*fontDetail, QImage::Format_RGBA8888);
+            textImage.fill(Qt::transparent);
+
+            QPainter painter(&textImage);
+            painter.setFont(font);
+            painter.setPen(textData.color);
+            painter.drawText(textImage.rect(), textData.text, textData.textOption());
+
+            textTexture = window()->createTextureFromImage(textImage);
             break;
+        }
         case MapObject::Shape::Point:
             data.type = ObjectGroupMaterial::ObjectType::Point;
             break;
@@ -120,6 +143,7 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
         data.width = object->width();
         data.height = object->height();
         data.zoom = mZoom;
+        data.polygon = object->polygon();
 
         if (!cell.isEmpty()) {
             data.twidth = cell.tile()->width();
@@ -135,10 +159,14 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
 
         data.alpha = object->opacity() * mGroup->tintColor().alpha();
 
-        if (mGroup->tintColor().isValid()) {
+        if (mGroup->tintColor().isValid() && data.type == ObjectGroupMaterial::ObjectType::Tile) {
             data.tint_r = mGroup->tintColor().red();
             data.tint_g = mGroup->tintColor().green();
             data.tint_b = mGroup->tintColor().blue();
+        } else if (mGroup->color().isValid()) {
+            data.tint_r = mGroup->color().red();
+            data.tint_g = mGroup->color().green();
+            data.tint_b = mGroup->color().blue();
         } else {
             data.tint_r = 255;
             data.tint_g = 255;
@@ -148,6 +176,16 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
         helper.setTextureCoordinates(data.tx, data.ty, cell);
 
         objectData.append(data);
+
+        if (textTexture) {
+            objectData[0].tx = 0;
+            objectData[0].ty = 0;
+            objectData[0].twidth = textTexture->textureSize().width();
+            objectData[0].theight = textTexture->textureSize().height();
+            node->appendChildNode(new ObjectsNode(textTexture, objectData));
+            node->setFlag(QSGNode::OwnsMaterial);
+            objectData.clear();
+        }
     }
 
     if (!objectData.isEmpty()) {

--- a/src/libtiledquick/objectgroupitem.cpp
+++ b/src/libtiledquick/objectgroupitem.cpp
@@ -20,92 +20,17 @@
 
 #include "objectgroupitem.h"
 
-#include "tile.h"
-#include "tilelayer.h"
-#include "tileset.h"
 #include "map.h"
 #include "maprenderer.h"
 
-#include "mapitem.h"
 #include "objectsnode.h"
+#include "tilesethelper.h"
 
 #include <QtMath>
 #include <QQuickWindow>
 
 using namespace Tiled;
 using namespace TiledQuick;
-
-namespace {
-
-static inline QSGTexture *tilesetTexture(Tileset *tileset,
-                                         QQuickWindow *window)
-{
-    static QHash<Tileset *, QSGTexture *> cache;
-
-    QSGTexture *texture = cache.value(tileset);
-    if (!texture) {
-        const QString imagePath(Tiled::urlToLocalFileOrQrc(tileset->imageSource()));
-        texture = window->createTextureFromImage(QImage(imagePath));
-        cache.insert(tileset, texture);
-    }
-    return texture;
-}
-
-struct TilesetHelper
-{
-    TilesetHelper(const MapItem *mapItem)
-        : mWindow(mapItem->window())
-        , mTileset(nullptr)
-        , mTexture(nullptr)
-        , mMargin(0)
-        , mTileHSpace(0)
-        , mTileVSpace(0)
-        , mTilesPerRow(0)
-    {
-    }
-
-    Tileset *tileset() const { return mTileset; }
-    QSGTexture *texture() const { return mTexture; }
-
-    void setTileset(Tileset *tileset)
-    {
-        mTileset = tileset;
-        mTexture = tilesetTexture(tileset, mWindow);
-        if (!mTexture)
-            return;
-
-        const int tileSpacing = tileset->tileSpacing();
-        mMargin = tileset->margin();
-        mTileHSpace = tileset->tileWidth() + tileSpacing;
-        mTileVSpace = tileset->tileHeight() + tileSpacing;
-
-        const QSize tilesetSize = mTexture->textureSize();
-        const int availableWidth = tilesetSize.width() + tileSpacing - mMargin;
-        mTilesPerRow = qMax(availableWidth / mTileHSpace, 1);
-    }
-
-    void setTextureCoordinates(ObjectData &data, const Cell &cell) const
-    {
-        const int tileId = cell.tileId();
-        const int column = tileId % mTilesPerRow;
-        const int row = tileId / mTilesPerRow;
-
-        data.tx = column * mTileHSpace + mMargin;
-        data.ty = row * mTileVSpace + mMargin;
-    }
-
-private:
-    QQuickWindow *mWindow;
-    Tileset *mTileset;
-    QSGTexture *mTexture;
-    int mMargin;
-    int mTileHSpace;
-    int mTileVSpace;
-    int mTilesPerRow;
-};
-
-} // anonymous namespace
-
 
 ObjectGroupItem::ObjectGroupItem(ObjectGroup *group, MapRenderer *renderer,
                                  MapItem *parent)
@@ -128,6 +53,11 @@ void ObjectGroupItem::syncWithObjectGroup()
     setSize(boundingRect.size());
 }
 
+void ObjectGroupItem::setMapScale(const qreal &scale)
+{
+    mScale = scale;
+}
+
 QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
                                           QQuickItem::UpdatePaintNodeData *)
 {
@@ -135,15 +65,14 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
     node = new QSGNode;
     node->setFlag(QSGNode::OwnedByParent);
 
-    TilesetHelper helper(static_cast<MapItem*>(parentItem()));
+    TilesetHelper helper = TilesetHelper::instance(static_cast<MapItem*>(parentItem()));
 
     QVector<ObjectData> objectData;
-    objectData.reserve(ObjectsNode::MaxObjectCount);
 
     for (auto object : *mGroup) {
         const Cell &cell = object->cell();
 
-        if (cell.tileset() != helper.tileset() || objectData.size() == ObjectsNode::MaxObjectCount) {
+        if (cell.tileset() != helper.tileset()) {
             if (!objectData.isEmpty()) {
                 node->appendChildNode(new ObjectsNode(helper.texture(), objectData));
                 objectData.clear();
@@ -190,8 +119,8 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
         data.height = object->height();
 
         if (!cell.isEmpty()) {
-            data.twidth = cell.tile()->height();
-            data.theight = cell.tile()->width();
+            data.twidth = cell.tile()->width();
+            data.theight = cell.tile()->height();
             data.flippedHorizontally = cell.flippedHorizontally();
             data.flippedVertically = cell.flippedVertically();
         } else {
@@ -201,7 +130,7 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
             data.flippedVertically = false;
         }
 
-        data.alpha = object->opacity() * mGroup->opacity() * mGroup->tintColor().alpha();
+        data.alpha = object->opacity() * mGroup->tintColor().alpha();
 
         if (mGroup->tintColor().isValid()) {
             data.tint_r = mGroup->tintColor().red();
@@ -213,7 +142,7 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
             data.tint_b = 255;
         }
 
-        helper.setTextureCoordinates(data, cell);
+        helper.setTextureCoordinates(data.tx, data.ty, cell);
 
         objectData.append(data);
     }
@@ -235,15 +164,15 @@ void ObjectGroupItem::groupVisibilityChanged()
     const bool visible = mGroup->isVisible();
     setVisible(visible);
 
-    MapItem *parent = qobject_cast<MapItem*>(parentItem());
+    // MapItem *parent = qobject_cast<MapItem*>(parentItem());
     if (visible) {
         updateVisibleObjects();
 
-        if (parent)
-            connect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
+        // if (parent)
+        //     connect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
     } else {
-        if (parent)
-            disconnect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
+        // if (parent)
+        //     disconnect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
     }
 }
 
@@ -282,7 +211,7 @@ QSGNode *ObjectItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeD
         data[0].y = (mPosition.y() + 1) * tileSize.height() - tileset->tileHeight() + offset.y();
         data[0].width = size.width();
         data[0].height = size.height();
-        helper.setTextureCoordinates(data[0], mCell);
+        helper.setTextureCoordinates(data[0].ty, data[0].ty, mCell);
 
         node = new ObjectsNode(helper.texture(), data);
     }

--- a/src/libtiledquick/objectgroupitem.cpp
+++ b/src/libtiledquick/objectgroupitem.cpp
@@ -53,9 +53,9 @@ void ObjectGroupItem::syncWithObjectGroup()
     setSize(boundingRect.size());
 }
 
-void ObjectGroupItem::setMapScale(const qreal &scale)
+void ObjectGroupItem::setZoom(const qreal &zoom)
 {
-    mScale = scale;
+    mZoom = zoom;
 }
 
 QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
@@ -80,6 +80,8 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
 
             if (!cell.isEmpty())
                 helper.setTileset(cell.tileset());
+            else
+                helper.setTileset(nullptr);
         }
 
         ObjectData data;
@@ -117,6 +119,7 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
         data.y = object->y() - y() - ((data.type == ObjectGroupMaterial::ObjectType::Tile) ? object->height() : 0);
         data.width = object->width();
         data.height = object->height();
+        data.zoom = mZoom;
 
         if (!cell.isEmpty()) {
             data.twidth = cell.tile()->width();
@@ -148,6 +151,8 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
     }
 
     if (!objectData.isEmpty()) {
+        if (!helper.texture())
+            helper.setTileset(nullptr);
         node->appendChildNode(new ObjectsNode(helper.texture(), objectData));
     }
 
@@ -164,15 +169,15 @@ void ObjectGroupItem::groupVisibilityChanged()
     const bool visible = mGroup->isVisible();
     setVisible(visible);
 
-    // MapItem *parent = qobject_cast<MapItem*>(parentItem());
+    MapItem *parent = qobject_cast<MapItem*>(parentItem());
     if (visible) {
         updateVisibleObjects();
 
-        // if (parent)
-        //     connect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
+        if (parent)
+            connect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
     } else {
-        // if (parent)
-        //     disconnect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
+        if (parent)
+            disconnect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
     }
 }
 

--- a/src/libtiledquick/objectgroupitem.cpp
+++ b/src/libtiledquick/objectgroupitem.cpp
@@ -1,0 +1,254 @@
+/*
+ * objectgroupitem.cpp
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "objectgroupitem.h"
+
+#include "tile.h"
+#include "tilelayer.h"
+#include "tileset.h"
+#include "map.h"
+#include "maprenderer.h"
+
+#include "mapitem.h"
+#include "objectsnode.h"
+
+#include <QtMath>
+#include <QQuickWindow>
+
+using namespace Tiled;
+using namespace TiledQuick;
+
+namespace {
+
+static inline QSGTexture *tilesetTexture(Tileset *tileset,
+                                         QQuickWindow *window)
+{
+    static QHash<Tileset *, QSGTexture *> cache;
+
+    QSGTexture *texture = cache.value(tileset);
+    if (!texture) {
+        const QString imagePath(Tiled::urlToLocalFileOrQrc(tileset->imageSource()));
+        texture = window->createTextureFromImage(QImage(imagePath));
+        cache.insert(tileset, texture);
+    }
+    return texture;
+}
+
+struct TilesetHelper
+{
+    TilesetHelper(const MapItem *mapItem)
+        : mWindow(mapItem->window())
+        , mTileset(nullptr)
+        , mTexture(nullptr)
+        , mMargin(0)
+        , mTileHSpace(0)
+        , mTileVSpace(0)
+        , mTilesPerRow(0)
+    {
+    }
+
+    Tileset *tileset() const { return mTileset; }
+    QSGTexture *texture() const { return mTexture; }
+
+    void setTileset(Tileset *tileset)
+    {
+        mTileset = tileset;
+        mTexture = tilesetTexture(tileset, mWindow);
+        if (!mTexture)
+            return;
+
+        const int tileSpacing = tileset->tileSpacing();
+        mMargin = tileset->margin();
+        mTileHSpace = tileset->tileWidth() + tileSpacing;
+        mTileVSpace = tileset->tileHeight() + tileSpacing;
+
+        const QSize tilesetSize = mTexture->textureSize();
+        const int availableWidth = tilesetSize.width() + tileSpacing - mMargin;
+        mTilesPerRow = qMax(availableWidth / mTileHSpace, 1);
+    }
+
+    void setTextureCoordinates(ObjectData &data, const Cell &cell) const
+    {
+        const int tileId = cell.tileId();
+        const int column = tileId % mTilesPerRow;
+        const int row = tileId / mTilesPerRow;
+
+        data.tx = column * mTileHSpace + mMargin;
+        data.ty = row * mTileVSpace + mMargin;
+    }
+
+private:
+    QQuickWindow *mWindow;
+    Tileset *mTileset;
+    QSGTexture *mTexture;
+    int mMargin;
+    int mTileHSpace;
+    int mTileVSpace;
+    int mTilesPerRow;
+};
+
+} // anonymous namespace
+
+
+ObjectGroupItem::ObjectGroupItem(ObjectGroup *group, MapRenderer *renderer,
+                                 MapItem *parent)
+    : QQuickItem(parent)
+    , mGroup(group)
+    , mRenderer(renderer)
+    , mVisibleArea(parent->visibleArea())
+{
+    setFlag(ItemHasContents);
+    groupVisibilityChanged();
+
+    syncWithObjectGroup();
+    setOpacity(mGroup->opacity());
+}
+
+void ObjectGroupItem::syncWithObjectGroup()
+{
+    const QRectF boundingRect = mGroup->objectsBoundingRect();
+    setPosition(boundingRect.topLeft());
+    setSize(boundingRect.size());
+}
+
+QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
+                                          QQuickItem::UpdatePaintNodeData *)
+{
+    delete node;
+    node = new QSGNode;
+    node->setFlag(QSGNode::OwnedByParent);
+
+    TilesetHelper helper(static_cast<MapItem*>(parentItem()));
+
+    QVector<ObjectData> objectData;
+    objectData.reserve(ObjectsNode::MaxObjectCount);
+
+    for (auto object : *mGroup) {
+        const Cell &cell = object->cell();
+
+        if (cell.tileset() != helper.tileset() || objectData.size() == ObjectsNode::MaxObjectCount) {
+            if (!objectData.isEmpty()) {
+                node->appendChildNode(new ObjectsNode(helper.texture(), objectData));
+                objectData.clear();
+            }
+
+            helper.setTileset(cell.tileset());
+        }
+
+        ObjectData data;
+        data.rotation = object->rotation();
+        data.x = object->x() - x();
+        data.y = object->y() - y() - object->height();
+        data.width = object->width();
+        data.height = object->height();
+        data.twidth = cell.tile()->height();
+        data.theight = cell.tile()->width();
+        data.flippedHorizontally = cell.flippedHorizontally();
+        data.flippedVertically = cell.flippedVertically();
+        data.shape = object->shape();
+        data.isTileObject = object->isTileObject();
+        data.alpha = object->opacity() * mGroup->opacity() * mGroup->tintColor().alpha();
+
+        if (mGroup->tintColor().isValid()) {
+            data.tintR = mGroup->tintColor().red();
+            data.tintG = mGroup->tintColor().green();
+            data.tintB = mGroup->tintColor().blue();
+        } else {
+            data.tintR = 255;
+            data.tintG = 255;
+            data.tintB = 255;
+        }
+
+        helper.setTextureCoordinates(data, cell);
+
+        objectData.append(data);
+    }
+
+    if (!objectData.isEmpty()) {
+        node->appendChildNode(new ObjectsNode(helper.texture(), objectData));
+    }
+
+    return node;
+}
+
+void ObjectGroupItem::updateVisibleObjects()
+{
+    update();
+}
+
+void ObjectGroupItem::groupVisibilityChanged()
+{
+    const bool visible = mGroup->isVisible();
+    setVisible(visible);
+
+    MapItem *parent = qobject_cast<MapItem*>(parentItem());
+    if (visible) {
+        updateVisibleObjects();
+
+        if (parent)
+            connect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
+    } else {
+        if (parent)
+            disconnect(parent, &MapItem::visibleAreaChanged, this, &ObjectGroupItem::updateVisibleObjects);
+    }
+}
+
+
+ObjectItem::ObjectItem(const Cell &cell, QPoint position, MapItem *parent)
+    : QQuickItem(parent)
+    , mCell(cell)
+    , mPosition(position)
+{
+    setFlag(ItemHasContents);
+    setZ(position.y() * parent->map()->tileHeight());
+}
+
+QSGNode *ObjectItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *)
+{
+    if (!node) {
+        const MapItem *mapItem = static_cast<MapItem*>(parent());
+
+        TilesetHelper helper(mapItem);
+        Tileset *tileset = mCell.tileset();
+        helper.setTileset(tileset);
+
+        if (!helper.texture())
+            return nullptr;
+
+        Tile *tile = mCell.tile();
+        if (!tile)
+            return nullptr;
+
+        const QSize tileSize = mapItem->map()->map()->tileSize();
+        const QSize size = tile->size();
+        const QPoint offset = tileset->tileOffset();
+
+        QVector<ObjectData> data(1);
+        data[0].x = mPosition.x() * tileSize.width() + offset.x();
+        data[0].y = (mPosition.y() + 1) * tileSize.height() - tileset->tileHeight() + offset.y();
+        data[0].width = size.width();
+        data[0].height = size.height();
+        helper.setTextureCoordinates(data[0], mCell);
+
+        node = new ObjectsNode(helper.texture(), data);
+    }
+
+    return node;
+}

--- a/src/libtiledquick/objectgroupitem.cpp
+++ b/src/libtiledquick/objectgroupitem.cpp
@@ -70,6 +70,11 @@ void ObjectGroupItem::setRenderer(Tiled::MapRenderer *renderer)
     mRenderer = renderer;
 }
 
+void ObjectGroupItem::setMousePos(const QPointF &pos)
+{
+    mMousePos = pos;
+}
+
 void ObjectGroupItem::setZoom(const qreal &zoom)
 {
     mZoom = zoom;
@@ -174,6 +179,8 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
 
         data.zoom = mZoom;
         data.polygon = object->polygon();
+        if (data.type == ObjectGroupMaterial::ObjectType::Polyline)
+            data.polygon.append(mousePos() - object->position());
 
         if (!cell.isEmpty()) {
             data.twidth = cell.tile()->width();

--- a/src/libtiledquick/objectgroupitem.cpp
+++ b/src/libtiledquick/objectgroupitem.cpp
@@ -43,14 +43,31 @@ ObjectGroupItem::ObjectGroupItem(ObjectGroup *group, MapRenderer *renderer,
     groupVisibilityChanged();
 
     syncWithObjectGroup();
-    setOpacity(mGroup->opacity());
+    if (mGroup)
+        setOpacity(mGroup->opacity());
+    else
+        setOpacity(1);
 }
 
 void ObjectGroupItem::syncWithObjectGroup()
 {
+    if (!mGroup)
+        return;
+
     const QRectF boundingRect = mGroup->objectsBoundingRect();
     setPosition(boundingRect.topLeft());
     setSize(boundingRect.size());
+}
+
+void ObjectGroupItem::setObjectGroup(Tiled::ObjectGroup *group)
+{
+    mGroup = group;
+    setOpacity(mGroup->opacity());
+}
+
+void ObjectGroupItem::setRenderer(Tiled::MapRenderer *renderer)
+{
+    mRenderer = renderer;
 }
 
 void ObjectGroupItem::setZoom(const qreal &zoom)
@@ -64,6 +81,9 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
     delete node;
     node = new QSGNode;
     node->setFlag(QSGNode::OwnedByParent);
+
+    if (!mGroup)
+        return node;
 
     TilesetHelper helper = TilesetHelper::instance(static_cast<MapItem*>(parentItem()));
 
@@ -116,11 +136,10 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
                 objectData.clear();
             }
 
+            const int fontDetail = qMax(1.0, (0.5) / mZoom);
             const auto& textData = object->textData();
             QFont font = textData.font;
-            const int fontDetail = qMax(1.0, (0.5) / mZoom);
             font.setPixelSize(font.pixelSize()*fontDetail);
-            qDebug() << fontDetail;
             QImage textImage(object->width()*fontDetail, object->height()*fontDetail, QImage::Format_RGBA8888);
             textImage.fill(Qt::transparent);
 
@@ -142,6 +161,17 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
         data.y = object->y() - y() - ((data.type == ObjectGroupMaterial::ObjectType::Tile) ? object->height() : 0);
         data.width = object->width();
         data.height = object->height();
+
+        if (object->width() == 0 && object->height() == 0 &&
+            (data.type == ObjectGroupMaterial::ObjectType::Rectangle ||
+             data.type == ObjectGroupMaterial::ObjectType::Ellipse ||
+             data.type == ObjectGroupMaterial::ObjectType::Capsule)) {
+            data.x -= 10;
+            data.y -= 10;
+            data.width += 20;
+            data.height += 20;
+        }
+
         data.zoom = mZoom;
         data.polygon = object->polygon();
 
@@ -204,6 +234,9 @@ void ObjectGroupItem::updateVisibleObjects()
 
 void ObjectGroupItem::groupVisibilityChanged()
 {
+    if (!mGroup)
+        return;
+
     const bool visible = mGroup->isVisible();
     setVisible(visible);
 

--- a/src/libtiledquick/objectgroupitem.cpp
+++ b/src/libtiledquick/objectgroupitem.cpp
@@ -87,7 +87,7 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
     node = new QSGNode;
     node->setFlag(QSGNode::OwnedByParent);
 
-    if (!mGroup)
+    if (!mGroup || !mGroup->isVisible())
         return node;
 
     TilesetHelper helper = TilesetHelper::instance(static_cast<MapItem*>(parentItem()));
@@ -95,6 +95,11 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
     QVector<ObjectData> objectData;
 
     for (auto object : *mGroup) {
+        // Ignore invisible objects and single/zero vertex polygons
+        if (!object->isVisible() ||
+            (object->shape() == MapObject::Shape::Polygon && object->polygon().size() < 2))
+            continue;
+
         const Cell &cell = object->cell();
         QSGTexture *textTexture = nullptr;
 
@@ -104,7 +109,7 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
                 objectData.clear();
             }
 
-            if (!cell.isEmpty())
+            if (cell.tile())
                 helper.setTileset(cell.tileset());
             else
                 helper.setTileset(nullptr);
@@ -182,9 +187,9 @@ QSGNode *ObjectGroupItem::updatePaintNode(QSGNode *node,
         if (data.type == ObjectGroupMaterial::ObjectType::Polyline)
             data.polygon.append(mousePos() - object->position());
 
-        if (!cell.isEmpty()) {
-            data.twidth = cell.tile()->width();
-            data.theight = cell.tile()->height();
+        if (Tile *tile = cell.tile()) {
+            data.twidth = tile->width();
+            data.theight = tile->height();
             data.flippedHorizontally = cell.flippedHorizontally();
             data.flippedVertically = cell.flippedVertically();
         } else {

--- a/src/libtiledquick/objectgroupitem.h
+++ b/src/libtiledquick/objectgroupitem.h
@@ -43,7 +43,7 @@ public:
                     MapItem *parent);
 
     void syncWithObjectGroup();
-    void setMapScale(const qreal &scale);
+    void setZoom(const qreal &zoom);
 
     QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *) override;
 
@@ -58,7 +58,7 @@ private:
     Tiled::ObjectGroup *mGroup;
     Tiled::MapRenderer *mRenderer;
     QRectF mVisibleArea;
-    qreal mScale;
+    qreal mZoom;
 };
 
 class ObjectItem : public QQuickItem

--- a/src/libtiledquick/objectgroupitem.h
+++ b/src/libtiledquick/objectgroupitem.h
@@ -26,7 +26,6 @@
 #include "tilelayer.h"
 #include "tiledquick_global.h"
 
-
 namespace Tiled {
 class MapRenderer;
 }
@@ -38,11 +37,13 @@ class MapItem;
 class TILEDQUICK_SHARED_EXPORT ObjectGroupItem : public QQuickItem
 {
     Q_OBJECT
+
 public:
     ObjectGroupItem(Tiled::ObjectGroup *group, Tiled::MapRenderer *renderer,
                     MapItem *parent);
 
     void syncWithObjectGroup();
+    void setMapScale(const qreal &scale);
 
     QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *) override;
 
@@ -57,6 +58,7 @@ private:
     Tiled::ObjectGroup *mGroup;
     Tiled::MapRenderer *mRenderer;
     QRectF mVisibleArea;
+    qreal mScale;
 };
 
 class ObjectItem : public QQuickItem

--- a/src/libtiledquick/objectgroupitem.h
+++ b/src/libtiledquick/objectgroupitem.h
@@ -1,0 +1,81 @@
+/*
+ * objectgroupitem.h
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QQuickItem>
+
+#include "objectgroup.h"
+#include "tilelayer.h"
+#include "tiledquick_global.h"
+
+
+namespace Tiled {
+class MapRenderer;
+}
+
+namespace TiledQuick {
+
+class MapItem;
+
+class TILEDQUICK_SHARED_EXPORT ObjectGroupItem : public QQuickItem
+{
+    Q_OBJECT
+public:
+    ObjectGroupItem(Tiled::ObjectGroup *group, Tiled::MapRenderer *renderer,
+                    MapItem *parent);
+
+    void syncWithObjectGroup();
+
+    QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *) override;
+
+    Tiled::ObjectGroup *group();
+
+public slots:
+    void updateVisibleObjects();
+
+private:
+    void groupVisibilityChanged();
+
+    Tiled::ObjectGroup *mGroup;
+    Tiled::MapRenderer *mRenderer;
+    QRectF mVisibleArea;
+};
+
+class ObjectItem : public QQuickItem
+{
+    Q_OBJECT
+
+public:
+    ObjectItem(const Tiled::Cell &cell, QPoint position, MapItem *parent);
+
+    QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *) override;
+
+private:
+    Tiled::Cell mCell;
+    QPoint mPosition;
+};
+
+inline Tiled::ObjectGroup *ObjectGroupItem::group()
+{
+    return mGroup;
+}
+
+} // namespace TiledQuick

--- a/src/libtiledquick/objectgroupitem.h
+++ b/src/libtiledquick/objectgroupitem.h
@@ -45,6 +45,9 @@ public:
     void setObjectGroup(Tiled::ObjectGroup *group);
     void setRenderer(Tiled::MapRenderer *renderer);
 
+    QPointF mousePos() const;
+    void setMousePos(const QPointF &pos);
+
     void syncWithObjectGroup();
     void setZoom(const qreal &zoom);
 
@@ -62,6 +65,7 @@ private:
     Tiled::MapRenderer *mRenderer;
     QRectF mVisibleArea;
     qreal mZoom;
+    QPointF mMousePos;
 };
 
 class ObjectItem : public QQuickItem
@@ -77,6 +81,11 @@ private:
     Tiled::Cell mCell;
     QPoint mPosition;
 };
+
+inline QPointF ObjectGroupItem::mousePos() const
+{
+    return mMousePos;
+}
 
 inline Tiled::ObjectGroup *ObjectGroupItem::group() const
 {

--- a/src/libtiledquick/objectgroupitem.h
+++ b/src/libtiledquick/objectgroupitem.h
@@ -42,12 +42,15 @@ public:
     ObjectGroupItem(Tiled::ObjectGroup *group, Tiled::MapRenderer *renderer,
                     MapItem *parent);
 
+    void setObjectGroup(Tiled::ObjectGroup *group);
+    void setRenderer(Tiled::MapRenderer *renderer);
+
     void syncWithObjectGroup();
     void setZoom(const qreal &zoom);
 
     QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *) override;
 
-    Tiled::ObjectGroup *group();
+    Tiled::ObjectGroup *group() const;
 
 public slots:
     void updateVisibleObjects();
@@ -75,7 +78,7 @@ private:
     QPoint mPosition;
 };
 
-inline Tiled::ObjectGroup *ObjectGroupItem::group()
+inline Tiled::ObjectGroup *ObjectGroupItem::group() const
 {
     return mGroup;
 }

--- a/src/libtiledquick/objectgroupmaterial.cpp
+++ b/src/libtiledquick/objectgroupmaterial.cpp
@@ -1,0 +1,101 @@
+/*
+ * objectgroupmaterial.cpp
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "objectgroupmaterial.h"
+
+#include <QSGTexture>
+
+using namespace TiledQuick;
+
+class ObjectGroupShader : public QSGMaterialShader
+{
+public:
+    ObjectGroupShader()
+    {
+        setShaderFileName(VertexStage, QStringLiteral(":/objectgroup.vert.qsb"));
+        setShaderFileName(FragmentStage, QStringLiteral(":/objectgroup.frag.qsb"));
+    }
+
+    bool updateUniformData(RenderState &state, QSGMaterial *, QSGMaterial *) override
+    {
+        if (!state.isMatrixDirty())
+            return false;
+
+        auto *buffer = state.uniformData()->data();
+        auto *ubuf = reinterpret_cast<ObjectGroupUniformBuffer*>(buffer);
+
+        memcpy(buffer + offsetof(ObjectGroupUniformBuffer, matrix),
+               state.combinedMatrix().constData(),
+               64);
+
+        ubuf->opacity = state.opacity();
+
+        return true;
+    }
+
+    void updateSampledImage(RenderState &state, int binding, QSGTexture **texture, QSGMaterial *newMaterial, QSGMaterial *) override
+    {
+        if (binding != 1)
+            return;
+
+        QSGTexture *tex = static_cast<ObjectGroupMaterial *>(newMaterial)->texture();
+
+        if (tex)
+            tex->commitTextureOperations(state.rhi(), state.resourceUpdateBatch());
+
+        *texture = tex;
+    }
+};
+
+ObjectGroupMaterial::ObjectGroupMaterial()
+{
+    setFlag(Blending, true);
+    setFlag(NoBatching, true);
+}
+
+ObjectGroupMaterial::~ObjectGroupMaterial()
+{
+}
+
+QSGMaterialType *ObjectGroupMaterial::type() const
+{
+    static QSGMaterialType type;
+    return &type;
+}
+
+QSGMaterialShader *ObjectGroupMaterial::createShader(QSGRendererInterface::RenderMode) const
+{
+    return new ObjectGroupShader();
+}
+
+int ObjectGroupMaterial::compare(const QSGMaterial *other) const
+{
+    auto *otherMaterial = static_cast<const ObjectGroupMaterial *>(other);
+    if (mTexture == otherMaterial->mTexture)
+        return 0;
+
+    return (mTexture < otherMaterial->mTexture) ? -1 : 1;
+}
+
+void ObjectGroupMaterial::setTexture(QSGTexture *texture)
+{
+    mTexture = texture;
+}
+

--- a/src/libtiledquick/objectgroupmaterial.cpp
+++ b/src/libtiledquick/objectgroupmaterial.cpp
@@ -22,6 +22,11 @@
 
 #include <QSGTexture>
 
+struct alignas(4) ObjectGroupUniformBuffer {
+    float matrix[16];
+    float opacity;
+};
+
 using namespace TiledQuick;
 
 class ObjectGroupShader : public QSGMaterialShader
@@ -35,19 +40,23 @@ public:
 
     bool updateUniformData(RenderState &state, QSGMaterial *, QSGMaterial *) override
     {
-        if (!state.isMatrixDirty())
-            return false;
-
         auto *buffer = state.uniformData()->data();
         auto *ubuf = reinterpret_cast<ObjectGroupUniformBuffer*>(buffer);
+        bool changed = false;
 
-        memcpy(buffer + offsetof(ObjectGroupUniformBuffer, matrix),
-               state.combinedMatrix().constData(),
-               64);
+        if (state.isMatrixDirty()) {
+            memcpy(buffer + offsetof(ObjectGroupUniformBuffer, matrix),
+                   state.combinedMatrix().constData(),
+                   64);
+            changed = true;
+        }
 
-        ubuf->opacity = state.opacity();
+        if (state.isOpacityDirty()) {
+            ubuf->opacity = state.opacity();
+            changed = true;
+        }
 
-        return true;
+        return changed;
     }
 
     void updateSampledImage(RenderState &state, int binding, QSGTexture **texture, QSGMaterial *newMaterial, QSGMaterial *) override

--- a/src/libtiledquick/objectgroupmaterial.h
+++ b/src/libtiledquick/objectgroupmaterial.h
@@ -24,11 +24,10 @@
 
 #include "tiledquick_global.h"
 
-struct ObjectGroupUniformBuffer {
+struct alignas(4) ObjectGroupUniformBuffer {
     float matrix[16];
 
     float opacity;
-    float padding[3];
 };
 
 namespace TiledQuick {
@@ -36,6 +35,22 @@ namespace TiledQuick {
 class TILEDQUICK_SHARED_EXPORT ObjectGroupMaterial : public QSGMaterial
 {
 public:
+    /**
+     * Enumerates the different object types for use by the objectgroup shader.
+     *
+     * This enum should be identical to the const ints in objectgroup.frag.
+     */
+    enum ObjectType {
+        Rectangle = 1,
+        Polygon = 2,
+        Polyline = 3,
+        Ellipse = 4,
+        Capsule = 5,
+        Text = 6,
+        Point = 7,
+        Tile = 8,
+    };
+
     ObjectGroupMaterial();
     ~ObjectGroupMaterial() override;
 

--- a/src/libtiledquick/objectgroupmaterial.h
+++ b/src/libtiledquick/objectgroupmaterial.h
@@ -1,0 +1,60 @@
+/*
+ * objectgroupmaterial.h
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QSGMaterial>
+
+#include "tiledquick_global.h"
+
+struct ObjectGroupUniformBuffer {
+    float matrix[16];
+
+    float opacity;
+    float padding[3];
+};
+
+namespace TiledQuick {
+
+class TILEDQUICK_SHARED_EXPORT ObjectGroupMaterial : public QSGMaterial
+{
+public:
+    ObjectGroupMaterial();
+    ~ObjectGroupMaterial() override;
+
+    QSGMaterialShader *createShader(QSGRendererInterface::RenderMode) const override;
+
+    QSGMaterialType *type() const override;
+
+    int compare(const QSGMaterial *other) const override;
+
+    void setTexture(QSGTexture *texture);
+    QSGTexture *texture() const;
+
+private:
+    QSGTexture *mTexture = nullptr;
+};
+
+inline QSGTexture *ObjectGroupMaterial::texture() const
+{
+    return mTexture;
+}
+
+} // namespace TiledQuick

--- a/src/libtiledquick/objectgroupmaterial.h
+++ b/src/libtiledquick/objectgroupmaterial.h
@@ -30,9 +30,7 @@ class TILEDQUICK_SHARED_EXPORT ObjectGroupMaterial : public QSGMaterial
 {
 public:
     /**
-     * Enumerates the different object types for use by the objectgroup shader.
-     *
-     * This enum should be identical to the const ints in objectgroup.frag.
+     * Enumerates the different object types for use by the objectsnode's rendering.
      */
     enum ObjectType {
         Rectangle = 1,

--- a/src/libtiledquick/objectgroupmaterial.h
+++ b/src/libtiledquick/objectgroupmaterial.h
@@ -24,12 +24,6 @@
 
 #include "tiledquick_global.h"
 
-struct alignas(4) ObjectGroupUniformBuffer {
-    float matrix[16];
-
-    float opacity;
-};
-
 namespace TiledQuick {
 
 class TILEDQUICK_SHARED_EXPORT ObjectGroupMaterial : public QSGMaterial

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -37,6 +37,23 @@ static QList<QPolygonF> outlines(const QList<Tiled::MapObject*> &objects)
     return outlines;
 }
 
+static QPolygonF handlePolygon(const ObjectHandleData &handle, const qreal &mZoom, const QList<QObject*> mSelectedObjects)
+{
+    QTransform transform;
+
+    const QRectF boundingRect = handle.drawPoints.boundingRect();
+    const qreal centerX = boundingRect.x() + boundingRect.width()/2;
+    const qreal centerY = boundingRect.y() + boundingRect.height()/2;
+    const qreal rotation = mSelectedObjects.count() == 1 ? dynamic_cast<EditableMapObject*>(mSelectedObjects[0])->mapObject()->rotation() : 0;
+
+    transform.translate(handle.pos.x(), handle.pos.y());
+    transform.translate(centerX * mZoom, centerY * mZoom);
+    transform.scale(mZoom, mZoom);
+    transform.translate(-centerX, -centerY);
+    transform.rotate(rotation);
+
+    return transform.map(handle.drawPoints);
+}
 
 ObjectInteractionItem::ObjectInteractionItem(QQuickItem *parent)
     : QQuickItem(parent)
@@ -118,20 +135,8 @@ QList<QPolygonF> ObjectInteractionItem::objectHandlePolygons() const
     QList<QPolygonF> polygons;
 
     for (const auto &handle : mObjectHandles)
-        if (handle.drawPoints.size() > 0 && !handle.isHovered) {
-            QTransform transform;
-
-            const QRectF boundingRect = handle.drawPoints.boundingRect();
-            const qreal centerX = boundingRect.x() + boundingRect.width()/2;
-            const qreal centerY = boundingRect.y() + boundingRect.height()/2;
-
-            transform.translate(handle.pos.x(), handle.pos.y());
-            transform.translate(centerX * mZoom, centerY * mZoom);
-            transform.scale(mZoom, mZoom);
-            transform.translate(-centerX, -centerY);
-
-            polygons.append(transform.map(handle.drawPoints));
-        }
+        if (handle.drawPoints.size() > 0 && !handle.isHovered)
+            polygons.append(handlePolygon(handle, mZoom, mSelectedObjects));
 
     return polygons;
 }
@@ -139,20 +144,8 @@ QList<QPolygonF> ObjectInteractionItem::objectHandlePolygons() const
 QPolygonF ObjectInteractionItem::hoveredHandlePolygon() const
 {
     for (const auto &handle : mObjectHandles)
-        if (handle.isHovered) {
-            QTransform transform;
-
-            const QRectF boundingRect = handle.drawPoints.boundingRect();
-            const qreal centerX = boundingRect.x() + boundingRect.width()/2;
-            const qreal centerY = boundingRect.y() + boundingRect.height()/2;
-
-            transform.translate(handle.pos.x(), handle.pos.y());
-            transform.translate(centerX * mZoom, centerY * mZoom);
-            transform.scale(mZoom, mZoom);
-            transform.translate(-centerX, -centerY);
-
-            return transform.map(handle.drawPoints);
-        }
+        if (handle.isHovered)
+            return handlePolygon(handle, mZoom, mSelectedObjects);
 
     return QPolygonF();
 }

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -106,7 +106,9 @@ void ObjectInteractionItem::updateOutlines()
 
 void ObjectInteractionItem::mousePressed(const QPointF &pos)
 {
-    if (mSelectedToolId != "ObjectSelectionTool" || mHoveredObjects.size() > 0)
+    if (!(mSelectedToolId == "EditPolygonTool" ||
+          mSelectedToolId == "ObjectSelectionTool") ||
+          mHoveredObjects.count() > 0)
         return;
 
     mMousePressed = true;

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -44,7 +44,7 @@ static QPolygonF handlePolygon(const ObjectHandleData &handle, const qreal &mZoo
     const QRectF boundingRect = handle.drawPoints.boundingRect();
     const qreal centerX = boundingRect.x() + boundingRect.width()/2;
     const qreal centerY = boundingRect.y() + boundingRect.height()/2;
-    const qreal rotation = mSelectedObjects.count() == 1 ? dynamic_cast<EditableMapObject*>(mSelectedObjects[0])->mapObject()->rotation() : 0;
+    const qreal rotation = mSelectedObjects.count() == 1 ? qobject_cast<EditableMapObject*>(mSelectedObjects[0])->mapObject()->rotation() : 0;
 
     transform.translate(handle.pos.x(), handle.pos.y());
     transform.translate(centerX * mZoom, centerY * mZoom);
@@ -157,7 +157,7 @@ QList<QPointF> ObjectInteractionItem::polygonEditPoints() const
         return points;
 
     for (auto object : std::as_const(mSelectedObjects)) {
-        auto mapObject = dynamic_cast<Tiled::EditableMapObject*>(object)->mapObject();
+        auto mapObject = qobject_cast<Tiled::EditableMapObject*>(object)->mapObject();
         if (!mapObject)
             continue;
 
@@ -173,7 +173,7 @@ QList<QPolygonF> ObjectInteractionItem::selectionOutlines() const
     QList<Tiled::MapObject*> selectedObjects;
 
     for (auto object : std::as_const(mSelectedObjects))
-        if (auto mapObject = dynamic_cast<Tiled::EditableMapObject*>(object)->mapObject())
+        if (auto mapObject = qobject_cast<Tiled::EditableMapObject*>(object)->mapObject())
             selectedObjects.append(mapObject);
 
     return outlines(selectedObjects);

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -1,0 +1,49 @@
+#include "objectinteractionitem.h"
+
+using namespace Tiled;
+using namespace TiledQuick;
+
+ObjectInteractionItem::ObjectInteractionItem(QQuickItem *parent)
+    : QQuickItem(parent)
+{
+}
+
+ObjectInteractionItem::~ObjectInteractionItem() = default;
+
+void ObjectInteractionItem::setSelectedObjects(const QList<Tiled::MapObject*> &objects)
+{
+    if (mSelectedObjects == objects)
+        return;
+
+    mSelectedObjects = objects;
+    emit selectedObjectsChanged();
+}
+
+QList<QPolygonF> ObjectInteractionItem::selectionOutlines() const
+{
+    QList<QPolygonF> outlines;
+
+    for (auto object : mSelectedObjects) {
+        QPolygonF outline = object->bounds();
+
+        if (object->isTileObject())
+            outline.translate(QPointF(0, -1 * object->height()));
+        else if (!object->polygon().isEmpty()) {
+            outline = object->polygon().boundingRect();
+            outline.translate(QPointF(object->x(), object->y()));
+        }
+
+        if (object->rotation() != 0) {
+            QPointF origin(object->x(), object->y());
+            QTransform transform;
+            transform.translate(origin.x(), origin.y());
+            transform.rotate(object->rotation());
+            transform.translate(-origin.x(), -origin.y());
+            outline = transform.map(outline);
+        }
+
+        outlines.append(outline);
+    }
+
+    return outlines;
+}

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -44,6 +44,16 @@ ObjectInteractionItem::ObjectInteractionItem(QQuickItem *parent)
 
 ObjectInteractionItem::~ObjectInteractionItem() = default;
 
+void ObjectInteractionItem::setZoom(const qreal zoom)
+{
+    if (mZoom == zoom)
+        return;
+
+    mZoom = zoom;
+    emit zoomChanged();
+    emit objectHandlesChanged();
+}
+
 void ObjectInteractionItem::setSelectedToolId(const QString &id)
 {
     if (mSelectedToolId == id)
@@ -92,6 +102,56 @@ void ObjectInteractionItem::setHighlightedPolygonEditPoints(const QList<QPointF>
 
     mHighlightedPolygonEditPoints = points;
     emit highlightedPolygonEditPointsChanged();
+}
+
+void ObjectInteractionItem::setObjectHandles(const QList<Tiled::ObjectHandleData> &handles)
+{
+    mObjectHandles = handles;
+    emit objectHandlesChanged();
+}
+
+QList<QPolygonF> ObjectInteractionItem::objectHandlePolygons() const
+{
+    QList<QPolygonF> polygons;
+
+    for (const auto &handle : mObjectHandles)
+        if (handle.drawPoints.size() > 0 && !handle.isHovered) {
+            QTransform transform;
+
+            const QRectF boundingRect = handle.drawPoints.boundingRect();
+            const qreal centerX = boundingRect.x() + boundingRect.width()/2;
+            const qreal centerY = boundingRect.y() + boundingRect.height()/2;
+
+            transform.translate(handle.pos.x(), handle.pos.y());
+            transform.translate(centerX * mZoom, centerY * mZoom);
+            transform.scale(mZoom, mZoom);
+            transform.translate(-centerX, -centerY);
+
+            polygons.append(transform.map(handle.drawPoints));
+        }
+
+    return polygons;
+}
+
+QPolygonF ObjectInteractionItem::hoveredHandlePolygon() const
+{
+    for (const auto &handle : mObjectHandles)
+        if (handle.isHovered) {
+            QTransform transform;
+
+            const QRectF boundingRect = handle.drawPoints.boundingRect();
+            const qreal centerX = boundingRect.x() + boundingRect.width()/2;
+            const qreal centerY = boundingRect.y() + boundingRect.height()/2;
+
+            transform.translate(handle.pos.x(), handle.pos.y());
+            transform.translate(centerX * mZoom, centerY * mZoom);
+            transform.scale(mZoom, mZoom);
+            transform.translate(-centerX, -centerY);
+
+            return transform.map(handle.drawPoints);
+        }
+
+    return QPolygonF();
 }
 
 QList<QPointF> ObjectInteractionItem::polygonEditPoints() const
@@ -145,6 +205,10 @@ void ObjectInteractionItem::mousePressed(const QPointF &pos)
           mSelectedToolId == QStringLiteral("ObjectSelectionTool")) ||
           mHoveredObjects.count() > 0)
         return;
+
+    for (const auto &handle : mObjectHandles)
+        if (handle.isHovered)
+            return;
 
     mDrawSelectionRect = true;
 

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -1,5 +1,8 @@
 #include "objectinteractionitem.h"
 
+#include <QApplication>
+#include <QPalette>
+
 using namespace Tiled;
 using namespace TiledQuick;
 
@@ -35,10 +38,20 @@ static QList<QPolygonF> outlines(const QList<Tiled::MapObject*> &objects)
 
 ObjectInteractionItem::ObjectInteractionItem(QQuickItem *parent)
     : QQuickItem(parent)
+    , mMousePressed(false)
 {
 }
 
 ObjectInteractionItem::~ObjectInteractionItem() = default;
+
+void ObjectInteractionItem::setSelectedToolId(const QByteArray &id)
+{
+    if (mSelectedToolId == id)
+        return;
+
+    mSelectedToolId = id;
+    emit selectedToolIdChanged();
+}
 
 void ObjectInteractionItem::setSelectedObjects(const QList<Tiled::MapObject*> &objects)
 {
@@ -70,10 +83,50 @@ QList<QPolygonF> ObjectInteractionItem::hoverOutlines() const
     return outlines(mHoveredObjects);
 }
 
+QColor ObjectInteractionItem::selectionRectBorderColor() const
+{
+    return QApplication::palette().highlight().color();
+}
+
+QColor ObjectInteractionItem::selectionRectFillColor() const
+{
+    QColor color = QApplication::palette().highlight().color();
+    color.setAlpha(32);
+
+    return color;
+}
+
 void ObjectInteractionItem::updateOutlines()
 {
     if (!mSelectedObjects.isEmpty())
         emit selectionOutlinesChanged();
     if (!mHoveredObjects.isEmpty())
         emit hoverOutlinesChanged();
+}
+
+void ObjectInteractionItem::mousePressed(const QPointF &pos)
+{
+    if (mSelectedToolId != "ObjectSelectionTool" || mHoveredObjects.size() > 0)
+        return;
+
+    mMousePressed = true;
+    mSelectionRect = QRectF(pos.x(), pos.y(), 0, 0);
+    emit selectionRectChanged();
+}
+
+void ObjectInteractionItem::mouseMoved(const QPointF &pos)
+{
+    if (!mMousePressed)
+        return;
+
+    mSelectionRect.setWidth(pos.x() - mSelectionRect.x());
+    mSelectionRect.setHeight(pos.y() - mSelectionRect.y());
+    emit selectionRectChanged();
+}
+
+void ObjectInteractionItem::mouseReleased(const QPointF &pos)
+{
+    mMousePressed = false;
+    mSelectionRect = QRectF(pos.x(), pos.y(), 0, 0);
+    emit selectionRectChanged();
 }

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -1,5 +1,7 @@
 #include "objectinteractionitem.h"
 
+#include "editablemapobject.h"
+
 #include <QApplication>
 #include <QPalette>
 
@@ -60,11 +62,12 @@ void ObjectInteractionItem::setSelectedToolId(const QString &id)
         return;
 
     mSelectedToolId = id;
+    setObjectHandles({});
     emit selectedToolIdChanged();
     emit polygonEditPointsChanged();
 }
 
-void ObjectInteractionItem::setSelectedObjects(const QList<Tiled::MapObject*> &objects)
+void ObjectInteractionItem::setSelectedObjects(const QList<QObject*> &objects)
 {
     if (mSelectedObjects == objects)
         return;
@@ -160,16 +163,27 @@ QList<QPointF> ObjectInteractionItem::polygonEditPoints() const
     if (mSelectedToolId != QStringLiteral("EditPolygonTool"))
         return points;
 
-    for (auto object : mSelectedObjects)
-        for (QPointF point : object->polygon())
-            points.append(point + object->position());
+    for (auto object : std::as_const(mSelectedObjects)) {
+        auto mapObject = dynamic_cast<Tiled::EditableMapObject*>(object)->mapObject();
+        if (!mapObject)
+            continue;
+
+        for (QPointF point : mapObject->polygon())
+            points.append(point + mapObject->position());
+    }
 
     return points;
 }
 
 QList<QPolygonF> ObjectInteractionItem::selectionOutlines() const
 {
-    return outlines(mSelectedObjects);
+    QList<Tiled::MapObject*> selectedObjects;
+
+    for (auto object : std::as_const(mSelectedObjects))
+        if (auto mapObject = dynamic_cast<Tiled::EditableMapObject*>(object)->mapObject())
+            selectedObjects.append(mapObject);
+
+    return outlines(selectedObjects);
 }
 
 QList<QPolygonF> ObjectInteractionItem::hoverOutlines() const
@@ -206,7 +220,7 @@ void ObjectInteractionItem::mousePressed(const QPointF &pos)
           mHoveredObjects.count() > 0)
         return;
 
-    for (const auto &handle : mObjectHandles)
+    for (const auto &handle : std::as_const(mObjectHandles))
         if (handle.isHovered)
             return;
 

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -47,6 +47,7 @@ void ObjectInteractionItem::setSelectedObjects(const QList<Tiled::MapObject*> &o
 
     mSelectedObjects = objects;
     emit selectedObjectsChanged();
+    emit selectionOutlinesChanged();
 }
 
 void ObjectInteractionItem::setHoveredObjects(const QList<Tiled::MapObject*> &objects)
@@ -56,6 +57,7 @@ void ObjectInteractionItem::setHoveredObjects(const QList<Tiled::MapObject*> &ob
 
     mHoveredObjects = objects;
     emit hoveredObjectsChanged();
+    emit hoverOutlinesChanged();
 }
 
 QList<QPolygonF> ObjectInteractionItem::selectionOutlines() const
@@ -66,4 +68,12 @@ QList<QPolygonF> ObjectInteractionItem::selectionOutlines() const
 QList<QPolygonF> ObjectInteractionItem::hoverOutlines() const
 {
     return outlines(mHoveredObjects);
+}
+
+void ObjectInteractionItem::updateOutlines()
+{
+    if (!mSelectedObjects.isEmpty())
+        emit selectionOutlinesChanged();
+    if (!mHoveredObjects.isEmpty())
+        emit hoverOutlinesChanged();
 }

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -38,19 +38,20 @@ static QList<QPolygonF> outlines(const QList<Tiled::MapObject*> &objects)
 
 ObjectInteractionItem::ObjectInteractionItem(QQuickItem *parent)
     : QQuickItem(parent)
-    , mMousePressed(false)
+    , mDrawSelectionRect(false)
 {
 }
 
 ObjectInteractionItem::~ObjectInteractionItem() = default;
 
-void ObjectInteractionItem::setSelectedToolId(const QByteArray &id)
+void ObjectInteractionItem::setSelectedToolId(const QString &id)
 {
     if (mSelectedToolId == id)
         return;
 
     mSelectedToolId = id;
     emit selectedToolIdChanged();
+    emit polygonEditPointsChanged();
 }
 
 void ObjectInteractionItem::setSelectedObjects(const QList<Tiled::MapObject*> &objects)
@@ -61,6 +62,7 @@ void ObjectInteractionItem::setSelectedObjects(const QList<Tiled::MapObject*> &o
     mSelectedObjects = objects;
     emit selectedObjectsChanged();
     emit selectionOutlinesChanged();
+    emit polygonEditPointsChanged();
 }
 
 void ObjectInteractionItem::setHoveredObjects(const QList<Tiled::MapObject*> &objects)
@@ -71,6 +73,38 @@ void ObjectInteractionItem::setHoveredObjects(const QList<Tiled::MapObject*> &ob
     mHoveredObjects = objects;
     emit hoveredObjectsChanged();
     emit hoverOutlinesChanged();
+}
+
+void ObjectInteractionItem::setSelectedPolygonEditPoints(const QList<QPointF> &points)
+{
+    if (mSelectedPolygonEditPoints == points)
+        return;
+
+    mSelectedPolygonEditPoints = points;
+    emit selectedPolygonEditPointsChanged();
+    emit polygonEditPointsChanged();
+}
+
+void ObjectInteractionItem::setHighlightedPolygonEditPoints(const QList<QPointF> &points)
+{
+    if (mHighlightedPolygonEditPoints == points)
+        return;
+
+    mHighlightedPolygonEditPoints = points;
+    emit highlightedPolygonEditPointsChanged();
+}
+
+QList<QPointF> ObjectInteractionItem::polygonEditPoints() const
+{
+    QList<QPointF> points;
+    if (mSelectedToolId != QStringLiteral("EditPolygonTool"))
+        return points;
+
+    for (auto object : mSelectedObjects)
+        for (QPointF point : object->polygon())
+            points.append(point + object->position());
+
+    return points;
 }
 
 QList<QPolygonF> ObjectInteractionItem::selectionOutlines() const
@@ -106,19 +140,21 @@ void ObjectInteractionItem::updateOutlines()
 
 void ObjectInteractionItem::mousePressed(const QPointF &pos)
 {
-    if (!(mSelectedToolId == "EditPolygonTool" ||
-          mSelectedToolId == "ObjectSelectionTool") ||
+    if (!((mSelectedToolId == QStringLiteral("EditPolygonTool") &&
+           mHighlightedPolygonEditPoints.count() == 0) ||
+          mSelectedToolId == QStringLiteral("ObjectSelectionTool")) ||
           mHoveredObjects.count() > 0)
         return;
 
-    mMousePressed = true;
+    mDrawSelectionRect = true;
+
     mSelectionRect = QRectF(pos.x(), pos.y(), 0, 0);
     emit selectionRectChanged();
 }
 
 void ObjectInteractionItem::mouseMoved(const QPointF &pos)
 {
-    if (!mMousePressed)
+    if (!mDrawSelectionRect)
         return;
 
     mSelectionRect.setWidth(pos.x() - mSelectionRect.x());
@@ -128,7 +164,7 @@ void ObjectInteractionItem::mouseMoved(const QPointF &pos)
 
 void ObjectInteractionItem::mouseReleased(const QPointF &pos)
 {
-    mMousePressed = false;
+    mDrawSelectionRect = false;
     mSelectionRect = QRectF(pos.x(), pos.y(), 0, 0);
     emit selectionRectChanged();
 }

--- a/src/libtiledquick/objectinteractionitem.cpp
+++ b/src/libtiledquick/objectinteractionitem.cpp
@@ -3,27 +3,11 @@
 using namespace Tiled;
 using namespace TiledQuick;
 
-ObjectInteractionItem::ObjectInteractionItem(QQuickItem *parent)
-    : QQuickItem(parent)
-{
-}
-
-ObjectInteractionItem::~ObjectInteractionItem() = default;
-
-void ObjectInteractionItem::setSelectedObjects(const QList<Tiled::MapObject*> &objects)
-{
-    if (mSelectedObjects == objects)
-        return;
-
-    mSelectedObjects = objects;
-    emit selectedObjectsChanged();
-}
-
-QList<QPolygonF> ObjectInteractionItem::selectionOutlines() const
+static QList<QPolygonF> outlines(const QList<Tiled::MapObject*> &objects)
 {
     QList<QPolygonF> outlines;
 
-    for (auto object : mSelectedObjects) {
+    for (auto object : objects) {
         QPolygonF outline = object->bounds();
 
         if (object->isTileObject())
@@ -46,4 +30,40 @@ QList<QPolygonF> ObjectInteractionItem::selectionOutlines() const
     }
 
     return outlines;
+}
+
+
+ObjectInteractionItem::ObjectInteractionItem(QQuickItem *parent)
+    : QQuickItem(parent)
+{
+}
+
+ObjectInteractionItem::~ObjectInteractionItem() = default;
+
+void ObjectInteractionItem::setSelectedObjects(const QList<Tiled::MapObject*> &objects)
+{
+    if (mSelectedObjects == objects)
+        return;
+
+    mSelectedObjects = objects;
+    emit selectedObjectsChanged();
+}
+
+void ObjectInteractionItem::setHoveredObjects(const QList<Tiled::MapObject*> &objects)
+{
+    if (mHoveredObjects == objects)
+        return;
+
+    mHoveredObjects = objects;
+    emit hoveredObjectsChanged();
+}
+
+QList<QPolygonF> ObjectInteractionItem::selectionOutlines() const
+{
+    return outlines(mSelectedObjects);
+}
+
+QList<QPolygonF> ObjectInteractionItem::hoverOutlines() const
+{
+    return outlines(mHoveredObjects);
 }

--- a/src/libtiledquick/objectinteractionitem.h
+++ b/src/libtiledquick/objectinteractionitem.h
@@ -14,8 +14,8 @@ class TILEDQUICK_SHARED_EXPORT ObjectInteractionItem : public QQuickItem
 
     Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects WRITE setSelectedObjects NOTIFY selectedObjectsChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> hoveredObjects READ hoveredObjects WRITE setHoveredObjects NOTIFY hoveredObjectsChanged)
-    Q_PROPERTY(QList<QPolygonF> selectionOutlines READ selectionOutlines NOTIFY selectedObjectsChanged)
-    Q_PROPERTY(QList<QPolygonF> hoverOutlines READ hoverOutlines NOTIFY hoveredObjectsChanged)
+    Q_PROPERTY(QList<QPolygonF> selectionOutlines READ selectionOutlines NOTIFY selectionOutlinesChanged)
+    Q_PROPERTY(QList<QPolygonF> hoverOutlines READ hoverOutlines NOTIFY hoverOutlinesChanged)
 
 public:
     ObjectInteractionItem(QQuickItem *parent = nullptr);
@@ -30,9 +30,13 @@ public:
     QList<QPolygonF> selectionOutlines() const;
     QList<QPolygonF> hoverOutlines() const;
 
+    Q_INVOKABLE void updateOutlines();
+
 signals:
     void selectedObjectsChanged();
     void hoveredObjectsChanged();
+    void selectionOutlinesChanged();
+    void hoverOutlinesChanged();
 
 private:
     QList<Tiled::MapObject*> mSelectedObjects;

--- a/src/libtiledquick/objectinteractionitem.h
+++ b/src/libtiledquick/objectinteractionitem.h
@@ -12,14 +12,19 @@ class TILEDQUICK_SHARED_EXPORT ObjectInteractionItem : public QQuickItem
 {
     Q_OBJECT
 
+    Q_PROPERTY(QByteArray selectedToolId READ selectedToolId WRITE setSelectedToolId NOTIFY selectedToolIdChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects WRITE setSelectedObjects NOTIFY selectedObjectsChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> hoveredObjects READ hoveredObjects WRITE setHoveredObjects NOTIFY hoveredObjectsChanged)
     Q_PROPERTY(QList<QPolygonF> selectionOutlines READ selectionOutlines NOTIFY selectionOutlinesChanged)
     Q_PROPERTY(QList<QPolygonF> hoverOutlines READ hoverOutlines NOTIFY hoverOutlinesChanged)
+    Q_PROPERTY(QRectF selectionRect READ selectionRect NOTIFY selectionRectChanged)
 
 public:
     ObjectInteractionItem(QQuickItem *parent = nullptr);
     ~ObjectInteractionItem() override;
+
+    QByteArray selectedToolId() const;
+    void setSelectedToolId(const QByteArray &id);
 
     QList<Tiled::MapObject*> selectedObjects() const;
     void setSelectedObjects(const QList<Tiled::MapObject*> &objects);
@@ -29,19 +34,35 @@ public:
 
     QList<QPolygonF> selectionOutlines() const;
     QList<QPolygonF> hoverOutlines() const;
+    QRectF selectionRect() const;
+
+    Q_INVOKABLE QColor selectionRectBorderColor() const;
+    Q_INVOKABLE QColor selectionRectFillColor() const;
 
     Q_INVOKABLE void updateOutlines();
+    Q_INVOKABLE void mousePressed(const QPointF &pos);
+    Q_INVOKABLE void mouseMoved(const QPointF &pos);
+    Q_INVOKABLE void mouseReleased(const QPointF &pos);
 
 signals:
+    void selectedToolIdChanged();
     void selectedObjectsChanged();
     void hoveredObjectsChanged();
     void selectionOutlinesChanged();
     void hoverOutlinesChanged();
+    void selectionRectChanged();
 
 private:
+    QByteArray mSelectedToolId;
     QList<Tiled::MapObject*> mSelectedObjects;
     QList<Tiled::MapObject*> mHoveredObjects;
+    bool mMousePressed;
+    QRectF mSelectionRect;
 };
+
+inline QByteArray ObjectInteractionItem::selectedToolId() const {
+    return mSelectedToolId;
+}
 
 inline QList<Tiled::MapObject*> ObjectInteractionItem::selectedObjects() const
 {
@@ -51,6 +72,11 @@ inline QList<Tiled::MapObject*> ObjectInteractionItem::selectedObjects() const
 inline QList<Tiled::MapObject*> ObjectInteractionItem::hoveredObjects() const
 {
     return mHoveredObjects;
+}
+
+inline QRectF ObjectInteractionItem::selectionRect() const
+{
+    return mSelectionRect.normalized();
 }
 
 } // namespace TiledQuick

--- a/src/libtiledquick/objectinteractionitem.h
+++ b/src/libtiledquick/objectinteractionitem.h
@@ -13,7 +13,10 @@ class TILEDQUICK_SHARED_EXPORT ObjectInteractionItem : public QQuickItem
     Q_OBJECT
 
     Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects WRITE setSelectedObjects NOTIFY selectedObjectsChanged)
+    Q_PROPERTY(QList<Tiled::MapObject*> hoveredObjects READ hoveredObjects WRITE setHoveredObjects NOTIFY hoveredObjectsChanged)
     Q_PROPERTY(QList<QPolygonF> selectionOutlines READ selectionOutlines NOTIFY selectedObjectsChanged)
+    Q_PROPERTY(QList<QPolygonF> hoverOutlines READ hoverOutlines NOTIFY hoveredObjectsChanged)
+
 public:
     ObjectInteractionItem(QQuickItem *parent = nullptr);
     ~ObjectInteractionItem() override;
@@ -21,18 +24,29 @@ public:
     QList<Tiled::MapObject*> selectedObjects() const;
     void setSelectedObjects(const QList<Tiled::MapObject*> &objects);
 
+    QList<Tiled::MapObject*> hoveredObjects() const;
+    void setHoveredObjects(const QList<Tiled::MapObject*> &objects);
+
     QList<QPolygonF> selectionOutlines() const;
+    QList<QPolygonF> hoverOutlines() const;
 
 signals:
     void selectedObjectsChanged();
+    void hoveredObjectsChanged();
 
 private:
     QList<Tiled::MapObject*> mSelectedObjects;
+    QList<Tiled::MapObject*> mHoveredObjects;
 };
 
 inline QList<Tiled::MapObject*> ObjectInteractionItem::selectedObjects() const
 {
     return mSelectedObjects;
+}
+
+inline QList<Tiled::MapObject*> ObjectInteractionItem::hoveredObjects() const
+{
+    return mHoveredObjects;
 }
 
 } // namespace TiledQuick

--- a/src/libtiledquick/objectinteractionitem.h
+++ b/src/libtiledquick/objectinteractionitem.h
@@ -3,6 +3,7 @@
 #include <QQuickItem>
 
 #include "mapobject.h"
+#include "objectselectiontool.h"
 
 #include "tiledquick_global.h"
 
@@ -12,20 +13,27 @@ class TILEDQUICK_SHARED_EXPORT ObjectInteractionItem : public QQuickItem
 {
     Q_OBJECT
 
+    Q_PROPERTY(qreal zoom READ zoom WRITE setZoom NOTIFY zoomChanged)
     Q_PROPERTY(QString selectedToolId READ selectedToolId WRITE setSelectedToolId NOTIFY selectedToolIdChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects WRITE setSelectedObjects NOTIFY selectedObjectsChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> hoveredObjects READ hoveredObjects WRITE setHoveredObjects NOTIFY hoveredObjectsChanged)
     Q_PROPERTY(QList<QPointF> selectedPolygonEditPoints READ selectedPolygonEditPoints WRITE setSelectedPolygonEditPoints NOTIFY selectedPolygonEditPointsChanged)
     Q_PROPERTY(QList<QPointF> highlightedPolygonEditPoints READ highlightedPolygonEditPoints WRITE setHighlightedPolygonEditPoints NOTIFY highlightedPolygonEditPointsChanged)
+    Q_PROPERTY(QList<Tiled::ObjectHandleData> objectHandles READ objectHandles WRITE setObjectHandles NOTIFY objectHandlesChanged)
 
     Q_PROPERTY(QList<QPolygonF> selectionOutlines READ selectionOutlines NOTIFY selectionOutlinesChanged)
     Q_PROPERTY(QList<QPolygonF> hoverOutlines READ hoverOutlines NOTIFY hoverOutlinesChanged)
     Q_PROPERTY(QRectF selectionRect READ selectionRect NOTIFY selectionRectChanged)
+    Q_PROPERTY(QList<QPolygonF> objectHandlePolygons READ objectHandlePolygons NOTIFY objectHandlesChanged)
+    Q_PROPERTY(QPolygonF hoveredHandlePolygon READ hoveredHandlePolygon NOTIFY objectHandlesChanged)
     Q_PROPERTY(QList<QPointF> polygonEditPoints READ polygonEditPoints NOTIFY polygonEditPointsChanged)
 
 public:
     ObjectInteractionItem(QQuickItem *parent = nullptr);
     ~ObjectInteractionItem() override;
+
+    qreal zoom() const;
+    void setZoom(const qreal zoom);
 
     QString selectedToolId() const;
     void setSelectedToolId(const QString &id);
@@ -42,9 +50,14 @@ public:
     QList<QPointF> highlightedPolygonEditPoints() const;
     void setHighlightedPolygonEditPoints(const QList<QPointF> &points);
 
+    QList<Tiled::ObjectHandleData> objectHandles() const;
+    void setObjectHandles(const QList<Tiled::ObjectHandleData> &handles);
+
     QList<QPolygonF> selectionOutlines() const;
     QList<QPolygonF> hoverOutlines() const;
     QRectF selectionRect() const;
+    QList<QPolygonF> objectHandlePolygons() const;
+    QPolygonF hoveredHandlePolygon() const;
     QList<QPointF> polygonEditPoints() const;
 
     Q_INVOKABLE void updateOutlines();
@@ -56,25 +69,33 @@ public:
     Q_INVOKABLE QColor selectionRectFillColor() const;
 
 signals:
+    void zoomChanged();
     void selectedToolIdChanged();
     void selectedObjectsChanged();
     void hoveredObjectsChanged();
     void selectedPolygonEditPointsChanged();
     void highlightedPolygonEditPointsChanged();
+    void objectHandlesChanged();
     void selectionOutlinesChanged();
     void hoverOutlinesChanged();
     void selectionRectChanged();
     void polygonEditPointsChanged();
 
 private:
+    qreal mZoom = 0;
     QString mSelectedToolId;
     QList<Tiled::MapObject*> mSelectedObjects;
     QList<Tiled::MapObject*> mHoveredObjects;
     QList<QPointF> mSelectedPolygonEditPoints;
     QList<QPointF> mHighlightedPolygonEditPoints;
+    QList<Tiled::ObjectHandleData> mObjectHandles;
     bool mDrawSelectionRect;
     QRectF mSelectionRect;
 };
+
+inline qreal ObjectInteractionItem::zoom() const {
+    return mZoom;
+}
 
 inline QString ObjectInteractionItem::selectedToolId() const {
     return mSelectedToolId;
@@ -98,6 +119,11 @@ inline QList<QPointF> ObjectInteractionItem::selectedPolygonEditPoints() const
 inline QList<QPointF> ObjectInteractionItem::highlightedPolygonEditPoints() const
 {
     return mHighlightedPolygonEditPoints;
+}
+
+inline QList<Tiled::ObjectHandleData> ObjectInteractionItem::objectHandles() const
+{
+    return mObjectHandles;
 }
 
 inline QRectF ObjectInteractionItem::selectionRect() const

--- a/src/libtiledquick/objectinteractionitem.h
+++ b/src/libtiledquick/objectinteractionitem.h
@@ -15,7 +15,7 @@ class TILEDQUICK_SHARED_EXPORT ObjectInteractionItem : public QQuickItem
 
     Q_PROPERTY(qreal zoom READ zoom WRITE setZoom NOTIFY zoomChanged)
     Q_PROPERTY(QString selectedToolId READ selectedToolId WRITE setSelectedToolId NOTIFY selectedToolIdChanged)
-    Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects WRITE setSelectedObjects NOTIFY selectedObjectsChanged)
+    Q_PROPERTY(QList<QObject*> selectedObjects READ selectedObjects WRITE setSelectedObjects NOTIFY selectedObjectsChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> hoveredObjects READ hoveredObjects WRITE setHoveredObjects NOTIFY hoveredObjectsChanged)
     Q_PROPERTY(QList<QPointF> selectedPolygonEditPoints READ selectedPolygonEditPoints WRITE setSelectedPolygonEditPoints NOTIFY selectedPolygonEditPointsChanged)
     Q_PROPERTY(QList<QPointF> highlightedPolygonEditPoints READ highlightedPolygonEditPoints WRITE setHighlightedPolygonEditPoints NOTIFY highlightedPolygonEditPointsChanged)
@@ -38,8 +38,8 @@ public:
     QString selectedToolId() const;
     void setSelectedToolId(const QString &id);
 
-    QList<Tiled::MapObject*> selectedObjects() const;
-    void setSelectedObjects(const QList<Tiled::MapObject*> &objects);
+    QList<QObject*> selectedObjects() const;
+    void setSelectedObjects(const QList<QObject*> &objects);
 
     QList<Tiled::MapObject*> hoveredObjects() const;
     void setHoveredObjects(const QList<Tiled::MapObject*> &objects);
@@ -84,7 +84,7 @@ signals:
 private:
     qreal mZoom = 0;
     QString mSelectedToolId;
-    QList<Tiled::MapObject*> mSelectedObjects;
+    QList<QObject*> mSelectedObjects;
     QList<Tiled::MapObject*> mHoveredObjects;
     QList<QPointF> mSelectedPolygonEditPoints;
     QList<QPointF> mHighlightedPolygonEditPoints;
@@ -101,7 +101,7 @@ inline QString ObjectInteractionItem::selectedToolId() const {
     return mSelectedToolId;
 }
 
-inline QList<Tiled::MapObject*> ObjectInteractionItem::selectedObjects() const
+inline QList<QObject*> ObjectInteractionItem::selectedObjects() const
 {
     return mSelectedObjects;
 }

--- a/src/libtiledquick/objectinteractionitem.h
+++ b/src/libtiledquick/objectinteractionitem.h
@@ -12,19 +12,23 @@ class TILEDQUICK_SHARED_EXPORT ObjectInteractionItem : public QQuickItem
 {
     Q_OBJECT
 
-    Q_PROPERTY(QByteArray selectedToolId READ selectedToolId WRITE setSelectedToolId NOTIFY selectedToolIdChanged)
+    Q_PROPERTY(QString selectedToolId READ selectedToolId WRITE setSelectedToolId NOTIFY selectedToolIdChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects WRITE setSelectedObjects NOTIFY selectedObjectsChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> hoveredObjects READ hoveredObjects WRITE setHoveredObjects NOTIFY hoveredObjectsChanged)
+    Q_PROPERTY(QList<QPointF> selectedPolygonEditPoints READ selectedPolygonEditPoints WRITE setSelectedPolygonEditPoints NOTIFY selectedPolygonEditPointsChanged)
+    Q_PROPERTY(QList<QPointF> highlightedPolygonEditPoints READ highlightedPolygonEditPoints WRITE setHighlightedPolygonEditPoints NOTIFY highlightedPolygonEditPointsChanged)
+
     Q_PROPERTY(QList<QPolygonF> selectionOutlines READ selectionOutlines NOTIFY selectionOutlinesChanged)
     Q_PROPERTY(QList<QPolygonF> hoverOutlines READ hoverOutlines NOTIFY hoverOutlinesChanged)
     Q_PROPERTY(QRectF selectionRect READ selectionRect NOTIFY selectionRectChanged)
+    Q_PROPERTY(QList<QPointF> polygonEditPoints READ polygonEditPoints NOTIFY polygonEditPointsChanged)
 
 public:
     ObjectInteractionItem(QQuickItem *parent = nullptr);
     ~ObjectInteractionItem() override;
 
-    QByteArray selectedToolId() const;
-    void setSelectedToolId(const QByteArray &id);
+    QString selectedToolId() const;
+    void setSelectedToolId(const QString &id);
 
     QList<Tiled::MapObject*> selectedObjects() const;
     void setSelectedObjects(const QList<Tiled::MapObject*> &objects);
@@ -32,35 +36,47 @@ public:
     QList<Tiled::MapObject*> hoveredObjects() const;
     void setHoveredObjects(const QList<Tiled::MapObject*> &objects);
 
+    QList<QPointF> selectedPolygonEditPoints() const;
+    void setSelectedPolygonEditPoints(const QList<QPointF> &points);
+
+    QList<QPointF> highlightedPolygonEditPoints() const;
+    void setHighlightedPolygonEditPoints(const QList<QPointF> &points);
+
     QList<QPolygonF> selectionOutlines() const;
     QList<QPolygonF> hoverOutlines() const;
     QRectF selectionRect() const;
-
-    Q_INVOKABLE QColor selectionRectBorderColor() const;
-    Q_INVOKABLE QColor selectionRectFillColor() const;
+    QList<QPointF> polygonEditPoints() const;
 
     Q_INVOKABLE void updateOutlines();
     Q_INVOKABLE void mousePressed(const QPointF &pos);
     Q_INVOKABLE void mouseMoved(const QPointF &pos);
     Q_INVOKABLE void mouseReleased(const QPointF &pos);
 
+    Q_INVOKABLE QColor selectionRectBorderColor() const;
+    Q_INVOKABLE QColor selectionRectFillColor() const;
+
 signals:
     void selectedToolIdChanged();
     void selectedObjectsChanged();
     void hoveredObjectsChanged();
+    void selectedPolygonEditPointsChanged();
+    void highlightedPolygonEditPointsChanged();
     void selectionOutlinesChanged();
     void hoverOutlinesChanged();
     void selectionRectChanged();
+    void polygonEditPointsChanged();
 
 private:
-    QByteArray mSelectedToolId;
+    QString mSelectedToolId;
     QList<Tiled::MapObject*> mSelectedObjects;
     QList<Tiled::MapObject*> mHoveredObjects;
-    bool mMousePressed;
+    QList<QPointF> mSelectedPolygonEditPoints;
+    QList<QPointF> mHighlightedPolygonEditPoints;
+    bool mDrawSelectionRect;
     QRectF mSelectionRect;
 };
 
-inline QByteArray ObjectInteractionItem::selectedToolId() const {
+inline QString ObjectInteractionItem::selectedToolId() const {
     return mSelectedToolId;
 }
 
@@ -72,6 +88,16 @@ inline QList<Tiled::MapObject*> ObjectInteractionItem::selectedObjects() const
 inline QList<Tiled::MapObject*> ObjectInteractionItem::hoveredObjects() const
 {
     return mHoveredObjects;
+}
+
+inline QList<QPointF> ObjectInteractionItem::selectedPolygonEditPoints() const
+{
+    return mSelectedPolygonEditPoints;
+}
+
+inline QList<QPointF> ObjectInteractionItem::highlightedPolygonEditPoints() const
+{
+    return mHighlightedPolygonEditPoints;
 }
 
 inline QRectF ObjectInteractionItem::selectionRect() const

--- a/src/libtiledquick/objectinteractionitem.h
+++ b/src/libtiledquick/objectinteractionitem.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QQuickItem>
+
+#include "mapobject.h"
+
+#include "tiledquick_global.h"
+
+namespace TiledQuick {
+
+class TILEDQUICK_SHARED_EXPORT ObjectInteractionItem : public QQuickItem
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects WRITE setSelectedObjects NOTIFY selectedObjectsChanged)
+    Q_PROPERTY(QList<QPolygonF> selectionOutlines READ selectionOutlines NOTIFY selectedObjectsChanged)
+public:
+    ObjectInteractionItem(QQuickItem *parent = nullptr);
+    ~ObjectInteractionItem() override;
+
+    QList<Tiled::MapObject*> selectedObjects() const;
+    void setSelectedObjects(const QList<Tiled::MapObject*> &objects);
+
+    QList<QPolygonF> selectionOutlines() const;
+
+signals:
+    void selectedObjectsChanged();
+
+private:
+    QList<Tiled::MapObject*> mSelectedObjects;
+};
+
+inline QList<Tiled::MapObject*> ObjectInteractionItem::selectedObjects() const
+{
+    return mSelectedObjects;
+}
+
+} // namespace TiledQuick

--- a/src/libtiledquick/objectsnode.cpp
+++ b/src/libtiledquick/objectsnode.cpp
@@ -24,10 +24,10 @@ namespace TiledQuick {
 
 static const QSGGeometry::Attribute ObjectAttributes[] = {
     QSGGeometry::Attribute::create(0, 2, QSGGeometry::FloatType, QSGGeometry::PositionAttribute), // Global Position
-    QSGGeometry::Attribute::create(1, 2, QSGGeometry::FloatType, QSGGeometry::PositionAttribute), // Local Position
-    QSGGeometry::Attribute::create(2, 2, QSGGeometry::FloatType, QSGGeometry::TexCoordAttribute), // Texture Coords
-    QSGGeometry::Attribute::create(3, 4, QSGGeometry::UnsignedByteType, true),                    // Tint colors (0-3) and alpha (4)
-    QSGGeometry::Attribute::create(4, 1, QSGGeometry::FloatType, false)                     // Object Type
+    // QSGGeometry::Attribute::create(1, 2, QSGGeometry::FloatType, QSGGeometry::PositionAttribute), // Local Position
+    QSGGeometry::Attribute::create(1, 2, QSGGeometry::FloatType, QSGGeometry::TexCoordAttribute), // Texture Coords
+    QSGGeometry::Attribute::create(2, 4, QSGGeometry::UnsignedByteType, true),                    // Tint colors (0-3) and alpha (4)
+    // QSGGeometry::Attribute::create(4, 1, QSGGeometry::FloatType, false),                          // Object Type
 };
 
 static const QSGGeometry::AttributeSet ObjectAttributeSet = {
@@ -44,6 +44,7 @@ ObjectsNode::ObjectsNode(QSGTexture *texture, const QVector<ObjectData> &objectD
     mMaterial.setTexture(texture);
 
     mGeometry.setDrawingMode(QSGGeometry::DrawTriangles);
+    // mGeometry.setDrawingMode(QSGGeometry::DrawLines);
     mGeometry.setVertexDataPattern(QSGGeometry::StaticPattern);
 
     processObjectData(objectData);
@@ -97,15 +98,15 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
 
         // ObjectGroupMaterial
         for (int i = 0; i < 6; i++) {
-            v[i].local_x = (v[i].x - data.x) / data.width;
-            v[i].local_y = (v[i].y - data.y) / data.width;
+            // v[i].local_x = (v[i].x - data.x) / data.width;
+            // v[i].local_y = (v[i].y - data.y) / data.width;
 
             v[i].tint_r = data.tint_r;
             v[i].tint_g = data.tint_g;
             v[i].tint_b = data.tint_b;
             v[i].alpha = data.alpha;
 
-            v[i].object_type = static_cast<float>(data.type);
+            // v[i].object_type = static_cast<float>(data.type);
         }
 
         if (data.flippedHorizontally) {

--- a/src/libtiledquick/objectsnode.cpp
+++ b/src/libtiledquick/objectsnode.cpp
@@ -20,6 +20,8 @@
 
 #include "objectsnode.h"
 
+#include "tilesethelper.h"
+
 namespace TiledQuick {
 
 static const QSGGeometry::Attribute ObjectAttributes[] = {
@@ -53,7 +55,415 @@ ObjectsNode::ObjectsNode(QSGTexture *texture, const QVector<ObjectData> &objectD
     setMaterial(&mMaterial);
 }
 
+/**
+ * Draws a border and shadow between two points.
+ *
+ * If totalBorderSegments is 0, no shadow will be drawn.
+ */
+static void processBorderSegment(const ObjectData &data, ObjectTexturedPoint2D *&v, const QPointF start, const QPointF end, const float thickness, const float border_tx, const int totalBorderSegments = 1, const float shadow_tx = 2.5, const QPointF shadowOffset = {1, 1}, const bool extendCorners = false)
+{
+    const float lineLength = sqrt(pow(end.x() - start.x(), 2) + pow(end.y() - start.y(), 2));
+    const QPointF thicknessOffset = thickness/2 * QPointF((start.y() - end.y())/lineLength,
+                                               (end.x() - start.x())/lineLength);
+    const float o_x = thicknessOffset.x();
+    const float o_y = thicknessOffset.y();
+    const float c = (extendCorners ? 1 : 0);
+    const int b = totalBorderSegments*6;
+
+    // Shadow
+    if (totalBorderSegments > 0) {
+        const float start_x = start.x() + shadowOffset.x();
+        const float start_y = start.y() + shadowOffset.y();
+        const float end_x = end.x() + shadowOffset.x();
+        const float end_y = end.y() + shadowOffset.y();
+
+        // StartLeft                        // StartRight
+        v[0].x = start_x + o_x - c*o_y;     v[2].x = start_x - o_x + c*o_y;
+        v[0].y = start_y + o_y + c*o_x;     v[2].y = start_y - o_y - c*o_x;
+        v[0].tx = shadow_tx;                v[2].tx = shadow_tx;
+
+        // EndLeft
+        v[1].x = end_x + o_x + c*o_y;
+        v[1].y = end_y + o_y - c*o_x;
+        v[1].tx = shadow_tx;
+
+                                            // StartRight
+                                            v[5].x = v[2].x;
+                                            v[5].y = v[2].y;
+                                            v[5].tx = v[2].tx;
+
+        // EndLeft                          // EndRight
+        v[3].x = v[1].x;                    v[4].x = end_x - o_x - c*o_y;
+        v[3].y = v[1].y;                    v[4].y = end_y - o_y + c*o_x;
+        v[3].tx = v[1].tx;                  v[4].tx = shadow_tx;
+
+        // ObjectGroupMaterial
+        for (int i = 0; i < 6; i++) {
+            v[i].tint_r = data.tint_r;
+            v[i].tint_g = data.tint_g;
+            v[i].tint_b = data.tint_b;
+            v[i].alpha = data.alpha;
+
+            v[i].ty = 0;
+        }
+
+        if (data.rotation != 0) {
+            const double r = data.rotation * M_PI / 180;
+            const double origin_x = data.x;
+            const double origin_y = data.y;
+
+            for (int i = 0; i < 6; i++) {
+                const double x = v[i].x;
+                const double y = v[i].y;
+                v[i].x = origin_x + (x - origin_x)*cos(r) - (y - origin_y)*sin(r);
+                v[i].y = origin_y + (y - origin_y)*cos(r) + (x - origin_x)*sin(r);
+            }
+        }
+    }
+
+    // Border
+    // StartLeft                            // StartRight
+    v[b+0].x = start.x() + o_x - c*o_y;     v[b+2].x = start.x() - o_x + c*o_y;
+    v[b+0].y = start.y() + o_y + c*o_x;     v[b+2].y = start.y() - o_y - c*o_x;
+    v[b+0].tx = border_tx;                  v[b+2].tx = border_tx;
+
+    // EndLeft
+    v[b+1].x = end.x() + o_x + c*o_y;
+    v[b+1].y = end.y() + o_y - c*o_x;
+    v[b+1].tx = border_tx;
+
+                                            // StartRight
+                                            v[b+5].x = v[b+2].x;
+                                            v[b+5].y = v[b+2].y;
+                                            v[b+5].tx = v[b+2].tx;
+
+    // EndLeft                              // EndRight
+    v[b+3].x = v[b+1].x;                    v[b+4].x = end.x() - o_x - c*o_y;
+    v[b+3].y = v[b+1].y;                    v[b+4].y = end.y() - o_y + c*o_x;
+    v[b+3].tx = v[b+1].tx;                  v[b+4].tx = border_tx;
+
+    // ObjectGroupMaterial
+    for (int i = 0; i < 6; i++) {
+        v[b+i].tint_r = data.tint_r;
+        v[b+i].tint_g = data.tint_g;
+        v[b+i].tint_b = data.tint_b;
+        v[b+i].alpha = data.alpha;
+
+        v[i].ty = 0;
+    }
+
+    if (data.rotation != 0) {
+        const double r = data.rotation * M_PI / 180;
+        const double origin_x = data.x;
+        const double origin_y = data.y;
+
+        for (int i = 0; i < 6; i++) {
+            const double x = v[b+i].x;
+            const double y = v[b+i].y;
+            v[b+i].x = origin_x + (x - origin_x)*cos(r) - (y - origin_y)*sin(r);
+            v[b+i].y = origin_y + (y - origin_y)*cos(r) + (x - origin_x)*sin(r);
+        }
+    }
+
+    v += 6;
+}
+
+/**
+ * Draws the filling for a convex polygon's points.
+ */
+static void processFillPoints(const ObjectData &data, ObjectTexturedPoint2D *&v, const QList<QPointF> &points, const float &fill_tx)
+{
+    for (int i = 0; i < points.count()-3; i++) {
+        v[0].x = points[0].x();
+        v[0].y = points[0].y();
+
+        v[1].x = points[i+1].x();
+        v[1].y = points[i+1].y();
+
+        v[2].x = points[i+2].x();
+        v[2].y = points[i+2].y();
+
+        // ObjectGroupMaterial
+        for (int ii = 0; ii < 3; ii++) {
+            v[ii].tint_r = data.tint_r;
+            v[ii].tint_g = data.tint_g;
+            v[ii].tint_b = data.tint_b;
+            v[ii].alpha = data.alpha;
+
+            v[ii].tx = fill_tx;
+            v[ii].ty = 0;
+        }
+
+        if (data.rotation != 0) {
+            const double r = data.rotation * M_PI / 180;
+            const double origin_x = data.x;
+            const double origin_y = data.y;
+
+            for (int ii = 0; ii < 3; ii++) {
+                const double x = v[ii].x;
+                const double y = v[ii].y;
+                v[ii].x = origin_x + (x - origin_x)*cos(r) - (y - origin_y)*sin(r);
+                v[ii].y = origin_y + (y - origin_y)*cos(r) + (x - origin_x)*sin(r);
+            }
+        }
+
+        v += 3;
+    }
+}
+
+static void processRectangleData(const ObjectData &data, ObjectTexturedPoint2D *&v)
+{
+    const float s_width = 1.0f / TilesetHelper::ColorCount;
+    const float fill_tx = (TilesetHelper::Fill + 0.5) * s_width;
+    const float border_tx = (TilesetHelper::Border + 0.5) * s_width;
+    const float shadow_tx = (TilesetHelper::Shadow + 0.5) * s_width;
+    const float thickness = 2*data.zoom;
+    const QPointF shadowOffset = QPointF(thickness * 2/3, thickness * 2/3);
+
+    // Fill
+    processBorderSegment(data, v, QPointF(data.x, data.y + data.height/2),
+                       QPointF(data.x + data.width, data.y + data.height/2),
+                       data.height, fill_tx, 0);
+
+    // Border + Shadow
+    const int totalBorders = 4;
+    processBorderSegment(data, v, QPointF(data.x, data.y),
+                       QPointF(data.x, data.y + data.height),
+                    thickness, border_tx, totalBorders, shadow_tx, shadowOffset, true);
+    processBorderSegment(data, v, QPointF(data.x + data.width, data.y),
+                       QPointF(data.x, data.y),
+                    thickness, border_tx, totalBorders, shadow_tx, shadowOffset, true);
+    processBorderSegment(data, v, QPointF(data.x + data.width, data.y + data.height),
+                       QPointF(data.x + data.width, data.y),
+                    thickness, border_tx, totalBorders, shadow_tx, shadowOffset, true);
+    processBorderSegment(data, v, QPointF(data.x, data.y + data.height),
+                       QPointF(data.x + data.width, data.y + data.height),
+                    thickness, border_tx, totalBorders, shadow_tx, shadowOffset, true);
+    v += totalBorders*6;
+}
+
+static void processEllipseData(const ObjectData &data, ObjectTexturedPoint2D *&v, const int &precision)
+{
+    const float s_width = 1.0f / TilesetHelper::ColorCount;
+    const float fill_tx = (TilesetHelper::Fill + 0.5) * s_width;
+    const float border_tx = (TilesetHelper::Border + 0.5) * s_width;
+    const float shadow_tx = (TilesetHelper::Shadow + 0.5) * s_width;
+    const float thickness = 2*data.zoom;
+    const QPointF shadowOffset = QPointF(thickness * 2/3, thickness * 2/3);
+
+    const int center_x = data.x + data.width/2;
+    const int center_y = data.y + data.height/2;
+
+    QList<QPointF> points;
+    for (int step = 0; step <= precision; step++)
+        points.append(QPointF(center_x + cos(2*M_PI*step / precision) * data.width/2,
+                              center_y + sin(2*M_PI*step / precision) * data.height/2));
+
+    // Fill
+    processFillPoints(data, v, points, fill_tx);
+
+    // Border + Shadow
+    const int totalBorders = points.count()-1;
+    for (int i = 0; i < totalBorders; i++)
+        processBorderSegment(data, v, points[i], points[i+1], thickness,
+                             border_tx, totalBorders, shadow_tx, shadowOffset);
+    v += totalBorders*6;
+}
+
+static void processCapsuleData(const ObjectData &data, ObjectTexturedPoint2D *&v, const int &precision)
+{
+    const float s_width = 1.0f / TilesetHelper::ColorCount;
+    const float fill_tx = (TilesetHelper::Fill + 0.5) * s_width;
+    const float border_tx = (TilesetHelper::Border + 0.5) * s_width;
+    const float shadow_tx = (TilesetHelper::Shadow + 0.5) * s_width;
+    const float thickness = 2*data.zoom;
+    const QPointF shadowOffset = QPointF(thickness * 2/3, thickness * 2/3);
+
+    QList<QPointF> points;
+
+    if (data.height > data.width) {
+        points.append(QPointF(data.x, data.y + data.width/2));
+        points.append(QPointF(data.x, data.y + data.height - data.width/2));
+
+        const float startAngle = M_PI;
+        const float endAngle = 0;
+        const float step = (endAngle-startAngle)/precision;
+        const float radius = data.width/2;
+
+        for (int s = 1; s < precision; s++)
+            points.append(QPointF(data.x + data.width/2 + cos(startAngle + s*step) * radius,
+                                  data.y + data.height - data.width/2 + sin(startAngle + s*step) * radius));
+    } else {
+        points.append(QPointF(data.x + data.height/2, data.y));
+        points.append(QPointF(data.x + data.width - data.height/2, data.y));
+
+        const float startAngle = M_PI * 1/2;
+        const float endAngle = M_PI * 3/2;
+        const float step = (endAngle-startAngle)/precision;
+        const float radius = data.height/2;
+
+        for (int s = 1; s < precision; s++)
+            points.append(QPointF(data.x + data.width - data.height/2 - cos(startAngle + s*step) * radius,
+                                  data.y + data.height/2 - sin(startAngle + s*step) * radius));
+    }
+
+    const int currentPoints = points.count();
+    for (int i = 0; i < currentPoints; i++) {
+        points.append(QPointF(2*data.x + data.width - points[i].x(),
+                              2*data.y + data.height - points[i].y()));
+    }
+    points.append(points[0]);
+
+    // Fill
+    processFillPoints(data, v, points, fill_tx);
+
+    // Border + Shadow
+    const int totalBorders = points.count()-1;
+    for (int i = 0; i < totalBorders; i++)
+        processBorderSegment(data, v, points[i], points[i+1], thickness,
+                             border_tx, totalBorders, shadow_tx, shadowOffset);
+    v += totalBorders*6;
+}
+
+static void processPointData(const ObjectData &data, ObjectTexturedPoint2D *&v, const int &precision)
+{
+    const float s_width = 1.0f / TilesetHelper::ColorCount;
+    const float fill_tx = (TilesetHelper::Fill + 0.5) * s_width;
+    const float border_tx = (TilesetHelper::Border + 0.5) * s_width;
+    const float shadow_tx = (TilesetHelper::Shadow + 0.5) * s_width;
+    const float thickness = 2*data.zoom;
+    const QPointF shadowOffset = QPointF(thickness * 2/3, thickness * 2/3);
+
+    QList<QPointF> points;
+    points.append(QPointF(data.x - 4*thickness, data.y - 8*thickness));
+    points.append(QPointF(data.x, data.y));
+    points.append(QPointF(data.x + 4*thickness, data.y - 8*thickness));
+
+    const float startAngle = M_PI * -1/4;
+    const float endAngle = M_PI * 5/4;
+    const float step = (endAngle-startAngle)/precision;
+    const float radius = sqrt(32) * thickness;
+
+    for (int s = 0; s <= precision; s++)
+        points.append(QPointF(data.x + cos(startAngle + s*step) * radius,
+                              data.y - 12*thickness - sin(startAngle + s*step) * radius));
+
+    // Fill
+    for (int i = 0; i < precision; i++) {
+        v[0].x = points[0].x();
+        v[0].y = points[0].y();
+
+        v[1].x = points[i+1].x();
+        v[1].y = points[i+1].y();
+
+        v[2].x = points[i+2].x();
+        v[2].y = points[i+2].y();
+
+        // ObjectGroupMaterial
+        for (int ii = 0; ii < 3; ii++) {
+            v[ii].tint_r = data.tint_r;
+            v[ii].tint_g = data.tint_g;
+            v[ii].tint_b = data.tint_b;
+            v[ii].alpha = data.alpha;
+
+            v[ii].tx = fill_tx;
+            v[ii].ty = 0;
+        }
+
+        v += 3;
+    }
+
+    // Dot
+    for (int s = 0; s < precision - 2; s++) {
+        v[0].x = data.x + radius/2;
+        v[0].y = data.y - 12*thickness;
+
+        v[1].x = data.x + cos((s+1)*2*M_PI / precision)*radius/2;
+        v[1].y = data.y - 12*thickness + sin((s+1)*2*M_PI / precision)*radius/2;
+
+        v[2].x = data.x + cos((s+2)*2*M_PI / precision)*radius/2;
+        v[2].y = data.y - 12*thickness + sin((s+2)*2*M_PI / precision)*radius/2;
+
+        // ObjectGroupMaterial
+        for (int ii = 0; ii < 3; ii++) {
+            v[ii].tint_r = data.tint_r;
+            v[ii].tint_g = data.tint_g;
+            v[ii].tint_b = data.tint_b;
+            v[ii].alpha = data.alpha;
+
+            v[ii].tx = border_tx;
+            v[ii].ty = 0;
+        }
+
+        v += 3;
+    }
+
+    // Border + Shadow
+    const int totalBorders = points.count()-1;
+    for (int i = 0; i < totalBorders; i++)
+        processBorderSegment(data, v, points[i], points[i+1], thickness,
+                             border_tx, totalBorders, shadow_tx, shadowOffset);
+    v += 6*totalBorders;
+}
+
 void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
+{
+    // TODO: Bounds can be adjusted to be more precise
+    const int precision = (objectData.isEmpty() || objectData[0].zoom == 0 ? 12 :
+                           qBound(12, int(18 / sqrt(objectData[0].zoom)), 56));
+
+    int totalVertices = 0;
+    for (const ObjectData &data : objectData) {
+        switch (data.type) {
+        case ObjectGroupMaterial::ObjectType::Rectangle:
+            totalVertices += 6 + 24 + 24;
+            break;
+        case ObjectGroupMaterial::ObjectType::Ellipse:
+            totalVertices += (3 + 6 + 6)*precision;
+            break;
+        case ObjectGroupMaterial::ObjectType::Capsule:
+            totalVertices += (3 + 6 + 6)*(2*(precision/2)) + 3;
+            break;
+        case ObjectGroupMaterial::ObjectType::Point:
+            totalVertices += 3 * 8 + (3 + 6 + 6)*(8 + 3);
+            break;
+        case ObjectGroupMaterial::ObjectType::Tile:
+            totalVertices += 6;
+            break;
+        default:
+            break;
+        }
+    }
+
+    mGeometry.allocate(totalVertices, 0);
+    ObjectTexturedPoint2D *v = reinterpret_cast<ObjectTexturedPoint2D*>(mGeometry.vertexData());
+
+    for (const ObjectData &data : objectData) {
+        switch (data.type) {
+        case ObjectGroupMaterial::ObjectType::Rectangle:
+            processRectangleData(data, v);
+            break;
+        case ObjectGroupMaterial::ObjectType::Ellipse:
+            processEllipseData(data, v, precision);
+            break;
+        case ObjectGroupMaterial::ObjectType::Capsule:
+            processCapsuleData(data, v, precision/2);
+            break;
+        case ObjectGroupMaterial::ObjectType::Point:
+            processPointData(data, v, 8);
+            break;
+        case ObjectGroupMaterial::ObjectType::Tile:
+            processTileData(data, v);
+            break;
+        default:
+            break;
+        }
+    }
+
+    markDirty(DirtyGeometry);
+}
+
+void ObjectsNode::processTileData(const ObjectData &data, ObjectTexturedPoint2D *&v)
 {
     const QSize s = mMaterial.texture()->textureSize();
     const QRectF r = mMaterial.texture()->normalizedTextureSubRect();
@@ -63,80 +473,68 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
     const float s_x = r.width() / s.width();
     const float s_y = r.height() / s.height();
 
-    mGeometry.allocate(objectData.size() * 6, 0);
-    ObjectTexturedPoint2D *v = reinterpret_cast<ObjectTexturedPoint2D*>(mGeometry.vertexData());
+    const float s_width = data.twidth * s_x;
+    const float s_height = data.theight * s_y;
+    const float s_tx = r_x + data.tx * s_x;
+    const float s_ty = r_y + data.ty * s_y;
 
-    for (const ObjectData &data : objectData) {
-        const float s_width = data.twidth * s_x;
-        const float s_height = data.theight * s_y;
-        const float s_tx = r_x + data.tx * s_x;
-        const float s_ty = r_y + data.ty * s_y;
+    // TopLeft                      // TopRight
+    v[0].x = data.x;                v[2].x = data.x + data.width;
+    v[0].y = data.y;                v[2].y = data.y;
+    v[0].tx = s_tx;                 v[2].tx = s_tx + s_width;
+    v[0].ty = s_ty;                 v[2].ty = s_ty;
 
-        // TopLeft                      // TopRight
-        v[0].x = data.x;                v[2].x = data.x + data.width;
-        v[0].y = data.y;                v[2].y = data.y;
-        v[0].tx = s_tx;                 v[2].tx = s_tx + s_width;
-        v[0].ty = s_ty;                 v[2].ty = s_ty;
+    // BottomLeft
+    v[1].x = data.x;
+    v[1].y = data.y + data.height;
+    v[1].tx = s_tx;
+    v[1].ty = s_ty + s_height;
 
-        // BottomLeft
-        v[1].x = data.x;
-        v[1].y = data.y + data.height;
-        v[1].tx = s_tx;
-        v[1].ty = s_ty + s_height;
+                                    // TopRight
+                                    v[5].x = data.x + data.width;
+                                    v[5].y = data.y;
+                                    v[5].tx = s_tx + s_width;
+                                    v[5].ty = s_ty;
 
-                                        // TopRight
-                                        v[5].x = data.x + data.width;
-                                        v[5].y = data.y;
-                                        v[5].tx = s_tx + s_width;
-                                        v[5].ty = s_ty;
+    // BottomLeft                   // BottomRight
+    v[3].x = data.x;                v[4].x = data.x + data.width;
+    v[3].y = data.y + data.height;  v[4].y = data.y + data.height;
+    v[3].tx = s_tx;                 v[4].tx = s_tx + s_width;
+    v[3].ty = s_ty + s_height;      v[4].ty = s_ty + s_height;
 
-        // BottomLeft                   // BottomRight
-        v[3].x = data.x;                v[4].x = data.x + data.width;
-        v[3].y = data.y + data.height;  v[4].y = data.y + data.height;
-        v[3].tx = s_tx;                 v[4].tx = s_tx + s_width;
-        v[3].ty = s_ty + s_height;      v[4].ty = s_ty + s_height;
-
-        // ObjectGroupMaterial
-        for (int i = 0; i < 6; i++) {
-            // v[i].local_x = (v[i].x - data.x) / data.width;
-            // v[i].local_y = (v[i].y - data.y) / data.width;
-
-            v[i].tint_r = data.tint_r;
-            v[i].tint_g = data.tint_g;
-            v[i].tint_b = data.tint_b;
-            v[i].alpha = data.alpha;
-
-            // v[i].object_type = static_cast<float>(data.type);
-        }
-
-        if (data.flippedHorizontally) {
-            std::swap(v[0].tx, v[4].tx);
-            std::swap(v[1].tx, v[5].tx);
-            std::swap(v[2].tx, v[3].tx);
-        }
-        if (data.flippedVertically) {
-            std::swap(v[0].ty, v[4].ty);
-            std::swap(v[1].ty, v[5].ty);
-            std::swap(v[2].ty, v[3].ty);
-        }
-
-        if (data.rotation != 0) {
-            const double r = data.rotation * M_PI / 180;
-            const double origin_x = data.x;
-            const double origin_y = data.y + data.height;
-
-            for (int i = 0; i < 6; i++) {
-                const double x = v[i].x;
-                const double y = v[i].y;
-                v[i].x = origin_x + (x - origin_x)*cos(r) - (y - origin_y)*sin(r);
-                v[i].y = origin_y + (y - origin_y)*cos(r) + (x - origin_x)*sin(r);
-            }
-        }
-
-        v += 6;
+    // ObjectGroupMaterial
+    for (int i = 0; i < 6; i++) {
+        v[i].tint_r = data.tint_r;
+        v[i].tint_g = data.tint_g;
+        v[i].tint_b = data.tint_b;
+        v[i].alpha = data.alpha;
     }
 
-    markDirty(DirtyGeometry);
+    if (data.flippedHorizontally) {
+        std::swap(v[0].tx, v[4].tx);
+        std::swap(v[1].tx, v[5].tx);
+        std::swap(v[2].tx, v[3].tx);
+    }
+    if (data.flippedVertically) {
+        std::swap(v[0].ty, v[4].ty);
+        std::swap(v[1].ty, v[5].ty);
+        std::swap(v[2].ty, v[3].ty);
+    }
+
+    if (data.rotation != 0) {
+        const double r = data.rotation * M_PI / 180;
+        const double origin_x = data.x;
+        const double origin_y = data.y + data.height;
+
+        for (int i = 0; i < 6; i++) {
+            const double x = v[i].x;
+            const double y = v[i].y;
+            v[i].x = origin_x + (x - origin_x)*cos(r) - (y - origin_y)*sin(r);
+            v[i].y = origin_y + (y - origin_y)*cos(r) + (x - origin_x)*sin(r);
+        }
+    }
+
+    v += 6;
 }
 
 } // namespace TiledQuick

--- a/src/libtiledquick/objectsnode.cpp
+++ b/src/libtiledquick/objectsnode.cpp
@@ -23,13 +23,15 @@
 namespace TiledQuick {
 
 static const QSGGeometry::Attribute ObjectAttributes[] = {
-    QSGGeometry::Attribute::create(0, 2, QSGGeometry::FloatType, QSGGeometry::PositionAttribute),
-    QSGGeometry::Attribute::create(1, 2, QSGGeometry::FloatType, QSGGeometry::TexCoordAttribute),
-    QSGGeometry::Attribute::create(2, 4, QSGGeometry::UnsignedByteType, true)
+    QSGGeometry::Attribute::create(0, 2, QSGGeometry::FloatType, QSGGeometry::PositionAttribute), // Global Position
+    QSGGeometry::Attribute::create(1, 2, QSGGeometry::FloatType, QSGGeometry::PositionAttribute), // Local Position
+    QSGGeometry::Attribute::create(2, 2, QSGGeometry::FloatType, QSGGeometry::TexCoordAttribute), // Texture Coords
+    QSGGeometry::Attribute::create(3, 4, QSGGeometry::UnsignedByteType, true),                    // Tint colors (0-3) and alpha (4)
+    QSGGeometry::Attribute::create(4, 1, QSGGeometry::FloatType, false)                     // Object Type
 };
 
 static const QSGGeometry::AttributeSet ObjectAttributeSet = {
-    3,
+    static_cast<int>(std::size(ObjectAttributes)),
     sizeof(ObjectTexturedPoint2D),
     ObjectAttributes
 };
@@ -64,84 +66,76 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
     ObjectTexturedPoint2D *v = reinterpret_cast<ObjectTexturedPoint2D*>(mGeometry.vertexData());
 
     for (const ObjectData &data : objectData) {
-        if (data.isTileObject) {
-            processTileObjectData(data, v, r_x, r_y, s_x, s_y);
-            continue;
+        const float s_width = data.twidth * s_x;
+        const float s_height = data.theight * s_y;
+        const float s_tx = r_x + data.tx * s_x;
+        const float s_ty = r_y + data.ty * s_y;
+
+        // TopLeft                      // TopRight
+        v[0].x = data.x;                v[2].x = data.x + data.width;
+        v[0].y = data.y;                v[2].y = data.y;
+        v[0].tx = s_tx;                 v[2].tx = s_tx + s_width;
+        v[0].ty = s_ty;                 v[2].ty = s_ty;
+
+        // BottomLeft
+        v[1].x = data.x;
+        v[1].y = data.y + data.height;
+        v[1].tx = s_tx;
+        v[1].ty = s_ty + s_height;
+
+                                        // TopRight
+                                        v[5].x = data.x + data.width;
+                                        v[5].y = data.y;
+                                        v[5].tx = s_tx + s_width;
+                                        v[5].ty = s_ty;
+
+        // BottomLeft                   // BottomRight
+        v[3].x = data.x;                v[4].x = data.x + data.width;
+        v[3].y = data.y + data.height;  v[4].y = data.y + data.height;
+        v[3].tx = s_tx;                 v[4].tx = s_tx + s_width;
+        v[3].ty = s_ty + s_height;      v[4].ty = s_ty + s_height;
+
+        // ObjectGroupMaterial
+        for (int i = 0; i < 6; i++) {
+            v[i].local_x = (v[i].x - data.x) / data.width;
+            v[i].local_y = (v[i].y - data.y) / data.width;
+
+            v[i].tint_r = data.tint_r;
+            v[i].tint_g = data.tint_g;
+            v[i].tint_b = data.tint_b;
+            v[i].alpha = data.alpha;
+
+            v[i].object_type = static_cast<float>(data.type);
         }
 
-        // switch (data.shape) {
-        // case Tiled::MapObject::Shape::
-        // }
+        if (data.flippedHorizontally) {
+            std::swap(v[0].tx, v[4].tx);
+            std::swap(v[1].tx, v[5].tx);
+            std::swap(v[2].tx, v[3].tx);
+        }
+        if (data.flippedVertically) {
+            std::swap(v[0].ty, v[4].ty);
+            std::swap(v[1].ty, v[5].ty);
+            std::swap(v[2].ty, v[3].ty);
+        }
+
+        if (data.rotation != 0) {
+            const double r = data.rotation * M_PI / 180;
+            const double origin_x = data.x;
+            const double origin_y = data.y + data.height;
+
+            for (int i = 0; i < 6; i++) {
+                const double x = v[i].x;
+                const double y = v[i].y;
+                v[i].x = origin_x + (x - origin_x)*cos(r) - (y - origin_y)*sin(r);
+                v[i].y = origin_y + (y - origin_y)*cos(r) + (x - origin_x)*sin(r);
+            }
+        }
+
+        v += 6;
     }
 
     markDirty(DirtyGeometry);
-}
-
-void ObjectsNode::processTileObjectData(const ObjectData &data, ObjectTexturedPoint2D *&v, const float &r_x, const float &r_y, const float &s_x, const float &s_y)
-{
-    const float s_width = data.twidth * s_x;
-    const float s_height = data.theight * s_y;
-    const float s_tx = r_x + data.tx * s_x;
-    const float s_ty = r_y + data.ty * s_y;
-
-    // TopLeft                      // TopRight
-    v[0].x = data.x;                v[2].x = data.x + data.width;
-    v[0].y = data.y;                v[2].y = data.y;
-    v[0].tx = s_tx;                 v[2].tx = s_tx + s_width;
-    v[0].ty = s_ty;                 v[2].ty = s_ty;
-
-    // BottomLeft
-    v[1].x = data.x;
-    v[1].y = data.y + data.height;
-    v[1].tx = s_tx;
-    v[1].ty = s_ty + s_height;
-
-                                    // TopRight
-                                    v[5].x = data.x + data.width;
-                                    v[5].y = data.y;
-                                    v[5].tx = s_tx + s_width;
-                                    v[5].ty = s_ty;
-
-    // BottomLeft                   // BottomRight
-    v[3].x = data.x;                v[4].x = data.x + data.width;
-    v[3].y = data.y + data.height;  v[4].y = data.y + data.height;
-    v[3].tx = s_tx;                 v[4].tx = s_tx + s_width;
-    v[3].ty = s_ty + s_height;      v[4].ty = s_ty + s_height;
-
-    // ObjectGroupMaterial
-    for (int i = 0; i < 6; i++) {
-        v[i].tintR = data.tintR;
-        v[i].tintG = data.tintG;
-        v[i].tintB = data.tintB;
-        qDebug() << data.alpha;
-        v[i].alpha = data.alpha;
-    }
-
-    if (data.flippedHorizontally) {
-        std::swap(v[0].tx, v[4].tx);
-        std::swap(v[1].tx, v[5].tx);
-        std::swap(v[2].tx, v[3].tx);
-    }
-    if (data.flippedVertically) {
-        std::swap(v[0].ty, v[4].ty);
-        std::swap(v[1].ty, v[5].ty);
-        std::swap(v[2].ty, v[3].ty);
-    }
-
-    if (data.rotation != 0) {
-        const double r = data.rotation * M_PI / 180;
-        const double origin_x = data.x;
-        const double origin_y = data.y + data.height;
-
-        for (int i = 0; i < 6; i++) {
-            const double x = v[i].x;
-            const double y = v[i].y;
-            v[i].x = origin_x + (x - origin_x)*cos(r) - (y - origin_y)*sin(r);
-            v[i].y = origin_y + (y - origin_y)*cos(r) + (x - origin_x)*sin(r);
-        }
-    }
-
-    v += 6;
 }
 
 } // namespace TiledQuick

--- a/src/libtiledquick/objectsnode.cpp
+++ b/src/libtiledquick/objectsnode.cpp
@@ -1,0 +1,147 @@
+/*
+ * objectsnode.cpp
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "objectsnode.h"
+
+namespace TiledQuick {
+
+static const QSGGeometry::Attribute ObjectAttributes[] = {
+    QSGGeometry::Attribute::create(0, 2, QSGGeometry::FloatType, QSGGeometry::PositionAttribute),
+    QSGGeometry::Attribute::create(1, 2, QSGGeometry::FloatType, QSGGeometry::TexCoordAttribute),
+    QSGGeometry::Attribute::create(2, 4, QSGGeometry::UnsignedByteType, true)
+};
+
+static const QSGGeometry::AttributeSet ObjectAttributeSet = {
+    3,
+    sizeof(ObjectTexturedPoint2D),
+    ObjectAttributes
+};
+
+ObjectsNode::ObjectsNode(QSGTexture *texture, const QVector<ObjectData> &objectData)
+    : mGeometry(ObjectAttributeSet, 0, 0)
+{
+    setFlag(QSGNode::OwnedByParent);
+
+    mMaterial.setTexture(texture);
+
+    mGeometry.setDrawingMode(QSGGeometry::DrawTriangles);
+    mGeometry.setVertexDataPattern(QSGGeometry::StaticPattern);
+
+    processObjectData(objectData);
+
+    setGeometry(&mGeometry);
+    setMaterial(&mMaterial);
+}
+
+void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
+{
+    const QSize s = mMaterial.texture()->textureSize();
+    const QRectF r = mMaterial.texture()->normalizedTextureSubRect();
+
+    const float r_x = r.x();
+    const float r_y = r.y();
+    const float s_x = r.width() / s.width();
+    const float s_y = r.height() / s.height();
+
+    mGeometry.allocate(objectData.size() * 6, 0);
+    ObjectTexturedPoint2D *v = reinterpret_cast<ObjectTexturedPoint2D*>(mGeometry.vertexData());
+
+    for (const ObjectData &data : objectData) {
+        if (data.isTileObject) {
+            processTileObjectData(data, v, r_x, r_y, s_x, s_y);
+            continue;
+        }
+
+        // switch (data.shape) {
+        // case Tiled::MapObject::Shape::
+        // }
+    }
+
+    markDirty(DirtyGeometry);
+}
+
+void ObjectsNode::processTileObjectData(const ObjectData &data, ObjectTexturedPoint2D *&v, const float &r_x, const float &r_y, const float &s_x, const float &s_y)
+{
+    const float s_width = data.twidth * s_x;
+    const float s_height = data.theight * s_y;
+    const float s_tx = r_x + data.tx * s_x;
+    const float s_ty = r_y + data.ty * s_y;
+
+    // TopLeft                      // TopRight
+    v[0].x = data.x;                v[2].x = data.x + data.width;
+    v[0].y = data.y;                v[2].y = data.y;
+    v[0].tx = s_tx;                 v[2].tx = s_tx + s_width;
+    v[0].ty = s_ty;                 v[2].ty = s_ty;
+
+    // BottomLeft
+    v[1].x = data.x;
+    v[1].y = data.y + data.height;
+    v[1].tx = s_tx;
+    v[1].ty = s_ty + s_height;
+
+                                    // TopRight
+                                    v[5].x = data.x + data.width;
+                                    v[5].y = data.y;
+                                    v[5].tx = s_tx + s_width;
+                                    v[5].ty = s_ty;
+
+    // BottomLeft                   // BottomRight
+    v[3].x = data.x;                v[4].x = data.x + data.width;
+    v[3].y = data.y + data.height;  v[4].y = data.y + data.height;
+    v[3].tx = s_tx;                 v[4].tx = s_tx + s_width;
+    v[3].ty = s_ty + s_height;      v[4].ty = s_ty + s_height;
+
+    // ObjectGroupMaterial
+    for (int i = 0; i < 6; i++) {
+        v[i].tintR = data.tintR;
+        v[i].tintG = data.tintG;
+        v[i].tintB = data.tintB;
+        qDebug() << data.alpha;
+        v[i].alpha = data.alpha;
+    }
+
+    if (data.flippedHorizontally) {
+        std::swap(v[0].tx, v[4].tx);
+        std::swap(v[1].tx, v[5].tx);
+        std::swap(v[2].tx, v[3].tx);
+    }
+    if (data.flippedVertically) {
+        std::swap(v[0].ty, v[4].ty);
+        std::swap(v[1].ty, v[5].ty);
+        std::swap(v[2].ty, v[3].ty);
+    }
+
+    if (data.rotation != 0) {
+        const double r = data.rotation * M_PI / 180;
+        const double origin_x = data.x;
+        const double origin_y = data.y + data.height;
+
+        for (int i = 0; i < 6; i++) {
+            const double x = v[i].x;
+            const double y = v[i].y;
+            v[i].x = origin_x + (x - origin_x)*cos(r) - (y - origin_y)*sin(r);
+            v[i].y = origin_y + (y - origin_y)*cos(r) + (x - origin_x)*sin(r);
+        }
+    }
+
+    v += 6;
+}
+
+} // namespace TiledQuick

--- a/src/libtiledquick/objectsnode.cpp
+++ b/src/libtiledquick/objectsnode.cpp
@@ -38,23 +38,6 @@ static const QSGGeometry::AttributeSet ObjectAttributeSet = {
     ObjectAttributes
 };
 
-ObjectsNode::ObjectsNode(QSGTexture *texture, const QVector<ObjectData> &objectData)
-    : mGeometry(ObjectAttributeSet, 0, 0)
-{
-    setFlag(QSGNode::OwnedByParent);
-
-    mMaterial.setTexture(texture);
-
-    mGeometry.setDrawingMode(QSGGeometry::DrawTriangles);
-    // mGeometry.setDrawingMode(QSGGeometry::DrawLines);
-    mGeometry.setVertexDataPattern(QSGGeometry::StaticPattern);
-
-    processObjectData(objectData);
-
-    setGeometry(&mGeometry);
-    setMaterial(&mMaterial);
-}
-
 /**
  * Draws a border and shadow between two points.
  *
@@ -242,6 +225,32 @@ static void processRectangleData(const ObjectData &data, ObjectTexturedPoint2D *
     v += totalBorders*6;
 }
 
+static void processPolygonData(const ObjectData &data, ObjectTexturedPoint2D *&v)
+{
+    const float s_width = 1.0f / TilesetHelper::ColorCount;
+    const float fill_tx = (TilesetHelper::Fill + 0.5) * s_width;
+    const float border_tx = (TilesetHelper::Border + 0.5) * s_width;
+    const float shadow_tx = (TilesetHelper::Shadow + 0.5) * s_width;
+    const float thickness = 2*data.zoom;
+    const QPointF shadowOffset = QPointF(thickness * 2/3, thickness * 2/3);
+
+    QList<QPointF> points;
+    for (QPointF p : data.polygon)
+        points.append(p + QPointF(data.x, data.y));
+    points.append(points[0]);
+
+    // Fill
+    // TODO: Add convex and intersecting polygon support
+    processFillPoints(data, v, points, fill_tx);
+
+    // Border + Shadow
+    const int totalBorders = points.count() - 1;
+    for (int i = 0; i < totalBorders; i++)
+        processBorderSegment(data, v, points[i], points[i+1], thickness,
+                             border_tx, totalBorders, shadow_tx, shadowOffset);
+    v += totalBorders*6;
+}
+
 static void processEllipseData(const ObjectData &data, ObjectTexturedPoint2D *&v, const int &precision)
 {
     const float s_width = 1.0f / TilesetHelper::ColorCount;
@@ -308,10 +317,9 @@ static void processCapsuleData(const ObjectData &data, ObjectTexturedPoint2D *&v
     }
 
     const int currentPoints = points.count();
-    for (int i = 0; i < currentPoints; i++) {
+    for (int i = 0; i < currentPoints; i++)
         points.append(QPointF(2*data.x + data.width - points[i].x(),
                               2*data.y + data.height - points[i].y()));
-    }
     points.append(points[0]);
 
     // Fill
@@ -406,6 +414,22 @@ static void processPointData(const ObjectData &data, ObjectTexturedPoint2D *&v, 
     v += 6*totalBorders;
 }
 
+ObjectsNode::ObjectsNode(QSGTexture *texture, const QVector<ObjectData> &objectData)
+    : mGeometry(ObjectAttributeSet, 0, 0)
+{
+    setFlag(QSGNode::OwnedByParent);
+
+    mMaterial.setTexture(texture);
+
+    mGeometry.setDrawingMode(QSGGeometry::DrawTriangles);
+    mGeometry.setVertexDataPattern(QSGGeometry::StaticPattern);
+
+    processObjectData(objectData);
+
+    setGeometry(&mGeometry);
+    setMaterial(&mMaterial);
+}
+
 void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
 {
     // TODO: Bounds can be adjusted to be more precise
@@ -418,14 +442,22 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
         case ObjectGroupMaterial::ObjectType::Rectangle:
             totalVertices += 6 + 24 + 24;
             break;
-        case ObjectGroupMaterial::ObjectType::Ellipse:
-            totalVertices += (3 + 6 + 6)*precision;
+        case ObjectGroupMaterial::ObjectType::Polygon:
+            totalVertices += 3*(data.polygon.size()-2) + 12*data.polygon.size();
             break;
-        case ObjectGroupMaterial::ObjectType::Capsule:
-            totalVertices += (3 + 6 + 6)*(2*(precision/2)) + 3;
+        case ObjectGroupMaterial::ObjectType::Ellipse:
+            totalVertices += 3*(precision-2) + 12*precision;
+            break;
+        case ObjectGroupMaterial::ObjectType::Capsule: {
+            const int edges = 2*(precision/2 + 1);
+            totalVertices += 3*(edges-2) + 12*(edges);
+            break;
+        }
+        case ObjectGroupMaterial::ObjectType::Text:
+            totalVertices += 6;
             break;
         case ObjectGroupMaterial::ObjectType::Point:
-            totalVertices += 3 * 8 + (3 + 6 + 6)*(8 + 3);
+            totalVertices += 3*8 + (3+6+6)*(8+3);
             break;
         case ObjectGroupMaterial::ObjectType::Tile:
             totalVertices += 6;
@@ -443,17 +475,23 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
         case ObjectGroupMaterial::ObjectType::Rectangle:
             processRectangleData(data, v);
             break;
+        case ObjectGroupMaterial::ObjectType::Polygon:
+            processPolygonData(data, v);
+            break;
         case ObjectGroupMaterial::ObjectType::Ellipse:
             processEllipseData(data, v, precision);
             break;
         case ObjectGroupMaterial::ObjectType::Capsule:
             processCapsuleData(data, v, precision/2);
             break;
+        case ObjectGroupMaterial::ObjectType::Text:
+            processTextureData(data, v, false);
+            break;
         case ObjectGroupMaterial::ObjectType::Point:
             processPointData(data, v, 8);
             break;
         case ObjectGroupMaterial::ObjectType::Tile:
-            processTileData(data, v);
+            processTextureData(data, v);
             break;
         default:
             break;
@@ -463,7 +501,7 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
     markDirty(DirtyGeometry);
 }
 
-void ObjectsNode::processTileData(const ObjectData &data, ObjectTexturedPoint2D *&v)
+void ObjectsNode::processTextureData(const ObjectData &data, ObjectTexturedPoint2D *&v, bool applyTint)
 {
     const QSize s = mMaterial.texture()->textureSize();
     const QRectF r = mMaterial.texture()->normalizedTextureSubRect();
@@ -504,9 +542,15 @@ void ObjectsNode::processTileData(const ObjectData &data, ObjectTexturedPoint2D 
 
     // ObjectGroupMaterial
     for (int i = 0; i < 6; i++) {
-        v[i].tint_r = data.tint_r;
-        v[i].tint_g = data.tint_g;
-        v[i].tint_b = data.tint_b;
+        if (applyTint) {
+            v[i].tint_r = data.tint_r;
+            v[i].tint_g = data.tint_g;
+            v[i].tint_b = data.tint_b;
+        } else {
+            v[i].tint_r = 255;
+            v[i].tint_g = 255;
+            v[i].tint_b = 255;
+        }
         v[i].alpha = data.alpha;
     }
 

--- a/src/libtiledquick/objectsnode.cpp
+++ b/src/libtiledquick/objectsnode.cpp
@@ -46,8 +46,9 @@ static const QSGGeometry::AttributeSet ObjectAttributeSet = {
 static void processBorderSegment(const ObjectData &data, ObjectTexturedPoint2D *&v, const QPointF start, const QPointF end, const float thickness, const float border_tx, const int totalBorderSegments = 1, const float shadow_tx = 2.5, const QPointF shadowOffset = {1, 1}, const bool extendCorners = false)
 {
     const float lineLength = sqrt(pow(end.x() - start.x(), 2) + pow(end.y() - start.y(), 2));
-    const QPointF thicknessOffset = thickness/2 * QPointF((start.y() - end.y())/lineLength,
-                                               (end.x() - start.x())/lineLength);
+    const QPointF thicknessOffset = lineLength == 0 ? QPointF(0,0) :
+                                    thickness/2 * QPointF((start.y() - end.y())/lineLength,
+                                    (end.x() - start.x())/lineLength);
     const float o_x = thicknessOffset.x();
     const float o_y = thicknessOffset.y();
     const float c = (extendCorners ? 1 : 0);
@@ -132,7 +133,7 @@ static void processBorderSegment(const ObjectData &data, ObjectTexturedPoint2D *
         v[b+i].tint_b = data.tint_b;
         v[b+i].alpha = data.alpha;
 
-        v[i].ty = 0;
+        v[b+i].ty = 0;
     }
 
     if (data.rotation != 0) {
@@ -455,9 +456,10 @@ ObjectsNode::ObjectsNode(QSGTexture *texture, const QVector<ObjectData> &objectD
 
 void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
 {
-    // TODO: Bounds can be adjusted to be more precise
+    // TODO: Bounds can be adjusted to be more precise (should take into account object size)
     const int precision = (objectData.isEmpty() || objectData[0].zoom == 0 ? 12 :
                            qBound(12, int(18 / sqrt(objectData[0].zoom)), 56));
+    const int staticPrecision = 8;
 
     int totalVertices = 0;
     for (const ObjectData &data : objectData) {
@@ -483,7 +485,7 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
             totalVertices += 6;
             break;
         case ObjectGroupMaterial::ObjectType::Point:
-            totalVertices += 3*8 + (3+6+6)*(8+3);
+            totalVertices += 3*staticPrecision + (3+6+6)*(staticPrecision+2);
             break;
         case ObjectGroupMaterial::ObjectType::Tile:
             totalVertices += 6;
@@ -515,7 +517,7 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
             processTextureData(data, v, false);
             break;
         case ObjectGroupMaterial::ObjectType::Point:
-            processPointData(data, v, 8);
+            processPointData(data, v, staticPrecision);
             break;
         case ObjectGroupMaterial::ObjectType::Tile:
             processTextureData(data, v);

--- a/src/libtiledquick/objectsnode.cpp
+++ b/src/libtiledquick/objectsnode.cpp
@@ -251,6 +251,29 @@ static void processPolygonData(const ObjectData &data, ObjectTexturedPoint2D *&v
     v += totalBorders*6;
 }
 
+static void processPolylineData(const ObjectData &data, ObjectTexturedPoint2D *&v)
+{
+    const float s_width = 1.0f / TilesetHelper::ColorCount;
+    const float border_tx = (TilesetHelper::Border + 0.5) * s_width;
+    const float shadow_tx = (TilesetHelper::Shadow + 0.5) * s_width;
+    const float thickness = 2*data.zoom;
+    const QPointF shadowOffset = QPointF(thickness * 2/3, thickness * 2/3);
+
+    if (data.polygon.count() <= 1)
+        return;
+
+    QList<QPointF> points;
+    for (QPointF p : data.polygon)
+        points.append(p + QPointF(data.x, data.y));
+
+    // Border + Shadow
+    const int totalBorders = points.count() - 1;
+    for (int i = 0; i < totalBorders; i++)
+        processBorderSegment(data, v, points[i], points[i+1], thickness,
+                             border_tx, totalBorders, shadow_tx, shadowOffset);
+    v += totalBorders*6;
+}
+
 static void processEllipseData(const ObjectData &data, ObjectTexturedPoint2D *&v, const int &precision)
 {
     const float s_width = 1.0f / TilesetHelper::ColorCount;
@@ -445,6 +468,9 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
         case ObjectGroupMaterial::ObjectType::Polygon:
             totalVertices += 3*(data.polygon.size()-2) + 12*data.polygon.size();
             break;
+        case ObjectGroupMaterial::ObjectType::Polyline:
+            totalVertices += 12*qMax(data.polygon.size() - 1, 0);
+            break;
         case ObjectGroupMaterial::ObjectType::Ellipse:
             totalVertices += 3*(precision-2) + 12*precision;
             break;
@@ -462,8 +488,6 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
         case ObjectGroupMaterial::ObjectType::Tile:
             totalVertices += 6;
             break;
-        default:
-            break;
         }
     }
 
@@ -477,6 +501,9 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
             break;
         case ObjectGroupMaterial::ObjectType::Polygon:
             processPolygonData(data, v);
+            break;
+        case ObjectGroupMaterial::ObjectType::Polyline:
+            processPolylineData(data, v);
             break;
         case ObjectGroupMaterial::ObjectType::Ellipse:
             processEllipseData(data, v, precision);
@@ -492,8 +519,6 @@ void ObjectsNode::processObjectData(const QVector<ObjectData> &objectData)
             break;
         case ObjectGroupMaterial::ObjectType::Tile:
             processTextureData(data, v);
-            break;
-        default:
             break;
         }
     }

--- a/src/libtiledquick/objectsnode.h
+++ b/src/libtiledquick/objectsnode.h
@@ -1,5 +1,5 @@
 /*
- * tilesnode.h
+ * objectsnode.h
  * Copyright 2026, UltraDagon
  *
  * This file is part of Tiled Quick.
@@ -57,21 +57,18 @@ struct ObjectData {
 
 struct alignas(4) ObjectTexturedPoint2D {
     float x, y;
-    float local_x, local_y;
+    // float local_x, local_y;
     float tx, ty;
     unsigned char tint_r, tint_g, tint_b, alpha;
-    float object_type;
+    // float object_type;
 };
 
 class TILEDQUICK_SHARED_EXPORT ObjectsNode : public QSGGeometryNode
 {
 public:
-    enum {
-        // TODO: Make actual max count
-        MaxObjectCount = 100
-    };
-
     ObjectsNode(QSGTexture *texture, const QVector<ObjectData> &objectData);
+
+    void setScale(qreal scale);
 
 private:
     void processObjectData(const QVector<ObjectData> &objectData);

--- a/src/libtiledquick/objectsnode.h
+++ b/src/libtiledquick/objectsnode.h
@@ -1,0 +1,84 @@
+/*
+ * tilesnode.h
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QSGGeometryNode>
+
+// Needed to avoid include issue when compiling with mingw_900
+#if defined(Q_OS_WIN)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+#include <QSGTextureMaterial>
+
+#include "mapobject.h"
+#include "objectgroupmaterial.h"
+#include "tiledquick_global.h"
+
+namespace TiledQuick {
+
+struct ObjectData {
+    qreal rotation;
+    Tiled::MapObject::Shape shape;
+    float x;
+    float y;
+    float width;
+    float height;
+    float tx;
+    float ty;
+    float twidth;
+    float theight;
+    unsigned char tintR;
+    unsigned char tintG;
+    unsigned char tintB;
+    unsigned char alpha;
+    bool flippedHorizontally;
+    bool flippedVertically;
+    bool isTileObject;
+};
+
+struct ObjectTexturedPoint2D {
+    float x, y;
+    float tx, ty;
+    unsigned char tintR, tintG, tintB;
+    unsigned char alpha;
+};
+
+class TILEDQUICK_SHARED_EXPORT ObjectsNode : public QSGGeometryNode
+{
+public:
+    enum {
+        // TODO: Make actual max count
+        MaxObjectCount = 100
+    };
+
+    ObjectsNode(QSGTexture *texture, const QVector<ObjectData> &objectData);
+
+private:
+    void processObjectData(const QVector<ObjectData> &objectData);
+    void processTileObjectData(const ObjectData &data, ObjectTexturedPoint2D *&v, const float &r_x, const float &r_y, const float &s_x, const float &s_y);
+
+    QSGGeometry mGeometry;
+    ObjectGroupMaterial mMaterial;
+};
+
+} // namespace TiledQuick

--- a/src/libtiledquick/objectsnode.h
+++ b/src/libtiledquick/objectsnode.h
@@ -36,6 +36,7 @@
 namespace TiledQuick {
 
 struct ObjectData {
+    QPolygonF polygon;
     qreal rotation;
     ObjectGroupMaterial::ObjectType type;
     float x;
@@ -70,7 +71,7 @@ public:
 
 private:
     void processObjectData(const QVector<ObjectData> &objectData);
-    void processTileData(const ObjectData &data, ObjectTexturedPoint2D *&v);
+    void processTextureData(const ObjectData &data, ObjectTexturedPoint2D *&v, bool applyTint = true);
 
     QSGGeometry mGeometry;
     ObjectGroupMaterial mMaterial;

--- a/src/libtiledquick/objectsnode.h
+++ b/src/libtiledquick/objectsnode.h
@@ -30,7 +30,6 @@
 
 #include <QSGTextureMaterial>
 
-#include "mapobject.h"
 #include "objectgroupmaterial.h"
 #include "tiledquick_global.h"
 
@@ -47,6 +46,7 @@ struct ObjectData {
     float ty;
     float twidth;
     float theight;
+    float zoom;
     unsigned char tint_r;
     unsigned char tint_g;
     unsigned char tint_b;
@@ -68,10 +68,9 @@ class TILEDQUICK_SHARED_EXPORT ObjectsNode : public QSGGeometryNode
 public:
     ObjectsNode(QSGTexture *texture, const QVector<ObjectData> &objectData);
 
-    void setScale(qreal scale);
-
 private:
     void processObjectData(const QVector<ObjectData> &objectData);
+    void processTileData(const ObjectData &data, ObjectTexturedPoint2D *&v);
 
     QSGGeometry mGeometry;
     ObjectGroupMaterial mMaterial;

--- a/src/libtiledquick/objectsnode.h
+++ b/src/libtiledquick/objectsnode.h
@@ -38,7 +38,7 @@ namespace TiledQuick {
 
 struct ObjectData {
     qreal rotation;
-    Tiled::MapObject::Shape shape;
+    ObjectGroupMaterial::ObjectType type;
     float x;
     float y;
     float width;
@@ -47,20 +47,20 @@ struct ObjectData {
     float ty;
     float twidth;
     float theight;
-    unsigned char tintR;
-    unsigned char tintG;
-    unsigned char tintB;
+    unsigned char tint_r;
+    unsigned char tint_g;
+    unsigned char tint_b;
     unsigned char alpha;
     bool flippedHorizontally;
     bool flippedVertically;
-    bool isTileObject;
 };
 
-struct ObjectTexturedPoint2D {
+struct alignas(4) ObjectTexturedPoint2D {
     float x, y;
+    float local_x, local_y;
     float tx, ty;
-    unsigned char tintR, tintG, tintB;
-    unsigned char alpha;
+    unsigned char tint_r, tint_g, tint_b, alpha;
+    float object_type;
 };
 
 class TILEDQUICK_SHARED_EXPORT ObjectsNode : public QSGGeometryNode
@@ -75,7 +75,6 @@ public:
 
 private:
     void processObjectData(const QVector<ObjectData> &objectData);
-    void processTileObjectData(const ObjectData &data, ObjectTexturedPoint2D *&v, const float &r_x, const float &r_y, const float &s_x, const float &s_y);
 
     QSGGeometry mGeometry;
     ObjectGroupMaterial mMaterial;

--- a/src/libtiledquick/objectsnode.h
+++ b/src/libtiledquick/objectsnode.h
@@ -58,10 +58,8 @@ struct ObjectData {
 
 struct alignas(4) ObjectTexturedPoint2D {
     float x, y;
-    // float local_x, local_y;
     float tx, ty;
     unsigned char tint_r, tint_g, tint_b, alpha;
-    // float object_type;
 };
 
 class TILEDQUICK_SHARED_EXPORT ObjectsNode : public QSGGeometryNode

--- a/src/libtiledquick/tilelayeritem.cpp
+++ b/src/libtiledquick/tilelayeritem.cpp
@@ -20,13 +20,10 @@
 
 #include "tilelayeritem.h"
 
-#include "tile.h"
-#include "tilelayer.h"
-#include "tileset.h"
 #include "map.h"
 #include "maprenderer.h"
 
-#include "mapitem.h"
+#include "tilesethelper.h"
 #include "tilesnode.h"
 
 #include <QtMath>
@@ -34,86 +31,6 @@
 
 using namespace Tiled;
 using namespace TiledQuick;
-
-namespace {
-
-/**
- * Returns the texture of a given tileset, or 0 if the image has not been
- * loaded yet.
- */
-static inline QSGTexture *tilesetTexture(Tileset *tileset,
-                                         QQuickWindow *window)
-{
-    static QHash<Tileset *, QSGTexture *> cache;
-
-    QSGTexture *texture = cache.value(tileset);
-    if (!texture) {
-        const QString imagePath(Tiled::urlToLocalFileOrQrc(tileset->imageSource()));
-        texture = window->createTextureFromImage(QImage(imagePath));
-        cache.insert(tileset, texture);
-    }
-    return texture;
-}
-
-/**
- * This helper class exists mainly to avoid redoing calculations that only need
- * to be done once per tileset.
- */
-struct TilesetHelper
-{
-    TilesetHelper(const MapItem *mapItem)
-        : mWindow(mapItem->window())
-        , mTileset(nullptr)
-        , mTexture(nullptr)
-        , mMargin(0)
-        , mTileHSpace(0)
-        , mTileVSpace(0)
-        , mTilesPerRow(0)
-    {
-    }
-
-    Tileset *tileset() const { return mTileset; }
-    QSGTexture *texture() const { return mTexture; }
-
-    void setTileset(Tileset *tileset)
-    {
-        mTileset = tileset;
-        mTexture = tilesetTexture(tileset, mWindow);
-        if (!mTexture)
-            return;
-
-        const int tileSpacing = tileset->tileSpacing();
-        mMargin = tileset->margin();
-        mTileHSpace = tileset->tileWidth() + tileSpacing;
-        mTileVSpace = tileset->tileHeight() + tileSpacing;
-
-        const QSize tilesetSize = mTexture->textureSize();
-        const int availableWidth = tilesetSize.width() + tileSpacing - mMargin;
-        mTilesPerRow = qMax(availableWidth / mTileHSpace, 1);
-    }
-
-    void setTextureCoordinates(TileData &data, const Cell &cell) const
-    {
-        const int tileId = cell.tileId();
-        const int column = tileId % mTilesPerRow;
-        const int row = tileId / mTilesPerRow;
-
-        data.tx = column * mTileHSpace + mMargin;
-        data.ty = row * mTileVSpace + mMargin;
-    }
-
-private:
-    QQuickWindow *mWindow;
-    Tileset *mTileset;
-    QSGTexture *mTexture;
-    int mMargin;
-    int mTileHSpace;
-    int mTileVSpace;
-    int mTilesPerRow;
-};
-
-} // anonymous namespace
-
 
 TileLayerItem::TileLayerItem(TileLayer *layer, MapRenderer *renderer,
                              MapItem *parent)
@@ -143,7 +60,7 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
     node = new QSGNode;
     node->setFlag(QSGNode::OwnedByParent);
 
-    TilesetHelper helper(static_cast<MapItem*>(parentItem()));
+    TilesetHelper helper = TilesetHelper::instance(static_cast<MapItem*>(parentItem()));
 
     QVector<TileData> tileData;
     tileData.reserve(TilesNode::MaxTileCount);
@@ -187,7 +104,7 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
         data.height = static_cast<float>(size.height());
         data.flippedHorizontally = cell.flippedHorizontally();
         data.flippedVertically = cell.flippedVertically();
-        helper.setTextureCoordinates(data, cell);
+        helper.setTextureCoordinates(data.tx, data.ty, cell);
         tileData.append(data);
     };
 
@@ -274,7 +191,7 @@ QSGNode *TileItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeDat
         data[0].y = (mPosition.y() + 1) * tileSize.height() - tileset->tileHeight() + offset.y();
         data[0].width = size.width();
         data[0].height = size.height();
-        helper.setTextureCoordinates(data[0], mCell);
+        helper.setTextureCoordinates(data[0].tx, data[0].ty, mCell);
 
         node = new TilesNode(helper.texture(), data);
     }

--- a/src/libtiledquick/tilelayeritem.cpp
+++ b/src/libtiledquick/tilelayeritem.cpp
@@ -60,6 +60,9 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
     node = new QSGNode;
     node->setFlag(QSGNode::OwnedByParent);
 
+    if (!mLayer->isVisible())
+        return node;
+
     TilesetHelper helper = TilesetHelper::instance(static_cast<MapItem*>(parentItem()));
 
     QVector<TileData> tileData;

--- a/src/libtiledquick/tilelayeritem.h
+++ b/src/libtiledquick/tilelayeritem.h
@@ -60,6 +60,8 @@ public:
      */
     void syncWithTileLayer();
 
+    void layerVisibilityChanged();
+
     QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *) override;
 
     Tiled::TileLayer *layer() const;
@@ -68,8 +70,6 @@ public slots:
     void updateVisibleTiles();
 
 private:
-    void layerVisibilityChanged();
-
     Tiled::TileLayer *mLayer;
     Tiled::MapRenderer *mRenderer;
     QRectF mVisibleArea;

--- a/src/libtiledquick/tilesethelper.cpp
+++ b/src/libtiledquick/tilesethelper.cpp
@@ -56,6 +56,7 @@ TilesetHelper::TilesetHelper(const MapItem *mapItem)
     mObjectPalette.setPixelColor(Fill, 0, QColor(191, 191, 191, 63));
     mObjectPalette.setPixelColor(Border, 0, QColor(191, 191, 191));
     mObjectPalette.setPixelColor(Shadow, 0, Qt::black);
+    mObjectTexture = mWindow->createTextureFromImage(mObjectPalette);
 }
 
 TilesetHelper &TilesetHelper::instance(const MapItem *mapItem)
@@ -74,9 +75,8 @@ void TilesetHelper::deleteInstance()
 void TilesetHelper::setTileset(Tileset *tileset)
 {
     mTileset = tileset;
-    // If tileset is nullptr, use default object texture
     if (!tileset) {
-        mTexture = mWindow->createTextureFromImage(mObjectPalette);
+        mTexture = nullptr;
         return;
     }
 

--- a/src/libtiledquick/tilesethelper.cpp
+++ b/src/libtiledquick/tilesethelper.cpp
@@ -1,0 +1,95 @@
+/*
+ * tilesethelper.cpp
+ * Copyright 2026, UltraDagon
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "tilesethelper.h"
+
+#include "tile.h"
+#include "tileset.h"
+
+/**
+ * Returns the texture of a given tileset, or 0 if the image has not been
+ * loaded yet.
+ */
+static inline QSGTexture *tilesetTexture(Tileset *tileset,
+                                         QQuickWindow *window)
+{
+    static QHash<Tileset *, QSGTexture *> cache;
+
+    QSGTexture *texture = cache.value(tileset);
+    if (!texture) {
+        const QString imagePath(Tiled::urlToLocalFileOrQrc(tileset->imageSource()));
+        texture = window->createTextureFromImage(QImage(imagePath));
+        cache.insert(tileset, texture);
+    }
+    return texture;
+}
+
+TilesetHelper *TilesetHelper::mInstance;
+
+TilesetHelper::TilesetHelper(const MapItem *mapItem)
+    : mWindow(mapItem->window())
+    , mTileset(nullptr)
+    , mTexture(nullptr)
+    , mMargin(0)
+    , mTileHSpace(0)
+    , mTileVSpace(0)
+    , mTilesPerRow(0)
+{
+}
+
+TilesetHelper &TilesetHelper::instance(const MapItem *mapItem)
+{
+    if (!mInstance)
+        mInstance = new TilesetHelper(mapItem);
+    return *mInstance;
+};
+
+void TilesetHelper::deleteInstance()
+{
+    delete mInstance;
+    mInstance = nullptr;
+};
+
+void TilesetHelper::setTileset(Tileset *tileset)
+{
+    mTileset = tileset;
+    mTexture = tilesetTexture(tileset, mWindow);
+    if (!mTexture)
+        return;
+
+    const int tileSpacing = tileset->tileSpacing();
+    mMargin = tileset->margin();
+    mTileHSpace = tileset->tileWidth() + tileSpacing;
+    mTileVSpace = tileset->tileHeight() + tileSpacing;
+
+    const QSize tilesetSize = mTexture->textureSize();
+    const int availableWidth = tilesetSize.width() + tileSpacing - mMargin;
+    mTilesPerRow = qMax(availableWidth / mTileHSpace, 1);
+}
+
+void TilesetHelper::setTextureCoordinates(float &tx, float &ty, const Cell &cell) const
+{
+    const int tileId = cell.tileId();
+    const int column = tileId % mTilesPerRow;
+    const int row = tileId / mTilesPerRow;
+
+    tx = column * mTileHSpace + mMargin;
+    ty = row * mTileVSpace + mMargin;
+}

--- a/src/libtiledquick/tilesethelper.cpp
+++ b/src/libtiledquick/tilesethelper.cpp
@@ -44,7 +44,8 @@ static inline QSGTexture *tilesetTexture(Tileset *tileset,
 TilesetHelper *TilesetHelper::mInstance;
 
 TilesetHelper::TilesetHelper(const MapItem *mapItem)
-    : mWindow(mapItem->window())
+    : mObjectPalette(3, 1, QImage::Format_RGBA8888)
+    , mWindow(mapItem->window())
     , mTileset(nullptr)
     , mTexture(nullptr)
     , mMargin(0)
@@ -52,6 +53,9 @@ TilesetHelper::TilesetHelper(const MapItem *mapItem)
     , mTileVSpace(0)
     , mTilesPerRow(0)
 {
+    mObjectPalette.setPixelColor(Fill, 0, QColor(191, 191, 191, 63));
+    mObjectPalette.setPixelColor(Border, 0, QColor(191, 191, 191));
+    mObjectPalette.setPixelColor(Shadow, 0, Qt::black);
 }
 
 TilesetHelper &TilesetHelper::instance(const MapItem *mapItem)
@@ -70,6 +74,12 @@ void TilesetHelper::deleteInstance()
 void TilesetHelper::setTileset(Tileset *tileset)
 {
     mTileset = tileset;
+    // If tileset is nullptr, use default object texture
+    if (!tileset) {
+        mTexture = mWindow->createTextureFromImage(mObjectPalette);
+        return;
+    }
+
     mTexture = tilesetTexture(tileset, mWindow);
     if (!mTexture)
         return;
@@ -86,6 +96,9 @@ void TilesetHelper::setTileset(Tileset *tileset)
 
 void TilesetHelper::setTextureCoordinates(float &tx, float &ty, const Cell &cell) const
 {
+    if (cell.isEmpty())
+        return;
+
     const int tileId = cell.tileId();
     const int column = tileId % mTilesPerRow;
     const int row = tileId / mTilesPerRow;

--- a/src/libtiledquick/tilesethelper.h
+++ b/src/libtiledquick/tilesethelper.h
@@ -36,6 +36,16 @@ using namespace TiledQuick;
 class TilesetHelper
 {
 public:
+    /**
+     * Enumerates the different parts of a geometry object's texture.
+     */
+    enum ObjectColorIndex {
+        Fill = 0,
+        Border = 1,
+        Shadow = 2,
+        ColorCount
+    };
+
     TilesetHelper(const MapItem *mapItem);
 
     static TilesetHelper &instance(const MapItem *mapItem);
@@ -50,6 +60,7 @@ public:
     void setTextureCoordinates(float &tx, float &ty, const Cell &cell) const;
 
 private:
+    QImage mObjectPalette;
     QQuickWindow *mWindow;
     Tileset *mTileset;
     QSGTexture *mTexture;

--- a/src/libtiledquick/tilesethelper.h
+++ b/src/libtiledquick/tilesethelper.h
@@ -1,0 +1,62 @@
+/*
+ * tilesethelper.h
+ * Copyright 2014, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled Quick.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "tilelayer.h"
+
+#include "mapitem.h"
+
+#include <QSGTexture>
+
+using namespace Tiled;
+using namespace TiledQuick;
+
+/**
+ * This helper class exists mainly to avoid redoing calculations that only need
+ * to be done once per tileset.
+ */
+class TilesetHelper
+{
+public:
+    TilesetHelper(const MapItem *mapItem);
+
+    static TilesetHelper &instance(const MapItem *mapItem);
+
+    static void deleteInstance();
+
+    inline Tileset *tileset() const { return mTileset; }
+    inline QSGTexture *texture() const { return mTexture; }
+
+    void setTileset(Tileset *tileset);
+
+    void setTextureCoordinates(float &tx, float &ty, const Cell &cell) const;
+
+private:
+    QQuickWindow *mWindow;
+    Tileset *mTileset;
+    QSGTexture *mTexture;
+    int mMargin;
+    int mTileHSpace;
+    int mTileVSpace;
+    int mTilesPerRow;
+
+    static TilesetHelper *mInstance;
+};

--- a/src/libtiledquick/tilesethelper.h
+++ b/src/libtiledquick/tilesethelper.h
@@ -53,7 +53,7 @@ public:
     static void deleteInstance();
 
     inline Tileset *tileset() const { return mTileset; }
-    inline QSGTexture *texture() const { return mTexture; }
+    inline QSGTexture *texture() const { return (mTexture ? mTexture : mObjectTexture); }
 
     void setTileset(Tileset *tileset);
 
@@ -64,6 +64,7 @@ private:
     QQuickWindow *mWindow;
     Tileset *mTileset;
     QSGTexture *mTexture;
+    QSGTexture *mObjectTexture;
     int mMargin;
     int mTileHSpace;
     int mTileVSpace;

--- a/src/libtiledquick/tilesnode.cpp
+++ b/src/libtiledquick/tilesnode.cpp
@@ -20,8 +20,6 @@
 
 #include "tilesnode.h"
 
-#include <QSGTexture>
-
 namespace TiledQuick {
 
 TilesNode::TilesNode(QSGTexture *texture, const QVector<TileData> &tileData)

--- a/src/tiled/createobjecttool.h
+++ b/src/tiled/createobjecttool.h
@@ -51,6 +51,8 @@ public:
     void mouseReleased(QGraphicsSceneMouseEvent *event) override;
     void modifiersChanged(Qt::KeyboardModifiers modifiers) override;
 
+    ObjectGroup *newMapObjectGroup() { return mNewMapObjectGroup.get(); }
+
 protected:
     void changeEvent(const ChangeEvent &event) override;
 
@@ -74,7 +76,6 @@ protected:
     State state() const { return mState; }
     void setState(State state) { mState = state; }
 
-    ObjectGroup *newMapObjectGroup() { return mNewMapObjectGroup.get(); }
     ObjectGroupItem *objectGroupItem() { return mObjectGroupItem.get(); }
 
     MapObjectItem *mNewMapObjectItem;   // owned by mObjectGroupItem if set

--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -224,12 +224,10 @@ void EditableMap::insertLayerAt(int index, EditableLayer *editableLayer)
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Index out of range"));
         return;
     }
-
     if (!editableLayer) {
         ScriptManager::instance().throwNullArgError(1);
         return;
     }
-
     if (!editableLayer->isOwning()) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Layer is in use"));
         return;

--- a/src/tiled/editablemapobject.h
+++ b/src/tiled/editablemapobject.h
@@ -22,6 +22,7 @@
 
 #include "editableobject.h"
 #include "mapobject.h"
+#include "tilededitor_global.h"
 
 #include <QJSValue>
 
@@ -48,7 +49,7 @@ public:
     Font(const QFont &font) : QFont(font) {}
 };
 
-class EditableMapObject : public EditableObject
+class TILED_EDITOR_EXPORT EditableMapObject : public EditableObject
 {
     Q_OBJECT
 

--- a/src/tiled/editpolygontool.cpp
+++ b/src/tiled/editpolygontool.cpp
@@ -350,6 +350,22 @@ void EditPolygonTool::languageChanged()
     setName(tr("Edit Polygons"));
 }
 
+QList<QPointF> EditPolygonTool::selectedHandlePoints() const
+{
+    QList<QPointF> points;
+    for (auto handle : std::as_const(mSelectedHandles))
+        points.append(handle->pos());
+    return points;
+}
+
+QList<QPointF> EditPolygonTool::highlightedHandlePoints() const
+{
+    QList<QPointF> points;
+    for (auto handle : std::as_const(mHighlightedHandles))
+        points.append(handle->pos());
+    return points;
+}
+
 void EditPolygonTool::setSelectedHandles(const QSet<PointHandle *> &handles)
 {
     for (PointHandle *handle : std::as_const(mSelectedHandles))
@@ -360,7 +376,11 @@ void EditPolygonTool::setSelectedHandles(const QSet<PointHandle *> &handles)
         if (!mSelectedHandles.contains(handle))
             handle->setSelected(true);
 
+    if (mSelectedHandles == handles)
+        return;
+
     mSelectedHandles = handles;
+    emit selectedHandlePointsChanged();
 }
 
 void EditPolygonTool::setHighlightedHandles(const QSet<PointHandle *> &handles)
@@ -373,7 +393,11 @@ void EditPolygonTool::setHighlightedHandles(const QSet<PointHandle *> &handles)
         if (!mHighlightedHandles.contains(handle))
             handle->setHighlighted(true);
 
+    if (mHighlightedHandles == handles)
+        return;
+
     mHighlightedHandles = handles;
+    emit highlightedHandlePointsChanged();
 }
 
 /**
@@ -591,6 +615,9 @@ void EditPolygonTool::updateMovingItems(const QPointF &pos,
     } else {
         delete command;
     }
+
+    emit highlightedHandlePointsChanged();
+    emit selectedHandlePointsChanged();
 }
 
 void EditPolygonTool::finishMoving()

--- a/src/tiled/editpolygontool.h
+++ b/src/tiled/editpolygontool.h
@@ -41,6 +41,9 @@ class EditPolygonTool : public AbstractObjectTool
 {
     Q_OBJECT
 
+    Q_PROPERTY(QList<QPointF> selectedHandlePoints READ selectedHandlePoints NOTIFY selectedHandlePointsChanged)
+    Q_PROPERTY(QList<QPointF> highlightedHandlePoints READ highlightedHandlePoints NOTIFY highlightedHandlePointsChanged)
+
 public:
     explicit EditPolygonTool(QObject *parent = nullptr);
     ~EditPolygonTool() override;
@@ -61,6 +64,13 @@ public:
     void languageChanged() override;
 
     bool hasSelectedHandles() const { return !mSelectedHandles.isEmpty(); }
+
+    QList<QPointF> selectedHandlePoints() const;
+    QList<QPointF> highlightedHandlePoints() const;
+
+signals:
+    void selectedHandlePointsChanged();
+    void highlightedHandlePointsChanged();
 
 public slots:
     void deleteNodes();

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -1475,6 +1475,12 @@ void MapDocument::onChanged(const ChangeEvent &change)
 
         break;
     }
+    case ChangeEvent::MapObjectsChanged: {
+        const auto &mapObjects = static_cast<const MapObjectsChangeEvent&>(change).mapObjects;
+
+        emit mapObjectsChanged(mapObjects);
+        break;
+    }
     default:
         break;
     }

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -1475,10 +1475,22 @@ void MapDocument::onChanged(const ChangeEvent &change)
 
         break;
     }
+    case ChangeEvent::MapObjectsAdded:
     case ChangeEvent::MapObjectsChanged: {
         const auto &mapObjects = static_cast<const MapObjectsChangeEvent&>(change).mapObjects;
-
         emit mapObjectsChanged(mapObjects);
+        break;
+    }
+    case ChangeEvent::MapObjectRemoved:
+    case ChangeEvent::ObjectGroupChanged: {
+        const auto &objectGroup = static_cast<const ObjectGroupChangeEvent&>(change);
+        emit mapObjectsChanged({}, objectGroup.objectGroup);
+        break;
+    }
+    case ChangeEvent::LayerChanged: {
+        const auto &layer = static_cast<const LayerChangeEvent&>(change);
+        if (layer.layer->isObjectGroup())
+            emit mapObjectsChanged({}, layer.layer->asObjectGroup());
         break;
     }
     default:

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -1491,6 +1491,8 @@ void MapDocument::onChanged(const ChangeEvent &change)
         const auto &layer = static_cast<const LayerChangeEvent&>(change);
         if (layer.layer->isObjectGroup())
             emit mapObjectsChanged({}, layer.layer->asObjectGroup());
+        if (layer.layer->isTileLayer())
+            emit tileLayerChanged(layer.layer->asTileLayer(), TileLayerChangeFlags());
         break;
     }
     default:

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -296,6 +296,11 @@ signals:
      */
     void hoveredMapObjectChanged(MapObject *object, MapObject *previous);
 
+    /**
+     * Emitted when one or more objects change.
+     */
+    void mapObjectsChanged(const QList<MapObject*> &objects);
+
     void aboutToBeSelectedObjectsChanged(const QList<MapObject*> &objects);
 
     /**

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -299,7 +299,7 @@ signals:
     /**
      * Emitted when one or more objects change.
      */
-    void mapObjectsChanged(const QList<MapObject*> &objects);
+    void mapObjectsChanged(const QList<MapObject*> &objects, ObjectGroup *group = nullptr);
 
     void aboutToBeSelectedObjectsChanged(const QList<MapObject*> &objects);
 

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -451,6 +451,8 @@ void MapEditor::setCurrentDocument(Document *document)
 //                this, &MapEditor::updateActions);
         connect(mapDocument, &MapDocument::selectedAreaChanged,
                 this, &MapEditor::selectedRegionChanged);
+        connect(mapDocument, &MapDocument::selectedObjectsChanged,
+                this, &MapEditor::selectedObjectsChanged);
 
         if (mapView) {
             mZoomable = mapView->zoomable();
@@ -750,6 +752,14 @@ QRegion MapEditor::selectedRegion() const
         return QRegion();
 
     return mCurrentMapDocument->selectedArea();
+}
+
+QList<MapObject*> MapEditor::selectedObjects() const
+{
+    if (!mCurrentMapDocument)
+        return QList<MapObject*>();
+
+    return mCurrentMapDocument->selectedObjects();
 }
 
 void MapEditor::updateActiveUndoStack()

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -453,6 +453,10 @@ void MapEditor::setCurrentDocument(Document *document)
                 this, &MapEditor::selectedRegionChanged);
         connect(mapDocument, &MapDocument::selectedObjectsChanged,
                 this, &MapEditor::selectedObjectsChanged);
+        connect(mapDocument, &MapDocument::aboutToBeSelectedObjectsChanged,
+                this, &MapEditor::aboutToBeSelectedObjectsChanged);
+        connect(mapDocument, &MapDocument::hoveredMapObjectChanged,
+                this, [this, mapDocument] {emit aboutToBeSelectedObjectsChanged(QList<MapObject*>{mapDocument->hoveredMapObject()}); });
 
         if (mapView) {
             mZoomable = mapView->zoomable();
@@ -760,6 +764,18 @@ QList<MapObject*> MapEditor::selectedObjects() const
         return QList<MapObject*>();
 
     return mCurrentMapDocument->selectedObjects();
+}
+
+QList<MapObject*> MapEditor::aboutToBeSelectedObjects() const
+{
+    if (!mCurrentMapDocument)
+        return QList<MapObject*>();
+
+    QList<MapObject*> list = mCurrentMapDocument->aboutToBeSelectedObjects();
+    if (mCurrentMapDocument->hoveredMapObject() && !list.contains(mCurrentMapDocument->hoveredMapObject()))
+        list.append(mCurrentMapDocument->hoveredMapObject());
+
+    return list;
 }
 
 void MapEditor::updateActiveUndoStack()

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -454,8 +454,6 @@ void MapEditor::setCurrentDocument(Document *document)
 //                this, &MapEditor::updateActions);
         connect(mapDocument, &MapDocument::selectedAreaChanged,
                 this, &MapEditor::selectedRegionChanged);
-        // connect(mapDocument, &MapDocument::selectedObjectsChanged,
-        //         this, &MapEditor::selectedObjectsChanged);
         connect(mapDocument, &MapDocument::aboutToBeSelectedObjectsChanged,
                 this, &MapEditor::aboutToBeSelectedObjectsChanged);
         connect(mapDocument, &MapDocument::hoveredMapObjectChanged,
@@ -764,14 +762,6 @@ QRegion MapEditor::selectedRegion() const
 
     return mCurrentMapDocument->selectedArea();
 }
-
-// QList<MapObject*> MapEditor::selectedObjects() const
-// {
-//     if (!mCurrentMapDocument)
-//         return QList<MapObject*>();
-
-//     return mCurrentMapDocument->selectedObjects();
-// }
 
 QList<MapObject*> MapEditor::aboutToBeSelectedObjects() const
 {

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -160,6 +160,7 @@ MapEditor::MapEditor(QObject *parent)
     , mZoomable(nullptr)
     , mZoomComboBox(new QComboBox)
     , mStatusInfoLabel(new QLabel)
+    , mNewObjectsPreview(nullptr)
     , mMainToolBar(new MainToolBar(mMainWindow))
     , mToolManager(new ToolManager(this))
     , mSelectedTool(nullptr)
@@ -743,6 +744,10 @@ void MapEditor::onSelectedToolChanged(AbstractTool *tool)
 #endif
 
         tool->populateToolBar(mToolSpecificToolBar);
+
+        CreateObjectTool *coTool = qobject_cast<CreateObjectTool*>(tool);
+        if (coTool)
+            setNewObjectsPreview(coTool->newMapObjectGroup());
     }
 
     updateActiveUndoStack();
@@ -1202,6 +1207,15 @@ void MapEditor::setTileEditPreview(const SharedMap &map)
     mTileEditPreview = map;
 
     emit tileEditPreviewChanged();
+}
+
+void MapEditor::setNewObjectsPreview(ObjectGroup *objects)
+{
+    if (mNewObjectsPreview == objects)
+        return;
+    mNewObjectsPreview = objects;
+
+    emit newObjectsPreviewChanged();
 }
 
 QRegion MapEditor::tileEditRegion() const

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -894,6 +894,12 @@ void MapEditor::cursorChanged(const QCursor &cursor)
 {
     if (mViewWithTool)
         mViewWithTool->setToolCursor(cursor);
+
+    if (mCursorShape == cursor.shape())
+        return;
+
+    mCursorShape = cursor.shape();
+    emit cursorShapeChanged();
 }
 
 void MapEditor::updateStatusInfoLabel(const QString &statusInfo)

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -419,6 +419,8 @@ void MapEditor::setCurrentDocument(Document *document)
         mCurrentMapDocument->disconnect(this);
     }
 
+    if (mCurrentMapDocument)
+        mCurrentMapDocument->setSelectedObjects({});
     mCurrentMapDocument = mapDocument;
 
     MapViewInterface *mapViewInterface = mViewForMap.value(mapDocument);
@@ -452,8 +454,8 @@ void MapEditor::setCurrentDocument(Document *document)
 //                this, &MapEditor::updateActions);
         connect(mapDocument, &MapDocument::selectedAreaChanged,
                 this, &MapEditor::selectedRegionChanged);
-        connect(mapDocument, &MapDocument::selectedObjectsChanged,
-                this, &MapEditor::selectedObjectsChanged);
+        // connect(mapDocument, &MapDocument::selectedObjectsChanged,
+        //         this, &MapEditor::selectedObjectsChanged);
         connect(mapDocument, &MapDocument::aboutToBeSelectedObjectsChanged,
                 this, &MapEditor::aboutToBeSelectedObjectsChanged);
         connect(mapDocument, &MapDocument::hoveredMapObjectChanged,
@@ -763,13 +765,13 @@ QRegion MapEditor::selectedRegion() const
     return mCurrentMapDocument->selectedArea();
 }
 
-QList<MapObject*> MapEditor::selectedObjects() const
-{
-    if (!mCurrentMapDocument)
-        return QList<MapObject*>();
+// QList<MapObject*> MapEditor::selectedObjects() const
+// {
+//     if (!mCurrentMapDocument)
+//         return QList<MapObject*>();
 
-    return mCurrentMapDocument->selectedObjects();
-}
+//     return mCurrentMapDocument->selectedObjects();
+// }
 
 QList<MapObject*> MapEditor::aboutToBeSelectedObjects() const
 {

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -79,7 +79,7 @@ class MapEditor final : public Editor
     Q_PROPERTY(Tiled::ObjectGroup *newObjectsPreview READ newObjectsPreview NOTIFY newObjectsPreviewChanged)
     Q_PROPERTY(QRegion tileEditRegion READ tileEditRegion NOTIFY tileEditRegionChanged)
     Q_PROPERTY(QRegion selectedRegion READ selectedRegion NOTIFY selectedRegionChanged)
-    Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects NOTIFY selectedObjectsChanged)
+    // Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects NOTIFY selectedObjectsChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> aboutToBeSelectedObjects READ aboutToBeSelectedObjects NOTIFY aboutToBeSelectedObjectsChanged)
     Q_PROPERTY(Tiled::EditableWangSet *currentWangSet READ currentWangSet WRITE setCurrentWangSet NOTIFY currentWangSetChanged)
     Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex WRITE setCurrentWangColorIndex NOTIFY currentWangColorIndexChanged)
@@ -139,7 +139,7 @@ public:
 
     QRegion selectedRegion() const;
 
-    QList<MapObject*> selectedObjects() const;
+    // QList<MapObject*> selectedObjects() const;
 
     QList<MapObject*> aboutToBeSelectedObjects() const;
 
@@ -175,7 +175,7 @@ signals:
     void newObjectsPreviewChanged();
     void tileEditRegionChanged();
     void selectedRegionChanged(const QRegion &newSelection, const QRegion &oldSelection);
-    void selectedObjectsChanged();
+    // void selectedObjectsChanged();
     void aboutToBeSelectedObjectsChanged(const QList<MapObject*> &objects);
     void cursorShapeChanged();
     void currentWangSetChanged();

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -79,6 +79,7 @@ class MapEditor final : public Editor
     Q_PROPERTY(QRegion tileEditRegion READ tileEditRegion NOTIFY tileEditRegionChanged)
     Q_PROPERTY(QRegion selectedRegion READ selectedRegion NOTIFY selectedRegionChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects NOTIFY selectedObjectsChanged)
+    Q_PROPERTY(QList<Tiled::MapObject*> aboutToBeSelectedObjects READ aboutToBeSelectedObjects NOTIFY aboutToBeSelectedObjectsChanged)
     Q_PROPERTY(Tiled::EditableWangSet *currentWangSet READ currentWangSet WRITE setCurrentWangSet NOTIFY currentWangSetChanged)
     Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex WRITE setCurrentWangColorIndex NOTIFY currentWangColorIndexChanged)
     Q_PROPERTY(Tiled::MapView *currentMapView READ currentMapView CONSTANT)
@@ -136,6 +137,8 @@ public:
 
     QList<MapObject*> selectedObjects() const;
 
+    QList<MapObject*> aboutToBeSelectedObjects() const;
+
     EditableWangSet *currentWangSet() const;
     void setCurrentWangSet(EditableWangSet *wangSet);
 
@@ -168,6 +171,7 @@ signals:
     void tileEditRegionChanged();
     void selectedRegionChanged(const QRegion &newSelection, const QRegion &oldSelection);
     void selectedObjectsChanged();
+    void aboutToBeSelectedObjectsChanged(const QList<MapObject*> &objects);
     void cursorShapeChanged();
     void currentWangSetChanged();
     void currentWangColorIndexChanged(int colorIndex);

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -78,6 +78,7 @@ class MapEditor final : public Editor
     Q_PROPERTY(Tiled::EditableMap *tileEditPreview READ tileEditPreview NOTIFY tileEditPreviewChanged)
     Q_PROPERTY(QRegion tileEditRegion READ tileEditRegion NOTIFY tileEditRegionChanged)
     Q_PROPERTY(QRegion selectedRegion READ selectedRegion NOTIFY selectedRegionChanged)
+    Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects NOTIFY selectedObjectsChanged)
     Q_PROPERTY(Tiled::EditableWangSet *currentWangSet READ currentWangSet WRITE setCurrentWangSet NOTIFY currentWangSetChanged)
     Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex WRITE setCurrentWangColorIndex NOTIFY currentWangColorIndexChanged)
     Q_PROPERTY(Tiled::MapView *currentMapView READ currentMapView CONSTANT)
@@ -132,6 +133,8 @@ public:
 
     QRegion selectedRegion() const;
 
+    QList<MapObject*> selectedObjects() const;
+
     EditableWangSet *currentWangSet() const;
     void setCurrentWangSet(EditableWangSet *wangSet);
 
@@ -161,6 +164,7 @@ signals:
     void tileEditPreviewChanged();
     void tileEditRegionChanged();
     void selectedRegionChanged(const QRegion &newSelection, const QRegion &oldSelection);
+    void selectedObjectsChanged();
     void currentWangSetChanged();
     void currentWangColorIndexChanged(int colorIndex);
     void selectedToolChanged(AbstractTool *tool);

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -83,6 +83,7 @@ class MapEditor final : public Editor
     Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex WRITE setCurrentWangColorIndex NOTIFY currentWangColorIndexChanged)
     Q_PROPERTY(Tiled::MapView *currentMapView READ currentMapView CONSTANT)
     Q_PROPERTY(Tiled::AbstractTool *selectedTool READ selectedTool WRITE setSelectedTool NOTIFY selectedToolChanged)
+    Q_PROPERTY(Qt::CursorShape cursorShape READ cursorShape NOTIFY cursorShapeChanged)
 
 public:
     explicit MapEditor(QObject *parent = nullptr);
@@ -150,6 +151,8 @@ public:
     void setSelectedTool(AbstractTool *tool);
     AbstractTool *activeTool() const;
 
+    Qt::CursorShape cursorShape() const;
+
 #ifdef TILEDQUICK_LIB
     Q_INVOKABLE void quickMouseMoved(QPointF coords, Qt::KeyboardModifiers modifiers);
     Q_INVOKABLE void quickMousePressed(Qt::MouseButton button, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, QPointF pos, QPointF scenePos, QPoint screenPos);
@@ -165,6 +168,7 @@ signals:
     void tileEditRegionChanged();
     void selectedRegionChanged(const QRegion &newSelection, const QRegion &oldSelection);
     void selectedObjectsChanged();
+    void cursorShapeChanged();
     void currentWangSetChanged();
     void currentWangColorIndexChanged(int colorIndex);
     void selectedToolChanged(AbstractTool *tool);
@@ -240,6 +244,7 @@ private:
 
     SharedMap mTileEditPreview;
     QRegion mTileEditRegion;
+    Qt::CursorShape mCursorShape;
 
     QToolBar *mMainToolBar;
     QToolBar *mToolsToolBar;
@@ -260,6 +265,11 @@ inline MapView *MapEditor::currentMapView() const
 inline AbstractTool *MapEditor::selectedTool() const
 {
     return mSelectedTool;
+}
+
+inline Qt::CursorShape MapEditor::cursorShape() const
+{
+    return mCursorShape;
 }
 
 } // namespace Tiled

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -79,7 +79,6 @@ class MapEditor final : public Editor
     Q_PROPERTY(Tiled::ObjectGroup *newObjectsPreview READ newObjectsPreview NOTIFY newObjectsPreviewChanged)
     Q_PROPERTY(QRegion tileEditRegion READ tileEditRegion NOTIFY tileEditRegionChanged)
     Q_PROPERTY(QRegion selectedRegion READ selectedRegion NOTIFY selectedRegionChanged)
-    // Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects NOTIFY selectedObjectsChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> aboutToBeSelectedObjects READ aboutToBeSelectedObjects NOTIFY aboutToBeSelectedObjectsChanged)
     Q_PROPERTY(Tiled::EditableWangSet *currentWangSet READ currentWangSet WRITE setCurrentWangSet NOTIFY currentWangSetChanged)
     Q_PROPERTY(int currentWangColorIndex READ currentWangColorIndex WRITE setCurrentWangColorIndex NOTIFY currentWangColorIndexChanged)
@@ -139,8 +138,6 @@ public:
 
     QRegion selectedRegion() const;
 
-    // QList<MapObject*> selectedObjects() const;
-
     QList<MapObject*> aboutToBeSelectedObjects() const;
 
     EditableWangSet *currentWangSet() const;
@@ -175,7 +172,6 @@ signals:
     void newObjectsPreviewChanged();
     void tileEditRegionChanged();
     void selectedRegionChanged(const QRegion &newSelection, const QRegion &oldSelection);
-    // void selectedObjectsChanged();
     void aboutToBeSelectedObjectsChanged(const QList<MapObject*> &objects);
     void cursorShapeChanged();
     void currentWangSetChanged();

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -76,6 +76,7 @@ class MapEditor final : public Editor
     Q_PROPERTY(Tiled::TilesetDock *tilesetsView READ tilesetDock CONSTANT)
     Q_PROPERTY(Tiled::EditableMap *currentBrush READ currentBrush WRITE setCurrentBrush NOTIFY currentBrushChanged)
     Q_PROPERTY(Tiled::EditableMap *tileEditPreview READ tileEditPreview NOTIFY tileEditPreviewChanged)
+    Q_PROPERTY(Tiled::ObjectGroup *newObjectsPreview READ newObjectsPreview NOTIFY newObjectsPreviewChanged)
     Q_PROPERTY(QRegion tileEditRegion READ tileEditRegion NOTIFY tileEditRegionChanged)
     Q_PROPERTY(QRegion selectedRegion READ selectedRegion NOTIFY selectedRegionChanged)
     Q_PROPERTY(QList<Tiled::MapObject*> selectedObjects READ selectedObjects NOTIFY selectedObjectsChanged)
@@ -130,6 +131,9 @@ public:
     EditableMap *tileEditPreview() const;
     void setTileEditPreview(const SharedMap &map);
 
+    ObjectGroup *newObjectsPreview() const;
+    void setNewObjectsPreview(ObjectGroup *objects);
+
     QRegion tileEditRegion() const;
     void setTileEditRegion(const QRegion &region);
 
@@ -168,6 +172,7 @@ public:
 signals:
     void currentBrushChanged();
     void tileEditPreviewChanged();
+    void newObjectsPreviewChanged();
     void tileEditRegionChanged();
     void selectedRegionChanged(const QRegion &newSelection, const QRegion &oldSelection);
     void selectedObjectsChanged();
@@ -247,6 +252,7 @@ private:
     EditPolygonTool *mEditPolygonTool;
 
     SharedMap mTileEditPreview;
+    ObjectGroup *mNewObjectsPreview;
     QRegion mTileEditRegion;
     Qt::CursorShape mCursorShape;
 
@@ -274,6 +280,11 @@ inline AbstractTool *MapEditor::selectedTool() const
 inline Qt::CursorShape MapEditor::cursorShape() const
 {
     return mCursorShape;
+}
+
+inline ObjectGroup *MapEditor::newObjectsPreview() const
+{
+    return mNewObjectsPreview;
 }
 
 } // namespace Tiled

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -221,6 +221,8 @@ public:
     QRectF boundingRect() const override { return Utils::dpiScaled(mArrow.boundingRect().adjusted(-1, -1, 1, 1)); }
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) override;
 
+    inline QPainterPath arrow() const { return mArrow; }
+
 private:
     QPainterPath mArrow;
 };
@@ -282,6 +284,8 @@ public:
 
     QRectF boundingRect() const override { return Utils::dpiScaled(mArrow.boundingRect().adjusted(-1, -1, 1, 1)); }
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) override;
+
+    inline QPainterPath arrow() const { return mArrow; }
 
 private:
     bool mResizingLimitHorizontal;
@@ -558,6 +562,14 @@ void ObjectSelectionTool::mousePressed(QGraphicsSceneMouseEvent *event)
 
             clickedHandle = dynamic_cast<Handle*>(clickedItem);
         }
+#ifdef TILEDQUICK_LIB
+        else if (Preferences::instance()->useNewHardwareRenderer()){
+            QGraphicsItem *clickedItem = mapScene()->itemAt(event->scenePos(),
+                                                            QTransform());
+
+            clickedHandle = dynamic_cast<Handle*>(clickedItem);
+        }
+#endif
 
         if (!clickedHandle) {
             mClickedObject = topMostMapObjectAt(mStart);
@@ -773,6 +785,33 @@ void ObjectSelectionTool::populateToolBar(QToolBar *toolBar)
     toolBar->addSeparator();
     toolBar->addAction(mSelectIntersected);
     toolBar->addAction(mSelectContained);
+}
+
+QList<ObjectHandleData> ObjectSelectionTool::objectHandles() const
+{
+    QList<ObjectHandleData> handles;
+
+    for (const auto &handle : mResizeHandles) {
+        if (handle->isVisible()) {
+            ObjectHandleData data;
+            data.pos = handle->pos();
+            data.drawPoints = handle->arrow().toFillPolygon();
+            data.isHovered = (handle == mHoveredHandle);
+            handles.append(data);
+        }
+    }
+
+    for (const auto &handle : mRotateHandles) {
+        if (handle->isVisible()) {
+            ObjectHandleData data;
+            data.pos = handle->pos();
+            data.drawPoints = handle->arrow().toFillPolygon();
+            data.isHovered = (handle == mHoveredHandle);
+            handles.append(data);
+        }
+    }
+
+    return handles;
 }
 
 void ObjectSelectionTool::changeEvent(const ChangeEvent &event)
@@ -1096,6 +1135,7 @@ void ObjectSelectionTool::updateHandleVisibility()
         handle->setVisible(showHandles && mMode == Resize);
 
     mOriginIndicator->setVisible(showOrigin);
+    emit objectHandlesChanged();
 }
 
 void ObjectSelectionTool::objectsAboutToBeRemoved(const QList<MapObject *> &objects)
@@ -1139,6 +1179,14 @@ void ObjectSelectionTool::updateHover(const QPointF &pos)
 
         hoveredHandle = dynamic_cast<Handle*>(hoveredItem);
     }
+#ifdef TILEDQUICK_LIB
+    else if (Preferences::instance()->useNewHardwareRenderer()){
+        QGraphicsItem *hoveredItem = mapScene()->itemAt(pos,
+                                                        QTransform());
+
+        hoveredHandle = dynamic_cast<Handle*>(hoveredItem);
+    }
+#endif
 
     if (mHoveredHandle != hoveredHandle) {
         if (mHoveredHandle)
@@ -1146,6 +1194,7 @@ void ObjectSelectionTool::updateHover(const QPointF &pos)
         if (hoveredHandle)
             hoveredHandle->setUnderMouse(true);
         mHoveredHandle = hoveredHandle;
+        emit objectHandlesChanged();
     }
 
     MapObject *hoveredObject = nullptr;

--- a/src/tiled/objectselectiontool.h
+++ b/src/tiled/objectselectiontool.h
@@ -39,9 +39,18 @@ class ResizeHandle;
 class RotateHandle;
 class SelectionRectangle;
 
+struct ObjectHandleData {
+    QPolygonF drawPoints;
+    QPointF pos;
+    bool isHovered = false;
+};
+
+
 class ObjectSelectionTool : public AbstractObjectTool
 {
     Q_OBJECT
+
+    Q_PROPERTY(QList<ObjectHandleData> objectHandles READ objectHandles NOTIFY objectHandlesChanged)
 
 public:
     explicit ObjectSelectionTool(QObject *parent = nullptr);
@@ -63,6 +72,11 @@ public:
     void languageChanged() override;
 
     void populateToolBar(QToolBar*) override;
+
+    QList<ObjectHandleData> objectHandles() const;
+
+signals:
+    void objectHandlesChanged();
 
 protected:
     void changeEvent(const ChangeEvent &event) override;

--- a/src/tiled/resources/qml/ObjectInteractionItem.qml
+++ b/src/tiled/resources/qml/ObjectInteractionItem.qml
@@ -120,6 +120,30 @@ Tiled.ObjectInteractionItem {
                 height: objectInteractionItem.selectionRect.height
             }
         }
+
+        ShapePath {
+            id: objectHandleArrows
+
+            fillColor: "black"
+            strokeColor: "white"
+            strokeWidth: 1 / mapContainer.scale
+
+            PathMultiline {
+                paths: objectHandlePolygons
+            }
+        }
+
+        ShapePath {
+            id: hoveredHandle
+
+            fillColor: "white"
+            strokeColor: "black"
+            strokeWidth: 1 / mapContainer.scale
+
+            PathPolyline {
+                path: hoveredHandlePolygon
+            }
+        }
     }
 
     // EditPolygonTool

--- a/src/tiled/resources/qml/ObjectInteractionItem.qml
+++ b/src/tiled/resources/qml/ObjectInteractionItem.qml
@@ -12,9 +12,7 @@ Tiled.ObjectInteractionItem {
         running: true
         repeat: true
 
-        onTriggered: {
-            borderDashOffset -= 0.5
-        }
+        onTriggered: borderDashOffset -= 0.5
     }
 
     Shape {
@@ -81,6 +79,41 @@ Tiled.ObjectInteractionItem {
 
             PathMultiline {
                 paths: hoverOutlines
+            }
+        }
+
+        ShapePath {
+            id: selectionToolRectShadow
+
+            fillColor: "transparent"
+            strokeColor: Qt.rgba(0, 0, 0, 0.5)
+            strokeWidth: 2 / mapContainer.scale
+
+            strokeStyle: ShapePath.DashLine
+            dashPattern: [1.5, 3]
+
+            PathRectangle {
+                x: objectInteractionItem.selectionRect.x + 1 / mapContainer.scale
+                y: objectInteractionItem.selectionRect.y + 1 / mapContainer.scale
+                width: objectInteractionItem.selectionRect.width
+                height: objectInteractionItem.selectionRect.height
+            }
+        }
+        ShapePath {
+            id: selectionToolRect
+
+            fillColor: objectInteractionItem.selectionRectFillColor()
+            strokeColor: objectInteractionItem.selectionRectBorderColor()
+            strokeWidth: 2 / mapContainer.scale
+
+            strokeStyle: ShapePath.DashLine
+            dashPattern: [1.5, 3]
+
+            PathRectangle {
+                x: objectInteractionItem.selectionRect.x
+                y: objectInteractionItem.selectionRect.y
+                width: objectInteractionItem.selectionRect.width
+                height: objectInteractionItem.selectionRect.height
             }
         }
     }

--- a/src/tiled/resources/qml/ObjectInteractionItem.qml
+++ b/src/tiled/resources/qml/ObjectInteractionItem.qml
@@ -15,6 +15,10 @@ Tiled.ObjectInteractionItem {
         onTriggered: borderDashOffset -= 0.5
     }
 
+    SystemPalette {
+        id: systemPalette
+    }
+
     Shape {
         anchors.fill: parent
 
@@ -117,4 +121,113 @@ Tiled.ObjectInteractionItem {
             }
         }
     }
+
+    // EditPolygonTool
+    property var highlightedSelectedPolygonEditPoints: innerJoin(objectInteractionItem.selectedPolygonEditPoints ?? [], objectInteractionItem.highlightedPolygonEditPoints ?? [])
+    property real editPointSize: 8 / mapContainer.scale
+    Repeater {
+        id: defaultEditPoints
+        model: objectInteractionItem.polygonEditPoints
+
+        delegate: Rectangle {
+            x: modelData.x - editPointSize/2
+            y: modelData.y - editPointSize/2
+
+            width: editPointSize
+            height: editPointSize
+            radius: editPointSize/2
+
+            color: "lightgray"
+
+            border.pixelAligned: false
+            border.color: "black"
+            border.width: width/8
+        }
+    }
+    Repeater {
+        id: highlightedEditPoints
+        model: objectInteractionItem.highlightedPolygonEditPoints
+        delegate: Rectangle {
+            x: modelData.x - editPointSize/2
+            y: modelData.y - editPointSize/2
+
+            width: editPointSize
+            height: editPointSize
+            radius: editPointSize/2
+
+            color: Qt.lighter("lightgray")
+
+            border.pixelAligned: false
+            border.color: "black"
+            border.width: width/8
+        }
+    }
+    Repeater {
+        id: selectedEditPoints
+        model: objectInteractionItem.selectedPolygonEditPoints
+
+        delegate: Rectangle {
+            x: modelData.x - 1.5 * editPointSize/2
+            y: modelData.y - 1.5 * editPointSize/2
+
+            width: 1.5 * editPointSize
+            height: 1.5 * editPointSize
+            radius: 1.5 * editPointSize/2
+
+            color: systemPalette.highlight
+
+            border.pixelAligned: false
+            border.color: "black"
+            border.width: width/8
+        }
+    }
+    Repeater {
+        id: highlightedSelectedEditPoints
+        model: highlightedSelectedPolygonEditPoints
+
+        delegate: Rectangle {
+            x: modelData.x - 1.5 * editPointSize/2
+            y: modelData.y - 1.5 * editPointSize/2
+
+            width: 1.5 * editPointSize
+            height: 1.5 * editPointSize
+            radius: 1.5 * editPointSize/2
+
+            color: Qt.lighter(systemPalette.highlight)
+
+            border.pixelAligned: false
+            border.color: "black"
+            border.width: width/8
+        }
+    }
+
+    function innerJoin(listA, listB) {
+        let mapA = {}
+        let output = []
+
+        for (let a = 0; a < listA.length; a++)
+            mapA[listA[a]] = true
+
+        for (let b = 0; b < listB.length; b++)
+            if (mapA[listB[b]])
+                output.push(listB[b])
+
+        return output
+    }
+
+    // function leftAntiJoin(listA, listB) {
+    //     let mapB = {}
+    //     let output = []
+
+    //     for (let b = 0; b < listB.length; b++)
+    //         mapB[listB[b]] = true
+
+    //     for (let a = 0; a < listA.length; a++) {
+    //         if (!mapB[listA[a]]) {
+    //             output.push(listA[a])
+    //         }
+    //     }
+
+    //     return output
+    // }
 }

--- a/src/tiled/resources/qml/ObjectInteractionItem.qml
+++ b/src/tiled/resources/qml/ObjectInteractionItem.qml
@@ -20,33 +20,67 @@ Tiled.ObjectInteractionItem {
     Shape {
         anchors.fill: parent
 
+        property var selectionOutlines: objectInteractionItem.selectionOutlines
         ShapePath {
-            id: primaryPath
+            id: primarySelectionOutline
 
             fillColor: "transparent"
             strokeColor: "black"
             strokeWidth: 2 / mapContainer.scale
 
             strokeStyle: ShapePath.DashLine
-            dashPattern: [1, 3]
             dashOffset: borderDashOffset
+            dashPattern: [2, 4]
 
             PathMultiline {
-                paths: objectInteractionItem.selectionOutlines
+                paths: selectionOutlines
+            }
+        }
+        ShapePath {
+            id: secondarySelectionOutline
+
+            fillColor: "transparent"
+            strokeColor: "white"
+            strokeWidth: primarySelectionOutline.strokeWidth
+
+            strokeStyle: primarySelectionOutline.strokeStyle
+            dashOffset: primarySelectionOutline.dashOffset + 3
+            dashPattern: primarySelectionOutline.dashPattern
+
+            PathMultiline {
+                paths: selectionOutlines
             }
         }
 
+        property var hoverOutlines: objectInteractionItem.hoverOutlines
         ShapePath {
-            fillColor: "transparent"
-            strokeColor: "white"
-            strokeWidth: primaryPath.strokeWidth
+            id: primaryHoverOutline
 
-            strokeStyle: primaryPath.strokeStyle
-            dashPattern: primaryPath.dashPattern
-            dashOffset: primaryPath.dashOffset + primaryPath.dashPattern[1] - primaryPath.dashPattern[0]
+            fillColor: "transparent"
+            strokeColor: Qt.rgba(0, 0, 0, 0.5)
+            strokeWidth: 2 / mapContainer.scale
+
+            strokeStyle: ShapePath.DashLine
+            dashOffset: 0
+            dashPattern: [2, 4]
 
             PathMultiline {
-                paths: objectInteractionItem.selectionOutlines
+                paths: hoverOutlines
+            }
+        }
+        ShapePath {
+            id: secondaryHoverOutline
+
+            fillColor: "transparent"
+            strokeColor: Qt.rgba(255, 255, 255, 0.5)
+            strokeWidth: primaryHoverOutline.strokeWidth
+
+            strokeStyle: primaryHoverOutline.strokeStyle
+            dashOffset: 3
+            dashPattern: primaryHoverOutline.dashPattern
+
+            PathMultiline {
+                paths: hoverOutlines
             }
         }
     }

--- a/src/tiled/resources/qml/ObjectInteractionItem.qml
+++ b/src/tiled/resources/qml/ObjectInteractionItem.qml
@@ -1,0 +1,53 @@
+import QtQuick
+import QtQuick.Shapes
+import org.mapeditor.Tiled as Tiled
+
+Tiled.ObjectInteractionItem {
+    id: objectInteractionItem
+
+    property real borderDashOffset: 0
+    Timer {
+        id: timer
+        interval: 50
+        running: true
+        repeat: true
+
+        onTriggered: {
+            borderDashOffset -= 0.5
+        }
+    }
+
+    Shape {
+        anchors.fill: parent
+
+        ShapePath {
+            id: primaryPath
+
+            fillColor: "transparent"
+            strokeColor: "black"
+            strokeWidth: 2 / mapContainer.scale
+
+            strokeStyle: ShapePath.DashLine
+            dashPattern: [1, 3]
+            dashOffset: borderDashOffset
+
+            PathMultiline {
+                paths: objectInteractionItem.selectionOutlines
+            }
+        }
+
+        ShapePath {
+            fillColor: "transparent"
+            strokeColor: "white"
+            strokeWidth: primaryPath.strokeWidth
+
+            strokeStyle: primaryPath.strokeStyle
+            dashPattern: primaryPath.dashPattern
+            dashOffset: primaryPath.dashOffset + primaryPath.dashPattern[1] - primaryPath.dashPattern[0]
+
+            PathMultiline {
+                paths: objectInteractionItem.selectionOutlines
+            }
+        }
+    }
+}

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -40,7 +40,7 @@ Rectangle {
                 id: mapItem
 
                 map: mapItemMap
-                scale: mapContainer.scale
+                zoom: 1 / mapContainer.scale
                 visibleArea: {
                     var scale = mapContainer.scale
                     Qt.rect(-mapContainer.x / scale,

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -38,8 +38,9 @@ Rectangle {
 
             Tiled.MapItem {
                 id: mapItem
-                map: mapItemMap
 
+                map: mapItemMap
+                scale: mapContainer.scale
                 visibleArea: {
                     var scale = mapContainer.scale
                     Qt.rect(-mapContainer.x / scale,

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -122,6 +122,8 @@ Rectangle {
         id: singleFingerPanArea
         anchors.fill: parent
 
+        cursorShape: mapEditor.cursorShape
+
         onDragged: function(dx, dy) {
             dx *= Screen.devicePixelRatio
             dy *= Screen.devicePixelRatio
@@ -207,5 +209,4 @@ Rectangle {
             mapContainer.y = (mapView.height / 2) - ((mapItem.height * scale) / 2)
         }
     }
-
 }

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -40,7 +40,6 @@ Rectangle {
                 id: mapItem
 
                 map: mapItemMap
-                zoom: 1 / mapContainer.scale
                 visibleArea: {
                     var scale = mapContainer.scale
                     Qt.rect(-mapContainer.x / scale,
@@ -48,6 +47,7 @@ Rectangle {
                             mapView.width / scale,
                             mapView.height / scale)
                 }
+                zoom: 1 / mapContainer.scale
 
                 onMapObjectsChanged: objectInteractionItem.updateOutlines()
             }
@@ -89,9 +89,6 @@ Rectangle {
                 property var toolPreviewMap: mapEditor.tileEditPreview
                 property var newObjectsPreviewGroup: mapEditor.newObjectsPreview
                 map: toolPreviewMap
-                zoom: 1 / mapContainer.scale
-                newObjectsPreview: newObjectsPreviewGroup
-
                 visibleArea: {
                     if (this.map)
                         Qt.rect(0,
@@ -101,6 +98,10 @@ Rectangle {
                     else
                         Qt.rect(0, 0, 0, 0)
                 }
+                zoom: 1 / mapContainer.scale
+
+                newObjectsPreview: newObjectsPreviewGroup
+                mousePos: singleFingerPanArea.mapToItem(mapItem, Qt.point(singleFingerPanArea.mouseX, singleFingerPanArea.mouseY))
             }
 
             RegionOverlay {

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -118,9 +118,25 @@ Rectangle {
             ObjectInteractionItem {
                 id: objectInteractionItem
 
-                selectedToolId: (mapEditor.selectedTool ? mapEditor.selectedTool.id : "")
+                selectedToolId: mapEditor.selectedTool?.id ?? ""
                 selectedObjects: mapEditor.selectedObjects
                 hoveredObjects: mapEditor.aboutToBeSelectedObjects
+
+                Binding {
+                    target: objectInteractionItem
+                    property: "selectedPolygonEditPoints"
+                    value: mapEditor.selectedTool?.selectedHandlePoints
+                    when: mapEditor.selectedTool !== null &&
+                          mapEditor.selectedTool?.selectedHandlePoints !== undefined
+                }
+
+                Binding {
+                    target: objectInteractionItem
+                    property: "highlightedPolygonEditPoints"
+                    value: mapEditor.selectedTool?.highlightedHandlePoints
+                    when: mapEditor.selectedTool !== null &&
+                          mapEditor.selectedTool?.highlightedHandlePoints !== undefined
+                }
             }
         }
     }

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -111,9 +111,10 @@ Rectangle {
             }
 
             ObjectInteractionItem {
-                anchors.fill: mapItem
+                anchors.fill: singleFingerPanArea
 
                 selectedObjects: mapEditor.selectedObjects
+                hoveredObjects: mapEditor.aboutToBeSelectedObjects
             }
         }
     }
@@ -166,7 +167,7 @@ Rectangle {
             event.buttons,
             event.modifiers,
             singleFingerPanArea.mapToItem(mapItem, event.x, event.y),
-            singleFingerPanArea.mapToItem(null, event.x, event.y),
+            singleFingerPanArea.mapToItem(mapItem, event.x, event.y),
             singleFingerPanArea.mapToGlobal(event.x, event.y)
         )
 
@@ -175,7 +176,7 @@ Rectangle {
             event.buttons,
             event.modifiers,
             singleFingerPanArea.mapToItem(mapItem, event.x, event.y),
-            singleFingerPanArea.mapToItem(null, event.x, event.y),
+            singleFingerPanArea.mapToItem(mapItem, event.x, event.y),
             singleFingerPanArea.mapToGlobal(event.x, event.y)
         )
 

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -109,6 +109,12 @@ Rectangle {
                 mapRect: Qt.rect(0, 0, mapItem.map.width, mapItem.map.height)
                 tileSize: Qt.point(mapItem.map.tileWidth, mapItem.map.tileHeight)
             }
+
+            ObjectInteractionItem {
+                anchors.fill: mapItem
+
+                selectedObjects: mapEditor.selectedObjects
+            }
         }
     }
 

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -115,6 +115,7 @@ Rectangle {
             ObjectInteractionItem {
                 id: objectInteractionItem
 
+                selectedToolId: (mapEditor.selectedTool ? mapEditor.selectedTool.id : "")
                 selectedObjects: mapEditor.selectedObjects
                 hoveredObjects: mapEditor.aboutToBeSelectedObjects
             }
@@ -164,28 +165,46 @@ Rectangle {
             containerAnimation.start()
         }
 
-        onPressed: (event) => mapEditor.quickMousePressed(
-            event.button,
-            event.buttons,
-            event.modifiers,
-            singleFingerPanArea.mapToItem(mapItem, event.x, event.y),
-            singleFingerPanArea.mapToItem(mapItem, event.x, event.y),
-            singleFingerPanArea.mapToGlobal(event.x, event.y)
-        )
+        onPressed: function(event) {
+            const localPos = singleFingerPanArea.mapToItem(mapItem, event.x, event.y);
 
-        onReleased: (event) => mapEditor.quickMouseReleased(
-            event.button,
-            event.buttons,
-            event.modifiers,
-            singleFingerPanArea.mapToItem(mapItem, event.x, event.y),
-            singleFingerPanArea.mapToItem(mapItem, event.x, event.y),
-            singleFingerPanArea.mapToGlobal(event.x, event.y)
-        )
+            mapEditor.quickMousePressed(
+                event.button,
+                event.buttons,
+                event.modifiers,
+                localPos,
+                localPos,
+                singleFingerPanArea.mapToGlobal(event.x, event.y)
+            )
 
-        onPositionChanged: (event) => mapEditor.quickMouseMoved(
-            singleFingerPanArea.mapToItem(mapItem, event.x, event.y),
-            event.modifiers
-        )
+            objectInteractionItem.mousePressed(localPos)
+        }
+
+        onReleased: function(event) {
+            const localPos = singleFingerPanArea.mapToItem(mapItem, event.x, event.y);
+
+            mapEditor.quickMouseReleased(
+                event.button,
+                event.buttons,
+                event.modifiers,
+                localPos,
+                localPos,
+                singleFingerPanArea.mapToGlobal(event.x, event.y)
+            )
+
+            objectInteractionItem.mouseReleased(localPos)
+        }
+
+        onPositionChanged: function(event) {
+            const localPos = singleFingerPanArea.mapToItem(mapItem, event.x, event.y);
+
+            mapEditor.quickMouseMoved(
+                localPos,
+                event.modifiers
+            )
+
+            objectInteractionItem.mouseMoved(localPos)
+        }
 
         onContainsMouseChanged: mapEditor.quickContainsMouseChanged(singleFingerPanArea.containsMouse)
     }

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -87,10 +87,12 @@ Rectangle {
                 visible: singleFingerPanArea.containsMouse || singleFingerPanArea.pressed
 
                 property var toolPreviewMap: mapEditor.tileEditPreview
+                property var newObjectsPreviewGroup: mapEditor.newObjectsPreview
                 map: toolPreviewMap
+                zoom: 1 / mapContainer.scale
+                newObjectsPreview: newObjectsPreviewGroup
 
                 visibleArea: {
-                    // TODO: Adjust to only show needed visible area
                     if (this.map)
                         Qt.rect(0,
                                 0,
@@ -204,6 +206,8 @@ Rectangle {
             )
 
             objectInteractionItem.mouseMoved(localPos)
+
+            toolBrush.repaintPreview();
         }
 
         onContainsMouseChanged: mapEditor.quickContainsMouseChanged(singleFingerPanArea.containsMouse)

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -48,6 +48,8 @@ Rectangle {
                             mapView.width / scale,
                             mapView.height / scale)
                 }
+
+                onMapObjectsChanged: objectInteractionItem.updateOutlines()
             }
 
             RegionOverlay {
@@ -111,7 +113,7 @@ Rectangle {
             }
 
             ObjectInteractionItem {
-                anchors.fill: singleFingerPanArea
+                id: objectInteractionItem
 
                 selectedObjects: mapEditor.selectedObjects
                 hoveredObjects: mapEditor.aboutToBeSelectedObjects

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -118,6 +118,7 @@ Rectangle {
             ObjectInteractionItem {
                 id: objectInteractionItem
 
+                zoom: 1 / mapContainer.scale
                 selectedToolId: mapEditor.selectedTool?.id ?? ""
                 selectedObjects: mapEditor.selectedObjects
                 hoveredObjects: mapEditor.aboutToBeSelectedObjects
@@ -129,13 +130,20 @@ Rectangle {
                     when: mapEditor.selectedTool !== null &&
                           mapEditor.selectedTool?.selectedHandlePoints !== undefined
                 }
-
                 Binding {
                     target: objectInteractionItem
                     property: "highlightedPolygonEditPoints"
                     value: mapEditor.selectedTool?.highlightedHandlePoints
                     when: mapEditor.selectedTool !== null &&
                           mapEditor.selectedTool?.highlightedHandlePoints !== undefined
+                }
+
+                Binding {
+                    target: objectInteractionItem
+                    property: "objectHandles"
+                    value: mapEditor.selectedTool?.objectHandles
+                    when: mapEditor.selectedTool !== null &&
+                          mapEditor.selectedTool?.objectHandles !== undefined
                 }
             }
         }

--- a/src/tiled/resources/qml/mapview.qml
+++ b/src/tiled/resources/qml/mapview.qml
@@ -120,7 +120,7 @@ Rectangle {
 
                 zoom: 1 / mapContainer.scale
                 selectedToolId: mapEditor.selectedTool?.id ?? ""
-                selectedObjects: mapEditor.selectedObjects
+                selectedObjects: mapItem.map.selectedObjects
                 hoveredObjects: mapEditor.aboutToBeSelectedObjects
 
                 Binding {

--- a/src/tiledquickplugin/tiledquickplugin.cpp
+++ b/src/tiledquickplugin/tiledquickplugin.cpp
@@ -25,7 +25,8 @@
 #include "mapborderitem.h"
 #include "mapgriditem.h"
 #include "regionoverlay.h"
-#include "tiled.h"
+#include "objectinteractionitem.h"
+// #include "tiled.h"
 
 #include <qqml.h>
 
@@ -40,6 +41,7 @@ void TiledQuickPlugin::registerTypes(const char *uri)
     qmlRegisterType<MapBorderItem>(uri, 1, 0, "MapBorderItem");
     qmlRegisterType<MapGridItem>(uri, 1, 0, "MapGridItem");
     qmlRegisterType<RegionOverlay>(uri, 1, 0, "RegionOverlay");
+    qmlRegisterType<ObjectInteractionItem>(uri, 1, 0, "ObjectInteractionItem");
 
     Tiled::increaseImageAllocationLimit();
 }


### PR DESCRIPTION
Adds support for the object layer type and its associated tools.

## Primary features:

Added objectgroupitem and objectsnode classes, which are similar to the existing tilelayeritem and tilesnode classes, for containing and rendering the map's objects.

Added the objectgroupmaterial class and objectgroup shader. These are needed to render the object texturepoint2d materials affected by opacity and tint modifiers.

Added the ObjectInteractionItem QML element and cpp class. This is similar to the tile regionoverlay QML element, but instead renders the various GUI elements needed to interact with objects. Examples: Object selection rect, polygon edit tool, and resize and rotation handles.

## Secondary features/changes:

Moved the tilesethelper struct to be its own class in its own file and added geometry-based object support. Geometry-based objects are ones like rectangles, polygons, ellipses, etc which have simple palettes (gray border, black shadow, and transparent gray fill) that the tileset helper holds and can use in place of an actual texture.

Several classes were modified to emit signals to support the primary features. These *could* be contained in `#ifdef TILEDQUICK_LIB`s, but it's not super necessary.