### PR TITLE
Add option to export selected area

### DIFF
--- a/src/tiled/exportasimagedialog.cpp
+++ b/src/tiled/exportasimagedialog.cpp
@@ -43,12 +43,38 @@ using namespace Tiled;
 namespace session {
 static SessionOption<bool> visibleLayersOnly { "exportAsImage.visibleLayersOnly", true };
 static SessionOption<bool> useCurrentScale { "exportAsImage.useCurrentScale", false };
+static SessionOption<bool> selectedAreaOnly { "exportAsImage.selectedAreaOnly", false };
 static SessionOption<bool> drawTileGrid { "exportAsImage.drawTileGrid", false };
 static SessionOption<bool> drawObjectLabels { "exportAsImage.drawObjectLabels", false };
 static SessionOption<bool> includeBackgroundColor { "exportAsImage.includeBackgroundColor", false };
 } // namespace session
 
 QString ExportAsImageDialog::mPath;
+
+QRect ExportAsImageDialog::selectedAreaImageRect(const QRect &mapBounds,
+                                                const QRect &selectionBounds,
+                                                const QSize &imageSize)
+{
+    if (selectionBounds.isEmpty())
+        return QRect();
+
+    const QSize mapSize = mapBounds.size();
+    if (mapSize.isEmpty())
+        return QRect();
+
+    const qreal scale = qMin(static_cast<qreal>(imageSize.width()) / mapSize.width(),
+                            static_cast<qreal>(imageSize.height()) / mapSize.height());
+    const QSize scaledMapSize = mapSize * scale;
+    const QPointF centerOffset((imageSize.width() - scaledMapSize.width()) / 2.0,
+                               (imageSize.height() - scaledMapSize.height()) / 2.0);
+
+    const QPointF imageTopLeft = QPointF(selectionBounds.left() - mapBounds.left(),
+                                         selectionBounds.top() - mapBounds.top()) * scale + centerOffset;
+    const QSizeF imageSizeF(selectionBounds.width() * scale,
+                            selectionBounds.height() * scale);
+
+    return QRectF(imageTopLeft, imageSizeF).toAlignedRect();
+}
 
 ExportAsImageDialog::ExportAsImageDialog(MapDocument *mapDocument,
                                          const QString &fileName,
@@ -89,6 +115,8 @@ ExportAsImageDialog::ExportAsImageDialog(MapDocument *mapDocument,
 
     mUi->visibleLayersOnly->setChecked(session::visibleLayersOnly);
     mUi->currentZoomLevel->setChecked(session::useCurrentScale);
+    mUi->selectedAreaOnly->setChecked(session::selectedAreaOnly);
+    mUi->selectedAreaOnly->setEnabled(!mMapDocument->selectedArea().isEmpty());
     mUi->drawTileGrid->setChecked(session::drawTileGrid);
     mUi->drawObjectLabels->setChecked(session::drawObjectLabels);
     mUi->includeBackgroundColor->setChecked(session::includeBackgroundColor);
@@ -134,9 +162,17 @@ void ExportAsImageDialog::accept()
 
     session::visibleLayersOnly = mUi->visibleLayersOnly->isChecked();
     session::useCurrentScale = mUi->currentZoomLevel->isChecked();
+    session::selectedAreaOnly = mUi->selectedAreaOnly->isChecked();
     session::drawTileGrid = mUi->drawTileGrid->isChecked();
     session::drawObjectLabels = mUi->drawObjectLabels->isChecked();
     session::includeBackgroundColor = mUi->includeBackgroundColor->isChecked();
+
+    if (session::selectedAreaOnly && mMapDocument->selectedArea().isEmpty()) {
+        QMessageBox::warning(this,
+                             tr("Export as Image"),
+                             tr("Please select an area before exporting only the selected area."));
+        return;
+    }
 
     MiniMapRenderer miniMapRenderer(mMapDocument->map());
     miniMapRenderer.setGridColor(Preferences::instance()->gridColor());
@@ -175,10 +211,11 @@ void ExportAsImageDialog::accept()
 
     MapRenderer *renderer = mMapDocument->renderer();
 
-    QRect boundingRect = renderer->mapBoundingRect();
-    mMapDocument->map()->adjustBoundingRectForOffsetsAndImageLayers(boundingRect);
+    const QRect mapBounds = renderer->mapBoundingRect();
+    QRect exportBounds = mapBounds;
+    mMapDocument->map()->adjustBoundingRectForOffsetsAndImageLayers(exportBounds);
 
-    QSize imageSize = boundingRect.size();
+    QSize imageSize = exportBounds.size();
 
     if (session::useCurrentScale)
         imageSize *= mCurrentScale;
@@ -202,6 +239,14 @@ void ExportAsImageDialog::accept()
         }
 
         miniMapRenderer.renderToImage(image, renderFlags);
+
+        if (session::selectedAreaOnly) {
+            const QRect selectionBounds = renderer->boundingRect(mMapDocument->selectedArea().boundingRect());
+            const QRect cropRect = ExportAsImageDialog::selectedAreaImageRect(exportBounds,
+                                                                             selectionBounds,
+                                                                             image.size());
+            image = image.copy(cropRect);
+        }
 
         QImageWriter imageWriter(fileName);
         if (!imageWriter.write(image)) {

--- a/src/tiled/exportasimagedialog.h
+++ b/src/tiled/exportasimagedialog.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "tilededitor_global.h"
+
 #include <QDialog>
 
 namespace Ui {
@@ -33,7 +35,7 @@ class MapDocument;
 /**
  * The dialog for exporting a map as an image.
  */
-class ExportAsImageDialog : public QDialog
+class TILED_EDITOR_EXPORT ExportAsImageDialog : public QDialog
 {
     Q_OBJECT
 
@@ -48,6 +50,14 @@ public:
                         qreal currentScale,
                         QWidget *parent = nullptr);
     ~ExportAsImageDialog() override;
+
+    /**
+     * Returns the rectangle of the selected area in the final exported image.
+     * This is based on the same scaling and centering logic as the rendered map.
+     */
+    static QRect selectedAreaImageRect(const QRect &mapBounds,
+                                       const QRect &selectionBounds,
+                                       const QSize &imageSize);
 
 public:
     void accept() override;

--- a/src/tiled/exportasimagedialog.ui
+++ b/src/tiled/exportasimagedialog.ui
@@ -70,6 +70,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="selectedAreaOnly">
+        <property name="text">
+         <string>Only export selected &amp;area</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="drawTileGrid">
         <property name="text">
          <string>&amp;Draw tile grid</string>

--- a/src/tiled/session.cpp
+++ b/src/tiled/session.cpp
@@ -391,6 +391,7 @@ static void migratePreferences()
 
     migrateToSession<bool>("SaveAsImage/VisibleLayersOnly", "exportAsImage.visibleLayersOnly");
     migrateToSession<bool>("SaveAsImage/CurrentScale", "exportAsImage.useCurrentScale");
+    migrateToSession<bool>("SaveAsImage/SelectionOnly", "exportAsImage.selectedAreaOnly");
     migrateToSession<bool>("SaveAsImage/DrawGrid", "exportAsImage.drawTileGrid");
     migrateToSession<bool>("SaveAsImage/IncludeBackgroundColor", "exportAsImage.includeBackgroundColor");
 

--- a/tests/export/export.qbs
+++ b/tests/export/export.qbs
@@ -1,0 +1,13 @@
+TiledTest {
+    name: "test_export"
+
+    Depends { name: "libtilededitor" }
+
+    cpp.includePaths: [
+        "/home/leenattress/Projects/tiled/src/tiled",
+    ]
+
+    files: [
+        "test_export.cpp",
+    ]
+}

--- a/tests/export/export.qbs
+++ b/tests/export/export.qbs
@@ -4,7 +4,7 @@ TiledTest {
     Depends { name: "libtilededitor" }
 
     cpp.includePaths: [
-        "/home/leenattress/Projects/tiled/src/tiled",
+        "../../src/tiled",
     ]
 
     files: [

--- a/tests/export/test_export.cpp
+++ b/tests/export/test_export.cpp
@@ -1,0 +1,54 @@
+#include "exportasimagedialog.h"
+
+#include <QtTest/QtTest>
+
+using namespace Tiled;
+
+class test_Export : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void selectedAreaImageRect_data();
+    void selectedAreaImageRect();
+};
+
+void test_Export::selectedAreaImageRect_data()
+{
+    QTest::addColumn<QRect>("mapBounds");
+    QTest::addColumn<QRect>("selectionBounds");
+    QTest::addColumn<QSize>("imageSize");
+    QTest::addColumn<QRect>("expected");
+
+    QTest::newRow("regular-selection")
+        << QRect(0, 0, 100, 80)
+        << QRect(10, 20, 30, 40)
+        << QSize(200, 160)
+        << QRect(20, 40, 60, 80);
+
+    QTest::newRow("non-zero-origin")
+        << QRect(50, 40, 100, 80)
+        << QRect(60, 50, 20, 30)
+        << QSize(300, 240)
+        << QRect(30, 30, 60, 90);
+
+    QTest::newRow("empty-selection")
+        << QRect(0, 0, 100, 80)
+        << QRect()
+        << QSize(200, 160)
+        << QRect();
+}
+
+void test_Export::selectedAreaImageRect()
+{
+    QFETCH(QRect, mapBounds);
+    QFETCH(QRect, selectionBounds);
+    QFETCH(QSize, imageSize);
+    QFETCH(QRect, expected);
+
+    const QRect result = ExportAsImageDialog::selectedAreaImageRect(mapBounds, selectionBounds, imageSize);
+    QCOMPARE(result, expected);
+}
+
+QTEST_MAIN(test_Export)
+#include "test_export.moc"

--- a/tests/tests.qbs
+++ b/tests/tests.qbs
@@ -3,6 +3,7 @@ Project {
 
     references: [
         "automapping",
+        "export",
         "mapreader",
         "properties",
         "staggeredrenderer",


### PR DESCRIPTION
## Summary

Adds an **Only export selected area** option to the Export As Image dialog.

When enabled, Tiled exports only the currently selected map area instead of the full map. The crop calculation accounts for renderer scaling and centering so the saved image matches the visible selection.

## How It Works

- Use **Rectangular Select** (`R`) to select the tiles you want to export.
- Open **Export As Image**.
- Enable **Only export selected area**.
- Tiled exports only the selected tiles.

## When Nothing Is Selected

- The option is disabled, so it cannot be turned on.
- Tiled remembers your previous choice, so it may appear ticked but greyed out.
- Tiled checks again before exporting and shows a message instead of creating an incorrect image.

## Why This Is Needed

For projects targeting constrained platforms such as the Game Boy (my personal use case), exported maps often need to stay within strict size limits.

A useful workflow is to design a large world as one connected map in Tiled: individual levels, rooms, and areas can be laid out together so their connections are visible and easy to verify. This is particularly helpful for tools such as GB Studio and NES studio, where seeing the whole world at once makes it easier to manage transitions and keep areas wired together correctly.

However, the game still needs each area exported separately. The new option allows selecting one area of the larger map and exporting only that selection as a PNG, without splitting the source world into many disconnected map files. This keeps the overview and editing workflow in Tiled while producing smaller images suitable for the target platform.

## Testing

- Added regression tests for selected-area image crop geometry.
- Built and ran `test_export` successfully.