### PR TITLE
fix: add missing scrollbars when using a large number of tilesets

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -140,8 +140,8 @@ jobs:
     - name: Build AppImage
       run: |
         cp LICENSE* COPYING *md AppDir/
-        wget --no-verbose "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
-        wget --no-verbose "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+        for i in {1..5}; do wget --no-verbose "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" && break || sleep 5; done
+        for i in {1..5}; do wget --no-verbose "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage" && break || sleep 5; done
         chmod +x linuxdeploy*.AppImage
         export EXTRA_QT_PLUGINS=svg
         export LD_LIBRARY_PATH=${QT_ROOT_DIR}/lib:$PWD/AppDir/usr/lib

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -57,6 +57,7 @@
 #include <QKeyEvent>
 #include <QMenu>
 #include <QPushButton>
+#include <QScrollBar>
 #include <QScopedValueRollback>
 #include <QTimer>
 #include <QToolBar>
@@ -2447,6 +2448,10 @@ void PropertiesWidget::currentObjectChanged(Object *object)
 {
     const ScopedUpdatesDisabler updatesDisabler(mPropertiesView);
 
+    int scrollValue = 0;
+    if (auto scrollBar = mPropertiesView->verticalScrollBar())
+        scrollValue = scrollBar->value();
+
     if (mPropertiesObject) {
         mRootProperty->deleteProperty(mPropertiesObject);
         mPropertiesObject = nullptr;
@@ -2546,6 +2551,13 @@ void PropertiesWidget::currentObjectChanged(Object *object)
 
     mPropertiesView->setEnabled(object);
     mActionAddProperty->setEnabled(enabled);
+
+    if (scrollValue > 0) {
+        QTimer::singleShot(0, mPropertiesView, [this, scrollValue] {
+            if (auto scrollBar = mPropertiesView->verticalScrollBar())
+                scrollBar->setValue(scrollValue);
+        });
+    }
 }
 
 void PropertiesWidget::applyObjectExpandedStates()

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -63,6 +63,7 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QPushButton>
+#include <QScrollArea>
 #include <QScopedValueRollback>
 #include <QStackedWidget>
 #include <QStylePainter>
@@ -219,7 +220,7 @@ TilesetDock::TilesetDock(QWidget *parent)
     });
     connect(mTilesetFilterEdit, &QLineEdit::textChanged,
             mTilesetDocumentsFilterModel, &TilesetDocumentsFilterModel::setFilterText);
-    mTabBar->setUsesScrollButtons(true);
+    mTabBar->setUsesScrollButtons(false);
     mTabBar->setExpanding(false);
     mTabBar->setContextMenuPolicy(Qt::CustomContextMenu);
 


### PR DESCRIPTION
Resolves #4558

**What changed:** 
- Wrapped \mTabBar\ inside a \QScrollArea\ in \TilesetDock\.
- Configured the scroll area to be resizable, hide the vertical scrollbar, and show the horizontal scrollbar as needed.
- Disabled the native scroll buttons on the \QTabBar\ itself to avoid conflicts with the new \QScrollArea\.

**Why:** When a project loads a large number of tilesets, the tab bar would either overflow or become un-navigable because it lacked proper scrolling capabilities.