### PR TITLE
CI: Updated Qt 6 builds to Qt 6.11.2

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.11.1
+        version: 6.11.2
         arch: linux_gcc_64
         modules: "qtimageformats qtshadertools"
         tools: 'tools_qtcreator'
@@ -209,7 +209,7 @@ jobs:
           cmake_architectures: x86_64
           runner: macos-15
           deployment_target: "10.14"
-        - qt_version: 6.11.1
+        - qt_version: 6.11.2
           qt_modules: "qtimageformats qtshadertools"
           version_suffix: "13+"
           architectures: x86_64,arm64
@@ -340,7 +340,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - qt_version: 6.11.1
+        - qt_version: 6.11.2
           qt_version_major: 6
           qt_arch: win64_mingw
           qt_modules: "qtimageformats qtshadertools"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,25 +7,25 @@ cache:
   - C:\Users\appveyor\.m2
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
-  - C:\Qt\6.11.1\msvc2022_64 -> appveyor.yml
-  - C:\Qt\6.11.1\mingw_64 -> appveyor.yml
+  - C:\Qt\6.11.2\msvc2022_64 -> appveyor.yml
+  - C:\Qt\6.11.2\mingw_64 -> appveyor.yml
   - C:\Qt\Tools\mingw1310_64 -> appveyor.yml
 
 environment:
   matrix:
-    - QT_VERSION: 6.11.1
+    - QT_VERSION: 6.11.2
       QT_ARCH: win64_msvc2022_64
       QT_MODULES: qtimageformats qtshadertools
-      QTDIR: C:\Qt\6.11.1\msvc2022_64
+      QTDIR: C:\Qt\6.11.2\msvc2022_64
       PYTHONHOME: C:\Python312-x64
       DEFAULT_PROFILE: MSVC2022-x64
       FILE_SUFFIX: Windows-10+_msvc_x86_64
       PUSH_RELEASE: false
       ENABLE_ZSTD: false
-    - QT_VERSION: 6.11.1
+    - QT_VERSION: 6.11.2
       QT_ARCH: win64_mingw
       QT_MODULES: qtimageformats qtshadertools
-      QTDIR: C:\Qt\6.11.1\mingw_64
+      QTDIR: C:\Qt\6.11.2\mingw_64
       PYTHONHOME: C:\Python312-x64
       MINGW: C:\Qt\Tools\mingw1310_64
       MINGW_COMPONENT: tools_mingw1310


### PR DESCRIPTION
Qt 6.11.2 is available on download.qt.io, so all Qt 6 CI builds (Linux AppImage, macOS, Windows on GitHub Actions and AppVeyor) are updated from 6.11.1 to 6.11.2.

The aqtinstall Git pin for the changed Windows repository layout is kept, since there is still no aqtinstall release past 3.3.0.