### PR TITLE
libtiled: Use incremental tileset reference counting in TileLayer

### DIFF
--- a/src/libtiled/tilelayer.cpp
+++ b/src/libtiled/tilelayer.cpp
@@ -131,7 +131,6 @@ TileLayer::TileLayer(const QString &name, int x, int y, int width, int height)
     : Layer(TileLayerType, name, x, y)
     , mWidth(width)
     , mHeight(height)
-    , mUsedTilesetsDirty(false)
 {
 }
 
@@ -193,6 +192,58 @@ QRegion TileLayer::region(std::function<bool (const Cell &)> condition) const
 }
 
 /**
+ * Increments the refcount for the given tileset, inserting it into
+ * mUsedTilesets on first reference.
+ */
+void TileLayer::addTilesetRef(Tileset *tileset)
+{
+    Q_ASSERT(tileset);
+    int &cnt = mTilesetRefCounts[tileset];
+    Q_ASSERT(cnt >= 0);
+    if (cnt == 0)
+        mUsedTilesets.insert(tileset->sharedFromThis());
+    ++cnt;
+}
+
+/**
+ * Decrements the refcount for the given tileset, removing it from
+ * mUsedTilesets when the count reaches zero.
+ */
+void TileLayer::removeTilesetRef(Tileset *tileset)
+{
+    Q_ASSERT(tileset);
+    auto it = mTilesetRefCounts.find(tileset);
+    Q_ASSERT(it != mTilesetRefCounts.end());
+    Q_ASSERT(it.value() > 0);
+    --it.value();
+    if (it.value() == 0) {
+        mTilesetRefCounts.erase(it);
+        mUsedTilesets.remove(tileset->sharedFromThis());
+    }
+}
+
+/**
+ * Rebuilds mUsedTilesets and mTilesetRefCounts from scratch by scanning all
+ * chunks. Called once after bulk mutations that bypass setCell().
+ */
+void TileLayer::rebuildTilesetRefs() const
+{
+    mTilesetRefCounts.clear();
+    mUsedTilesets.clear();
+
+    for (const Chunk &chunk : mChunks) {
+        for (const Cell &cell : chunk) {
+            if (Tileset *ts = cell.tileset()) {
+                int &cnt = mTilesetRefCounts[ts];
+                if (cnt == 0)
+                    mUsedTilesets.insert(ts->sharedFromThis());
+                ++cnt;
+            }
+        }
+    }
+}
+
+/**
  * Sets the cell at the given coordinates.
  */
 void Tiled::TileLayer::setCell(int x, int y, const Cell &cell)
@@ -210,15 +261,14 @@ void Tiled::TileLayer::setCell(int x, int y, const Cell &cell)
 
     Chunk &_chunk = chunk(x, y);
 
-    if (!mUsedTilesetsDirty) {
-        Tileset *oldTileset = _chunk.cellAt(x & CHUNK_MASK, y & CHUNK_MASK).tileset();
-        Tileset *newTileset = cell.tileset();
-        if (oldTileset != newTileset) {
-            if (oldTileset)
-                mUsedTilesetsDirty = true;
-            else if (newTileset)
-                mUsedTilesets.insert(newTileset->sharedFromThis());
-        }
+    Tileset *oldTileset = _chunk.cellAt(x & CHUNK_MASK, y & CHUNK_MASK).tileset();
+    Tileset *newTileset = cell.tileset();
+
+    if (oldTileset != newTileset) {
+        if (newTileset)
+            addTilesetRef(newTileset);
+        if (oldTileset)
+            removeTilesetRef(oldTileset);
     }
 
     _chunk.setCell(x & CHUNK_MASK, y & CHUNK_MASK, cell);
@@ -306,7 +356,7 @@ void TileLayer::clear()
     mChunks.clear();
     mBounds = QRect();
     mUsedTilesets.clear();
-    mUsedTilesetsDirty = false;
+    mTilesetRefCounts.clear();
 }
 
 void TileLayer::flip(FlipDirection direction)
@@ -341,6 +391,8 @@ void TileLayer::flip(FlipDirection direction)
 
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
+    mUsedTilesets = newLayer->mUsedTilesets;
+    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 void TileLayer::flipHexagonal(FlipDirection direction)
@@ -391,6 +443,8 @@ void TileLayer::flipHexagonal(FlipDirection direction)
 
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
+    mUsedTilesets = newLayer->mUsedTilesets;
+    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 void TileLayer::rotate(RotateDirection direction)
@@ -441,6 +495,8 @@ void TileLayer::rotate(RotateDirection direction)
     mHeight = newHeight;
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
+    mUsedTilesets = newLayer->mUsedTilesets;
+    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 void TileLayer::rotateHexagonal(RotateDirection direction, Map *map)
@@ -530,6 +586,8 @@ void TileLayer::rotateHexagonal(RotateDirection direction, Map *map)
     mHeight = newHeight;
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
+    mUsedTilesets = newLayer->mUsedTilesets;
+    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 
     QRect filledRect = region().boundingRect();
 
@@ -547,19 +605,6 @@ void TileLayer::rotateHexagonal(RotateDirection direction, Map *map)
 
 QSet<SharedTileset> TileLayer::usedTilesets() const
 {
-    if (mUsedTilesetsDirty) {
-        QSet<SharedTileset> tilesets;
-
-        for (const Chunk &chunk : mChunks) {
-            for (const Cell &cell : chunk)
-                if (const Tile *tile = cell.tile())
-                    tilesets.insert(tile->sharedTileset());
-        }
-
-        mUsedTilesets.swap(tilesets);
-        mUsedTilesetsDirty = false;
-    }
-
     return mUsedTilesets;
 }
 
@@ -575,7 +620,7 @@ bool TileLayer::hasCell(std::function<bool (const Cell &)> condition) const
 
 bool TileLayer::referencesTileset(const Tileset *tileset) const
 {
-    return ::contains(usedTilesets(), tileset);
+    return ::contains(mUsedTilesets, tileset);
 }
 
 void TileLayer::removeReferencesToTileset(Tileset *tileset)
@@ -583,7 +628,9 @@ void TileLayer::removeReferencesToTileset(Tileset *tileset)
     for (Chunk &chunk : mChunks)
         chunk.removeReferencesToTileset(tileset);
 
-    mUsedTilesets.remove(tileset->sharedFromThis());
+    // Chunk::removeReferencesToTileset bypasses setCell(), so rebuild refs
+    // rather than trying to decrement per cell.
+    rebuildTilesetRefs();
 }
 
 void TileLayer::replaceReferencesToTileset(Tileset *oldTileset,
@@ -592,8 +639,8 @@ void TileLayer::replaceReferencesToTileset(Tileset *oldTileset,
     for (Chunk &chunk : mChunks)
         chunk.replaceReferencesToTileset(oldTileset, newTileset);
 
-    if (mUsedTilesets.remove(oldTileset->sharedFromThis()))
-        mUsedTilesets.insert(newTileset->sharedFromThis());
+    // Chunk::replaceReferencesToTileset bypasses setCell(), so rebuild refs.
+    rebuildTilesetRefs();
 }
 
 void TileLayer::resize(QSize size, QPoint offset)
@@ -612,7 +659,7 @@ void TileLayer::resize(QSize size, QPoint offset)
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
     mUsedTilesets = newLayer->mUsedTilesets;
-    mUsedTilesetsDirty = newLayer->mUsedTilesetsDirty;
+    mTilesetRefCounts = newLayer->mTilesetRefCounts;
     setSize(size);
 }
 
@@ -657,7 +704,7 @@ void TileLayer::offsetTiles(QPoint offset,
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
     mUsedTilesets = newLayer->mUsedTilesets;
-    mUsedTilesetsDirty = newLayer->mUsedTilesetsDirty;
+    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 void TileLayer::offsetTiles(QPoint offset)
@@ -686,6 +733,8 @@ void TileLayer::offsetTiles(QPoint offset)
 
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
+    mUsedTilesets = newLayer->mUsedTilesets;
+    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 bool TileLayer::canMergeWith(const Layer *other) const
@@ -855,7 +904,7 @@ TileLayer *TileLayer::initializeClone(TileLayer *clone) const
     clone->mChunks = mChunks;
     clone->mBounds = mBounds;
     clone->mUsedTilesets = mUsedTilesets;
-    clone->mUsedTilesetsDirty = mUsedTilesetsDirty;
+    clone->mTilesetRefCounts = mTilesetRefCounts;
     return clone;
 }
 

--- a/src/libtiled/tilelayer.cpp
+++ b/src/libtiled/tilelayer.cpp
@@ -192,58 +192,6 @@ QRegion TileLayer::region(std::function<bool (const Cell &)> condition) const
 }
 
 /**
- * Increments the refcount for the given tileset, inserting it into
- * mUsedTilesets on first reference.
- */
-void TileLayer::addTilesetRef(Tileset *tileset)
-{
-    Q_ASSERT(tileset);
-    int &cnt = mTilesetRefCounts[tileset];
-    Q_ASSERT(cnt >= 0);
-    if (cnt == 0)
-        mUsedTilesets.insert(tileset->sharedFromThis());
-    ++cnt;
-}
-
-/**
- * Decrements the refcount for the given tileset, removing it from
- * mUsedTilesets when the count reaches zero.
- */
-void TileLayer::removeTilesetRef(Tileset *tileset)
-{
-    Q_ASSERT(tileset);
-    auto it = mTilesetRefCounts.find(tileset);
-    Q_ASSERT(it != mTilesetRefCounts.end());
-    Q_ASSERT(it.value() > 0);
-    --it.value();
-    if (it.value() == 0) {
-        mTilesetRefCounts.erase(it);
-        mUsedTilesets.remove(tileset->sharedFromThis());
-    }
-}
-
-/**
- * Rebuilds mUsedTilesets and mTilesetRefCounts from scratch by scanning all
- * chunks. Called once after bulk mutations that bypass setCell().
- */
-void TileLayer::rebuildTilesetRefs() const
-{
-    mTilesetRefCounts.clear();
-    mUsedTilesets.clear();
-
-    for (const Chunk &chunk : mChunks) {
-        for (const Cell &cell : chunk) {
-            if (Tileset *ts = cell.tileset()) {
-                int &cnt = mTilesetRefCounts[ts];
-                if (cnt == 0)
-                    mUsedTilesets.insert(ts->sharedFromThis());
-                ++cnt;
-            }
-        }
-    }
-}
-
-/**
  * Sets the cell at the given coordinates.
  */
 void Tiled::TileLayer::setCell(int x, int y, const Cell &cell)
@@ -265,10 +213,19 @@ void Tiled::TileLayer::setCell(int x, int y, const Cell &cell)
     Tileset *newTileset = cell.tileset();
 
     if (oldTileset != newTileset) {
-        if (newTileset)
-            addTilesetRef(newTileset);
-        if (oldTileset)
-            removeTilesetRef(oldTileset);
+        if (newTileset) {
+            SharedTileset sharedNew = newTileset->sharedFromThis();
+            mUsedTilesets[sharedNew]++;
+        }
+        if (oldTileset) {
+            SharedTileset sharedOld = oldTileset->sharedFromThis();
+            auto it = mUsedTilesets.find(sharedOld);
+            Q_ASSERT(it != mUsedTilesets.end());
+            if (it != mUsedTilesets.end()) {
+                if (--it.value() <= 0)
+                    mUsedTilesets.erase(it);
+            }
+        }
     }
 
     _chunk.setCell(x & CHUNK_MASK, y & CHUNK_MASK, cell);
@@ -356,7 +313,6 @@ void TileLayer::clear()
     mChunks.clear();
     mBounds = QRect();
     mUsedTilesets.clear();
-    mTilesetRefCounts.clear();
 }
 
 void TileLayer::flip(FlipDirection direction)
@@ -392,7 +348,6 @@ void TileLayer::flip(FlipDirection direction)
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
     mUsedTilesets = newLayer->mUsedTilesets;
-    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 void TileLayer::flipHexagonal(FlipDirection direction)
@@ -444,7 +399,6 @@ void TileLayer::flipHexagonal(FlipDirection direction)
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
     mUsedTilesets = newLayer->mUsedTilesets;
-    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 void TileLayer::rotate(RotateDirection direction)
@@ -496,7 +450,6 @@ void TileLayer::rotate(RotateDirection direction)
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
     mUsedTilesets = newLayer->mUsedTilesets;
-    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 void TileLayer::rotateHexagonal(RotateDirection direction, Map *map)
@@ -587,7 +540,6 @@ void TileLayer::rotateHexagonal(RotateDirection direction, Map *map)
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
     mUsedTilesets = newLayer->mUsedTilesets;
-    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 
     QRect filledRect = region().boundingRect();
 
@@ -605,7 +557,7 @@ void TileLayer::rotateHexagonal(RotateDirection direction, Map *map)
 
 QSet<SharedTileset> TileLayer::usedTilesets() const
 {
-    return mUsedTilesets;
+    return { mUsedTilesets.keyBegin(), mUsedTilesets.keyEnd() };
 }
 
 bool TileLayer::hasCell(std::function<bool (const Cell &)> condition) const
@@ -620,27 +572,42 @@ bool TileLayer::hasCell(std::function<bool (const Cell &)> condition) const
 
 bool TileLayer::referencesTileset(const Tileset *tileset) const
 {
-    return ::contains(mUsedTilesets, tileset);
+    if (!tileset)
+        return false;
+
+    // sharedFromThis() on a const Tileset yields QSharedPointer<const Tileset>,
+    // but mUsedTilesets stores QSharedPointer<Tileset>. We cast here only to
+    // perform the lookup; no mutation occurs.
+    auto sharedTileset = qSharedPointerConstCast<Tileset>(tileset->sharedFromThis());
+    return mUsedTilesets.contains(sharedTileset);
 }
 
 void TileLayer::removeReferencesToTileset(Tileset *tileset)
 {
+    if (!tileset)
+        return;
+
     for (Chunk &chunk : mChunks)
         chunk.removeReferencesToTileset(tileset);
 
-    // Chunk::removeReferencesToTileset bypasses setCell(), so rebuild refs
-    // rather than trying to decrement per cell.
-    rebuildTilesetRefs();
+    mUsedTilesets.remove(tileset->sharedFromThis());
 }
 
 void TileLayer::replaceReferencesToTileset(Tileset *oldTileset,
                                            Tileset *newTileset)
 {
+    if (!oldTileset || !newTileset || oldTileset == newTileset)
+        return;
+
     for (Chunk &chunk : mChunks)
         chunk.replaceReferencesToTileset(oldTileset, newTileset);
 
-    // Chunk::replaceReferencesToTileset bypasses setCell(), so rebuild refs.
-    rebuildTilesetRefs();
+    auto it = mUsedTilesets.find(oldTileset->sharedFromThis());
+    if (it != mUsedTilesets.end()) {
+        int count = it.value();
+        mUsedTilesets.erase(it);
+        mUsedTilesets[newTileset->sharedFromThis()] += count;
+    }
 }
 
 void TileLayer::resize(QSize size, QPoint offset)
@@ -659,7 +626,6 @@ void TileLayer::resize(QSize size, QPoint offset)
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
     mUsedTilesets = newLayer->mUsedTilesets;
-    mTilesetRefCounts = newLayer->mTilesetRefCounts;
     setSize(size);
 }
 
@@ -704,7 +670,6 @@ void TileLayer::offsetTiles(QPoint offset,
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
     mUsedTilesets = newLayer->mUsedTilesets;
-    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 void TileLayer::offsetTiles(QPoint offset)
@@ -734,7 +699,6 @@ void TileLayer::offsetTiles(QPoint offset)
     mChunks = newLayer->mChunks;
     mBounds = newLayer->mBounds;
     mUsedTilesets = newLayer->mUsedTilesets;
-    mTilesetRefCounts = newLayer->mTilesetRefCounts;
 }
 
 bool TileLayer::canMergeWith(const Layer *other) const
@@ -904,7 +868,6 @@ TileLayer *TileLayer::initializeClone(TileLayer *clone) const
     clone->mChunks = mChunks;
     clone->mBounds = mBounds;
     clone->mUsedTilesets = mUsedTilesets;
-    clone->mTilesetRefCounts = mTilesetRefCounts;
     return clone;
 }
 

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -448,7 +448,7 @@ public:
     void rotateHexagonal(RotateDirection direction, Map *map);
 
     /**
-     * Computes and returns the set of tilesets used by this tile layer.
+     * Returns the set of tilesets used by this tile layer.
      */
     QSet<SharedTileset> usedTilesets() const override;
 
@@ -526,12 +526,16 @@ protected:
     TileLayer *initializeClone(TileLayer *clone) const;
 
 private:
+    void addTilesetRef(Tileset *tileset);
+    void removeTilesetRef(Tileset *tileset);
+    void rebuildTilesetRefs() const;
+
     int mWidth;
     int mHeight;
     QHash<QPoint, Chunk> mChunks;
     QRect mBounds;
+    mutable QHash<Tileset*, int> mTilesetRefCounts;
     mutable QSet<SharedTileset> mUsedTilesets;
-    mutable bool mUsedTilesetsDirty;
 };
 
 inline QPoint TileLayer::iterator::key() const

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -451,6 +451,11 @@ public:
      * Returns the set of tilesets used by this tile layer.
      */
     QSet<SharedTileset> usedTilesets() const override;
+
+    /**
+     * Returns whether this tile layer has any cell for which the given
+     * \a condition returns true.
+     */
     bool hasCell(std::function<bool (const Cell &)> condition) const;
 
     /**
@@ -525,7 +530,7 @@ private:
     int mHeight;
     QHash<QPoint, Chunk> mChunks;
     QRect mBounds;
-    mutable QHash<SharedTileset, int> mUsedTilesets;
+    QHash<SharedTileset, int> mUsedTilesets;
 };
 
 inline QPoint TileLayer::iterator::key() const

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -451,11 +451,6 @@ public:
      * Returns the set of tilesets used by this tile layer.
      */
     QSet<SharedTileset> usedTilesets() const override;
-
-    /**
-     * Returns whether this tile layer has any cell for which the given
-     * \a condition returns true.
-     */
     bool hasCell(std::function<bool (const Cell &)> condition) const;
 
     /**
@@ -526,16 +521,11 @@ protected:
     TileLayer *initializeClone(TileLayer *clone) const;
 
 private:
-    void addTilesetRef(Tileset *tileset);
-    void removeTilesetRef(Tileset *tileset);
-    void rebuildTilesetRefs() const;
-
     int mWidth;
     int mHeight;
     QHash<QPoint, Chunk> mChunks;
     QRect mBounds;
-    mutable QHash<Tileset*, int> mTilesetRefCounts;
-    mutable QSet<SharedTileset> mUsedTilesets;
+    mutable QHash<SharedTileset, int> mUsedTilesets;
 };
 
 inline QPoint TileLayer::iterator::key() const


### PR DESCRIPTION
This takes over the performance fix from #4354 by @rhythmcache, which was closed when its fork was deleted. The two libtiled commits are cherry-picked unchanged from the final revision of that PR (which already addressed the review feedback), leaving out the unrelated stamp brush commits that were also on that branch. A small follow-up commit restores a doc comment that got lost and drops a no longer needed `mutable`.

Replaces the dirty-flag full rescan of `TileLayer::usedTilesets()` with per-tileset reference counting, updated in O(1) in `setCell()`. Previously, replacing a tile with one from a different tileset, or erasing a tile, marked the layer dirty and triggered a full scan of all tiles on the next repaint, which made painting over existing tiles very slow on large maps.

Closes #4185
Replaces #4354
