### PR TITLE
Improved minimap performance by only re-rendering changed regions

### DIFF
--- a/src/libtiled/minimaprenderer.cpp
+++ b/src/libtiled/minimaprenderer.cpp
@@ -120,7 +120,8 @@ static void extendMapRect(QRect &mapBoundingRect, const MapRenderer &renderer)
     mapBoundingRect = rect.toAlignedRect();
 }
 
-void MiniMapRenderer::renderToImage(QImage &image, RenderFlags renderFlags) const
+void MiniMapRenderer::renderToImage(QImage &image, RenderFlags renderFlags,
+                                    const QRectF &exposed) const
 {
     if (!mMap)
         return;
@@ -147,10 +148,12 @@ void MiniMapRenderer::renderToImage(QImage &image, RenderFlags renderFlags) cons
     const qreal scale = qMin(static_cast<qreal>(image.width()) / mapSize.width(),
                              static_cast<qreal>(image.height()) / mapSize.height());
 
-    if (renderFlags.testFlag(DrawBackground) && mMap->backgroundColor().isValid())
-        image.fill(mMap->backgroundColor());
-    else
-        image.fill(Qt::transparent);
+    const QColor background = renderFlags.testFlag(DrawBackground) && mMap->backgroundColor().isValid()
+            ? mMap->backgroundColor()
+            : QColor(Qt::transparent);
+
+    if (exposed.isNull())
+        image.fill(background);
 
     QPainter painter(&image);
     painter.setRenderHints(QPainter::SmoothPixmapTransform, renderFlags.testFlag(SmoothPixmapTransform));
@@ -165,6 +168,13 @@ void MiniMapRenderer::renderToImage(QImage &image, RenderFlags renderFlags) cons
     painter.translate(-mapBoundingRect.topLeft());
 
     mRenderer->setPainterScale(scale);
+
+    if (!exposed.isNull()) {
+        painter.setClipRect(exposed);
+        painter.setCompositionMode(QPainter::CompositionMode_Source);
+        painter.fillRect(exposed, background);
+        painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+    }
 
     LayerIterator iterator(mMap);
     while (const Layer *layer = iterator.next()) {
@@ -184,7 +194,7 @@ void MiniMapRenderer::renderToImage(QImage &image, RenderFlags renderFlags) cons
                 painter.setCompositionMode(compositionMode);
 
                 const TileLayer *tileLayer = static_cast<const TileLayer*>(layer);
-                mRenderer->drawTileLayer(&painter, tileLayer);
+                mRenderer->drawTileLayer(&painter, tileLayer, exposed.translated(-offset));
             }
             break;
         }

--- a/src/libtiled/minimaprenderer.h
+++ b/src/libtiled/minimaprenderer.h
@@ -72,7 +72,8 @@ public:
 
     QImage render(QSize size, RenderFlags renderFlags) const;
 
-    void renderToImage(QImage &image, RenderFlags renderFlags) const;
+    void renderToImage(QImage &image, RenderFlags renderFlags,
+                       const QRectF &exposed = QRectF()) const;
 
 private:
     const Map *mMap;

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -21,18 +21,23 @@
 
 #include "minimap.h"
 
+#include "changeevents.h"
 #include "documentmanager.h"
+#include "geometry.h"
 #include "map.h"
 #include "mapdocument.h"
 #include "maprenderer.h"
 #include "mapscene.h"
 #include "mapview.h"
+#include "objectgroup.h"
+#include "tilelayer.h"
 #include "utils.h"
 #include "zoomable.h"
 
 #include <QCursor>
 #include <QResizeEvent>
 #include <QScrollBar>
+#include <QtMath>
 #include <QUndoStack>
 
 using namespace Tiled;
@@ -43,6 +48,8 @@ MiniMap::MiniMap(QWidget *parent)
     , mDragging(false)
     , mMouseMoveCursorState(false)
     , mRedrawMapImage(false)
+    , mNeedsFullRedraw(true)
+    , mSawTrackedChange(false)
     , mRenderFlags(MiniMapRenderer::DrawTileLayers
                    | MiniMapRenderer::DrawMapObjects
                    | MiniMapRenderer::DrawImageLayers
@@ -66,16 +73,29 @@ void MiniMap::setMapDocument(MapDocument *map)
 
     if (mMapDocument) {
         mMapDocument->disconnect(this);
+        mMapDocument->undoStack()->disconnect(this);
 
         if (MapView *mapView = dm->viewForDocument(mMapDocument))
             mapView->disconnect(this);
     }
 
     mMapDocument = map;
+    mDirtyRegion = QRegion();
+    mSawTrackedChange = false;
 
     if (mMapDocument) {
         connect(mMapDocument->undoStack(), &QUndoStack::indexChanged,
-                this, &MiniMap::scheduleMapImageUpdate);
+                this, &MiniMap::undoStackIndexChanged);
+        connect(mMapDocument, &Document::changed,
+                this, &MiniMap::documentChanged);
+        connect(mMapDocument, &MapDocument::regionChanged,
+                this, &MiniMap::regionChanged);
+        connect(mMapDocument, &MapDocument::tileLayerChanged,
+                this, [this] (TileLayer *, MapDocument::TileLayerChangeFlags flags) {
+            // Layer bounds only affect the rendered area of infinite maps
+            if (flags & MapDocument::LayerBoundsChanged && mMapDocument->map()->infinite())
+                mNeedsFullRedraw = true;
+        });
 
         if (MapView *mapView = dm->viewForDocument(mMapDocument))
             connect(mapView, &MapView::viewRectChanged, this, [this] { update(); });
@@ -91,6 +111,63 @@ QSize MiniMap::sizeHint() const
 
 void MiniMap::scheduleMapImageUpdate()
 {
+    mNeedsFullRedraw = true;
+    mMapImageUpdateTimer.start(100);
+}
+
+void MiniMap::undoStackIndexChanged()
+{
+    // When a command didn't report the changed area, a full redraw is needed
+    if (!mSawTrackedChange)
+        mNeedsFullRedraw = true;
+
+    mSawTrackedChange = false;
+    mMapImageUpdateTimer.start(100);
+}
+
+void MiniMap::documentChanged(const ChangeEvent &change)
+{
+    switch (change.type) {
+    case ChangeEvent::MapObjectAboutToBeAdded:
+    case ChangeEvent::MapObjectAdded:
+    case ChangeEvent::MapObjectAboutToBeRemoved:
+    case ChangeEvent::MapObjectRemoved:
+    case ChangeEvent::MapObjectsRemoved:
+        // Handled by MapObjectsAdded and MapObjectsAboutToBeRemoved
+        break;
+    case ChangeEvent::MapObjectsAdded:
+    case ChangeEvent::MapObjectsAboutToBeRemoved:
+        for (MapObject *object : static_cast<const MapObjectsEvent&>(change).mapObjects)
+            markObjectDirty(object);
+        break;
+    default:
+        mNeedsFullRedraw = true;
+        break;
+    }
+}
+
+void MiniMap::regionChanged(const QRegion &region, TileLayer *tileLayer)
+{
+    const MapRenderer *renderer = mMapDocument->renderer();
+    const QMargins margins = mMapDocument->map()->drawMargins();
+    const QPoint offset = tileLayer->totalOffset().toPoint();
+
+    for (const QRect &r : region)
+        mDirtyRegion |= renderer->boundingRect(r).marginsAdded(margins).translated(offset);
+
+    mSawTrackedChange = true;
+    mMapImageUpdateTimer.start(100);
+}
+
+void MiniMap::markObjectDirty(MapObject *object)
+{
+    const MapRenderer *renderer = mMapDocument->renderer();
+    const QPointF screenPos = renderer->pixelToScreenCoords(object->position());
+    QRectF bounds = rotateAt(screenPos, object->rotation()).mapRect(object->screenBounds(*renderer));
+    bounds.translate(object->objectGroup()->totalOffset());
+
+    mDirtyRegion |= bounds.toAlignedRect();
+    mSawTrackedChange = true;
     mMapImageUpdateTimer.start(100);
 }
 
@@ -185,12 +262,25 @@ void MiniMap::renderMapToImage()
     if (mMapImage.size() != imageSize) {
         mMapImage = QImage(imageSize, QImage::Format_ARGB32_Premultiplied);
         updateImageRect();
+        mNeedsFullRedraw = true;
     }
 
     if (imageSize.isEmpty())
         return;
 
-    miniMapRenderer.renderToImage(mMapImage, mRenderFlags);
+    if (mNeedsFullRedraw || mDirtyRegion.isEmpty()) {
+        miniMapRenderer.renderToImage(mMapImage, mRenderFlags);
+    } else {
+        // The margin accounts for anti-aliasing and for object outlines and
+        // markers, which are drawn at a constant size in image pixels.
+        const int margin = qCeil(20 / scale);
+        const QRect exposed = mDirtyRegion.boundingRect().adjusted(-margin, -margin,
+                                                                   margin, margin);
+        miniMapRenderer.renderToImage(mMapImage, mRenderFlags, exposed);
+    }
+
+    mNeedsFullRedraw = false;
+    mDirtyRegion = QRegion();
 }
 
 void MiniMap::centerViewOnLocalPixel(const QPointF &centerPos, int delta)

--- a/src/tiled/minimap.h
+++ b/src/tiled/minimap.h
@@ -25,11 +25,15 @@
 
 #include <QFrame>
 #include <QImage>
+#include <QRegion>
 #include <QTimer>
 
 namespace Tiled {
 
+class ChangeEvent;
 class MapDocument;
+class MapObject;
+class TileLayer;
 
 class MiniMap : public QFrame
 {
@@ -58,6 +62,10 @@ protected:
     void mouseMoveEvent(QMouseEvent *event) override;
 
 private:
+    void undoStackIndexChanged();
+    void documentChanged(const ChangeEvent &change);
+    void regionChanged(const QRegion &region, TileLayer *tileLayer);
+    void markObjectDirty(MapObject *object);
     void redrawTimeout();
 
     MapDocument *mMapDocument;
@@ -68,7 +76,10 @@ private:
     QPoint mDragOffset;
     bool mMouseMoveCursorState;
     bool mRedrawMapImage;
+    bool mNeedsFullRedraw;
+    bool mSawTrackedChange;
     MiniMapRenderer::RenderFlags mRenderFlags;
+    QRegion mDirtyRegion;
 
     QRect viewportRect() const;
     QPointF mapToScene(QPointF p) const;


### PR DESCRIPTION
Previously the minimap re-rendered the entire map shortly after every undo stack change, which on large maps (e.g. 2064x2064 tiles) could freeze the UI for several seconds per edit while the minimap was open.

Now tile layer edits and adding/removing map objects repaint only the affected part of the minimap, using the exposed rect already supported by MapRenderer::drawTileLayer, padded based on the render scale to cover anti-aliasing and the constant image-pixel size of object outlines and markers. Anything else, including moving existing objects and commands that don't report what changed, still does a full re-render, keeping the worst case at the previous behavior. Tile layer bounds changes only force this for infinite maps, since painting an untouched chunk grows the bounds without affecting a fixed-size map's rendered area.

Also disconnect from the previous document's undo stack in setMapDocument, which previously accumulated connections when switching documents.