### PR TITLE
Fixed crash after importing custom types with enums in lists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
 * Fixed crash when the selection becomes empty while starting a move (#4536)
+* Fixed crash after importing custom types due to unresolved type references in lists (#4570)
 * Fixed Properties view update on 'Reset Template Instance' and 'Replace With Template' actions
 * Linux: Added file associations for .tmj, .tsj, .tiled-project and .world files (by miffe, #4550)
 * Linux: Fixed the window icon on some Wayland compositors (by Balló György, #4567)

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -532,24 +532,49 @@ void PropertyTypes::merge(PropertyTypes typesToMerge)
     }
 
     // Update the type IDs for the class members
-    for (auto classType : std::as_const(classesToProcess)) {
-        QMutableMapIterator<QString, QVariant> it(classType->members);
-        while (it.hasNext()) {
-            QVariant &classMember = it.next().value();
+    for (auto classType : std::as_const(classesToProcess))
+        for (auto &classMember : classType->members)
+            updateTypeIds(classMember, oldTypeIdToName);
+}
 
-            if (classMember.userType() == propertyValueId()) {
-                auto classMemberValue = classMember.value<PropertyValue>();
+/**
+ * Recursively updates the type IDs of any PropertyValue found in the given
+ * value, making them refer to the merged types by name. Recursion is needed
+ * to reach values in lists and members of nested class values (#4570).
+ */
+void PropertyTypes::updateTypeIds(QVariant &value, const QHash<int, QString> &oldTypeIdToName)
+{
+    switch (value.userType()) {
+    case QMetaType::QVariantList: {
+        QVariantList list = value.toList();
+        for (QVariant &item : list)
+            updateTypeIds(item, oldTypeIdToName);
+        value = list;
+        break;
+    }
+    case QMetaType::QVariantMap: {
+        QVariantMap map = value.toMap();
+        for (QVariant &item : map)
+            updateTypeIds(item, oldTypeIdToName);
+        value = map;
+        break;
+    }
+    default:
+        if (value.userType() == propertyValueId()) {
+            auto propertyValue = value.value<PropertyValue>();
 
-                const QString typeName = oldTypeIdToName.value(classMemberValue.typeId);
-                auto type = findPropertyValueType(typeName);
-                Q_ASSERT(type);
+            updateTypeIds(propertyValue.value, oldTypeIdToName);
 
-                if (classMemberValue.typeId != type->id) {
-                    classMemberValue.typeId = type->id;
-                    classMember = QVariant::fromValue(classMemberValue);
-                }
-            }
+            const QString typeName = oldTypeIdToName.value(propertyValue.typeId);
+            auto type = findPropertyValueType(typeName);
+            Q_ASSERT(type);
+
+            if (type)
+                propertyValue.typeId = type->id;
+
+            value = QVariant::fromValue(propertyValue);
         }
+        break;
     }
 }
 

--- a/src/libtiled/propertytype.cpp
+++ b/src/libtiled/propertytype.cpp
@@ -464,7 +464,15 @@ bool ClassPropertyType::canAddMember(const QVariant &member, const PropertyTypes
                 return false;
         }
     } else if (member.userType() == QMetaType::QVariantMap) {
-        return false; // Nested class members are not supported
+        // A plain map is a not-yet-resolved member. Any class references in
+        // there are still plain type names, which get checked when that member
+        // is resolved, but check any PropertyValue instances that might
+        // already be present.
+        const auto map = member.toMap();
+        for (const auto &item : map) {
+            if (!canAddMember(item, types))
+                return false;
+        }
     }
 
     return true;

--- a/src/libtiled/propertytype.h
+++ b/src/libtiled/propertytype.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <QColor>
+#include <QHash>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QMetaType>
@@ -220,6 +221,7 @@ public:
     Types::const_iterator end() const { return mTypes.end(); }
 
 private:
+    void updateTypeIds(QVariant &value, const QHash<int, QString> &oldTypeIdToName);
     void ensureMembersResolvedHelper(const QVariant &value, const ExportContext &context);
     void ensureMembersResolved(const QVariantMap &valueMap, const ExportContext &context);
     void resolveValue(ClassPropertyType *classType, QVariant &value, const ExportContext &context);

--- a/tests/properties/test_properties.cpp
+++ b/tests/properties/test_properties.cpp
@@ -180,6 +180,45 @@ constexpr auto propertyTypesToMerge = R"([
 ]
 )";
 
+// Mirrors the file from issue #4570: the enum has a higher ID than the class
+// that refers to it, so merging into an empty set assigns different IDs.
+constexpr auto propertyTypesWithListOfEnumsToMerge = R"([
+    {
+        "id": 2,
+        "name": "AnEnumerate",
+        "storageType": "string",
+        "type": "enum",
+        "values": [ "AnEnumerate_1", "AnEnumerate_2" ],
+        "valuesAsFlags": false
+    },
+    {
+        "id": 1,
+        "members": [
+            {
+                "name": "list_of_enums",
+                "type": "list",
+                "value": [
+                    {
+                        "propertyType": "AnEnumerate",
+                        "type": "string",
+                        "value": "AnEnumerate_1"
+                    }
+                ]
+            },
+            {
+                "name": "single_enum",
+                "propertyType": "AnEnumerate",
+                "type": "string",
+                "value": "AnEnumerate_1"
+            }
+        ],
+        "name": "TopLevelType",
+        "type": "class",
+        "useAs": [ "property" ]
+    }
+]
+)";
+
 constexpr auto propertyTypesWithEnumInNestedClass = R"([
     {
         "color": "#ffff0000",
@@ -261,6 +300,7 @@ private slots:
     void roundTripListProperty();
     void typedListPassesThroughDefaultMode();
     void mergeProperties();
+    void mergeListOfEnums();
 
     void cleanupTestCase();
 
@@ -638,6 +678,38 @@ void test_Properties::mergeProperties()
     QVERIFY(classType && classType->isClass());
     const auto classMember = classType->members.value(QStringLiteral("newEnumString")).value<PropertyValue>();
     QCOMPARE(classMember.typeId, newEnumStringType->id);
+}
+
+void test_Properties::mergeListOfEnums()
+{
+    QJsonParseError error;
+    auto doc = QJsonDocument::fromJson(propertyTypesWithListOfEnumsToMerge, &error);
+    QVERIFY(error.error == QJsonParseError::NoError);
+
+    PropertyTypes typesToMerge;
+    typesToMerge.loadFromJson(doc.array(), QString());
+    QCOMPARE(typesToMerge.count(), size_t(2));
+
+    // Merging into an empty set assigns new IDs in order of appearance,
+    // effectively swapping the IDs of the enum and the class.
+    PropertyTypes types;
+    types.merge(std::move(typesToMerge));
+
+    const auto enumType = types.findPropertyValueType(QStringLiteral("AnEnumerate"));
+    const auto classType = static_cast<const ClassPropertyType*>(types.findPropertyValueType(QStringLiteral("TopLevelType")));
+    QVERIFY(enumType);
+    QVERIFY(classType && classType->isClass());
+    QVERIFY(enumType->id != classType->id);
+
+    const auto singleEnum = classType->members.value(QStringLiteral("single_enum")).value<PropertyValue>();
+    QCOMPARE(singleEnum.typeId, enumType->id);
+
+    // The enum values in the list also need to have their type ID updated
+    // (issue #4570, where they ended up referring to the class itself)
+    const auto listOfEnums = classType->members.value(QStringLiteral("list_of_enums")).toList();
+    QCOMPARE(listOfEnums.size(), 1);
+    const auto listItem = listOfEnums.first().value<PropertyValue>();
+    QCOMPARE(listItem.typeId, enumType->id);
 }
 
 void test_Properties::cleanupTestCase()


### PR DESCRIPTION
Fixes the crash reported in #4570, where importing an external custom types file containing a class with a list of enum values could crash Tiled and corrupt the project on save.

### Wrong type IDs for values in lists after import (crash)

When merging imported property types, the referenced type IDs were only updated for class members that are directly a `PropertyValue`. Values inside lists, as well as members of nested class values, kept the IDs from the imported file.

In the reported case, the enum had a higher ID than the class referring to it, so after importing into a fresh project the IDs effectively swapped and the items of `list_of_enums` ended up referring to the class containing the list. Selecting the class in the Custom Types Editor then crashed through infinite recursion, and saving the project wrote an actual circular reference.

The ID update now recursively processes lists and nested class values.

### Circular reference detection triggering on the wrong class

While writing a test for the above I found that `loadCircularReference` had been failing since a875056a0: `canAddMember` rejected any member that is a plain `QVariantMap`, intended to reject unsupported nested class members. During loading however, a plain map just means the member is not yet resolved, which caused the check to break a reference cycle from the perspective of the wrong class (dropping B's reference to A instead of A's reference to B).

The check now recurses into map values instead. Actual class references are always wrapped in `PropertyValue` instances, so cycles are still detected by the existing checks, at the point where the cycle closes.
