### PR TITLE
Several fixes related to resizing maps

### DIFF
--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -511,16 +511,23 @@ void AbstractWorldTool::populateToolBar(QToolBar *toolBar)
     });
 }
 
+// The world grid to snap to, or an empty size when the map is not in a world
+// with a grid or snapping to it is disabled.
+QSize AbstractWorldTool::worldGridSize(MapDocument *document) const
+{
+    if (Preferences::instance()->snapToWorldGrid())
+        if (auto worldDocument = worldForMap(document))
+            return worldDocument->world()->gridSize;
+
+    return QSize();
+}
+
 QSize AbstractWorldTool::snapSize(MapDocument *document) const
 {
     // Snap to the world grid when set and enabled, otherwise the tile size
-    if (Preferences::instance()->snapToWorldGrid()) {
-        if (auto worldDocument = worldForMap(document)) {
-            const QSize gridSize = worldDocument->world()->gridSize;
-            if (!gridSize.isEmpty())
-                return gridSize;
-        }
-    }
+    const QSize gridSize = worldGridSize(document);
+    if (!gridSize.isEmpty())
+        return gridSize;
 
     return document->map()->tileSize();
 }

--- a/src/tiled/abstractworldtool.cpp
+++ b/src/tiled/abstractworldtool.cpp
@@ -542,7 +542,18 @@ QPoint AbstractWorldTool::snapPoint(QPoint point, MapDocument *document) const
 
 void AbstractWorldTool::setTargetMap(MapDocument *mapDocument)
 {
-    mTargetMap = mapDocument;
+    if (mTargetMap != mapDocument) {
+        if (mTargetMap)
+            disconnect(mTargetMap, &MapDocument::mapResized,
+                       this, &AbstractWorldTool::updateSelectionRectangle);
+
+        mTargetMap = mapDocument;
+
+        if (mTargetMap)
+            connect(mTargetMap, &MapDocument::mapResized,
+                    this, &AbstractWorldTool::updateSelectionRectangle);
+    }
+
     updateSelectionRectangle();
 }
 

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -103,6 +103,7 @@ protected:
     void removeFromWorld(WorldDocument *worldDocument, const QString &mapFileName);
     void addToWorld(WorldDocument *worldDocument);
 
+    QSize worldGridSize(MapDocument *document) const;
     QSize snapSize(MapDocument *document) const;
     QPoint snapPoint(QPoint point, MapDocument *document) const;
 

--- a/src/tiled/abstractworldtool.h
+++ b/src/tiled/abstractworldtool.h
@@ -22,6 +22,8 @@
 
 #include "abstracttool.h"
 
+#include <QPointer>
+
 #include <array>
 #include <memory>
 
@@ -125,7 +127,9 @@ private:
 
     void populateAddToWorldMenu(QMenu &menu);
 
-    MapDocument *mTargetMap = nullptr;
+    // A QPointer, since the target map may be a document other than the
+    // current one and can be closed while it is targeted
+    QPointer<MapDocument> mTargetMap;
 
     QAction *mNewWorldForMapAction;
     QAction *mAddAnotherMapToWorldAction;

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -398,6 +398,13 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
     const QPointF newOrigin = renderer()->tileToPixelCoords(-offset);
     const QPointF pixelOffset = origin - newOrigin;
 
+    // Image layers and worlds position the map by its bounding rect, whose
+    // screen-space shift can differ from the pixel-space object movement.
+    const QRect oldBounds = renderer()->boundingRect(QRect(QPoint(), map()->size()));
+    const QRect newBounds = renderer()->boundingRect(newArea);
+    const QPoint boundsOffset = newBounds.topLeft() - oldBounds.topLeft();
+    const QPoint screenOffset = -boundsOffset;
+
     // Resize the map and each layer
     auto command = new QUndoCommand(tr("Resize Map"));
 
@@ -428,7 +435,7 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
             // Adjust image layer by changing its offset
             auto imageLayer = static_cast<ImageLayer*>(layer);
             new SetLayerOffset(this, { layer },
-                               imageLayer->offset() + pixelOffset,
+                               imageLayer->offset() + screenOffset,
                                command);
             break;
         }
@@ -453,13 +460,6 @@ void MapDocument::resizeMap(QSize size, QPoint offset, bool removeObjects)
 
     new ResizeMap(this, size, offset, command);
     new ChangeSelectedArea(this, movedSelection, command);
-
-    // A world positions a map by its bounding rect, so move by how much that
-    // rect shifts. The pixel offset moved isometric maps twice as far as their
-    // rect actually shifts
-    const QRect oldBounds = renderer()->boundingRect(QRect(QPoint(), map()->size()));
-    const QRect newBounds = renderer()->boundingRect(QRect(-offset, size));
-    const QPoint boundsOffset = newBounds.topLeft() - oldBounds.topLeft();
 
     // Adjust world position if this map is part of any loaded worlds
     if (!boundsOffset.isNull()) {

--- a/src/tiled/worldmovemaptool.cpp
+++ b/src/tiled/worldmovemaptool.cpp
@@ -148,8 +148,23 @@ void WorldMoveMapTool::updateResizingMap(const QPointF &pos,
 {
     const Map *map = mResizingMap->map();
     const MapRenderer *renderer = mResizingMap->renderer();
-    const QSize step = snapSize(mResizingMap);
     const HandleEdges edges = handleEdges[mResizeHandle];
+
+    // ask the renderer what one more column or row adds on screen, since that
+    // is only the tile size for orthogonal maps
+    const QSize mapSize = map->size();
+    const QRect mapRect = renderer->boundingRect(QRect(QPoint(), mapSize));
+    const QRect oneMoreColumn = renderer->boundingRect(QRect(QPoint(), mapSize + QSize(1, 0)));
+    const QRect oneMoreRow = renderer->boundingRect(QRect(QPoint(), mapSize + QSize(0, 1)));
+    const int columnPixels = qMax(1, oneMoreColumn.width() - mapRect.width());
+    const int rowPixels = qMax(1, oneMoreRow.height() - mapRect.height());
+
+    // snap the drag to the world grid when enabled, otherwise to whole columns
+    // and rows (which is less than the tile size for staggered and hexagonal
+    // maps, so snapping to the tile size would skip rows)
+    QSize step = worldGridSize(mResizingMap);
+    if (step.isEmpty())
+        step = QSize(columnPixels, rowPixels);
 
     int left = mResizeStartWorldRect.left();
     int top = mResizeStartWorldRect.top();
@@ -175,15 +190,6 @@ void WorldMoveMapTool::updateResizingMap(const QPointF &pos,
         top += snap(delta.y(), step.height());
     if (edges.bottom)
         bottom += snap(delta.y(), step.height());
-
-    // ask the renderer what one more column or row adds on screen, since that
-    // is only the tile size for orthogonal maps
-    const QSize mapSize = map->size();
-    const QRect mapRect = renderer->boundingRect(QRect(QPoint(), mapSize));
-    const QRect oneMoreColumn = renderer->boundingRect(QRect(QPoint(), mapSize + QSize(1, 0)));
-    const QRect oneMoreRow = renderer->boundingRect(QRect(QPoint(), mapSize + QSize(0, 1)));
-    const int columnPixels = qMax(1, oneMoreColumn.width() - mapRect.width());
-    const int rowPixels = qMax(1, oneMoreRow.height() - mapRect.height());
 
     // count from the size we started at, so grabbing a handle without dragging
     // leaves the map as it is


### PR DESCRIPTION
Three fixes related to resizing maps, both through the Resize Map dialog and with the World Tool:

- Image layers ended up at the wrong position after a map resize on non-orthogonal maps. Their offset was adjusted by the pixel offset, but image layers are positioned in screen coordinates relative to the map's bounding rect. They are now moved by the shift of that bounding rect, which is the same offset already used to adjust the map's world position.

- Resizing hexagonal and staggered maps with the World Tool skipped rows. The drag was snapped to the tile size and then converted to whole rows and columns, but a row of such a map adds less than a tile on screen, so a row was skipped every few rows. The drag now snaps directly to the on-screen size of one column or row, unless snapping to the world grid is enabled.

- The World Tool selection rectangle went stale when the target map was resized by undo or redo. The rectangle and handles only followed the tool's own resizes and world changes, so undoing a resize left them in place until the next mouse event. The tool now follows the target map's resize signal. The target is also held in a `QPointer`, since it can be a neighbouring map that is closed while targeted.