### PR TITLE
fix: clear properties view when tile selection becomes empty

### DIFF
--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -1334,7 +1334,7 @@ QList<Object*> MapDocument::currentObjects() const
                     objects.append(mapObj);
                 return objects;
             }
-            break;
+            return {};
         case Object::LayerType:
             if (!mSelectedLayers.isEmpty()) {
                 QList<Object*> objects;
@@ -1342,7 +1342,7 @@ QList<Object*> MapDocument::currentObjects() const
                     objects.append(layer);
                 return objects;
             }
-            break;
+            return {};
         default:
             break;
         }

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -57,6 +57,7 @@
 #include <QKeyEvent>
 #include <QMenu>
 #include <QPushButton>
+#include <QScrollBar>
 #include <QScopedValueRollback>
 #include <QTimer>
 #include <QToolBar>
@@ -2447,6 +2448,10 @@ void PropertiesWidget::currentObjectChanged(Object *object)
 {
     const ScopedUpdatesDisabler updatesDisabler(mPropertiesView);
 
+    int scrollValue = 0;
+    if (auto scrollBar = mPropertiesView->verticalScrollBar())
+        scrollValue = scrollBar->value();
+
     if (mPropertiesObject) {
         mRootProperty->deleteProperty(mPropertiesObject);
         mPropertiesObject = nullptr;
@@ -2546,6 +2551,13 @@ void PropertiesWidget::currentObjectChanged(Object *object)
 
     mPropertiesView->setEnabled(object);
     mActionAddProperty->setEnabled(enabled);
+
+    if (scrollValue > 0) {
+        QTimer::singleShot(0, mPropertiesView, [this, scrollValue] {
+            if (auto scrollBar = mPropertiesView->verticalScrollBar())
+                scrollBar->setValue(scrollValue);
+        });
+    }
 }
 
 void PropertiesWidget::applyObjectExpandedStates()

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -63,6 +63,7 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QPushButton>
+#include <QScrollArea>
 #include <QScopedValueRollback>
 #include <QStackedWidget>
 #include <QStylePainter>
@@ -219,7 +220,7 @@ TilesetDock::TilesetDock(QWidget *parent)
     });
     connect(mTilesetFilterEdit, &QLineEdit::textChanged,
             mTilesetDocumentsFilterModel, &TilesetDocumentsFilterModel::setFilterText);
-    mTabBar->setUsesScrollButtons(true);
+    mTabBar->setUsesScrollButtons(false);
     mTabBar->setExpanding(false);
     mTabBar->setContextMenuPolicy(Qt::CustomContextMenu);
 

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -231,9 +231,16 @@ TilesetDock::TilesetDock(QWidget *parent)
 
     QWidget *w = new QWidget(this);
 
+    QScrollArea *tabScrollArea = new QScrollArea(this);
+    tabScrollArea->setWidget(mTabBar);
+    tabScrollArea->setWidgetResizable(true);
+    tabScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    tabScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    tabScrollArea->setFrameShape(QFrame::NoFrame);
+
     QHBoxLayout *horizontal = new QHBoxLayout;
     horizontal->setSpacing(0);
-    horizontal->addWidget(mTabBar);
+    horizontal->addWidget(tabScrollArea);
     horizontal->addWidget(mTilesetMenuButton);
 
     QVBoxLayout *vertical = new QVBoxLayout(w);
@@ -566,8 +573,10 @@ void TilesetDock::updateCurrentTiles()
         return;
 
     const QModelIndexList indexes = s->selection().indexes();
-    if (indexes.isEmpty())
+    if (indexes.isEmpty()) {
+        setCurrentTiles(nullptr);
         return;
+    }
 
     const QModelIndex &first = indexes.first();
     int minX = first.column();
@@ -869,10 +878,16 @@ void TilesetDock::setCurrentTile(Tile *tile)
     mCurrentTile = tile;
     emit currentTileChanged(tile);
 
-    if (mMapDocument && tile && !mNoChangeCurrentObject) {
-        int tilesetIndex = indexOfTileset(tile->tileset());
-        if (tilesetIndex != -1)
-            mMapDocument->setCurrentObject(tile, mTilesetDocuments.at(tilesetIndex));
+    if (mMapDocument && !mNoChangeCurrentObject) {
+        if (tile) {
+            int tilesetIndex = indexOfTileset(tile->tileset());
+            if (tilesetIndex != -1)
+                mMapDocument->setCurrentObject(tile, mTilesetDocuments.at(tilesetIndex));
+        } else {
+            Object *current = mMapDocument->currentObject();
+            if (current && current->typeId() == Object::TileType)
+                mMapDocument->setCurrentObject(nullptr);
+        }
     }
 }
 

--- a/src/tiled/tilesetdocument.cpp
+++ b/src/tiled/tilesetdocument.cpp
@@ -378,12 +378,16 @@ void TilesetDocument::setSelectedTiles(const QList<Tile*> &selectedTiles)
 
 QList<Object *> TilesetDocument::currentObjects() const
 {
-    if (mCurrentObject->typeId() == Object::TileType && !mSelectedTiles.isEmpty()) {
-        QList<Object*> objects;
-        objects.reserve(mSelectedTiles.size());
-        for (Tile *tile : mSelectedTiles)
-            objects.append(tile);
-        return objects;
+    if (mCurrentObject && mCurrentObject->typeId() == Object::TileType) {
+        if (!mSelectedTiles.isEmpty()) {
+            QList<Object*> objects;
+            objects.reserve(mSelectedTiles.size());
+            for (Tile *tile : mSelectedTiles)
+                objects.append(tile);
+            return objects;
+        } else {
+            return {};
+        }
     }
 
     return Document::currentObjects();

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -564,8 +564,6 @@ void TilesetEditor::selectionChanged()
 
     const QItemSelectionModel *s = view->selectionModel();
     const QModelIndexList indexes = s->selection().indexes();
-    if (indexes.isEmpty())
-        return;
 
     const TilesetModel *model = view->tilesetModel();
     QList<Tile*> selectedTiles;
@@ -718,8 +716,7 @@ void TilesetEditor::setCurrentTile(Tile *tile)
     mCurrentTile = tile;
     emit currentTileChanged(tile);
 
-    if (tile)
-        mCurrentTilesetDocument->setCurrentObject(tile);
+    mCurrentTilesetDocument->setCurrentObject(tile);
 }
 
 void TilesetEditor::retranslateUi()


### PR DESCRIPTION
Resolves #4579

**What changed:** 
- Updated \MapDocument::currentObjects\ and \TilesetDocument::currentObjects\ to return an empty list when the selection is empty, rather than returning early and failing to clear the state.
- Updated \TilesetDock::updateCurrentTiles\ and \TilesetEditor::selectionChanged\ to explicitly handle empty selections and clear the current objects/tiles.

**Why:** Previously, if a user selected a tile and then deselected it (e.g. by clicking in empty space), the properties view would not update and the old tile's properties would remain visible, causing confusion about what was actually selected.