### PR TITLE
Scripting: Added a script server and --eval command-line option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Persisted collapsed state of the properties groups in the session (#4561)
 * Scripting: Added 'tiled.cell' function, 'cell.flags' property and 'TileLayerEdit.setCell' function (#4538)
 * Scripting: Added MapObject.resolvedClassName() (by MatusGuy, #4529)
+* Scripting: Added a script server and --eval, --eval-file and --script-server options, for running scripts in a running Tiled instance from the command-line
 * Fixed crash when the selection becomes empty while starting a move (#4536)
 * Fixed Properties view update on 'Reset Template Instance' and 'Replace With Template' actions
 * Linux: Added file associations for .tmj, .tsj, .tiled-project and .world files (by miffe, #4550)

--- a/docs/manual/scripting.rst
+++ b/docs/manual/scripting.rst
@@ -135,6 +135,58 @@ If you want to evaluate several scripts, use ``--evaluate`` for each file. Note
 that evaluating the same JavaScript module (``.mjs``) does not work, since
 modules are loaded only once.
 
+.. raw:: html
+
+   <div class="new">New in Tiled 1.13</div>
+
+.. _script-server:
+
+Running Scripts in a Running Instance
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Scripts can also be evaluated in an already running Tiled instance, with
+access to its open documents and UI. This is useful for automation and for
+tools like AI coding agents, which can run a script and read back its output
+without the user having to copy anything in and out of the Console view.
+
+For this to work, the running instance needs to have the script server
+enabled. It can be enabled in *Edit > Preferences > Plugins*, or by starting
+Tiled with the ``--script-server`` option. The server is a local socket that
+only accepts connections from the same user.
+
+Once enabled, use ``--eval`` to evaluate script code or ``--eval-file`` to
+evaluate a script file:
+
+.. code:: sh
+
+    tiled --eval 'tiled.activeAsset.fileName'
+    tiled --eval-file count-objects.js
+
+Anything logged with ``tiled.log`` is printed to standard output, while
+warnings, errors and script errors are printed to standard error. The value of
+the last expression is printed to standard output as well, unless it is
+``undefined``. The exit code is 1 when the script raised an error. The script
+and its result are also shown in the Console view of the running instance, and
+the result is available there as a ``$N`` variable, like for scripts entered
+in the Console view directly.
+
+Output produced after the script finished, for example from a callback
+connected to a signal, is not captured.
+
+If no running instance with an enabled script server is found, ``--eval``
+fails with exit code 2. To evaluate a script without UI, use ``--evaluate``
+instead. When several Tiled instances are running, only the first one that
+enabled the script server will accept scripts.
+
+The protocol is newline-delimited JSON over a local socket named
+``tiled-script-server-<uid>`` (or ``tiled-script-server-<username>`` on
+Windows), so other tools can also talk to it directly. Each request is an
+object with a ``script`` property and an optional ``fileName`` property. Each
+response is an object with an ``output`` array of ``{ type, text }`` objects,
+where ``type`` is ``info``, ``warning`` or ``error``, and optionally a
+``result`` and ``tempName`` (when the result was not ``undefined``) or an
+``error`` string.
+
 API Reference
 -------------
 

--- a/man/tiled.1
+++ b/man/tiled.1
@@ -1,45 +1,44 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "TILED" "1" "May 2015" "" ""
-.
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "TILED" "1" "August 2026" ""
 .SH "NAME"
 \fBtiled\fR \- tile map editor
-.
 .SH "SYNOPSIS"
-\fBtiled\fR [\fIOPTIONS\fR] [FILES\.\.\.]
-.
+\fBtiled\fR [\fIOPTIONS\fR] [FILES\|\.\|\.\|\.]
 .SH "DESCRIPTION"
-Tiled is a general purpose tile map editor\. It\'s built to be easy to use, yet flexible enough to work with varying game engines, whether your game is an RPG, platformer or Breakout clone\. Tiled is free software and written in C++, using the Qt application framework\.
-.
+Tiled is a general purpose tile map editor\. It's built to be easy to use, yet flexible enough to work with varying game engines, whether your game is an RPG, platformer or Breakout clone\. Tiled is free software and written in C++, using the Qt application framework\.
 .SH "OPTIONS"
-.
 .TP
 \fB\-h\fR \fB\-\-help\fR
 Displays the help
-.
 .TP
 \fB\-v\fR \fB\-\-version\fR
 Displays the version
-.
 .TP
 \fB\-\-quit\fR
 Only check validity of arguments
-.
 .TP
 \fB\-\-disable\-opengl\fR
 Disables hardware accelerated rendering
-.
 .TP
 \fB\-\-export\-map\fR [format] \fItmx file\fR \fItarget file\fR
 Exports the specified tmx file to target
-.
 .TP
 \fB\-\-export\-formats\fR
 Prints a list of supported export formats
-.
+.TP
+\fB\-e\fR \fB\-\-evaluate\fR \fIfile\fR [args]
+Evaluates a script file without UI and quits
+.TP
+\fB\-\-eval\fR \fIjs code\fR
+Evaluates the given script code in a running instance and prints its output and result
+.TP
+\fB\-\-eval\-file\fR \fIfile\fR
+Evaluates the given script file in a running instance and prints its output and result
+.TP
+\fB\-\-script\-server\fR
+Enables the script server, which allows \-\-eval to run scripts in this instance
 .SH "AUTHORS"
 \fIhttps://github\.com/mapeditor/tiled/blob/master/AUTHORS\fR
-.
 .SH "SEE ALSO"
 tmxviewer(1), tmxrasterizer(1), \fIhttps://www\.mapeditor\.org/\fR

--- a/man/tiled.1.ronn
+++ b/man/tiled.1.ronn
@@ -26,10 +26,18 @@ in C++, using the Qt application framework.
     Exports the specified tmx file to target
   * `--export-formats`:
     Prints a list of supported export formats
+  * `-e` `--evaluate` <file> [args]:
+    Evaluates a script file without UI and quits
+  * `--eval` <js code>:
+    Evaluates the given script code in a running instance and prints its output and result
+  * `--eval-file` <file>:
+    Evaluates the given script file in a running instance and prints its output and result
+  * `--script-server`:
+    Enables the script server, which allows --eval to run scripts in this instance
 
 ## AUTHORS
 <https://github.com/mapeditor/tiled/blob/master/AUTHORS>
 
 ## SEE ALSO
 
-tmxviewer(1), tmxrasterizer(1), <http://www.mapeditor.org/>
+tmxviewer(1), tmxrasterizer(1), <https://www.mapeditor.org/>

--- a/src/tiled/consoledock.cpp
+++ b/src/tiled/consoledock.cpp
@@ -164,11 +164,9 @@ void ConsoleDock::executeScript()
 
     appendScript(script);
 
-    const QJSValue result = ScriptManager::instance().evaluate(script);
-    if (!result.isError() && !result.isUndefined()) {
-        auto name = ScriptManager::instance().createTempValue(result);
-        appendScriptResult(name, result.toString());
-    }
+    const auto result = ScriptManager::instance().evaluateCaptured(script);
+    if (result.hasResult)
+        appendScriptResult(result.tempName, result.result);
 
     mLineEdit->clear();
 

--- a/src/tiled/consoledock.h
+++ b/src/tiled/consoledock.h
@@ -37,6 +37,9 @@ public:
     explicit ConsoleDock(QWidget *parent = nullptr);
     ~ConsoleDock() override;
 
+    void appendScript(const QString &str);
+    void appendScriptResult(const QString &tempName, const QString &result);
+
 protected:
     void changeEvent(QEvent *e) override;
 
@@ -44,8 +47,6 @@ private:
     void appendInfo(const QString &str);
     void appendWarning(const QString &str);
     void appendError(const QString &str);
-    void appendScript(const QString &str);
-    void appendScriptResult(const QString &tempName, const QString &result);
 
     void executeScript();
 

--- a/src/tiled/libtilededitor.qbs
+++ b/src/tiled/libtilededitor.qbs
@@ -457,6 +457,8 @@ DynamicLibrary {
         "scriptmodule.h",
         "scriptprocess.cpp",
         "scriptprocess.h",
+        "scriptserver.cpp",
+        "scriptserver.h",
         "scriptsession.cpp",
         "scriptsession.h",
         "scriptpropertytype.cpp",

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -61,6 +61,7 @@
 #include "propertytypeseditor.h"
 #include "resizedialog.h"
 #include "scriptmanager.h"
+#include "scriptserver.h"
 #include "sentryhelper.h"
 #include "templatesdock.h"
 #include "tileset.h"
@@ -390,6 +391,26 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
 
     mConsoleDock->setVisible(false);
     mIssuesDock->setVisible(false);
+
+    auto updateScriptServer = [this] (bool enabled) {
+        if (enabled || ScriptServer::forceEnabled) {
+            if (!mScriptServer) {
+                mScriptServer = new ScriptServer(this);
+                connect(mScriptServer, &ScriptServer::scriptReceived,
+                        mConsoleDock, &ConsoleDock::appendScript);
+                connect(mScriptServer, &ScriptServer::scriptEvaluated,
+                        mConsoleDock, [this] (const QString &, const ScriptManager::EvaluationResult &result) {
+                    if (result.hasResult)
+                        mConsoleDock->appendScriptResult(result.tempName, result.result);
+                });
+            }
+            mScriptServer->listen();
+        } else if (mScriptServer) {
+            mScriptServer->close();
+        }
+    };
+    updateScriptServer(preferences->scriptServerEnabled());
+    connect(preferences, &Preferences::scriptServerEnabledChanged, this, updateScriptServer);
 
     mMapEditor = new MapEditor;
     mTilesetEditor = new TilesetEditor;

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -52,6 +52,7 @@ class ConsoleDock;
 class DocumentManager;
 class Editor;
 class IssuesDock;
+class ScriptServer;
 class LocatorSource;
 class LocatorWidget;
 class MapDocument;
@@ -244,6 +245,7 @@ private:
     ConsoleDock *mConsoleDock;
     ProjectDock *mProjectDock;
     IssuesDock *mIssuesDock;
+    ScriptServer *mScriptServer = nullptr;
     PropertyTypesEditor *mPropertyTypesEditor;
     QPointer<LocatorWidget> mLocatorWidget;
     QPointer<QWidget> mPopupWidget;

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -580,6 +580,17 @@ void Preferences::setUseOpenGL(bool useOpenGL)
     emit useOpenGLChanged(useOpenGL);
 }
 
+bool Preferences::scriptServerEnabled() const
+{
+    return get("Scripting/ServerEnabled", false);
+}
+
+void Preferences::setScriptServerEnabled(bool enabled)
+{
+    setValue(QLatin1String("Scripting/ServerEnabled"), enabled);
+    emit scriptServerEnabledChanged(enabled);
+}
+
 void Preferences::setPropertyTypes(const SharedPropertyTypes &propertyTypes)
 {
     Object::setPropertyTypes(propertyTypes);

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -146,6 +146,9 @@ public:
     bool useOpenGL() const;
     void setUseOpenGL(bool useOpenGL);
 
+    bool scriptServerEnabled() const;
+    void setScriptServerEnabled(bool enabled);
+
     void setPropertyTypes(const SharedPropertyTypes &propertyTypes);
 
     void setObjectTypesFile(const QString &filePath);
@@ -254,6 +257,7 @@ signals:
     void applicationFontChanged();
 
     void useOpenGLChanged(bool useOpenGL);
+    void scriptServerEnabledChanged(bool enabled);
 
     void languageChanged();
 

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -183,6 +183,9 @@ PreferencesDialog::PreferencesDialog(QWidget *parent)
         QDesktopServices::openUrl(QUrl::fromLocalFile(extensionsPath));
     });
 
+    connect(mUi->scriptServer, &QCheckBox::toggled,
+            preferences, &Preferences::setScriptServerEnabled);
+
     resize(sizeHint());
 }
 
@@ -236,6 +239,7 @@ void PreferencesDialog::fromPreferences()
     mUi->preciseTileObjectSelection->setChecked(MapObjectItem::preciseTileObjectSelection);
     if (mUi->openGL->isEnabled())
         mUi->openGL->setChecked(prefs->useOpenGL());
+    mUi->scriptServer->setChecked(prefs->scriptServerEnabled());
     mUi->wheelZoomsByDefault->setChecked(prefs->wheelZoomsByDefault());
     mUi->autoScrolling->setChecked(MapView::ourAutoScrollingEnabled);
     mUi->smoothScrolling->setChecked(MapView::ourSmoothScrollingEnabled);

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -627,25 +627,39 @@
          <property name="title">
           <string>Extensions</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
+         <layout class="QVBoxLayout" name="extensionsLayout">
           <item>
-           <widget class="QLabel" name="extensionsPathLabel">
-            <property name="text">
-             <string>Directory:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="extensionsPathLabel">
+              <property name="text">
+               <string>Directory:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="extensionsPathEdit">
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="openExtensionsPathButton">
+              <property name="text">
+               <string>Open...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
-           <widget class="QLineEdit" name="extensionsPathEdit">
-            <property name="readOnly">
-             <bool>true</bool>
+           <widget class="QCheckBox" name="scriptServer">
+            <property name="toolTip">
+             <string>Allows scripts to be evaluated in this instance by other processes, using &quot;tiled --eval&quot;. Only accessible to the current user.</string>
             </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="openExtensionsPathButton">
             <property name="text">
-             <string>Open...</string>
+             <string>Enable script server (allows &quot;tiled --eval&quot; to run scripts in this instance)</string>
             </property>
            </widget>
           </item>
@@ -727,6 +741,8 @@
   <tabstop>fontSize</tabstop>
   <tabstop>pluginList</tabstop>
   <tabstop>extensionsPathEdit</tabstop>
+  <tabstop>openExtensionsPathButton</tabstop>
+  <tabstop>scriptServer</tabstop>
   <tabstop>openExtensionsPathButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -178,6 +178,55 @@ QJSValue ScriptManager::evaluate(const QString &program,
     return result;
 }
 
+/**
+ * Evaluates the given program, capturing any output emitted while doing so.
+ *
+ * Errors are still reported through the LoggingInterface as usual, but they
+ * are not included in the captured output. Instead, the error message is
+ * available in the returned result. When the result is neither undefined nor
+ * an error, it is stored as a global temporary value.
+ */
+ScriptManager::EvaluationResult ScriptManager::evaluateCaptured(const QString &program,
+                                                                const QString &fileName)
+{
+    EvaluationResult result;
+
+    auto &logger = LoggingInterface::instance();
+    auto captureOutput = [&result] (LoggingInterface::OutputType type) {
+        return [&result, type] (const QString &message) {
+            result.output.append({ type, message });
+        };
+    };
+
+    QMetaObject::Connection connections[] = {
+        connect(&logger, &LoggingInterface::info, captureOutput(LoggingInterface::INFO)),
+        connect(&logger, &LoggingInterface::warning, captureOutput(LoggingInterface::WARNING)),
+        connect(&logger, &LoggingInterface::error, captureOutput(LoggingInterface::ERROR)),
+    };
+
+    QJSValue globalObject = mEngine->globalObject();
+    if (!fileName.isEmpty())
+        globalObject.setProperty(QStringLiteral("__filename"), fileName);
+
+    const QJSValue value = mEngine->evaluate(program, fileName);
+
+    globalObject.deleteProperty(QStringLiteral("__filename"));
+
+    for (const auto &connection : connections)
+        disconnect(connection);
+
+    if (value.isError()) {
+        result.error = errorString(value, program);
+        mModule->error(result.error);
+    } else if (!value.isUndefined()) {
+        result.tempName = createTempValue(value);
+        result.result = value.toString();
+        result.hasResult = true;
+    }
+
+    return result;
+}
+
 void ScriptManager::evaluateFileOrLoadModule(const QString &fileName)
 {
     if (fileName.endsWith(QLatin1String(".js"), Qt::CaseInsensitive)) {
@@ -276,6 +325,16 @@ bool ScriptManager::checkError(QJSValue value, const QString &program)
     if (!value.isError())
         return false;
 
+    mModule->error(errorString(value, program));
+    return true;
+}
+
+/**
+ * Returns the error message for the given error value, including a stack
+ * trace or line number where available.
+ */
+QString ScriptManager::errorString(const QJSValue &value, const QString &program)
+{
     QString errorString = value.toString();
     QString stack = value.property(QStringLiteral("stack")).toString();
 
@@ -300,8 +359,7 @@ bool ScriptManager::checkError(QJSValue value, const QString &program)
                 .arg(errorString);
     }
 
-    mModule->error(errorString);
-    return true;
+    return errorString;
 }
 
 void ScriptManager::throwError(const QString &message)

--- a/src/tiled/scriptmanager.h
+++ b/src/tiled/scriptmanager.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "filesystemwatcher.h"
+#include "logginginterface.h"
 #include "tilededitor_global.h"
 
 #include <QJSValue>
@@ -58,6 +59,27 @@ public:
         {}
     };
 
+    /**
+     * A line of output emitted while a script was being evaluated.
+     */
+    struct OutputLine {
+        LoggingInterface::OutputType type;
+        QString text;
+    };
+
+    /**
+     * The result of evaluating a script with evaluateCaptured().
+     */
+    struct EvaluationResult {
+        QString tempName;           // global name assigned to the result ($0, $1, ...)
+        QString result;             // string representation of the result
+        QString error;              // error message, if evaluation failed
+        QList<OutputLine> output;   // output emitted during evaluation
+        bool hasResult = false;     // false when the result was undefined or an error
+
+        bool hasError() const { return !error.isNull(); }
+    };
+
     static ScriptManager &instance();
     static void deleteInstance();
 
@@ -73,6 +95,9 @@ public:
     QJSValue evaluate(const QString &program,
                       const QString &fileName = QString(), int lineNumber = 1);
 
+    EvaluationResult evaluateCaptured(const QString &program,
+                                      const QString &fileName = QString());
+
     void evaluateFileOrLoadModule(const QString &fileName);
 
     /**
@@ -82,6 +107,7 @@ public:
     QString createTempValue(const QJSValue &value);
 
     bool checkError(QJSValue value, const QString &program = QString());
+    static QString errorString(const QJSValue &value, const QString &program = QString());
     void throwError(const QString &message);
     void throwNullArgError(int argNumber);
 

--- a/src/tiled/scriptserver.cpp
+++ b/src/tiled/scriptserver.cpp
@@ -1,0 +1,286 @@
+/*
+ * scriptserver.cpp
+ * Copyright 2026, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "scriptserver.h"
+
+#include "logginginterface.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLocalServer>
+#include <QLocalSocket>
+
+#if defined(Q_OS_UNIX)
+#include <unistd.h>
+#endif
+
+using namespace Tiled;
+
+bool ScriptServer::forceEnabled = false;
+
+static QString outputTypeToString(LoggingInterface::OutputType type)
+{
+    switch (type) {
+    case LoggingInterface::INFO:
+        return QStringLiteral("info");
+    case LoggingInterface::WARNING:
+        return QStringLiteral("warning");
+    case LoggingInterface::ERROR:
+        return QStringLiteral("error");
+    }
+    return QString();
+}
+
+static LoggingInterface::OutputType outputTypeFromString(const QString &type)
+{
+    if (type == QLatin1String("warning"))
+        return LoggingInterface::WARNING;
+    if (type == QLatin1String("error"))
+        return LoggingInterface::ERROR;
+    return LoggingInterface::INFO;
+}
+
+static QJsonObject toJson(const ScriptManager::EvaluationResult &result)
+{
+    QJsonObject object;
+
+    if (result.hasResult) {
+        object.insert(QStringLiteral("result"), result.result);
+        object.insert(QStringLiteral("tempName"), result.tempName);
+    }
+    if (result.hasError())
+        object.insert(QStringLiteral("error"), result.error);
+
+    QJsonArray output;
+    for (const auto &line : result.output) {
+        output.append(QJsonObject {
+            { QStringLiteral("type"), outputTypeToString(line.type) },
+            { QStringLiteral("text"), line.text },
+        });
+    }
+    object.insert(QStringLiteral("output"), output);
+
+    return object;
+}
+
+static ScriptManager::EvaluationResult fromJson(const QJsonObject &object)
+{
+    ScriptManager::EvaluationResult result;
+
+    if (object.contains(QLatin1String("result"))) {
+        result.hasResult = true;
+        result.result = object.value(QLatin1String("result")).toString();
+        result.tempName = object.value(QLatin1String("tempName")).toString();
+    }
+    if (object.contains(QLatin1String("error")))
+        result.error = object.value(QLatin1String("error")).toString();
+
+    const QJsonArray output = object.value(QLatin1String("output")).toArray();
+    for (const QJsonValue &value : output) {
+        const QJsonObject line = value.toObject();
+        result.output.append({
+            outputTypeFromString(line.value(QLatin1String("type")).toString()),
+            line.value(QLatin1String("text")).toString()
+        });
+    }
+
+    return result;
+}
+
+
+ScriptServer::ScriptServer(QObject *parent)
+    : QObject(parent)
+    , mServer(new QLocalServer(this))
+{
+    // Only allow connections from the same user
+    mServer->setSocketOptions(QLocalServer::UserAccessOption);
+
+    connect(mServer, &QLocalServer::newConnection,
+            this, &ScriptServer::newConnection);
+}
+
+ScriptServer::~ScriptServer()
+{
+    close();
+}
+
+QString ScriptServer::serverName()
+{
+    QString name = QStringLiteral("tiled-script-server");
+#if defined(Q_OS_UNIX)
+    name += QLatin1Char('-') + QString::number(::getuid());
+#elif defined(Q_OS_WIN)
+    name += QLatin1Char('-') + qEnvironmentVariable("USERNAME");
+#endif
+    return name;
+}
+
+bool ScriptServer::listen()
+{
+    if (mServer->isListening())
+        return true;
+
+    const QString name = serverName();
+
+    // Don't take over from another instance that is already serving
+    QLocalSocket probe;
+    probe.connectToServer(name);
+    if (probe.waitForConnected(100)) {
+        probe.disconnectFromServer();
+        INFO(tr("Script server already running in another Tiled instance"));
+        return false;
+    }
+
+    // Remove any stale socket left behind by a crashed instance
+    QLocalServer::removeServer(name);
+
+    if (!mServer->listen(name)) {
+        ERROR(tr("Failed to start script server: %1").arg(mServer->errorString()));
+        return false;
+    }
+
+    INFO(tr("Script server listening at '%1'").arg(mServer->fullServerName()));
+    return true;
+}
+
+void ScriptServer::close()
+{
+    if (!mServer->isListening())
+        return;
+
+    mServer->close();
+    mBuffers.clear();
+}
+
+bool ScriptServer::isListening() const
+{
+    return mServer->isListening();
+}
+
+void ScriptServer::newConnection()
+{
+    while (QLocalSocket *socket = mServer->nextPendingConnection()) {
+        connect(socket, &QLocalSocket::readyRead, this, [this, socket] { readyRead(socket); });
+        connect(socket, &QLocalSocket::disconnected, this, [this, socket] {
+            mBuffers.remove(socket);
+            socket->deleteLater();
+        });
+    }
+}
+
+void ScriptServer::readyRead(QLocalSocket *socket)
+{
+    QByteArray &buffer = mBuffers[socket];
+    buffer.append(socket->readAll());
+
+    int newline;
+    while ((newline = buffer.indexOf('\n')) != -1) {
+        const QByteArray request = buffer.left(newline);
+        buffer.remove(0, newline + 1);
+
+        if (!request.trimmed().isEmpty())
+            handleRequest(socket, request);
+
+        // The socket may have been deleted while evaluating the script
+        if (!mBuffers.contains(socket))
+            return;
+    }
+}
+
+void ScriptServer::handleRequest(QLocalSocket *socket, const QByteArray &request)
+{
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(request, &parseError);
+
+    ScriptManager::EvaluationResult result;
+
+    if (parseError.error != QJsonParseError::NoError) {
+        result.error = tr("Invalid request: %1").arg(parseError.errorString());
+    } else if (mBusy) {
+        result.error = tr("Script server is busy evaluating another script");
+    } else {
+        const QJsonObject object = document.object();
+        const QString script = object.value(QLatin1String("script")).toString();
+        const QString fileName = object.value(QLatin1String("fileName")).toString();
+
+        mBusy = true;
+        emit scriptReceived(script);
+        result = ScriptManager::instance().evaluateCaptured(script, fileName);
+        emit scriptEvaluated(script, result);
+        mBusy = false;
+    }
+
+    socket->write(QJsonDocument(toJson(result)).toJson(QJsonDocument::Compact));
+    socket->write("\n");
+    socket->flush();
+}
+
+std::optional<ScriptManager::EvaluationResult>
+ScriptServer::evaluateRemotely(const QString &script,
+                               const QString &fileName,
+                               QString *errorMessage)
+{
+    QLocalSocket socket;
+    socket.connectToServer(serverName());
+
+    if (!socket.waitForConnected(500)) {
+        if (errorMessage)
+            *errorMessage = socket.errorString();
+        return std::nullopt;
+    }
+
+    QJsonObject request { { QStringLiteral("script"), script } };
+    if (!fileName.isEmpty())
+        request.insert(QStringLiteral("fileName"), fileName);
+
+    socket.write(QJsonDocument(request).toJson(QJsonDocument::Compact));
+    socket.write("\n");
+    if (!socket.waitForBytesWritten(5000)) {
+        if (errorMessage)
+            *errorMessage = socket.errorString();
+        return std::nullopt;
+    }
+
+    // Wait indefinitely, since the script may take a while or wait for user
+    // interaction
+    QByteArray response;
+    while (!response.contains('\n')) {
+        if (!socket.waitForReadyRead(-1)) {
+            if (errorMessage)
+                *errorMessage = socket.errorString();
+            return std::nullopt;
+        }
+        response.append(socket.readAll());
+    }
+
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(response.left(response.indexOf('\n')),
+                                                           &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        if (errorMessage)
+            *errorMessage = tr("Invalid response: %1").arg(parseError.errorString());
+        return std::nullopt;
+    }
+
+    return fromJson(document.object());
+}
+
+#include "moc_scriptserver.cpp"

--- a/src/tiled/scriptserver.h
+++ b/src/tiled/scriptserver.h
@@ -1,0 +1,94 @@
+/*
+ * scriptserver.h
+ * Copyright 2026, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "scriptmanager.h"
+#include "tilededitor_global.h"
+
+#include <QHash>
+#include <QObject>
+
+#include <optional>
+
+class QLocalServer;
+class QLocalSocket;
+
+namespace Tiled {
+
+/**
+ * Local socket server that allows other processes to evaluate scripts in
+ * this Tiled instance. Used by the "tiled --eval" command-line option.
+ *
+ * The protocol is newline-delimited JSON. Each request is an object with a
+ * "script" property and an optional "fileName" property. Each response is
+ * an object with the following properties:
+ *
+ *  - "result": string representation of the result (absent when undefined)
+ *  - "tempName": global name assigned to the result (absent when undefined)
+ *  - "error": error message (absent when the script evaluated successfully)
+ *  - "output": array of { "type": "info"|"warning"|"error", "text": ... }
+ */
+class TILED_EDITOR_EXPORT ScriptServer : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ScriptServer(QObject *parent = nullptr);
+    ~ScriptServer() override;
+
+    bool listen();
+    void close();
+    bool isListening() const;
+
+    static QString serverName();
+
+    /**
+     * Whether the script server was requested on the command-line, in which
+     * case it is started regardless of the preference.
+     */
+    static bool forceEnabled;
+
+    /**
+     * Evaluates the given script in a running Tiled instance. Returns nothing
+     * when no running instance could be reached, in which case an error
+     * message is set.
+     */
+    static std::optional<ScriptManager::EvaluationResult>
+    evaluateRemotely(const QString &script,
+                     const QString &fileName,
+                     QString *errorMessage = nullptr);
+
+signals:
+    void scriptReceived(const QString &script);
+    void scriptEvaluated(const QString &script,
+                         const Tiled::ScriptManager::EvaluationResult &result);
+
+private:
+    void newConnection();
+    void readyRead(QLocalSocket *socket);
+    void handleRequest(QLocalSocket *socket, const QByteArray &request);
+
+    QLocalServer *mServer;
+    QHash<QLocalSocket*, QByteArray> mBuffers;
+    bool mBusy = false;
+};
+
+} // namespace Tiled

--- a/src/tiledapp/main.cpp
+++ b/src/tiledapp/main.cpp
@@ -512,11 +512,23 @@ static int evaluateInRunningInstance(const CommandLineHandler &commandLine)
 int main(int argc, char *argv[])
 {
 #if defined(Q_OS_WIN) && (!defined(Q_CC_MINGW) || __GNUC__ >= 5)
-    // Make console output work on Windows, if running in a console.
+    // Make console output work on Windows, if running in a console. Streams
+    // that were redirected to a pipe or file by the parent process are left
+    // alone, so that their output can be captured.
     if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+        auto isRedirected = [] (DWORD handleId) {
+            const HANDLE handle = GetStdHandle(handleId);
+            if (handle == nullptr || handle == INVALID_HANDLE_VALUE)
+                return false;
+            const DWORD type = GetFileType(handle);
+            return type == FILE_TYPE_PIPE || type == FILE_TYPE_DISK;
+        };
+
         FILE *dummy = nullptr;
-        freopen_s(&dummy, "CONOUT$", "w", stdout);
-        freopen_s(&dummy, "CONOUT$", "w", stderr);
+        if (!isRedirected(STD_OUTPUT_HANDLE))
+            freopen_s(&dummy, "CONOUT$", "w", stdout);
+        if (!isRedirected(STD_ERROR_HANDLE))
+            freopen_s(&dummy, "CONOUT$", "w", stderr);
     }
 #endif
 

--- a/src/tiledapp/main.cpp
+++ b/src/tiledapp/main.cpp
@@ -28,6 +28,7 @@
 #include "pluginmanager.h"
 #include "preferences.h"
 #include "scriptmanager.h"
+#include "scriptserver.h"
 #include "sentryhelper.h"
 #include "stylehelper.h"
 #include "tiledapplication.h"
@@ -65,6 +66,12 @@ static QTextStream& stdOut()
     return ts;
 }
 
+static QTextStream& stdErr()
+{
+    static QTextStream ts(stderr);
+    return ts;
+}
+
 namespace {
 
 class CommandLineHandler : public CommandLineParser
@@ -80,6 +87,9 @@ public:
     bool exportMap = false;
     bool exportTileset = false;
     bool newInstance = false;
+    bool evaluate = false;
+    QString evalScript;
+    QString evalFileName;
     Preferences::ExportOptions exportOptions;
 
 private:
@@ -96,6 +106,9 @@ private:
     void showExportFormats();
     void setCompatibilityVersion();
     void evaluateScript();
+    void setEvaluateScript();
+    void setEvaluateFile();
+    void enableScriptServer();
     void startNewInstance();
 
     // Convenience wrapper around registerOption
@@ -110,6 +123,19 @@ private:
                                                            help);
     }
 };
+
+static void connectLoggerToStdio()
+{
+    static bool connected = false;
+    if (connected)
+        return;
+    connected = true;
+
+    auto& logger = LoggingInterface::instance();
+    QObject::connect(&logger, &LoggingInterface::info, [] (const QString &message) { stdOut() << message << Qt::endl; });
+    QObject::connect(&logger, &LoggingInterface::warning, [] (const QString &message) { stdErr() << message << Qt::endl; });
+    QObject::connect(&logger, &LoggingInterface::error, [] (const QString &message) { stdErr() << message << Qt::endl; });
+}
 
 static void initializePluginsAndExtensions()
 {
@@ -252,6 +278,21 @@ CommandLineHandler::CommandLineHandler()
                 QLatin1Char('e'),
                 QLatin1String("--evaluate"),
                 tr("Evaluate a script file and quit"));
+
+    option<&CommandLineHandler::setEvaluateScript>(
+                QChar(),
+                QLatin1String("--eval"),
+                tr("Evaluate the given script code in a running instance and print the result"));
+
+    option<&CommandLineHandler::setEvaluateFile>(
+                QChar(),
+                QLatin1String("--eval-file"),
+                tr("Evaluate the given script file in a running instance and print the result"));
+
+    option<&CommandLineHandler::enableScriptServer>(
+                QChar(),
+                QLatin1String("--script-server"),
+                tr("Enable the script server, which allows --eval to run scripts in this instance"));
 }
 
 void CommandLineHandler::showVersion()
@@ -386,13 +427,7 @@ void CommandLineHandler::evaluateScript()
     static bool initialized = false;
     if (!initialized) {
         initialized = true;
-
-        // Output messages to command-line
-        auto& logger = LoggingInterface::instance();
-        QObject::connect(&logger, &LoggingInterface::info, [] (const QString &message) { stdOut() << message << Qt::endl; });
-        QObject::connect(&logger, &LoggingInterface::warning, [] (const QString &message) { qWarning() << message; });
-        QObject::connect(&logger, &LoggingInterface::error, [] (const QString &message) { qWarning() << message; });
-
+        connectLoggerToStdio();
         initializePluginsAndExtensions();
     }
 
@@ -401,9 +436,76 @@ void CommandLineHandler::evaluateScript()
     scriptManager.evaluateFileOrLoadModule(scriptFile);
 }
 
+void CommandLineHandler::setEvaluateScript()
+{
+    const QString script = nextArgument();
+    if (script.isNull()) {
+        qWarning().noquote() << QCoreApplication::translate("Command line", "Missing argument, evaluate a script using: --eval <script>");
+        justQuit();
+        return;
+    }
+
+    evaluate = true;
+    evalScript = script;
+    evalFileName.clear();
+}
+
+void CommandLineHandler::setEvaluateFile()
+{
+    const QString fileName = nextArgument();
+    if (fileName.isNull()) {
+        qWarning().noquote() << QCoreApplication::translate("Command line", "Missing argument, evaluate a script file using: --eval-file <script-file>");
+        justQuit();
+        return;
+    }
+
+    QFile file(fileName);
+    if (!file.open(QFile::ReadOnly | QFile::Text)) {
+        qWarning().noquote() << QCoreApplication::translate("Command line", "Error opening file: %1").arg(fileName);
+        justQuit();
+        return;
+    }
+
+    evaluate = true;
+    evalScript = QString::fromUtf8(file.readAll());
+    evalFileName = QFileInfo(fileName).absoluteFilePath();
+}
+
+void CommandLineHandler::enableScriptServer()
+{
+    ScriptServer::forceEnabled = true;
+}
+
 void CommandLineHandler::startNewInstance()
 {
     newInstance = true;
+}
+
+/**
+ * Evaluates the script given with --eval or --eval-file in a running Tiled
+ * instance. Returns the exit code.
+ */
+static int evaluateInRunningInstance(const CommandLineHandler &commandLine)
+{
+    const auto result = ScriptServer::evaluateRemotely(commandLine.evalScript,
+                                                       commandLine.evalFileName);
+    if (!result) {
+        stdErr() << QCoreApplication::translate("Command line", "No running Tiled instance with script server found. Enable the script server in the Preferences or start Tiled with --script-server.") << Qt::endl;
+        return 2;
+    }
+
+    for (const auto &line : result->output) {
+        if (line.type == LoggingInterface::INFO)
+            stdOut() << line.text << Qt::endl;
+        else
+            stdErr() << line.text << Qt::endl;
+    }
+    if (result->hasError())
+        stdErr() << result->error << Qt::endl;
+    if (result->hasResult)
+        stdOut() << result->result << Qt::endl;
+
+    return result->hasError() ? 1 : 0;
 }
 
 
@@ -459,6 +561,9 @@ int main(int argc, char *argv[])
         return 0;
     if (commandLine.disableOpenGL)
         Preferences::instance()->setUseOpenGL(false);
+
+    if (commandLine.evaluate)
+        return evaluateInRunningInstance(commandLine);
 
     if (commandLine.exportMap) {
         // Get the path to the source file and target file


### PR DESCRIPTION
Allows scripts to be evaluated in a running Tiled instance from the command-line, with their output and result printed to the terminal. This makes it possible for external tools, including AI coding agents, to run scripts against the open documents and read back the results without the user needing to manually copy/paste to/from the Console view.

The server listens on a local socket that only accepts connections from the same user. It can be enabled in the Preferences or with the new `--script-server` option. The new `--eval` and `--eval-file` options send a script to it and print its output, the result and any error, exiting with code 1 on error and code 2 when no server is reachable.

`ScriptManager` gained `evaluateCaptured()`, which captures the output emitted while evaluating a script. It is now also used by the Console view. Warnings and errors from `--evaluate` are now written to stderr without the quoting added by `qWarning`.