### PR TITLE
Allow assigning shortcuts to the built-in dock views

### DIFF
--- a/src/tiled/actionmanager.cpp
+++ b/src/tiled/actionmanager.cpp
@@ -22,6 +22,7 @@
 
 #include "preferences.h"
 
+#include <QAction>
 #include <QMenu>
 #include <QScopedValueRollback>
 
@@ -161,17 +162,43 @@ QAction *ActionManager::findAction(Id id)
     return d->mIdToActions.value(id);
 }
 
+/**
+ * Returns whether the action can currently be reached, based on whether any
+ * of the widgets it was added to is visible. This is the same rule Qt applies
+ * when resolving shortcuts, and it is what tells the actions of the map and
+ * tileset editors apart when they share an ID.
+ */
+static bool isReachable(const QAction *action)
+{
+    const auto objects = action->associatedObjects();
+    for (QObject *object : objects)
+        if (auto widget = qobject_cast<QWidget*>(object))
+            if (widget->isVisible())
+                return true;
+
+    return false;
+}
+
 QAction *ActionManager::findEnabledAction(Id id)
 {
     auto d = instance();
 
+    QAction *fallback = nullptr;
+
     const auto [start, end] = std::as_const(d->mIdToActions).equal_range(id);
     for (auto it = start; it != end; ++it) {
-        if (it.value()->isEnabled())
-            return it.value();
+        QAction *action = it.value();
+        if (!action->isEnabled())
+            continue;
+        if (isReachable(action))
+            return action;
+        if (!fallback)
+            fallback = action;
     }
 
-    return nullptr;
+    // Most actions are only added to a menu, which is not visible unless it
+    // happens to be open, so an unreachable action is still better than none.
+    return fallback;
 }
 
 bool ActionManager::hasMenu(Id id)

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -391,6 +391,16 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     mConsoleDock->setVisible(false);
     mIssuesDock->setVisible(false);
 
+    ActionManager::registerAction(mProjectDock->toggleViewAction(), "ViewProject");
+    ActionManager::registerAction(mConsoleDock->toggleViewAction(), "ViewConsole");
+    ActionManager::registerAction(mIssuesDock->toggleViewAction(), "ViewIssues");
+
+    // A shortcut only triggers when its action has been added to a widget, and
+    // the 'Views and Toolbars' menu is rebuilt each time it is shown.
+    addAction(mProjectDock->toggleViewAction());
+    addAction(mConsoleDock->toggleViewAction());
+    addAction(mIssuesDock->toggleViewAction());
+
     mMapEditor = new MapEditor;
     mTilesetEditor = new TilesetEditor;
 

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -20,6 +20,7 @@
 
 #include "mapeditor.h"
 
+#include "actionmanager.h"
 #include "addremovetileset.h"
 #include "bucketfilltool.h"
 #include "changeselectedarea.h"
@@ -232,6 +233,24 @@ MapEditor::MapEditor(QObject *parent)
     mPropertiesDock = new PropertiesDock(mMainWindow);
     mTemplatesDock->setPropertiesDock(mPropertiesDock);
     mTileStampsDock = new TileStampsDock(mTileStampManager, mMainWindow);
+
+    ActionManager::registerAction(mPropertiesDock->toggleViewAction(), "ViewProperties");
+    ActionManager::registerAction(mLayerDock->toggleViewAction(), "ViewLayers");
+    ActionManager::registerAction(mUndoDock->toggleViewAction(), "ViewHistory");
+    ActionManager::registerAction(mObjectsDock->toggleViewAction(), "ViewObjects");
+    ActionManager::registerAction(mTemplatesDock->toggleViewAction(), "ViewTemplateEditor");
+    ActionManager::registerAction(mTilesetDock->toggleViewAction(), "ViewTilesets");
+    ActionManager::registerAction(mWangDock->toggleViewAction(), "ViewTerrainSets");
+    ActionManager::registerAction(mMiniMapDock->toggleViewAction(), "ViewMiniMap");
+    ActionManager::registerAction(mTileStampsDock->toggleViewAction(), "ViewTileStamps");
+
+    // A shortcut only triggers when its action has been added to a widget, and
+    // the 'Views and Toolbars' menu is rebuilt each time it is shown. Adding
+    // the toggle actions to this editor's main window also makes sure they are
+    // only active while this editor is the current one.
+    const QList<QDockWidget*> dockWidgets = this->dockWidgets();
+    for (QDockWidget *dockWidget : dockWidgets)
+        mMainWindow->addAction(dockWidget->toggleViewAction());
 
     resetLayout();
 

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -156,6 +156,9 @@ TilesetEditor::TilesetEditor(QObject *parent)
 
     ActionManager::registerAction(editCollision, "EditCollision");
     ActionManager::registerAction(editWang, "EditWang");
+    ActionManager::registerAction(mPropertiesDock->toggleViewAction(), "ViewProperties");
+    ActionManager::registerAction(mUndoDock->toggleViewAction(), "ViewHistory");
+    ActionManager::registerAction(mTemplatesDock->toggleViewAction(), "ViewTemplateEditor");
     ActionManager::registerAction(mAddTiles, "AddTiles");
     ActionManager::registerAction(mRemoveTiles, "RemoveTiles");
     ActionManager::registerAction(mEditTilesetParameters, "EditTilesetParameters");
@@ -183,6 +186,14 @@ TilesetEditor::TilesetEditor(QObject *parent)
     // The shortcut set on the 'Remove Tiles' action should only be active
     // while the tileset view is focused, to avoid ambiguities.
     mWidgetStack->addAction(mRemoveTiles);
+
+    // A shortcut only triggers when its action has been added to a widget, and
+    // the 'Views and Toolbars' menu is rebuilt each time it is shown. Adding
+    // the toggle actions to this editor's main window also makes sure they are
+    // only active while this editor is the current one.
+    const QList<QDockWidget*> dockWidgets = this->dockWidgets();
+    for (QDockWidget *dockWidget : dockWidgets)
+        mMainWindow->addAction(dockWidget->toggleViewAction());
 
     Utils::setThemeIcon(mAddTiles, "add");
     Utils::setThemeIcon(mRemoveTiles, "remove");


### PR DESCRIPTION
The toggle actions of the built-in docks were not registered with the ActionManager, so they could not be given a keyboard shortcut. They are now registered under `View*` IDs and show up in *Preferences > Keyboard* and in the action search. No default shortcuts are assigned.

Registration alone is not enough, which is likely what went wrong in earlier attempts: Qt only activates the shortcut of an action that was added to a widget, and the *Views and Toolbars* menu is cleared and rebuilt each time it is shown, so membership of that menu cannot be relied on. Each toggle action is therefore also added to the window that owns the dock, which additionally makes it active only while that editor is current. This also covers `EditCollision` and `EditWang`, which so far worked only because they sit on the tileset toolbar.

The map and tileset editors share the `ViewProperties`, `ViewHistory` and `ViewTemplateEditor` IDs, so one shortcut covers the same view in both. The second commit makes the action search prefer the action of the visible editor, since it previously picked whichever one the hash returned first.

Since the actions are registered, scripts can also toggle these views through `tiled.trigger("ViewConsole")` and friends.

Fixes #3952
Refs #3166, whose toolbar entries are not covered by this change.