### PR TITLE
Add per-object color override property

### DIFF
--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -381,6 +381,7 @@ MapObject *MapObject::clone() const
     o->setPolygon(mPolygon);
     o->setShape(mShape);
     o->setCell(mCell);
+    o->setColor(mColor);
     o->setRotation(mRotation);
     o->setOpacity(mOpacity);
     o->setVisible(mVisible);
@@ -397,6 +398,7 @@ void MapObject::copyPropertiesFrom(const MapObject *object)
     setPolygon(object->polygon());
     setShape(object->shape());
     setCell(object->cell());
+    setColor(object->color());
     setRotation(object->rotation());
     setOpacity(object->opacity());
     setVisible(object->isVisible());
@@ -434,6 +436,9 @@ void MapObject::syncWithTemplate()
 
     if (!propertyChanged(MapObject::CellProperty))
         setCell(base->cell());
+
+    if (!propertyChanged(MapObject::ColorProperty))     // <-- tambahkan blok ini
+           setColor(base->color());
 
     if (!propertyChanged(MapObject::RotationProperty))
         setRotation(base->rotation());

--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -286,6 +286,9 @@ MapObjectColors MapObject::effectiveColors() const
     if (auto classType = Object::propertyTypes().findClassFor(effectiveClassName(), *this)) {
         colors.main = classType->color;
         drawFill = classType->drawFill;
+    } else if (mColor.isValid()) {
+        // Per-object color override takes priority over the layer's color
+        colors.main = mColor;
     } else if (mObjectGroup && mObjectGroup->color().isValid()) {
         colors.main = mObjectGroup->color();
     } else {
@@ -310,6 +313,7 @@ QVariant MapObject::mapObjectProperty(Property property) const
     case TextAlignmentProperty: return QVariant::fromValue(mTextData.alignment);
     case TextWordWrapProperty:  return mTextData.wordWrap;
     case TextColorProperty:     return mTextData.color;
+    case ColorProperty:         return mColor;     // color pada object
     case PositionProperty:      return mPos;
     case SizeProperty:          return mSize;
     case RotationProperty:      return mRotation;
@@ -333,6 +337,7 @@ void MapObject::setMapObjectProperty(Property property, const QVariant &value)
     case TextAlignmentProperty: mTextData.alignment = value.value<Qt::Alignment>(); break;
     case TextWordWrapProperty:  mTextData.wordWrap = value.toBool(); break;
     case TextColorProperty:     mTextData.color = value.value<QColor>(); break;
+    case ColorProperty:         mColor = value.value<QColor>(); break;   // <-- tambahkan
     case PositionProperty:      setPosition(value.toPointF()); break;
     case SizeProperty:          setSize(value.toSizeF()); break;
     case RotationProperty:      setRotation(value.toReal()); break;

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -123,6 +123,7 @@ public:
         ShapeProperty           = 1 << 12,
         TemplateProperty        = 1 << 13,
         CustomProperties        = 1 << 14,
+        ColorProperty            = 1 << 15,   // <-- tambahkan ini
         AllProperties           = 0xFF
     };
 
@@ -191,6 +192,9 @@ public:
     const Cell &cell() const;
     void setCell(const Cell &cell);
 
+    QColor color() const;              // <-- tambahkan
+    void setColor(const QColor &color); // <-- tambahkan
+
     const ObjectTemplate *objectTemplate() const;
     void setObjectTemplate(const ObjectTemplate *objectTemplate);
 
@@ -249,6 +253,7 @@ private:
     TextData mTextData;
     QPolygonF mPolygon;
     Cell mCell;
+    QColor mColor;
     const ObjectTemplate *mObjectTemplate = nullptr;
     ObjectGroup *mObjectGroup = nullptr;
     qreal mRotation = 0.0;
@@ -445,6 +450,11 @@ inline QRectF MapObject::bounds() const
 inline const Cell &MapObject::cell() const
 { return mCell; }
 
+inline QColor MapObject::color() const
+{ return mColor; }
+
+inline void MapObject::setColor(const QColor &color)
+{ mColor = color; }
 /**
  * Sets the tile that is associated with this object. The object will
  * display as the tile image.

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -1247,6 +1247,14 @@ std::unique_ptr<MapObject> MapReaderPrivate::readObject()
         object->setPropertyChanged(MapObject::VisibleProperty);
     }
 
+    // vvv tambahkan blok ini vvv
+    const QString colorString = atts.value(QLatin1String("color")).toString();
+    if (!colorString.isEmpty()) {
+        object->setColor(QColor(colorString));
+        object->setPropertyChanged(MapObject::ColorProperty);
+    }
+    // ^^^ sampai sini ^^^
+
     while (xml.readNextStartElement()) {
         if (xml.name() == QLatin1String("properties")) {
             object->mergeProperties(readProperties());

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -600,6 +600,11 @@ QVariant MapToVariantConverter::toVariant(const MapObject &object) const
     if (notTemplateInstance || object.propertyChanged(MapObject::VisibleProperty))
         objectVariant[QStringLiteral("visible")] = object.isVisible();
 
+    // vvv tambahkan blok ini vvv
+    if (object.color().isValid() && (notTemplateInstance || object.propertyChanged(MapObject::ColorProperty)))
+        objectVariant[QStringLiteral("color")] = colorToString(object.color());
+    // ^^^ sampai sini ^^^
+
     /* Polygons are stored in this format:
      *
      *   "polygon/polyline": [

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -774,6 +774,11 @@ void MapWriterPrivate::writeObject(QXmlStreamWriter &w,
     if (shouldWrite(!mapObject.isVisible(), isTemplateInstance, mapObject.propertyChanged(MapObject::VisibleProperty)))
         w.writeAttribute(QStringLiteral("visible"), QLatin1String(mapObject.isVisible() ? "1" : "0"));
 
+    // vvv tambahkan blok ini vvv
+       if (shouldWrite(mapObject.color().isValid(), isTemplateInstance, mapObject.propertyChanged(MapObject::ColorProperty)))
+           w.writeAttribute(QStringLiteral("color"), colorToString(mapObject.color()));
+    // ^^^ sampai sini ^^^
+
     writeProperties(w, mapObject.properties());
 
     switch (mapObject.shape()) {

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -783,6 +783,16 @@ std::unique_ptr<MapObject> VariantToMapConverter::toMapObject(const QVariantMap 
         object->setPropertyChanged(MapObject::VisibleProperty);
     }
 
+    // vvv tambahkan blok ini vvv
+    if (variantMap.contains(QLatin1String("color"))) {
+        const QString colorString = variantMap[QStringLiteral("color")].toString();
+        if (!colorString.isEmpty()) {
+            object->setColor(QColor(colorString));
+            object->setPropertyChanged(MapObject::ColorProperty);
+        }
+    }
+    // ^^^ sampai sini ^^^
+
     object->setProperties(extractProperties(variantMap));
 
     const QVariant polylineVariant = variantMap[QStringLiteral("polyline")];

--- a/src/tiled/propertieswidget.cpp
+++ b/src/tiled/propertieswidget.cpp
@@ -1839,6 +1839,14 @@ public:
                     [this](const QColor &value) {
                         changeMapObject(MapObject::TextColorProperty, value);
                     });
+        mColorProperty = new ColorProperty(
+                    tr("Color"),
+                    [this] {
+                        return mapObject()->color();
+                    },
+                    [this](const QColor &value) {
+                        changeMapObject(MapObject::ColorProperty, value);
+                    });
 
         mObjectProperties = new GroupProperty(tr("Object"));
         mObjectProperties->addProperty(mIdProperty);
@@ -1851,6 +1859,7 @@ public:
             mObjectProperties->addProperty(mVisibleProperty);
 
         mObjectProperties->addProperty(mOpacityProperty);
+        mObjectProperties->addProperty(mColorProperty);   // <-- tambahkan
 
         if (mapObject()->hasDimensions())
             mObjectProperties->addProperty(mBoundsProperty);
@@ -1918,6 +1927,8 @@ private:
             emit mTextWordWrapProperty->valueChanged();
         if (change.properties & MapObject::TextColorProperty)
             emit mTextColorProperty->valueChanged();
+        if (change.properties & MapObject::ColorProperty)
+            emit mColorProperty->valueChanged();
     }
 
     void updateEnabledState()
@@ -1976,6 +1987,7 @@ private:
     Property *mNameProperty;
     BoolProperty *mVisibleProperty;
     IntProperty *mOpacityProperty;
+    Property *mColorProperty;   // <-- tambahkan di sini
     Property *mPositionProperty;
     Property *mBoundsProperty;
     FloatProperty *mRotationProperty;


### PR DESCRIPTION
Adds a Color property on MapObject that takes priority over the object layer's color but is overridden by a Class color: Class > Object Color > Layer Color > gray default.