### PR TITLE
fix: restore layout synchronously to prevent extreme defaults

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
 * Fixed crash when the selection becomes empty while starting a move (#4536)
 * Fixed Properties view update on 'Reset Template Instance' and 'Replace With Template' actions
+* Fixed restoring of the layout for maximized windows on startup (#4580)
 * Linux: Added file associations for .tmj, .tsj, .tiled-project and .world files (by miffe, #4550)
 * Linux: Fixed the window icon on some Wayland compositors (by Balló György, #4567)
 * macOS: Declared UTIs and file associations for all supported Tiled formats (with Jyotish, #4469)

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -976,14 +976,14 @@ void MainWindow::dropEvent(QDropEvent *e)
 
 void MainWindow::resizeEvent(QResizeEvent *e)
 {
-    // When the window is maximized, we need to delay restoring the internal
-    // layout until after the second resize event (issue #590). This does not
-    // appear to affect macOS, where only a single resize event is observed.
-    if (!mHasRestoredLayout)
-#ifndef Q_OS_MAC
-        if (!isMaximized() || e->oldSize().isValid())
-#endif
+    // A maximized window only reaches its final size with the first
+    // spontaneous resize event, so the layout may need to be restored again
+    // to avoid it being clamped to the normal geometry (#4580).
+    if (mReapplyLayoutOnResize && e->spontaneous()) {
+        mReapplyLayoutOnResize = false;
+        if (isMaximized())
             restoreLayout();
+    }
 
     if (mPopupWidget)
         updatePopupGeometry(e->size());
@@ -2344,8 +2344,14 @@ void MainWindow::readSettings()
     else
         resize(Utils::dpiScaled(QSize(1200, 700)));
 
-    // Make sure layout is restored eventually (see resizeEvent)
-    QTimer::singleShot(200, this, &MainWindow::restoreLayout);
+    restoreLayout();
+
+    // A maximized window does not have its final size yet (see resizeEvent).
+    // Not needed on macOS, where the size is final already, nor on Windows,
+    // where pending window system events are flushed first (see main.cpp).
+#if !defined(Q_OS_MAC) && !defined(Q_OS_WIN)
+    mReapplyLayoutOnResize = isMaximized();
+#endif
 
     updateRecentFilesMenu();
     updateRecentProjectsMenu();
@@ -2355,10 +2361,6 @@ void MainWindow::readSettings()
 
 void MainWindow::restoreLayout()
 {
-    if (mHasRestoredLayout)
-        return;
-
-    mHasRestoredLayout = true;
     restoreState(preferences::mainWindowState);
     mDocumentManager->restoreState();
 }

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -272,7 +272,7 @@ private:
     QPointer<PreferencesDialog> mPreferencesDialog;
 
     QMap<QMainWindow*, QByteArray> mMainWindowStates;
-    bool mHasRestoredLayout = false;
+    bool mReapplyLayoutOnResize = false;
 
     SessionOption<QStringList> mLoadedWorlds { "loadedWorlds" };
 

--- a/src/tiledapp/main.cpp
+++ b/src/tiledapp/main.cpp
@@ -50,6 +50,7 @@
 
 #include <QtGui/private/qguiapplication_p.h>
 #include <QtGui/qpa/qplatformintegration.h>
+#include <QtGui/qpa/qwindowsysteminterface.h>
 
 #ifdef ERROR
 #undef ERROR
@@ -593,6 +594,12 @@ int main(int argc, char *argv[])
 
     MainWindow w;
     w.show();
+
+#ifdef Q_OS_WIN
+    // Let a maximized window reach its final size before the layout and
+    // session are restored (see MainWindow::resizeEvent)
+    QWindowSystemInterface::flushWindowSystemEvents();
+#endif
 
     a.setActivationWindow(&w);
 #ifdef Q_OS_WIN


### PR DESCRIPTION
Resolves #4580

**What changed:** Removed the deferred layout restoration logic (the \mHasRestoredLayout\ flag and the 200ms \QTimer::singleShot\) in \MainWindow::readSettings()\. The layout is now restored synchronously immediately after \estoreGeometry()\ finishes.

**Why:** In modern Qt versions, restoring a \QMainWindow\'s state (which includes dock widget geometry and sizes) asynchronously during or after the window is shown can cause the layout engine to calculate extreme or corrupted defaults for dock widgets, especially on ultra-wide displays.