### PR TITLE
Fixed view jumping when undoing map resizes and moves

### DIFF
--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -563,16 +563,6 @@ void AbstractWorldTool::setSelectionScreenRect(const QRect &rect)
     }
 }
 
-// Move the camera back by offset, to keep the active map steady after it shifts
-void AbstractWorldTool::recenterView(const QPoint &offset)
-{
-    if (offset.isNull())
-        return;
-
-    MapView *view = DocumentManager::instance()->viewForDocument(mapDocument());
-    view->forceCenterOn(view->viewCenter() - offset);
-}
-
 } // namespace Tiled
 
 #include "moc_abstractworldtool.cpp"

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -112,8 +112,6 @@ protected:
     void setSelectionScreenRect(const QRect &rect);
     int resizeHandleNear(const QPointF &scenePos, MapDocument *&mapDocument) const;
 
-    void recenterView(const QPoint &offset);
-
     bool mapCanBeMoved(MapDocument *mapDocument) const;
     bool mapCanBeResized(MapDocument *mapDocument) const;
     QRect mapRect(MapDocument *mapDocument) const;

--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -492,7 +492,7 @@ QPointF EditableMap::tileToPixel(qreal x, qreal y) const
 void EditableMap::setSize(int width, int height)
 {
     if (auto doc = mapDocument()) {
-        push(new ResizeMap(doc, QSize(width, height)));
+        push(new ResizeMap(doc, QSize(width, height), QPoint()));
     } else if (!checkReadOnly()) {
         map()->setWidth(width);
         map()->setHeight(height);

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -451,7 +451,7 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
         new TransformMapObjects(this, objectsToMove, states, command);
     }
 
-    new ResizeMap(this, size, command);
+    new ResizeMap(this, size, offset, command);
     new ChangeSelectedArea(this, movedSelection, command);
 
     // Adjust world position if this map is part of any loaded worlds

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -454,10 +454,16 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
     new ResizeMap(this, size, offset, command);
     new ChangeSelectedArea(this, movedSelection, command);
 
+    // A world positions a map by its bounding rect, so move by how much that
+    // rect shifts. The pixel offset moved isometric maps twice as far as their
+    // rect actually shifts
+    const QRect oldBounds = renderer()->boundingRect(QRect(QPoint(), map()->size()));
+    const QRect newBounds = renderer()->boundingRect(QRect(-offset, size));
+    const QPoint boundsOffset = newBounds.topLeft() - oldBounds.topLeft();
+
     // Adjust world position if this map is part of any loaded worlds
-    if (!pixelOffset.isNull()) {
+    if (!boundsOffset.isNull()) {
         const QString &mapName = fileName();
-        const QPoint offsetPixels = pixelOffset.toPoint();
 
         for (const auto &worldDocument : WorldManager::instance().worlds()) {
             auto world = worldDocument->world();
@@ -466,7 +472,7 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
                 continue; // also skips maps matched via pattern
 
             const QPoint prevPos = world->mapRect(mapName).topLeft();
-            const QPoint newPos = prevPos - offsetPixels;
+            const QPoint newPos = prevPos + boundsOffset;
             new SetMapPosInLoadedWorld(worldDocument->fileName(), mapName, prevPos, newPos, command);
         }
     }

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -322,9 +322,10 @@ signals:
     void mapObjectPicked(MapObject *object);
 
     /**
-     * Emitted when the map size changes.
+     * Emitted when the map size changes. The offset tells by how many tiles
+     * the contents were shifted during the resize.
      */
-    void mapResized();
+    void mapResized(QPoint offset);
 
     void layerAdded(Layer *layer);
     void layerAboutToBeRemoved(GroupLayer *parentLayer, int index);

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -322,10 +322,10 @@ signals:
     void mapObjectPicked(MapObject *object);
 
     /**
-     * Emitted when the map size changes. The offset tells by how many tiles
-     * the contents were shifted during the resize.
+     * Emitted when the map size changes. The screen offset tells by how much
+     * the contents were shifted during the resize, in screen coordinates.
      */
-    void mapResized(QPoint offset);
+    void mapResized(QPointF screenOffset);
 
     void layerAdded(Layer *layer);
     void layerAboutToBeRemoved(GroupLayer *parentLayer, int index);

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -31,6 +31,7 @@
 #include "map.h"
 #include "mapobject.h"
 #include "maprenderer.h"
+#include "mapview.h"
 #include "objectgroup.h"
 #include "objecttemplate.h"
 #include "preferences.h"
@@ -117,6 +118,8 @@ void MapScene::setMapDocument(MapDocument *mapDocument)
                 this, [this] { update(); });
         connect(mMapDocument, &MapDocument::tilesetReplaced,
                 this, &MapScene::tilesetReplaced);
+        connect(mMapDocument, &MapDocument::mapResized,
+                this, &MapScene::mapResized);
     }
 
     refreshScene();
@@ -286,6 +289,32 @@ QPointF MapScene::parallaxOffset(const Layer &layer) const
 }
 
 /**
+ * When a resize shifted the map contents, move the view along by the same
+ * amount so the contents appear to stay in place.
+ */
+void MapScene::mapResized(QPoint offset)
+{
+    if (offset.isNull())
+        return;
+
+    // when the map has its own entry in a world, the resize also moves its
+    // world position and refreshScene handles the view, so nothing to do here
+    const QString &fileName = mMapDocument->fileName();
+    if (auto worldDocument = WorldManager::instance().worldForMap(fileName))
+        if (worldDocument->world()->mapIndex(fileName) >= 0)
+            return;
+
+    const MapRenderer *renderer = mMapDocument->renderer();
+    const QPointF pixelOffset = renderer->tileToPixelCoords(QPointF())
+                              - renderer->tileToPixelCoords(-offset);
+
+    const auto sceneViews = views();
+    for (QGraphicsView *view : sceneViews)
+        if (auto mapView = qobject_cast<MapView*>(view))
+            mapView->forceCenterOn(mapView->viewCenter() + pixelOffset);
+}
+
+/**
  * Refreshes the map scene.
  */
 void MapScene::refreshScene()
@@ -293,6 +322,7 @@ void MapScene::refreshScene()
     QHash<MapDocument*, MapItem*> mapItems;
 
     if (!mMapDocument) {
+        mLastWorldPositionMapFile.clear();
         mMapItems.swap(mapItems);
         qDeleteAll(mapItems);
         updateSceneRect();
@@ -306,6 +336,20 @@ void MapScene::refreshScene()
         const auto world = worldDocument->world();
         const QPoint currentMapPosition = world->mapRect(currentMapFile).topLeft();
         auto const contextMaps = world->contextMaps(currentMapFile);
+
+        // If the current map moved in its world (by a move or an undo),
+        // shift the view along so the map visibly moves instead of the
+        // world around it.
+        if (mLastWorldPositionMapFile == currentMapFile
+                && currentMapPosition != mLastWorldPosition) {
+            const QPoint delta = currentMapPosition - mLastWorldPosition;
+            const auto sceneViews = views();
+            for (QGraphicsView *view : sceneViews)
+                if (auto mapView = qobject_cast<MapView*>(view))
+                    mapView->forceCenterOn(mapView->viewCenter() - delta);
+        }
+        mLastWorldPositionMapFile = currentMapFile;
+        mLastWorldPosition = currentMapPosition;
 
         for (const WorldMapEntry &mapEntry : contextMaps) {
             MapDocumentPtr mapDocument;
@@ -329,6 +373,8 @@ void MapScene::refreshScene()
             }
         }
     } else {
+        mLastWorldPositionMapFile.clear();
+
         auto mapItem = takeOrCreateMapItem(mMapDocument->sharedFromThis(), MapItem::Editable);
         mapItems.insert(mMapDocument, mapItem);
     }

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -292,9 +292,9 @@ QPointF MapScene::parallaxOffset(const Layer &layer) const
  * When a resize shifted the map contents, move the view along by the same
  * amount so the contents appear to stay in place.
  */
-void MapScene::mapResized(QPoint offset)
+void MapScene::mapResized(QPointF screenOffset)
 {
-    if (offset.isNull())
+    if (screenOffset.isNull())
         return;
 
     // when the map has its own entry in a world, the resize also moves its
@@ -303,10 +303,6 @@ void MapScene::mapResized(QPoint offset)
     if (auto worldDocument = WorldManager::instance().worldForMap(fileName))
         if (worldDocument->world()->mapIndex(fileName) >= 0)
             return;
-
-    const MapRenderer *renderer = mMapDocument->renderer();
-    const QPointF screenOffset = renderer->tileToScreenCoords(QPointF())
-                               - renderer->tileToScreenCoords(-offset);
 
     translateViews(screenOffset);
 }

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -305,13 +305,21 @@ void MapScene::mapResized(QPoint offset)
             return;
 
     const MapRenderer *renderer = mMapDocument->renderer();
-    const QPointF pixelOffset = renderer->tileToPixelCoords(QPointF())
-                              - renderer->tileToPixelCoords(-offset);
+    const QPointF screenOffset = renderer->tileToScreenCoords(QPointF())
+                               - renderer->tileToScreenCoords(-offset);
 
+    translateViews(screenOffset);
+}
+
+/**
+ * Moves all views on this scene along by the given delta.
+ */
+void MapScene::translateViews(const QPointF &delta)
+{
     const auto sceneViews = views();
     for (QGraphicsView *view : sceneViews)
         if (auto mapView = qobject_cast<MapView*>(view))
-            mapView->forceCenterOn(mapView->viewCenter() + pixelOffset);
+            mapView->forceCenterOn(mapView->viewCenter() + delta);
 }
 
 /**
@@ -343,10 +351,7 @@ void MapScene::refreshScene()
         if (mLastWorldPositionMapFile == currentMapFile
                 && currentMapPosition != mLastWorldPosition) {
             const QPoint delta = currentMapPosition - mLastWorldPosition;
-            const auto sceneViews = views();
-            for (QGraphicsView *view : sceneViews)
-                if (auto mapView = qobject_cast<MapView*>(view))
-                    mapView->forceCenterOn(mapView->viewCenter() - delta);
+            translateViews(-delta);
         }
         mLastWorldPositionMapFile = currentMapFile;
         mLastWorldPosition = currentMapPosition;

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -114,6 +114,7 @@ private:
     void refreshScene();
 
     void changeEvent(const ChangeEvent &change);
+    void mapResized(QPoint offset);
     void repaintTileset(Tileset *tileset);
 
     void tilesetReplaced(int index, Tileset *tileset, Tileset *oldTileset);
@@ -133,6 +134,8 @@ private:
 
     MapDocument *mMapDocument = nullptr;
     QHash<MapDocument*, MapItem*> mMapItems;
+    QString mLastWorldPositionMapFile;
+    QPoint mLastWorldPosition;
     AbstractTool *mSelectedTool = nullptr;
     DebugDrawItem *mDebugDrawItem = nullptr;
     bool mUnderMouse = false;

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -115,6 +115,7 @@ private:
 
     void changeEvent(const ChangeEvent &change);
     void mapResized(QPoint offset);
+    void translateViews(const QPointF &delta);
     void repaintTileset(Tileset *tileset);
 
     void tilesetReplaced(int index, Tileset *tileset, Tileset *oldTileset);

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -114,7 +114,7 @@ private:
     void refreshScene();
 
     void changeEvent(const ChangeEvent &change);
-    void mapResized(QPoint offset);
+    void mapResized(QPointF screenOffset);
     void translateViews(const QPointF &delta);
     void repaintTileset(Tileset *tileset);
 

--- a/src/tiled/resizemap.cpp
+++ b/src/tiled/resizemap.cpp
@@ -29,12 +29,14 @@ namespace Tiled {
 
 ResizeMap::ResizeMap(MapDocument *mapDocument,
                      QSize size,
+                     QPoint offset,
                      QUndoCommand *parent)
     : QUndoCommand(QCoreApplication::translate("Undo Commands",
                                                "Resize Map"),
                    parent)
     , mMapDocument(mapDocument)
     , mSize(size)
+    , mOffset(offset)
 {
 }
 
@@ -56,7 +58,8 @@ void ResizeMap::swapSize()
     map->setHeight(mSize.height());
     mSize = oldSize;
 
-    emit mMapDocument->mapResized();
+    emit mMapDocument->mapResized(mOffset);
+    mOffset = -mOffset;
 }
 
 } // namespace Tiled

--- a/src/tiled/resizemap.cpp
+++ b/src/tiled/resizemap.cpp
@@ -22,6 +22,7 @@
 
 #include "map.h"
 #include "mapdocument.h"
+#include "maprenderer.h"
 
 #include <QCoreApplication>
 
@@ -53,12 +54,27 @@ void ResizeMap::redo()
 void ResizeMap::swapSize()
 {
     Map *map = mMapDocument->map();
+    const MapRenderer *renderer = mMapDocument->renderer();
+
+    // Determine by how much the contents shift on screen, by sampling around
+    // the resize. Sampling both sides is necessary because for isometric maps
+    // the screen origin depends on the map height.
+    const QPointF beforeResize = renderer->tileToScreenCoords(QPointF());
+
     QSize oldSize(map->width(), map->height());
     map->setWidth(mSize.width());
     map->setHeight(mSize.height());
     mSize = oldSize;
 
-    emit mMapDocument->mapResized(mOffset);
+    // For staggered and hexagonal maps this is only exact when the offset
+    // keeps the stagger parity, since there the shift depends on where the
+    // contents are.
+    const QPointF afterResize = renderer->tileToScreenCoords(mOffset);
+
+    emit mMapDocument->mapResized(afterResize - beforeResize);
+
+    // Shift the other way when this command is applied again, so that undo
+    // and redo each restore the previous state.
     mOffset = -mOffset;
 }
 

--- a/src/tiled/resizemap.cpp
+++ b/src/tiled/resizemap.cpp
@@ -56,22 +56,22 @@ void ResizeMap::swapSize()
     Map *map = mMapDocument->map();
     const MapRenderer *renderer = mMapDocument->renderer();
 
-    // Determine by how much the contents shift on screen, by sampling around
-    // the resize. Sampling both sides is necessary because for isometric maps
-    // the screen origin depends on the map height.
-    const QPointF beforeResize = renderer->tileToScreenCoords(QPointF());
+    const QSize oldSize = map->size();
 
-    QSize oldSize(map->width(), map->height());
+    // Measure the bounding rect rather than the contents, since on hexagonal
+    // and staggered maps the contents jump half a tile whenever the stagger
+    // parity changes. Taken before the resize, because the isometric origin
+    // follows the map height.
+    const QRect oldBounds = renderer->boundingRect(QRect(QPoint(), oldSize));
+    const QRect newBounds = renderer->boundingRect(QRect(-mOffset, mSize));
+    const QPoint boundsOffset = newBounds.topLeft() - oldBounds.topLeft();
+
     map->setWidth(mSize.width());
     map->setHeight(mSize.height());
     mSize = oldSize;
 
-    // For staggered and hexagonal maps this is only exact when the offset
-    // keeps the stagger parity, since there the shift depends on where the
-    // contents are.
-    const QPointF afterResize = renderer->tileToScreenCoords(mOffset);
-
-    emit mMapDocument->mapResized(afterResize - beforeResize);
+    // The view goes the other way, so the map stays where it was on screen.
+    emit mMapDocument->mapResized(-boundsOffset);
 
     // Shift the other way when this command is applied again, so that undo
     // and redo each restore the previous state.

--- a/src/tiled/resizemap.h
+++ b/src/tiled/resizemap.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <QPoint>
 #include <QSize>
 #include <QUndoCommand>
 
@@ -36,6 +37,7 @@ class ResizeMap : public QUndoCommand
 public:
     ResizeMap(MapDocument *mapDocument,
               QSize size,
+              QPoint offset,
               QUndoCommand *parent = nullptr);
 
     void undo() override;
@@ -46,6 +48,7 @@ private:
 
     MapDocument *mMapDocument;
     QSize mSize;
+    QPoint mOffset;
 };
 
 } // namespace Tiled

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -141,11 +141,6 @@ void WorldMoveMapTool::moveMap(MapDocument *document, QPoint moveBy)
 
     auto undoStack = worldDocument->undoStack();
     undoStack->push(new SetMapRectCommand(worldDocument, document->fileName(), rect));
-
-    if (document == mapDocument()) {
-        // undo camera movement, by the actual snapped offset
-        recenterView(rect.topLeft() - prevRect.topLeft());
-    }
 }
 
 void WorldMoveMapTool::updateResizingMap(const QPointF &pos,
@@ -326,19 +321,8 @@ void WorldMoveMapTool::finishResizing()
     auto resizedMap = std::exchange(mResizingMap, nullptr);
     mResizeHandle = -1;
 
-    if (mResizeNewSize != resizedMap->map()->size() || !mResizeOffset.isNull()) {
+    if (mResizeNewSize != resizedMap->map()->size() || !mResizeOffset.isNull())
         resizedMap->resizeMap(mResizeNewSize, mResizeOffset, false);
-
-        // keep the view steady by compensating for the content shift, which
-        // matches the pixelOffset applied by MapDocument::resizeMap (a map
-        // in a world has its position adjusted by exactly this amount)
-        if (resizedMap == mapDocument()) {
-            const MapRenderer *renderer = resizedMap->renderer();
-            const QPointF pixelOffset = renderer->tileToPixelCoords(QPointF())
-                                      - renderer->tileToPixelCoords(-mResizeOffset);
-            recenterView(-pixelOffset.toPoint());
-        }
-    }
 
     updateSelectionRectangle();
     refreshCursor();
@@ -363,11 +347,6 @@ void WorldMoveMapTool::finishMoving()
 
             auto undoStack = worldDocument->undoStack();
             undoStack->push(new SetMapRectCommand(worldDocument, draggedMap->fileName(), rect));
-
-            if (draggedMap == mapDocument()) {
-                // undo camera movement
-                view->forceCenterOn(view->viewCenter() - mDragOffset);
-            }
         }
     } else {
         // switch to the document

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -159,19 +159,22 @@ void WorldMoveMapTool::updateResizingMap(const QPointF &pos,
     const QPoint delta = (pos - mDragStartScenePos).toPoint();
     const bool snapToGrid = !(modifiers & Qt::ControlModifier);
 
-    const auto snap = [&](int value, int gridStep) {
-        return (snapToGrid && gridStep > 0) ? qRound(qreal(value) / gridStep) * gridStep
-                                            : value;
+    // snap the drag rather than the resulting edge, since the bounds of a
+    // staggered or hexagonal map don't line up with the grid and the edge
+    // would otherwise jump as soon as a handle is grabbed
+    const auto snap = [&](int amount, int gridStep) {
+        return (snapToGrid && gridStep > 0) ? qRound(qreal(amount) / gridStep) * gridStep
+                                            : amount;
     };
 
     if (edges.left)
-        left = snap(left + delta.x(), step.width());
+        left += snap(delta.x(), step.width());
     if (edges.right)
-        right = snap(right + delta.x(), step.width());
+        right += snap(delta.x(), step.width());
     if (edges.top)
-        top = snap(top + delta.y(), step.height());
+        top += snap(delta.y(), step.height());
     if (edges.bottom)
-        bottom = snap(bottom + delta.y(), step.height());
+        bottom += snap(delta.y(), step.height());
 
     // ask the renderer what one more column or row adds on screen, since that
     // is only the tile size for orthogonal maps

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -147,8 +147,7 @@ void WorldMoveMapTool::updateResizingMap(const QPointF &pos,
                                          Qt::KeyboardModifiers modifiers)
 {
     const Map *map = mResizingMap->map();
-    const int tileWidth = map->tileWidth();
-    const int tileHeight = map->tileHeight();
+    const MapRenderer *renderer = mResizingMap->renderer();
     const QSize step = snapSize(mResizingMap);
     const HandleEdges edges = handleEdges[mResizeHandle];
 
@@ -174,23 +173,31 @@ void WorldMoveMapTool::updateResizingMap(const QPointF &pos,
     if (edges.bottom)
         bottom = snap(bottom + delta.y(), step.height());
 
-    // a map is always a whole number of tiles, so round to the nearest tile
-    const int newWidth = qMax(1, qRound(qreal(right - left) / tileWidth));
-    const int newHeight = qMax(1, qRound(qreal(bottom - top) / tileHeight));
+    // ask the renderer what one more column or row adds on screen, since that
+    // is only the tile size for orthogonal maps
+    const QSize mapSize = map->size();
+    const QRect mapRect = renderer->boundingRect(QRect(QPoint(), mapSize));
+    const QRect oneMoreColumn = renderer->boundingRect(QRect(QPoint(), mapSize + QSize(1, 0)));
+    const QRect oneMoreRow = renderer->boundingRect(QRect(QPoint(), mapSize + QSize(0, 1)));
+    const int columnPixels = qMax(1, oneMoreColumn.width() - mapRect.width());
+    const int rowPixels = qMax(1, oneMoreRow.height() - mapRect.height());
+
+    // count from the size we started at, so grabbing a handle without dragging
+    // leaves the map as it is
+    const int widthDragged = right - left - mResizeStartWorldRect.width();
+    const int heightDragged = bottom - top - mResizeStartWorldRect.height();
+    const int newWidth = qMax(1, mapSize.width() + qRound(qreal(widthDragged) / columnPixels));
+    const int newHeight = qMax(1, mapSize.height() + qRound(qreal(heightDragged) / rowPixels));
 
     // the content only shifts when the left or top edge is the one being moved
-    mResizeOffset = QPoint(edges.left ? newWidth - map->width() : 0,
-                           edges.top ? newHeight - map->height() : 0);
+    mResizeOffset = QPoint(edges.left ? newWidth - mapSize.width() : 0,
+                           edges.top ? newHeight - mapSize.height() : 0);
     mResizeNewSize = QSize(newWidth, newHeight);
 
-    // preview the result, matching what resizeMap() will produce, using the
-    // renderer so the size is correct for isometric and other orientations
-    const MapRenderer *renderer = mResizingMap->renderer();
-    const QPointF pixelOffset = renderer->tileToPixelCoords(QPointF())
-                              - renderer->tileToPixelCoords(-mResizeOffset);
-    const QPoint topLeft = mResizeStartWorldRect.topLeft() - pixelOffset.toPoint();
-    const QSize previewSize = renderer->boundingRect(QRect(QPoint(), mResizeNewSize)).size();
-    setSelectionScreenRect(QRect(topLeft, previewSize).translated(mResizeSceneOffset));
+    // preview the result, positioned the way resizeMap() will position it
+    const QRect newBounds = renderer->boundingRect(QRect(-mResizeOffset, mResizeNewSize));
+    const QPoint topLeft = mResizeStartWorldRect.topLeft() + newBounds.topLeft() - mapRect.topLeft();
+    setSelectionScreenRect(QRect(topLeft, newBounds.size()).translated(mResizeSceneOffset));
 
     setStatusInfo(tr("Resize map to %1 x %2").arg(newWidth).arg(newHeight));
 }


### PR DESCRIPTION
When undoing a resize from the left/top edge, the resize gets undone but the whole map jumps in the view. Same problem when undoing a map move in a world, the other maps move in the view instead of the moved one going back. This happens because the view was only adjusted when the change was made through the tool, so undo/redo never adjusted it.

Now the ResizeMap command reports the contents shift through the mapResized signal and MapScene adjusts the view when it happens. For maps that are in a world, refreshScene compensates for the change in world position instead. So the view stays steady no matter where the change came from.