### PR TITLE
Fix crash when loading Wang tilesets with out-of-range color indices

### DIFF
--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -807,10 +807,15 @@ void MapReaderPrivate::readTilesetWangSets(Tileset &tileset)
                         }
                     }
 
-                    if (!wangSet->wangIdIsValid(wangId) || !ok) {
-                        xml.raiseError(QStringLiteral("Invalid wangId \"%1\" given for tileId %2").arg(wangIdString.toString(),
-                                                                                                       QString::number(tileId)));
-                        return;
+                    if (!ok || !wangSet->wangIdIsValid(wangId)) {
+                        // Skip invalid wang tiles rather than aborting the
+                        // entire wangset load. This can happen when a tileset
+                        // was saved with a newer Tiled version that supported
+                        // more colors (e.g. 255) than the current limit.
+                        qWarning() << "Skipping invalid wangId" << wangIdString.toString()
+                                   << "for tileId" << tileId;
+                        xml.skipCurrentElement();
+                        continue;
                     }
 
                     wangSet->setWangId(tileId, wangId);

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -35,6 +35,7 @@
 #include "wangset.h"
 
 #include <memory>
+#include <QDebug>
 
 namespace Tiled {
 
@@ -535,8 +536,11 @@ std::unique_ptr<WangSet> VariantToMapConverter::toWangSet(const QVariantMap &var
         }
 
         if (!ok || !wangSet->wangIdIsValid(wangId)) {
-            mError = QStringLiteral("Invalid wangId given for tileId: ") + QString::number(tileId);
-            return nullptr;
+            // Skip invalid wang tiles rather than aborting the entire wangset
+            // load. This can happen when a tileset was saved with a newer
+            // Tiled version that supported more colors than the current limit.
+            qWarning() << "Skipping invalid wangId for tileId:" << tileId;
+            continue;
         }
 
         wangSet->setWangId(tileId, wangId);

--- a/src/libtiled/wangset.cpp
+++ b/src/libtiled/wangset.cpp
@@ -332,7 +332,10 @@ WangId WangId::fromString(QStringView string, bool *ok)
             if (ok && !(*ok))
                 return id;
 
-            if (color > WangId::MAX_COLOR_COUNT) {
+            // Accept any value that fits in the 8-bit storage (0–255).
+            // Values above MAX_COLOR_COUNT may be rejected later by
+            // wangIdIsValid() in the context of a specific WangSet.
+            if (color > INDEX_MASK) {
                 if (ok)
                     *ok = false;
                 return id;

--- a/tests/wangtiles/regression-4591.tsx
+++ b/tests/wangtiles/regression-4591.tsx
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.5" tiledversion="1.5.0" name="regression-4591" tilewidth="32" tileheight="32" tilecount="9" columns="3">
+ <image source="wangblob.png" width="96" height="96"/>
+ <wangsets>
+  <wangset name="ManyColors" type="corner" tile="0">
+   <wangcolor name="Color1" color="#ff0000" tile="0" probability="1"/>
+   <wangcolor name="Color2" color="#00ff00" tile="1" probability="1"/>
+   <wangtile tileid="0" wangid="1,1,1,1,1,1,1,1"/>
+   <wangtile tileid="1" wangid="2,2,2,2,2,2,2,2"/>
+   <wangtile tileid="2" wangid="255,255,255,255,255,255,255,255"/>
+   <wangtile tileid="3" wangid="200,200,200,200,200,200,200,200"/>
+  </wangset>
+ </wangsets>
+</tileset>


### PR DESCRIPTION
When a tileset containing a Wang set was saved with a version of Tiled
that supported more colors than the current build's `MAX_COLOR_COUNT`
limit, loading it would raise a fatal error and abort the entire wang
set load — leaving the tileset with no wang data at all.

This fixes the issue by gracefully skipping invalid wang tiles instead
of aborting, so that the rest of the wang set loads correctly.

### Changes

- **`WangId::fromString()`**: Relaxed the parse-time rejection threshold
  from `MAX_COLOR_COUNT` (254) to `INDEX_MASK` (255), so that any value
  fitting in the 8-bit storage parses successfully. Validity against a
  specific wang set's color count is deferred to `wangIdIsValid()`.

- **`mapreader.cpp`** (XML/TMX path): Replaced `xml.raiseError()` +
  early return with `qWarning()` + `skipCurrentElement()` + `continue`.

- **`varianttomapconverter.cpp`** (JSON path): Applied the same
  graceful-skip fix, which previously still had the old fatal behavior.

- **`tests/wangtiles/regression-4591.tsx`**: Added a regression test
  fixture with a wang set containing tiles whose color indices exceed the
  wang set's color count (200, 255), verifying they are skipped without
  aborting the load.

Fixes #4591
