### PR TITLE
libtiled-java: Prepare for 1.5.0 release

### DIFF
--- a/util/java/CHANGELOG.md
+++ b/util/java/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [1.5.0] - 2026-09-06
+
+### Added
+- Support for modern TMX features: object templates, infinite maps with
+  chunked layers, class properties, Wang sets, editor settings, tileset
+  transformations, embedded and cropped tile images, group layers, parallax,
+  tint colors, zstd-compressed and CSV-encoded layer data and SVG tilesets
+  (by Taz Tatsuno, #4325)
+- The writer now always stamps the current format version and supports CSV
+  encoding, zstd compression and chunked infinite layers (by Taz Tatsuno, #4325)
+- New oblique renderer, rewritten hexagonal renderer, flip flag rendering,
+  group layer opacity and corrected rotation pivot (by Taz Tatsuno, #4325)
+- Added `ROTATED_HEXAGONAL_120_FLAG` (#4315)
+- The `zstd-jni` and `jsvg` dependencies can be excluded by consumers that
+  use neither zstd compression nor SVG tilesets (by Taz Tatsuno, #4325)
+
+### Changed
+- Migrated from `javax.xml.bind` to `jakarta.xml.bind` for Java 21 support,
+  which raises the minimum supported Java version to 11 (by Taz Tatsuno, #4326)
+- Optimized image scaling in `MapObject.getImage` (by Taz Tatsuno, #4327)
+
+### Fixed
+- Fixed "Can't find ReflectionNavigator class" error when running tmxviewer
+  (by Taz Tatsuno, #4328)
+- XML escaping, XXE-hardened parsing, errors on truncated or invalid tile
+  data, correct unsigned gid handling and locale-independent number
+  formatting (by Taz Tatsuno, #4325)
+
 ## [1.4.3] - 2025-06-02
 
 ### Fixed

--- a/util/java/libtiled-java/pom.xml
+++ b/util/java/libtiled-java/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.mapeditor</groupId>
         <artifactId>tiled-parent</artifactId>
-        <version>1.4.4-SNAPSHOT</version>
+        <version>1.5.0</version>
     </parent>
 
     <artifactId>libtiled</artifactId>

--- a/util/java/libtiled-java/pom.xml
+++ b/util/java/libtiled-java/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.mapeditor</groupId>
         <artifactId>tiled-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>libtiled</artifactId>

--- a/util/java/pom.xml
+++ b/util/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.mapeditor</groupId>
     <artifactId>tiled-parent</artifactId>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>1.5.0</version>
     <packaging>pom</packaging>
 
     <name>Tiled</name>
@@ -63,16 +63,6 @@
         <system>GitHub Actions</system>
         <url>https://github.com/mapeditor/tiled/actions</url>
     </ciManagement>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
 
     <properties>
@@ -196,6 +186,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.11.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -376,13 +375,6 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <updateReleaseInfo>true</updateReleaseInfo>
-                        </configuration>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>

--- a/util/java/pom.xml
+++ b/util/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.mapeditor</groupId>
     <artifactId>tiled-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Tiled</name>

--- a/util/java/tmxviewer-java/pom.xml
+++ b/util/java/tmxviewer-java/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.mapeditor</groupId>
         <artifactId>tiled-parent</artifactId>
-        <version>1.4.4-SNAPSHOT</version>
+        <version>1.5.0</version>
     </parent>
 
     <artifactId>tmxviewer</artifactId>

--- a/util/java/tmxviewer-java/pom.xml
+++ b/util/java/tmxviewer-java/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.mapeditor</groupId>
         <artifactId>tiled-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>tmxviewer</artifactId>


### PR DESCRIPTION
Bumps libtiled-java to 1.5.0, adds the changelog entry, and switches publishing from the retired OSSRH endpoint to the Sonatype Central Portal via the central-publishing-maven-plugin. A second commit bumps the poms to 1.5.1-SNAPSHOT.

The 1.5.0 artifacts are already published: https://central.sonatype.com/artifact/org.mapeditor/libtiled/1.5.0