### PR TITLE
CI: Updated ccache-action to a Node.js 24 release

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -85,7 +85,7 @@ jobs:
         cache: true
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         max-size: 250M
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         max-size: 250M
 


### PR DESCRIPTION
The floating v1 tag still runs on Node.js 20, which GitHub is deprecating.