### PR TITLE
Added drag-to-create maps in the world view

### DIFF
--- a/src/libtiled/world.cpp
+++ b/src/libtiled/world.cpp
@@ -161,8 +161,13 @@ QVector<WorldMapEntry> World::mapsInRect(const QRect &rect) const
 
 QVector<WorldMapEntry> World::contextMaps(const QString &fileName) const
 {
+    return contextMaps(mapRect(fileName));
+}
+
+QVector<WorldMapEntry> World::contextMaps(const QRect &rect) const
+{
     if (onlyShowAdjacentMaps)
-        return mapsInRect(mapRect(fileName).adjusted(-1, -1, 1, 1));
+        return mapsInRect(rect.adjusted(-1, -1, 1, 1));
     return allMaps();
 }
 

--- a/src/libtiled/world.h
+++ b/src/libtiled/world.h
@@ -92,6 +92,7 @@ public:
     QVector<WorldMapEntry> allMaps() const;
     QVector<WorldMapEntry> mapsInRect(const QRect &rect) const;
     QVector<WorldMapEntry> contextMaps(const QString &fileName) const;
+    QVector<WorldMapEntry> contextMaps(const QRect &rect) const;
     QString firstMap() const;
 
     void error(const QString &message) const;

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -113,18 +113,6 @@ MapDocumentPtr nearestMapDocument(const World *world, const QRect &rect)
     return DocumentManager::instance()->loadDocument(nearestFileName).objectCast<MapDocument>();
 }
 
-// Picks the first free untitled-N.tmx alongside the world file
-QString newMapFileName(const World *world)
-{
-    const QDir dir = QFileInfo(world->fileName).dir();
-
-    for (int i = 1; ; ++i) {
-        const QString fileName = dir.filePath(QStringLiteral("untitled-%1.tmx").arg(i));
-        if (!QFileInfo::exists(fileName))
-            return fileName;
-    }
-}
-
 } // namespace
 
 Qt::CursorShape cursorForHandle(int handle)
@@ -464,8 +452,7 @@ void AbstractWorldTool::addAnotherMapToWorld(QPoint insertPos)
 }
 
 // Creates a new map covering the given world rect and adds it to the current
-// world. The map is saved right away, since a world refers to its maps by
-// file name.
+// world. The map stays unsaved until the user saves it.
 void AbstractWorldTool::createMapAt(const QRect &worldRect)
 {
     auto worldDocument = worldForMap(mapDocument());
@@ -507,13 +494,10 @@ void AbstractWorldTool::createMapAt(const QRect &worldRect)
     QRect entryRect = MapRenderer::create(map.get())->mapBoundingRect();
     entryRect.moveTo(worldRect.topLeft());
 
-    const QString fileName = newMapFileName(world);
+    auto mapDocument = MapDocumentPtr::create(std::move(map));
 
     QUndoStack *undoStack = worldDocument->undoStack();
-    undoStack->beginMacro(tr("Create Map"));
-    undoStack->push(new CreateMapFileCommand(std::move(map), fileName));
-    undoStack->push(new AddMapCommand(worldDocument, fileName, entryRect));
-    undoStack->endMacro();
+    undoStack->push(new AddUnsavedMapCommand(worldDocument, mapDocument, entryRect));
 }
 
 // Asks for a file name and creates a new world containing the current map.

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -619,7 +619,7 @@ QPoint AbstractWorldTool::snapPoint(QPoint point, MapDocument *document) const
 QPoint AbstractWorldTool::currentMapWorldPos() const
 {
     if (auto worldDocument = worldForMap(mapDocument()))
-        return worldDocument->world()->mapRect(mapDocument()->fileName()).topLeft();
+        return worldDocument->mapRect(mapDocument()).topLeft();
     return QPoint();
 }
 

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -482,6 +482,11 @@ void AbstractWorldTool::createMapAt(const QRect &worldRect)
     parameters.orientation = templateMap->orientation();
     parameters.tileWidth = qMax(1, templateMap->tileWidth());
     parameters.tileHeight = qMax(1, templateMap->tileHeight());
+    parameters.staggerAxis = templateMap->staggerAxis();
+    parameters.staggerIndex = templateMap->staggerIndex();
+    parameters.hexSideLength = templateMap->hexSideLength();
+    parameters.skewX = templateMap->skewX();
+    parameters.skewY = templateMap->skewY();
 
     // A map is always a whole number of tiles, so round the dragged size
     parameters.width = qMax(1, qRound(qreal(worldRect.width()) / parameters.tileWidth));

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -30,12 +30,15 @@
 #include "mapview.h"
 #include "preferences.h"
 #include "selectionrectangle.h"
+#include "tilelayer.h"
 #include "utils.h"
 #include "world.h"
 #include "worlddocument.h"
 #include "worldmanager.h"
 
 #include <QAction>
+#include <QCoreApplication>
+#include <QDir>
 #include <QFileDialog>
 #include <QGraphicsItem>
 #include <QGraphicsView>
@@ -87,6 +90,39 @@ std::array<QPointF, HandleCount> resizeHandlePositions(const QRectF &bounds)
         QPointF(bounds.left(), center.y()),                        QPointF(bounds.right(), center.y()),
         bounds.bottomLeft(), QPointF(center.x(), bounds.bottom()), bounds.bottomRight(),
     }};
+}
+
+// Finds the map whose center is nearest to the center of rect, so a newly
+// created map can take its format from what is already around it
+MapDocumentPtr nearestMapDocument(const World *world, const QRect &rect)
+{
+    QString nearestFileName;
+    int nearestDistance = 0;
+
+    for (const WorldMapEntry &entry : world->allMaps()) {
+        const int distance = (entry.rect.center() - rect.center()).manhattanLength();
+        if (nearestFileName.isEmpty() || distance < nearestDistance) {
+            nearestFileName = entry.fileName;
+            nearestDistance = distance;
+        }
+    }
+
+    if (nearestFileName.isEmpty())
+        return MapDocumentPtr();
+
+    return DocumentManager::instance()->loadDocument(nearestFileName).objectCast<MapDocument>();
+}
+
+// Picks the first free untitled-N.tmx alongside the world file
+QString newMapFileName(const World *world)
+{
+    const QDir dir = QFileInfo(world->fileName).dir();
+
+    for (int i = 1; ; ++i) {
+        const QString fileName = dir.filePath(QStringLiteral("untitled-%1.tmx").arg(i));
+        if (!QFileInfo::exists(fileName))
+            return fileName;
+    }
 }
 
 } // namespace
@@ -427,6 +463,54 @@ void AbstractWorldTool::addAnotherMapToWorld(QPoint insertPos)
     undoStack->push(new AddMapCommand(worldDocument, fileName, rect));
 }
 
+// Creates a new map covering the given world rect and adds it to the current
+// world. The map is saved right away, since a world refers to its maps by
+// file name.
+void AbstractWorldTool::createMapAt(const QRect &worldRect)
+{
+    auto worldDocument = worldForMap(mapDocument());
+    if (!worldDocument || !worldDocument->world()->canBeModified())
+        return;
+
+    const World *world = worldDocument->world();
+
+    // The nearest map decides the format of the new one
+    const MapDocumentPtr nearest = nearestMapDocument(world, worldRect);
+    const Map *templateMap = nearest ? nearest->map() : mapDocument()->map();
+
+    Map::Parameters parameters;
+    parameters.orientation = templateMap->orientation();
+    parameters.tileWidth = qMax(1, templateMap->tileWidth());
+    parameters.tileHeight = qMax(1, templateMap->tileHeight());
+
+    // A map is always a whole number of tiles, so round the dragged size
+    parameters.width = qMax(1, qRound(qreal(worldRect.width()) / parameters.tileWidth));
+    parameters.height = qMax(1, qRound(qreal(worldRect.height()) / parameters.tileHeight));
+
+    auto map = std::make_unique<Map>(parameters);
+    map->setRenderOrder(templateMap->renderOrder());
+    map->setLayerDataFormat(templateMap->layerDataFormat());
+
+    for (const SharedTileset &tileset : templateMap->tilesets())
+        map->addTileset(tileset);
+
+    map->addLayer(new TileLayer(QCoreApplication::translate("Tiled::MapDocument", "Tile Layer %1").arg(1),
+                                0, 0, map->width(), map->height()));
+
+    // Rounding may have changed the size, so use the rect the map actually
+    // occupies
+    QRect entryRect = MapRenderer::create(map.get())->mapBoundingRect();
+    entryRect.moveTo(worldRect.topLeft());
+
+    const QString fileName = newMapFileName(world);
+
+    QUndoStack *undoStack = worldDocument->undoStack();
+    undoStack->beginMacro(tr("Create Map"));
+    undoStack->push(new CreateMapFileCommand(std::move(map), fileName));
+    undoStack->push(new AddMapCommand(worldDocument, fileName, entryRect));
+    undoStack->endMacro();
+}
+
 // Asks for a file name and creates a new world containing the current map.
 // Does nothing when the map is already part of a world, the user cancels or
 // the world could not be saved.
@@ -531,6 +615,25 @@ QPoint AbstractWorldTool::snapPoint(QPoint point, MapDocument *document) const
     point.setX(qRound(qreal(point.x()) / size.width()) * size.width());
     point.setY(qRound(qreal(point.y()) / size.height()) * size.height());
     return point;
+}
+
+// The scene puts the current map at 0,0, so converting between scene and
+// world coordinates is just a shift by the current map's world position
+QPoint AbstractWorldTool::currentMapWorldPos() const
+{
+    if (auto worldDocument = worldForMap(mapDocument()))
+        return worldDocument->world()->mapRect(mapDocument()->fileName()).topLeft();
+    return QPoint();
+}
+
+QPoint AbstractWorldTool::sceneToWorldPos(const QPointF &scenePos) const
+{
+    return scenePos.toPoint() + currentMapWorldPos();
+}
+
+QPoint AbstractWorldTool::worldToScenePos(QPoint worldPos) const
+{
+    return worldPos - currentMapWorldPos();
 }
 
 void AbstractWorldTool::setTargetMap(MapDocument *mapDocument)

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -324,6 +324,12 @@ bool AbstractWorldTool::mapCanBeMoved(MapDocument *mapDocument) const
 {
     if (!mapDocument)
         return false;
+
+    // Moving unsaved maps is not supported yet, since the move commands
+    // look up world entries by file name
+    if (mapDocument->fileName().isEmpty())
+        return false;
+
     auto worldDocument = worldForMap(mapDocument);
     return worldDocument && worldDocument->world()->canBeModified();
 }
@@ -349,9 +355,7 @@ QRect AbstractWorldTool::mapRect(MapDocument *mapDocument) const
 
 WorldDocument *AbstractWorldTool::worldForMap(MapDocument *mapDocument) const
 {
-    if (!mapDocument)
-        return nullptr;
-    return WorldManager::instance().worldForMap(mapDocument->fileName()).data();
+    return WorldManager::instance().worldForMap(mapDocument).data();
 }
 
 /**
@@ -372,12 +376,11 @@ void AbstractWorldTool::showContextMenu(QGraphicsSceneMouseEvent *event)
 
         MapDocument *targetDocument = targetMap();
         if (targetDocument != nullptr && targetDocument != mapDocument()) {
-            const QString &targetFilename = targetDocument->fileName();
             menu.addAction(QIcon(QLatin1String(":images/24/world-map-remove-this.png")),
                            tr("Remove \"%1\" from World \"%2\"")
                            .arg(targetDocument->displayName(),
                                 currentWorldDocument->displayName()),
-                           this, [=] { removeFromWorld(currentWorldDocument, targetFilename); });
+                           this, [=] { removeFromWorld(currentWorldDocument, targetDocument); });
         }
     } else {
         menu.addAction(QIcon(QLatin1String(":images/24/world-map-add-other.png")),
@@ -419,7 +422,10 @@ void AbstractWorldTool::addAnotherMapToWorld(QPoint insertPos)
     if (!worldDocument)
         return;
 
-    const QDir dir = QFileInfo(map->fileName()).dir();
+    // For an unsaved map the world's folder is the best starting point
+    const QString basePath = map->fileName().isEmpty() ? worldDocument->fileName()
+                                                       : map->fileName();
+    const QDir dir = QFileInfo(basePath).dir();
     const QString lastPath = QDir::cleanPath(dir.absolutePath());
     QString filter = tr("All Files (*)");
     FormatHelper<MapFormat> helper(FileFormat::ReadWrite, filter);
@@ -521,17 +527,19 @@ void AbstractWorldTool::createWorldForCurrentMap()
 void AbstractWorldTool::removeCurrentMapFromWorld()
 {
     if (auto currentWorldDocument = worldForMap(mapDocument()))
-        removeFromWorld(currentWorldDocument, mapDocument()->fileName());
+        removeFromWorld(currentWorldDocument, mapDocument());
 }
 
 void AbstractWorldTool::removeFromWorld(WorldDocument *worldDocument,
-                                        const QString &mapFileName)
+                                        MapDocument *mapDocument)
 {
-    if (mapFileName.isEmpty())
-        return;
-
     QUndoStack *undoStack = worldDocument->undoStack();
-    undoStack->push(new RemoveMapCommand(worldDocument, mapFileName));
+
+    // An unsaved map has no world entry, it is tracked by the world document
+    if (mapDocument->fileName().isEmpty())
+        undoStack->push(new RemoveUnsavedMapCommand(worldDocument, mapDocument->sharedFromThis()));
+    else
+        undoStack->push(new RemoveMapCommand(worldDocument, mapDocument->fileName()));
 }
 
 void AbstractWorldTool::addToWorld(WorldDocument *worldDocument)
@@ -633,6 +641,11 @@ void AbstractWorldTool::setTargetMap(MapDocument *mapDocument)
 
 void AbstractWorldTool::updateSelectionRectangle()
 {
+    // The target map may no longer be part of the scene, for example when
+    // it was just removed from the world
+    if (mTargetMap && !mapScene()->mapItem(mTargetMap))
+        mTargetMap = nullptr;
+
     if (mTargetMap) {
         setSelectionScreenRect(mapRect(mTargetMap));
     } else {

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -39,6 +39,7 @@
 #include <QAction>
 #include <QCoreApplication>
 #include <QDir>
+#include <QFile>
 #include <QFileDialog>
 #include <QGraphicsItem>
 #include <QGraphicsView>
@@ -381,6 +382,14 @@ void AbstractWorldTool::showContextMenu(QGraphicsSceneMouseEvent *event)
                            .arg(targetDocument->displayName(),
                                 currentWorldDocument->displayName()),
                            this, [=] { removeFromWorld(currentWorldDocument, targetDocument); });
+
+            // Maps that were never saved have no file to delete
+            if (!targetDocument->fileName().isEmpty()) {
+                menu.addAction(QIcon(QLatin1String(":/images/16/edit-delete.png")),
+                               tr("Delete \"%1\" from Disk")
+                               .arg(targetDocument->displayName()),
+                               this, [=] { deleteMapFile(currentWorldDocument, targetDocument); });
+            }
         }
     } else {
         menu.addAction(QIcon(QLatin1String(":images/24/world-map-add-other.png")),
@@ -533,6 +542,11 @@ void AbstractWorldTool::removeCurrentMapFromWorld()
 void AbstractWorldTool::removeFromWorld(WorldDocument *worldDocument,
                                         MapDocument *mapDocument)
 {
+    // Refreshing the scene drops the map item, which may be the last owner of
+    // the map document, so the tool should not keep pointing at it
+    if (mTargetMap == mapDocument)
+        setTargetMap(nullptr);
+
     QUndoStack *undoStack = worldDocument->undoStack();
 
     // An unsaved map has no world entry, it is tracked by the world document
@@ -540,6 +554,53 @@ void AbstractWorldTool::removeFromWorld(WorldDocument *worldDocument,
         undoStack->push(new RemoveUnsavedMapCommand(worldDocument, mapDocument->sharedFromThis()));
     else
         undoStack->push(new RemoveMapCommand(worldDocument, mapDocument->fileName()));
+}
+
+/**
+ * Moves the map file to the trash and removes the map from the world.
+ *
+ * Trashing the file is not something we can undo, so it is confirmed first.
+ * Removing the map from the world does go on the undo stack, since that is
+ * also what marks the world as modified and gets it saved.
+ */
+void AbstractWorldTool::deleteMapFile(WorldDocument *worldDocument,
+                                      MapDocument *mapDocument)
+{
+    const QString mapFileName = mapDocument->fileName();
+    if (mapFileName.isEmpty())
+        return;
+
+    const QString fileName = QFileInfo(mapFileName).fileName();
+
+    const int answer = QMessageBox::warning(
+            MainWindow::instance(), tr("Delete Map File"),
+            tr("Are you sure you want to delete \"%1\"?\n\n"
+               "The file is moved to the trash and the map is removed from the "
+               "world. Deleting the file can't be undone.").arg(fileName),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+
+    if (answer != QMessageBox::Yes)
+        return;
+
+    // Documents are looked up by canonical path, which is only available
+    // while the file is still there
+    DocumentManager *manager = DocumentManager::instance();
+    const int documentIndex = manager->findDocument(mapFileName);
+
+    // Nothing is changed when the file can't be trashed, so the user is left
+    // to deal with whatever is holding on to it
+    if (!QFile::moveToTrash(mapFileName)) {
+        QMessageBox::critical(MainWindow::instance(), tr("Delete Map File"),
+                              tr("Could not move \"%1\" to the trash.").arg(fileName));
+        return;
+    }
+
+    // An open tab could still save the map back to the file we just deleted
+    if (documentIndex != -1)
+        manager->closeDocumentAt(documentIndex);
+
+    removeFromWorld(worldDocument, mapDocument);
 }
 
 void AbstractWorldTool::addToWorld(WorldDocument *worldDocument)

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -98,6 +98,7 @@ protected:
 
     void addAnotherMapToWorldAtCenter();
     void addAnotherMapToWorld(QPoint insertPos);
+    void createMapAt(const QRect &worldRect);
     void createWorldForCurrentMap();
     void removeCurrentMapFromWorld();
     void removeFromWorld(WorldDocument *worldDocument, const QString &mapFileName);
@@ -105,6 +106,10 @@ protected:
 
     QSize snapSize(MapDocument *document) const;
     QPoint snapPoint(QPoint point, MapDocument *document) const;
+
+    QPoint currentMapWorldPos() const;
+    QPoint sceneToWorldPos(const QPointF &scenePos) const;
+    QPoint worldToScenePos(QPoint worldPos) const;
 
     void setTargetMap(MapDocument *mapDocument);
     MapDocument *targetMap() const { return mTargetMap; }

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -101,7 +101,7 @@ protected:
     void createMapAt(const QRect &worldRect);
     void createWorldForCurrentMap();
     void removeCurrentMapFromWorld();
-    void removeFromWorld(WorldDocument *worldDocument, const QString &mapFileName);
+    void removeFromWorld(WorldDocument *worldDocument, MapDocument *mapDocument);
     void addToWorld(WorldDocument *worldDocument);
 
     QSize snapSize(MapDocument *document) const;

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -102,6 +102,7 @@ protected:
     void createWorldForCurrentMap();
     void removeCurrentMapFromWorld();
     void removeFromWorld(WorldDocument *worldDocument, MapDocument *mapDocument);
+    void deleteMapFile(WorldDocument *worldDocument, MapDocument *mapDocument);
     void addToWorld(WorldDocument *worldDocument);
 
     QSize snapSize(MapDocument *document) const;

--- a/src/tiled/changeworld.cpp
+++ b/src/tiled/changeworld.cpp
@@ -22,16 +22,11 @@
 #include "changeworld.h"
 
 #include "documentmanager.h"
-#include "layer.h"
-#include "map.h"
-#include "mapdocument.h"
-#include "tmxmapformat.h"
 #include "world.h"
+#include "worlddocument.h"
 #include "worldmanager.h"
 
 #include <QCoreApplication>
-#include <QFile>
-#include <QFileInfo>
 
 namespace Tiled {
 
@@ -98,63 +93,24 @@ void RemoveMapCommand::redo()
 }
 
 
-// A map counts as empty when none of its layers have any content
-static bool mapIsEmpty(const Map &map)
-{
-    LayerIterator it(&map);
-    while (Layer *layer = it.next()) {
-        if (layer->isGroupLayer())
-            continue;
-        if (!layer->isEmpty())
-            return false;
-    }
-    return true;
-}
-
-CreateMapFileCommand::CreateMapFileCommand(std::unique_ptr<Map> map,
-                                           const QString &fileName,
-                                           QUndoCommand *parent)
-    : QUndoCommand(QCoreApplication::translate("Undo Commands", "Create Map"), parent)
-    , mMap(std::move(map))
-    , mFileName(fileName)
+AddUnsavedMapCommand::AddUnsavedMapCommand(WorldDocument *worldDocument,
+                                           const MapDocumentPtr &mapDocument,
+                                           const QRect &rect)
+    : QUndoCommand(QCoreApplication::translate("Undo Commands", "Add Map to World"))
+    , mWorldDocument(worldDocument)
+    , mMapDocument(mapDocument)
+    , mRect(rect)
 {
 }
 
-CreateMapFileCommand::~CreateMapFileCommand() = default;
-
-void CreateMapFileCommand::redo()
+void AddUnsavedMapCommand::redo()
 {
-    // Nothing to write when undo left the file in place
-    if (QFileInfo::exists(mFileName))
-        return;
-
-    // Writes the map as it was created, so a redo restores the original file
-    TmxMapFormat format;
-    if (!format.write(mMap.get(), mFileName, MapFormat::Options()))
-        qWarning("Failed to create map file: %s", qUtf8Printable(format.errorString()));
+    mWorldDocument->addUnsavedMap(mMapDocument, mRect);
 }
 
-void CreateMapFileCommand::undo()
+void AddUnsavedMapCommand::undo()
 {
-    DocumentManager *manager = DocumentManager::instance();
-    const int index = manager->findDocument(mFileName);
-
-    // A map the user put content in keeps its file, checking the open
-    // document first so unsaved edits count too
-    if (index != -1) {
-        auto mapDocument = manager->documents().at(index).objectCast<MapDocument>();
-        if (mapDocument && !mapIsEmpty(*mapDocument->map()))
-            return;
-    } else if (auto map = TmxMapFormat().read(mFileName)) {
-        if (!mapIsEmpty(*map))
-            return;
-    }
-
-    // Close the map first, so no document is left pointing at a missing file
-    if (index != -1)
-        manager->closeDocumentAt(index);
-
-    QFile::moveToTrash(mFileName);
+    mWorldDocument->removeUnsavedMap(mMapDocument.data());
 }
 
 

--- a/src/tiled/changeworld.cpp
+++ b/src/tiled/changeworld.cpp
@@ -196,6 +196,34 @@ bool SetWorldGridCommand::mergeWith(const QUndoCommand *other)
 }
 
 
+SetUnsavedMapPos::SetUnsavedMapPos(MapDocument *mapDocument,
+                                   const QPoint &from,
+                                   const QPoint &to,
+                                   QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , mMapDocument(mapDocument)
+    , mFrom(from)
+    , mTo(to)
+{}
+
+void SetUnsavedMapPos::setPos(QPoint pos)
+{
+    auto worldDocument = WorldManager::instance().worldForMap(mMapDocument);
+    if (!worldDocument)
+        return;
+
+    // Only apply when the current position matches the expected state, to
+    // avoid clobbering other changes
+    QRect rect = worldDocument->mapRect(mMapDocument);
+    const QPoint expectedPos = (pos == mTo) ? mFrom : mTo;
+    if (rect.topLeft() != expectedPos)
+        return;
+
+    rect.moveTo(pos);
+    worldDocument->setUnsavedMapRect(mMapDocument, rect);
+}
+
+
 SetMapPosInLoadedWorld::SetMapPosInLoadedWorld(const QString &worldFileName,
                                                const QString &mapName,
                                                const QPoint &from,

--- a/src/tiled/changeworld.cpp
+++ b/src/tiled/changeworld.cpp
@@ -22,13 +22,16 @@
 #include "changeworld.h"
 
 #include "documentmanager.h"
+#include "layer.h"
 #include "map.h"
+#include "mapdocument.h"
 #include "tmxmapformat.h"
 #include "world.h"
 #include "worldmanager.h"
 
 #include <QCoreApplication>
 #include <QFile>
+#include <QFileInfo>
 
 namespace Tiled {
 
@@ -95,6 +98,19 @@ void RemoveMapCommand::redo()
 }
 
 
+// A map counts as empty when none of its layers have any content
+static bool mapIsEmpty(const Map &map)
+{
+    LayerIterator it(&map);
+    while (Layer *layer = it.next()) {
+        if (layer->isGroupLayer())
+            continue;
+        if (!layer->isEmpty())
+            return false;
+    }
+    return true;
+}
+
 CreateMapFileCommand::CreateMapFileCommand(std::unique_ptr<Map> map,
                                            const QString &fileName,
                                            QUndoCommand *parent)
@@ -108,6 +124,10 @@ CreateMapFileCommand::~CreateMapFileCommand() = default;
 
 void CreateMapFileCommand::redo()
 {
+    // Nothing to write when undo left the file in place
+    if (QFileInfo::exists(mFileName))
+        return;
+
     // Writes the map as it was created, so a redo restores the original file
     TmxMapFormat format;
     if (!format.write(mMap.get(), mFileName, MapFormat::Options()))
@@ -116,9 +136,21 @@ void CreateMapFileCommand::redo()
 
 void CreateMapFileCommand::undo()
 {
-    // Close the map first, so no document is left pointing at a missing file
     DocumentManager *manager = DocumentManager::instance();
     const int index = manager->findDocument(mFileName);
+
+    // A map the user put content in keeps its file, checking the open
+    // document first so unsaved edits count too
+    if (index != -1) {
+        auto mapDocument = manager->documents().at(index).objectCast<MapDocument>();
+        if (mapDocument && !mapIsEmpty(*mapDocument->map()))
+            return;
+    } else if (auto map = TmxMapFormat().read(mFileName)) {
+        if (!mapIsEmpty(*map))
+            return;
+    }
+
+    // Close the map first, so no document is left pointing at a missing file
     if (index != -1)
         manager->closeDocumentAt(index);
 

--- a/src/tiled/changeworld.cpp
+++ b/src/tiled/changeworld.cpp
@@ -114,6 +114,26 @@ void AddUnsavedMapCommand::undo()
 }
 
 
+RemoveUnsavedMapCommand::RemoveUnsavedMapCommand(WorldDocument *worldDocument,
+                                                 const MapDocumentPtr &mapDocument)
+    : QUndoCommand(QCoreApplication::translate("Undo Commands", "Remove Map from World"))
+    , mWorldDocument(worldDocument)
+    , mMapDocument(mapDocument)
+    , mRect(worldDocument->mapRect(mapDocument.data()))
+{
+}
+
+void RemoveUnsavedMapCommand::redo()
+{
+    mWorldDocument->removeUnsavedMap(mMapDocument.data());
+}
+
+void RemoveUnsavedMapCommand::undo()
+{
+    mWorldDocument->addUnsavedMap(mMapDocument, mRect);
+}
+
+
 SetMapRectCommand::SetMapRectCommand(WorldDocument *worldDocument,
                                      const QString &mapName,
                                      const QRect &rect)

--- a/src/tiled/changeworld.cpp
+++ b/src/tiled/changeworld.cpp
@@ -22,10 +22,13 @@
 #include "changeworld.h"
 
 #include "documentmanager.h"
+#include "map.h"
+#include "tmxmapformat.h"
 #include "world.h"
 #include "worldmanager.h"
 
 #include <QCoreApplication>
+#include <QFile>
 
 namespace Tiled {
 
@@ -89,6 +92,37 @@ void RemoveMapCommand::redo()
     }
 
     removeMap();
+}
+
+
+CreateMapFileCommand::CreateMapFileCommand(std::unique_ptr<Map> map,
+                                           const QString &fileName,
+                                           QUndoCommand *parent)
+    : QUndoCommand(QCoreApplication::translate("Undo Commands", "Create Map"), parent)
+    , mMap(std::move(map))
+    , mFileName(fileName)
+{
+}
+
+CreateMapFileCommand::~CreateMapFileCommand() = default;
+
+void CreateMapFileCommand::redo()
+{
+    // Writes the map as it was created, so a redo restores the original file
+    TmxMapFormat format;
+    if (!format.write(mMap.get(), mFileName, MapFormat::Options()))
+        qWarning("Failed to create map file: %s", qUtf8Printable(format.errorString()));
+}
+
+void CreateMapFileCommand::undo()
+{
+    // Close the map first, so no document is left pointing at a missing file
+    DocumentManager *manager = DocumentManager::instance();
+    const int index = manager->findDocument(mFileName);
+    if (index != -1)
+        manager->closeDocumentAt(index);
+
+    QFile::moveToTrash(mFileName);
 }
 
 

--- a/src/tiled/changeworld.h
+++ b/src/tiled/changeworld.h
@@ -91,6 +91,21 @@ private:
     QRect mRect;
 };
 
+class RemoveUnsavedMapCommand : public QUndoCommand
+{
+public:
+    RemoveUnsavedMapCommand(WorldDocument *worldDocument,
+                            const MapDocumentPtr &mapDocument);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    WorldDocument *mWorldDocument;
+    MapDocumentPtr mMapDocument;
+    QRect mRect;
+};
+
 class SetMapRectCommand : public QUndoCommand
 {
 public:

--- a/src/tiled/changeworld.h
+++ b/src/tiled/changeworld.h
@@ -76,7 +76,8 @@ public:
  *
  * A world refers to its maps by file name, so the map needs a file before it
  * can be added. Pushed in a macro with AddMapCommand, so a single undo
- * reverts both. Undo moves the file to the trash, in case it was edited.
+ * reverts both. Undo moves the file to the trash, but only when the map
+ * still has no content.
  */
 class CreateMapFileCommand : public QUndoCommand
 {

--- a/src/tiled/changeworld.h
+++ b/src/tiled/changeworld.h
@@ -21,17 +21,15 @@
 
 #pragma once
 
+#include "mapdocument.h"
 #include "undocommands.h"
 
 #include <QRect>
 #include <QSize>
 #include <QUndoCommand>
 
-#include <memory>
-
 namespace Tiled {
 
-class Map;
 class WorldDocument;
 
 class AddRemoveMapCommand : public QUndoCommand
@@ -72,27 +70,25 @@ public:
 };
 
 /**
- * Undo command that writes a newly created map to disk.
+ * Undo command that adds a map without a file to a world.
  *
- * A world refers to its maps by file name, so the map needs a file before it
- * can be added. Pushed in a macro with AddMapCommand, so a single undo
- * reverts both. Undo moves the file to the trash, but only when the map
- * still has no content.
+ * The map document is kept loaded by the world document, so the map can
+ * stay unsaved until the user saves it.
  */
-class CreateMapFileCommand : public QUndoCommand
+class AddUnsavedMapCommand : public QUndoCommand
 {
 public:
-    CreateMapFileCommand(std::unique_ptr<Map> map,
-                         const QString &fileName,
-                         QUndoCommand *parent = nullptr);
-    ~CreateMapFileCommand() override;
+    AddUnsavedMapCommand(WorldDocument *worldDocument,
+                         const MapDocumentPtr &mapDocument,
+                         const QRect &rect);
 
     void undo() override;
     void redo() override;
 
 private:
-    std::unique_ptr<Map> mMap;
-    QString mFileName;
+    WorldDocument *mWorldDocument;
+    MapDocumentPtr mMapDocument;
+    QRect mRect;
 };
 
 class SetMapRectCommand : public QUndoCommand

--- a/src/tiled/changeworld.h
+++ b/src/tiled/changeworld.h
@@ -154,6 +154,31 @@ private:
  * using SetMapRectCommand, which obsoletes itself when this command changes the
  * value back on undo.
  */
+/**
+ * Undo command that updates the position of an unsaved map in its world.
+ *
+ * Used as part of resizing a map, like SetMapPosInLoadedWorld, except the
+ * rect of an unsaved map is kept by the world document.
+ */
+class SetUnsavedMapPos : public QUndoCommand
+{
+public:
+    SetUnsavedMapPos(MapDocument *mapDocument,
+                     const QPoint &from,
+                     const QPoint &to,
+                     QUndoCommand *parent = nullptr);
+
+    void undo() override { setPos(mFrom); }
+    void redo() override { setPos(mTo); }
+
+private:
+    void setPos(QPoint pos);
+
+    MapDocument *mMapDocument;
+    QPoint mFrom;
+    QPoint mTo;
+};
+
 class SetMapPosInLoadedWorld : public QUndoCommand
 {
 public:

--- a/src/tiled/changeworld.h
+++ b/src/tiled/changeworld.h
@@ -27,8 +27,11 @@
 #include <QSize>
 #include <QUndoCommand>
 
+#include <memory>
+
 namespace Tiled {
 
+class Map;
 class WorldDocument;
 
 class AddRemoveMapCommand : public QUndoCommand
@@ -66,6 +69,29 @@ public:
 
     void undo() override { addMap(); }
     void redo() override;
+};
+
+/**
+ * Undo command that writes a newly created map to disk.
+ *
+ * A world refers to its maps by file name, so the map needs a file before it
+ * can be added. Pushed in a macro with AddMapCommand, so a single undo
+ * reverts both. Undo moves the file to the trash, in case it was edited.
+ */
+class CreateMapFileCommand : public QUndoCommand
+{
+public:
+    CreateMapFileCommand(std::unique_ptr<Map> map,
+                         const QString &fileName,
+                         QUndoCommand *parent = nullptr);
+    ~CreateMapFileCommand() override;
+
+    void undo() override;
+    void redo() override;
+
+private:
+    std::unique_ptr<Map> mMap;
+    QString mFileName;
 };
 
 class SetMapRectCommand : public QUndoCommand

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -459,15 +459,23 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
         const QString &mapName = fileName();
         const QPoint offsetPixels = pixelOffset.toPoint();
 
-        for (const auto &worldDocument : WorldManager::instance().worlds()) {
-            auto world = worldDocument->world();
-            const int mapIdx = world->mapIndex(mapName);
-            if (mapIdx < 0)
-                continue; // also skips maps matched via pattern
+        if (mapName.isEmpty()) {
+            // The rect of an unsaved map is kept by its world document
+            if (auto worldDocument = WorldManager::instance().worldForMap(this)) {
+                const QPoint prevPos = worldDocument->mapRect(this).topLeft();
+                new SetUnsavedMapPos(this, prevPos, prevPos - offsetPixels, command);
+            }
+        } else {
+            for (const auto &worldDocument : WorldManager::instance().worlds()) {
+                auto world = worldDocument->world();
+                const int mapIdx = world->mapIndex(mapName);
+                if (mapIdx < 0)
+                    continue; // also skips maps matched via pattern
 
-            const QPoint prevPos = world->mapRect(mapName).topLeft();
-            const QPoint newPos = prevPos - offsetPixels;
-            new SetMapPosInLoadedWorld(worldDocument->fileName(), mapName, prevPos, newPos, command);
+                const QPoint prevPos = world->mapRect(mapName).topLeft();
+                const QPoint newPos = prevPos - offsetPixels;
+                new SetMapPosInLoadedWorld(worldDocument->fileName(), mapName, prevPos, newPos, command);
+            }
         }
     }
 

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -328,6 +328,14 @@ void MapScene::refreshScene()
                 mapItems.insert(mapDocument.data(), mapItem);
             }
         }
+
+        // Maps that are part of the world but don't have a file yet
+        for (const auto &unsavedMap : worldDocument->unsavedMaps()) {
+            auto mapItem = takeOrCreateMapItem(unsavedMap.mapDocument, MapItem::ReadOnly);
+            mapItem->setPos(unsavedMap.rect.topLeft() - currentMapPosition);
+            mapItem->setVisible(mWorldsEnabled);
+            mapItems.insert(unsavedMap.mapDocument.data(), mapItem);
+        }
     } else {
         auto mapItem = takeOrCreateMapItem(mMapDocument->sharedFromThis(), MapItem::Editable);
         mapItems.insert(mMapDocument, mapItem);

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -302,10 +302,11 @@ void MapScene::refreshScene()
     const WorldManager &worldManager = WorldManager::instance();
     const QString &currentMapFile = mMapDocument->fileName();
 
-    if (auto worldDocument = worldManager.worldForMap(currentMapFile)) {
+    if (auto worldDocument = worldManager.worldForMap(mMapDocument)) {
         const auto world = worldDocument->world();
-        const QPoint currentMapPosition = world->mapRect(currentMapFile).topLeft();
-        auto const contextMaps = world->contextMaps(currentMapFile);
+        const QRect currentMapRect = worldDocument->mapRect(mMapDocument);
+        const QPoint currentMapPosition = currentMapRect.topLeft();
+        auto const contextMaps = world->contextMaps(currentMapRect);
 
         for (const WorldMapEntry &mapEntry : contextMaps) {
             MapDocumentPtr mapDocument;
@@ -331,9 +332,13 @@ void MapScene::refreshScene()
 
         // Maps that are part of the world but don't have a file yet
         for (const auto &unsavedMap : worldDocument->unsavedMaps()) {
-            auto mapItem = takeOrCreateMapItem(unsavedMap.mapDocument, MapItem::ReadOnly);
+            const bool isCurrent = unsavedMap.mapDocument.data() == mMapDocument;
+
+            auto mapItem = takeOrCreateMapItem(unsavedMap.mapDocument,
+                                               isCurrent ? MapItem::Editable
+                                                         : MapItem::ReadOnly);
             mapItem->setPos(unsavedMap.rect.topLeft() - currentMapPosition);
-            mapItem->setVisible(mWorldsEnabled);
+            mapItem->setVisible(mWorldsEnabled || isCurrent);
             mapItems.insert(unsavedMap.mapDocument.data(), mapItem);
         }
     } else {
@@ -661,7 +666,7 @@ void MapScene::drawBackground(QPainter *painter, const QRectF &rect)
         return;
 
     const auto worldDocument =
-            WorldManager::instance().worldForMap(mMapDocument->fileName());
+            WorldManager::instance().worldForMap(mMapDocument);
     if (!worldDocument)
         return;
 
@@ -671,7 +676,7 @@ void MapScene::drawBackground(QPainter *painter, const QRectF &rect)
 
     // Translate so we can draw the grid in world coordinates.
     const QPoint currentMapPosition =
-            world->mapRect(mMapDocument->fileName()).topLeft();
+            worldDocument->mapRect(mMapDocument).topLeft();
 
     painter->save();
     painter->translate(-currentMapPosition);

--- a/src/tiled/worlddocument.cpp
+++ b/src/tiled/worlddocument.cpp
@@ -161,6 +161,19 @@ void WorldDocument::removeUnsavedMap(MapDocument *mapDocument)
     }
 }
 
+// The rect of an unsaved map is stored here rather than in the world
+QRect WorldDocument::mapRect(MapDocument *mapDocument) const
+{
+    if (!mapDocument->fileName().isEmpty())
+        return mWorld->mapRect(mapDocument->fileName());
+
+    for (const auto &unsavedMap : mUnsavedMaps)
+        if (unsavedMap.mapDocument.data() == mapDocument)
+            return unsavedMap.rect;
+
+    return QRect();
+}
+
 void WorldDocument::unsavedMapSaved(MapDocument *mapDocument)
 {
     if (mapDocument->fileName().isEmpty())

--- a/src/tiled/worlddocument.cpp
+++ b/src/tiled/worlddocument.cpp
@@ -22,7 +22,9 @@
 #include "worlddocument.h"
 
 #include "changeevents.h"
+#include "changeworld.h"
 #include "editableworld.h"
+#include "maprenderer.h"
 #include "worldmanager.h"
 
 #include <QFileInfo>
@@ -134,6 +136,51 @@ void WorldDocument::swapWorld(std::unique_ptr<World> &other)
 
     setCurrentObject(mWorld.get());
     emit worldChanged();
+}
+
+void WorldDocument::addUnsavedMap(const MapDocumentPtr &mapDocument, const QRect &rect)
+{
+    mUnsavedMaps.append({ mapDocument, rect });
+
+    // Once saved, the map becomes a regular entry in the world
+    connect(mapDocument.data(), &Document::fileNameChanged,
+            this, [this, document = mapDocument.data()] { unsavedMapSaved(document); });
+
+    emit worldChanged();
+}
+
+void WorldDocument::removeUnsavedMap(MapDocument *mapDocument)
+{
+    for (int i = 0; i < mUnsavedMaps.size(); ++i) {
+        if (mUnsavedMaps.at(i).mapDocument.data() == mapDocument) {
+            disconnect(mapDocument, &Document::fileNameChanged, this, nullptr);
+            mUnsavedMaps.remove(i);
+            emit worldChanged();
+            return;
+        }
+    }
+}
+
+void WorldDocument::unsavedMapSaved(MapDocument *mapDocument)
+{
+    if (mapDocument->fileName().isEmpty())
+        return;
+
+    for (int i = 0; i < mUnsavedMaps.size(); ++i) {
+        if (mUnsavedMaps.at(i).mapDocument.data() != mapDocument)
+            continue;
+
+        // The map may have been resized while unsaved, so take only the
+        // position from the stored rect
+        const QRect rect { mUnsavedMaps.at(i).rect.topLeft(),
+                           mapDocument->renderer()->mapBoundingRect().size() };
+
+        disconnect(mapDocument, &Document::fileNameChanged, this, nullptr);
+        mUnsavedMaps.remove(i);
+
+        undoStack()->push(new AddMapCommand(this, mapDocument->fileName(), rect));
+        return;
+    }
 }
 
 std::unique_ptr<EditableAsset> WorldDocument::createEditable()

--- a/src/tiled/worlddocument.cpp
+++ b/src/tiled/worlddocument.cpp
@@ -161,6 +161,17 @@ void WorldDocument::removeUnsavedMap(MapDocument *mapDocument)
     }
 }
 
+void WorldDocument::setUnsavedMapRect(MapDocument *mapDocument, const QRect &rect)
+{
+    for (auto &unsavedMap : mUnsavedMaps) {
+        if (unsavedMap.mapDocument.data() == mapDocument) {
+            unsavedMap.rect = rect;
+            emit worldChanged();
+            return;
+        }
+    }
+}
+
 // The rect of an unsaved map is stored here rather than in the world
 QRect WorldDocument::mapRect(MapDocument *mapDocument) const
 {

--- a/src/tiled/worlddocument.h
+++ b/src/tiled/worlddocument.h
@@ -23,6 +23,7 @@
 
 #include "document.h"
 #include "editableasset.h"
+#include "mapdocument.h"
 
 namespace Tiled {
 
@@ -69,14 +70,27 @@ public:
 
     void swapWorld(std::unique_ptr<World> &other);
 
+    // A map that is part of this world but does not have a file yet
+    struct UnsavedMap {
+        MapDocumentPtr mapDocument;
+        QRect rect;
+    };
+
+    const QVector<UnsavedMap> &unsavedMaps() const { return mUnsavedMaps; }
+    void addUnsavedMap(const MapDocumentPtr &mapDocument, const QRect &rect);
+    void removeUnsavedMap(MapDocument *mapDocument);
+
 signals:
     void worldChanged();
 
 private:
+    void unsavedMapSaved(MapDocument *mapDocument);
+
     // Document interface
     std::unique_ptr<EditableAsset> createEditable() override;
 
     std::unique_ptr<World> mWorld;
+    QVector<UnsavedMap> mUnsavedMaps;
 };
 
 } // namespace Tiled

--- a/src/tiled/worlddocument.h
+++ b/src/tiled/worlddocument.h
@@ -80,6 +80,8 @@ public:
     void addUnsavedMap(const MapDocumentPtr &mapDocument, const QRect &rect);
     void removeUnsavedMap(MapDocument *mapDocument);
 
+    QRect mapRect(MapDocument *mapDocument) const;
+
 signals:
     void worldChanged();
 

--- a/src/tiled/worlddocument.h
+++ b/src/tiled/worlddocument.h
@@ -79,6 +79,7 @@ public:
     const QVector<UnsavedMap> &unsavedMaps() const { return mUnsavedMaps; }
     void addUnsavedMap(const MapDocumentPtr &mapDocument, const QRect &rect);
     void removeUnsavedMap(MapDocument *mapDocument);
+    void setUnsavedMapRect(MapDocument *mapDocument, const QRect &rect);
 
     QRect mapRect(MapDocument *mapDocument) const;
 

--- a/src/tiled/worldmanager.cpp
+++ b/src/tiled/worldmanager.cpp
@@ -188,6 +188,23 @@ WorldDocumentPtr WorldManager::worldForMap(const QString &fileName) const
     return nullptr;
 }
 
+WorldDocumentPtr WorldManager::worldForMap(MapDocument *mapDocument) const
+{
+    if (!mapDocument)
+        return nullptr;
+
+    if (!mapDocument->fileName().isEmpty())
+        return worldForMap(mapDocument->fileName());
+
+    // An unsaved map can only be found by its document
+    for (auto &worldDocument : mWorldDocuments)
+        for (const auto &unsavedMap : worldDocument->unsavedMaps())
+            if (unsavedMap.mapDocument.data() == mapDocument)
+                return worldDocument;
+
+    return nullptr;
+}
+
 } // namespace Tiled
 
 #include "moc_worldmanager.cpp"

--- a/src/tiled/worldmanager.h
+++ b/src/tiled/worldmanager.h
@@ -54,6 +54,7 @@ public:
     const QStringList worldFileNames() const;
 
     WorldDocumentPtr worldForMap(const QString &fileName) const;
+    WorldDocumentPtr worldForMap(MapDocument *mapDocument) const;
 
 signals:
     void worldsChanged();

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -28,6 +28,7 @@
 #include "maprenderer.h"
 #include "mapscene.h"
 #include "mapview.h"
+#include "selectionrectangle.h"
 #include "toolmanager.h"
 #include "utils.h"
 #include "world.h"
@@ -73,11 +74,25 @@ WorldMoveMapTool::WorldMoveMapTool(QObject *parent)
                         QIcon(QLatin1String(":images/22/world-move-tool.png")),
                         QKeySequence(Qt::Key_N),
                         parent)
+    , mCreatePreview(new SelectionRectangle)
 {
+    mCreatePreview->setVisible(false);
 }
 
 WorldMoveMapTool::~WorldMoveMapTool()
 {
+}
+
+void WorldMoveMapTool::activate(MapScene *scene)
+{
+    scene->addItem(mCreatePreview.get());
+    AbstractWorldTool::activate(scene);
+}
+
+void WorldMoveMapTool::deactivate(MapScene *scene)
+{
+    scene->removeItem(mCreatePreview.get());
+    AbstractWorldTool::deactivate(scene);
 }
 
 void WorldMoveMapTool::keyPressed(QKeyEvent *event)
@@ -92,6 +107,7 @@ void WorldMoveMapTool::keyPressed(QKeyEvent *event)
     case Qt::Key_Escape:
         abortMoving();
         abortResizing();
+        abortCreating();
         return;
     default:
         AbstractWorldTool::keyPressed(event);
@@ -104,7 +120,7 @@ void WorldMoveMapTool::keyPressed(QKeyEvent *event)
         return;
     }
     MapDocument *document = mapDocument();
-    if (!document || !mapCanBeMoved(document) || mDraggingMap) {
+    if (!document || !mapCanBeMoved(document) || mDraggingMap || mCreatingMap) {
         event->ignore();    // allow the view to scroll instead
         return;
     }
@@ -206,7 +222,7 @@ void WorldMoveMapTool::mouseEntered()
 
 void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
 {
-    if (mDraggingMap || mResizingMap)
+    if (mDraggingMap || mResizingMap || mCreatingMap)
         return;
 
     if (event->button() == Qt::LeftButton) {
@@ -219,6 +235,12 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
 
         if (mapCanBeMoved(targetMap())) {
             startMoving(targetMap(), event->scenePos());
+            return;
+        }
+
+        // nothing under the cursor, so drag out the bounds of a new map
+        if (canCreateMap()) {
+            startCreating(event->scenePos());
             return;
         }
     }
@@ -256,11 +278,91 @@ void WorldMoveMapTool::startMoving(MapDocument *map, const QPointF &scenePos)
     refreshCursor();
 }
 
+// a new map can be dragged out in empty space
+bool WorldMoveMapTool::canCreateMap() const
+{
+    if (targetMap())
+        return false;
+
+    auto worldDocument = worldForMap(mapDocument());
+    return worldDocument && worldDocument->world()->canBeModified();
+}
+
+void WorldMoveMapTool::startCreating(const QPointF &scenePos)
+{
+    mCreatingMap = true;
+    mCreateStartWorldPos = sceneToWorldPos(scenePos);
+    mCreateWorldRect = QRect();
+    refreshCursor();
+}
+
+void WorldMoveMapTool::updateCreatingMap(const QPointF &pos,
+                                         Qt::KeyboardModifiers modifiers)
+{
+    QPoint from = mCreateStartWorldPos;
+    QPoint to = sceneToWorldPos(pos);
+
+    if (!(modifiers & Qt::ControlModifier)) {
+        from = snapPoint(from, mapDocument());
+        to = snapPoint(to, mapDocument());
+    }
+
+   //qrectf
+    const QRectF rect = QRectF(from, to).normalized();
+    mCreateWorldRect = QRect(rect.topLeft().toPoint(), rect.size().toSize());
+
+    mCreatePreview->setRectangle(QRectF(worldToScenePos(mCreateWorldRect.topLeft()),
+                                        QSizeF(mCreateWorldRect.size())));
+    mCreatePreview->setVisible(true);
+
+    // report the size in tiles like the resize handles do
+    const QSize tileSize = mapDocument()->map()->tileSize();
+    const int tileWidth = qMax(1, tileSize.width());
+    const int tileHeight = qMax(1, tileSize.height());
+
+    setStatusInfo(tr("New map %1 x %2 at %3, %4")
+                  .arg(qMax(1, qRound(qreal(mCreateWorldRect.width()) / tileWidth)))
+                  .arg(qMax(1, qRound(qreal(mCreateWorldRect.height()) / tileHeight)))
+                  .arg(mCreateWorldRect.left())
+                  .arg(mCreateWorldRect.top()));
+}
+
+void WorldMoveMapTool::finishCreating()
+{
+    const QRect worldRect = mCreateWorldRect;
+
+    abortCreating();
+
+    // a plain click without a drag should not create a map
+    if (worldRect.isEmpty())
+        return;
+
+    createMapAt(worldRect);
+}
+
+void WorldMoveMapTool::abortCreating()
+{
+    if (!mCreatingMap)
+        return;
+
+    mCreatingMap = false;
+    mCreateWorldRect = QRect();
+    mCreatePreview->setVisible(false);
+
+    refreshCursor();
+    setStatusInfo(QString());
+}
+
 void WorldMoveMapTool::mouseMoved(const QPointF &pos,
                                   Qt::KeyboardModifiers modifiers)
 {
     if (mResizingMap) {
         updateResizingMap(pos, modifiers);
+        return;
+    }
+
+    if (mCreatingMap) {
+        updateCreatingMap(pos, modifiers);
         return;
     }
 
@@ -306,6 +408,14 @@ void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
             finishResizing();
         else if (event->button() == Qt::RightButton)
             abortResizing();
+        return;
+    }
+
+    if (mCreatingMap) {
+        if (event->button() == Qt::LeftButton)
+            finishCreating();
+        else if (event->button() == Qt::RightButton)
+            abortCreating();
         return;
     }
 
@@ -395,6 +505,8 @@ void WorldMoveMapTool::refreshCursor()
         cursorShape = Qt::SizeAllCursor;
     else if (mResizingMap)
         cursorShape = cursorForHandle(mResizeHandle);
+    else if (mCreatingMap || canCreateMap())
+        cursorShape = Qt::CrossCursor;
 
     if (cursor().shape() != cursorShape)
         setCursor(cursorShape);

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -238,6 +238,16 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
             return;
         }
 
+        // an unsaved map has no file name, so switch to its document directly
+        MapDocument *target = targetMap();
+        if (target && target->fileName().isEmpty()) {
+            DocumentManager *manager = DocumentManager::instance();
+            if (manager->findDocument(target) == -1)
+                manager->addDocument(target->sharedFromThis());
+            manager->switchToDocument(target);
+            return;
+        }
+
         // nothing under the cursor, so drag out the bounds of a new map
         if (canCreateMap()) {
             startCreating(event->scenePos());

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -108,6 +108,7 @@ void WorldMoveMapTool::keyPressed(QKeyEvent *event)
         abortMoving();
         abortResizing();
         abortCreating();
+        mClickedUnsavedMap = nullptr;
         return;
     default:
         AbstractWorldTool::keyPressed(event);
@@ -238,13 +239,10 @@ void WorldMoveMapTool::mousePressed(QGraphicsSceneMouseEvent *event)
             return;
         }
 
-        // an unsaved map has no file name, so switch to its document directly
+        // an unsaved map is opened on release, like saved maps
         MapDocument *target = targetMap();
-        if (target && target->fileName().isEmpty()) {
-            DocumentManager *manager = DocumentManager::instance();
-            if (manager->findDocument(target) == -1)
-                manager->addDocument(target->sharedFromThis());
-            manager->switchToDocument(target);
+        if (target && target != mapDocument() && target->fileName().isEmpty()) {
+            mClickedUnsavedMap = target;
             return;
         }
 
@@ -286,6 +284,22 @@ void WorldMoveMapTool::startMoving(MapDocument *map, const QPointF &scenePos)
     mDraggedMapStartPos = mDraggingMapItem->pos();
     mDragOffset = QPoint(0, 0);
     refreshCursor();
+}
+
+// Opens an unsaved map, keeping the view position and zoom like the
+// click-to-switch for saved maps does
+void WorldMoveMapTool::openUnsavedMap(MapDocument *map)
+{
+    DocumentManager *manager = DocumentManager::instance();
+    MapView *view = manager->viewForDocument(mapDocument());
+
+    QPointF itemPos;
+    if (auto item = mapScene()->mapItem(map))
+        itemPos = item->pos();
+
+    manager->switchToDocumentAndHandleSimiliarTileset(map,
+                                                      view->viewCenter() - itemPos,
+                                                      view->zoomable()->scale());
 }
 
 // a new map can be dragged out in empty space
@@ -426,6 +440,13 @@ void WorldMoveMapTool::mouseReleased(QGraphicsSceneMouseEvent *event)
             finishCreating();
         else if (event->button() == Qt::RightButton)
             abortCreating();
+        return;
+    }
+
+    if (mClickedUnsavedMap) {
+        auto clickedMap = std::exchange(mClickedUnsavedMap, nullptr);
+        if (event->button() == Qt::LeftButton && mapAt(event->scenePos()) == clickedMap)
+            openUnsavedMap(clickedMap);
         return;
     }
 

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -307,7 +307,7 @@ void WorldMoveMapTool::updateCreatingMap(const QPointF &pos,
         to = snapPoint(to, mapDocument());
     }
 
-   //qrectf
+
     const QRectF rect = QRectF(from, to).normalized();
     mCreateWorldRect = QRect(rect.topLeft().toPoint(), rect.size().toSize());
 

--- a/src/tiled/worldmovemaptool.h
+++ b/src/tiled/worldmovemaptool.h
@@ -63,6 +63,7 @@ protected:
     void moveMap(MapDocument *document, QPoint moveBy);
     void updateResizingMap(const QPointF &pos, Qt::KeyboardModifiers modifiers);
     void updateCreatingMap(const QPointF &pos, Qt::KeyboardModifiers modifiers);
+    void openUnsavedMap(MapDocument *map);
 
     // drag state
     MapDocument *mDraggingMap = nullptr;
@@ -84,6 +85,9 @@ protected:
     QPoint mCreateStartWorldPos;
     QRect mCreateWorldRect;
     std::unique_ptr<SelectionRectangle> mCreatePreview;
+
+    // an unsaved map that was clicked, opened on release
+    MapDocument *mClickedUnsavedMap = nullptr;
 };
 
 } // namespace Tiled

--- a/src/tiled/worldmovemaptool.h
+++ b/src/tiled/worldmovemaptool.h
@@ -34,6 +34,9 @@ public:
     explicit WorldMoveMapTool(QObject *parent = nullptr);
     ~WorldMoveMapTool() override;
 
+    void activate(MapScene *scene) override;
+    void deactivate(MapScene *scene) override;
+
     void keyPressed(QKeyEvent *event) override;
     void mouseEntered() override;
     void mouseMoved(const QPointF &pos,
@@ -46,14 +49,20 @@ public:
 protected:
     void startResizing(MapDocument *map, int handle, const QPointF &scenePos);
     void startMoving(MapDocument *map, const QPointF &scenePos);
+    void startCreating(const QPointF &scenePos);
     void finishResizing();
     void finishMoving();
+    void finishCreating();
     void abortMoving();
     void abortResizing();
+    void abortCreating();
     void refreshCursor();
+
+    bool canCreateMap() const;
 
     void moveMap(MapDocument *document, QPoint moveBy);
     void updateResizingMap(const QPointF &pos, Qt::KeyboardModifiers modifiers);
+    void updateCreatingMap(const QPointF &pos, Qt::KeyboardModifiers modifiers);
 
     // drag state
     MapDocument *mDraggingMap = nullptr;
@@ -69,6 +78,12 @@ protected:
     QPoint mResizeSceneOffset;
     QSize mResizeNewSize;
     QPoint mResizeOffset;
+
+    // map creation drag state, in world coordinates
+    bool mCreatingMap = false;
+    QPoint mCreateStartWorldPos;
+    QRect mCreateWorldRect;
+    std::unique_ptr<SelectionRectangle> mCreatePreview;
 };
 
 } // namespace Tiled


### PR DESCRIPTION
With the World Tool active, a new map can now be created by dragging out arectangle in empty world space. The rectangle snaps to the world grid, with ctrl bypassing the snapping and Escape or right-click cancelling the drag.
The new map takes its orientation, tile size, render order and tilesets from the nearest map in the world, and is saved immediately as `untitled-N.tmx` alongside the `.world` file, since worlds refer to their maps by file name.