### PR TITLE
fix: preserve properties scrollbar position when switching objects

### DIFF
--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -2554,8 +2554,10 @@ void PropertiesWidget::currentObjectChanged(Object *object)
 
     if (scrollValue > 0) {
         QTimer::singleShot(0, mPropertiesView, [view = mPropertiesView, scrollValue] {
-            if (auto scrollBar = view->verticalScrollBar())
-                scrollBar->setValue(scrollValue);
+            QTimer::singleShot(0, view, [view, scrollValue] {
+                if (auto scrollBar = view->verticalScrollBar())
+                    scrollBar->setValue(scrollValue);
+            });
         });
     }
 }

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -57,6 +57,7 @@
 #include <QKeyEvent>
 #include <QMenu>
 #include <QPushButton>
+#include <QScrollBar>
 #include <QScopedValueRollback>
 #include <QTimer>
 #include <QToolBar>
@@ -2447,6 +2448,10 @@ void PropertiesWidget::currentObjectChanged(Object *object)
 {
     const ScopedUpdatesDisabler updatesDisabler(mPropertiesView);
 
+    int scrollValue = 0;
+    if (auto scrollBar = mPropertiesView->verticalScrollBar())
+        scrollValue = scrollBar->value();
+
     if (mPropertiesObject) {
         mRootProperty->deleteProperty(mPropertiesObject);
         mPropertiesObject = nullptr;
@@ -2546,6 +2551,13 @@ void PropertiesWidget::currentObjectChanged(Object *object)
 
     mPropertiesView->setEnabled(object);
     mActionAddProperty->setEnabled(enabled);
+
+    if (scrollValue > 0) {
+        QTimer::singleShot(0, mPropertiesView, [this, scrollValue] {
+            if (auto scrollBar = mPropertiesView->verticalScrollBar())
+                scrollBar->setValue(scrollValue);
+        });
+    }
 }
 
 void PropertiesWidget::applyObjectExpandedStates()

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -2553,8 +2553,8 @@ void PropertiesWidget::currentObjectChanged(Object *object)
     mActionAddProperty->setEnabled(enabled);
 
     if (scrollValue > 0) {
-        QTimer::singleShot(0, mPropertiesView, [this, scrollValue] {
-            if (auto scrollBar = mPropertiesView->verticalScrollBar())
+        QTimer::singleShot(0, mPropertiesView, [view = mPropertiesView, scrollValue] {
+            if (auto scrollBar = view->verticalScrollBar())
                 scrollBar->setValue(scrollValue);
         });
     }


### PR DESCRIPTION
Resolves #4554

**What changed:** Updated \PropertiesWidget::currentObjectChanged\ to cache the vertical scrollbar value at the start of the function. If it's greater than 0, it schedules it to be restored on the next event loop iteration (via \QTimer::singleShot\) after the layout has updated with the new property widgets.

**Why:** When switching between items (such as Tiles in the same Tileset), the \PropertiesWidget\ deletes the old properties and creates new ones. Because the widgets are removed and re-added synchronously, the \QScrollArea\ resets its vertical scrollbar position back to \