### PR TITLE
Qbs: Fixed installing of moc files alongside the headers

### DIFF
--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -186,11 +186,18 @@ DynamicLibrary {
         "world.h",
     ]
 
+    // Tag the source headers, so that the group below won't match generated
+    // artifacts like the moc files, which are also tagged with "hpp".
+    FileTagger {
+        patterns: "*.h"
+        fileTags: ["hpp", "public_hpp"]
+    }
+
     Group {
         condition: project.installHeaders
         qbs.install: true
         qbs.installDir: "include/tiled"
-        fileTagsFilter: "hpp"
+        fileTagsFilter: "public_hpp"
     }
 
     Export {

--- a/src/libtiledquick/libtiledquick.qbs
+++ b/src/libtiledquick/libtiledquick.qbs
@@ -46,11 +46,18 @@ DynamicLibrary {
         "tilesnode.h",
     ]
 
+    // Tag the source headers, so that the group below won't match generated
+    // artifacts like the moc files, which are also tagged with "hpp".
+    FileTagger {
+        patterns: "*.h"
+        fileTags: ["hpp", "public_hpp"]
+    }
+
     Group {
         condition: project.installHeaders
         qbs.install: true
         qbs.installDir: "include/tiledquick"
-        fileTagsFilter: "hpp"
+        fileTagsFilter: "public_hpp"
     }
 
     Group {


### PR DESCRIPTION
The generated `moc_*.cpp` files are tagged with "hpp" when they are included by a source file rather than compiled separately, since in that case they behave like headers. This caused them to be matched by the install group using `fileTagsFilter: "hpp"` and to be installed to the include directory.

Now the source headers are explicitly tagged with an additional "public_hpp" tag, which the install group matches instead. Generated artifacts are not affected by FileTagger items, so the moc files are no longer installed.

Closes #4260